### PR TITLE
feat: add security preflight checks

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -44,6 +44,19 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Security preflight
+      shell: bash
+      run: |
+        DEFAULT_BRANCH=$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.default_branch')
+        PROTECTED=$(gh api "repos/${GITHUB_REPOSITORY}/branches/${DEFAULT_BRANCH}" --jq '.protected')
+        if [ "$PROTECTED" != "true" ]; then
+          echo "::error::Default branch '${DEFAULT_BRANCH}' is NOT protected. Without branch protection, the bot can merge PRs without review. Add a branch protection rule or ruleset before using Continuous. See docs/security-model.md in the Continuous repo."
+          exit 1
+        fi
+        echo "Security preflight passed: default branch '${DEFAULT_BRANCH}' is protected"
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+
     - name: Install CI skills
       shell: bash
       run: |

--- a/generator/src/continuous/checks.py
+++ b/generator/src/continuous/checks.py
@@ -1,0 +1,130 @@
+"""Security checks for continuous setup.
+
+Verifies the repository has the security prerequisites described in
+docs/security-model.md: branch protection on the default branch, bot
+permission level, and required secrets.
+
+Uses the `gh` CLI for GitHub API access. Checks degrade gracefully when
+gh is unavailable or the token lacks permission.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from dataclasses import dataclass
+
+from continuous.config import Config
+
+
+@dataclass
+class CheckResult:
+    name: str
+    passed: bool | None  # None = skipped/error
+    message: str
+
+
+def _gh(*args: str) -> subprocess.CompletedProcess[str] | None:
+    """Run a gh CLI command. Returns None if gh is not installed."""
+    gh = shutil.which("gh")
+    if not gh:
+        return None
+    try:
+        return subprocess.run(
+            [gh, *args], capture_output=True, text=True, timeout=30
+        )
+    except subprocess.TimeoutExpired:
+        return None
+
+
+def detect_repo() -> str | None:
+    """Detect owner/repo from the gh CLI context."""
+    result = _gh("repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner")
+    if result and result.returncode == 0:
+        repo = result.stdout.strip()
+        return repo or None
+    return None
+
+
+def check_branch_protection(repo: str, branch: str) -> CheckResult:
+    """Check if the default branch is protected."""
+    result = _gh("api", f"repos/{repo}/branches/{branch}", "--jq", ".protected")
+    if result is None:
+        return CheckResult("branch-protection", None, "gh CLI not found")
+    if result.returncode != 0:
+        return CheckResult("branch-protection", None, f"API error: {result.stderr.strip()}")
+
+    if result.stdout.strip() == "true":
+        return CheckResult("branch-protection", True, f"Default branch '{branch}' is protected")
+    return CheckResult(
+        "branch-protection",
+        False,
+        f"Default branch '{branch}' is NOT protected. "
+        "The bot must not be able to merge PRs — this is the primary security boundary. "
+        "Add a branch protection rule or ruleset. See docs/security-model.md.",
+    )
+
+
+def check_bot_permission(repo: str, bot_name: str) -> CheckResult:
+    """Check the bot's permission level (should be write, not admin)."""
+    result = _gh("api", f"repos/{repo}/collaborators/{bot_name}/permission", "--jq", ".permission")
+    if result is None:
+        return CheckResult("bot-permission", None, "gh CLI not found")
+    if result.returncode != 0:
+        return CheckResult("bot-permission", None, "Could not check (may require admin access to read)")
+
+    perm = result.stdout.strip()
+    if perm == "admin":
+        return CheckResult(
+            "bot-permission",
+            False,
+            f"Bot '{bot_name}' has admin permission — it can bypass branch protection. "
+            "Downgrade to write access.",
+        )
+    return CheckResult("bot-permission", True, f"Bot '{bot_name}' has '{perm}' permission")
+
+
+def check_secrets(repo: str, expected: list[str]) -> CheckResult:
+    """Check that required secrets exist in the repository."""
+    result = _gh("api", f"repos/{repo}/actions/secrets", "--jq", "[.secrets[].name]")
+    if result is None:
+        return CheckResult("secrets", None, "gh CLI not found")
+    if result.returncode != 0:
+        return CheckResult("secrets", None, "Could not list secrets (may require admin access)")
+
+    try:
+        secret_names = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return CheckResult("secrets", None, "Could not parse secrets response")
+
+    missing = [s for s in expected if s not in secret_names]
+    if missing:
+        return CheckResult(
+            "secrets",
+            False,
+            f"Missing secrets: {', '.join(missing)}. "
+            "Add them in repo Settings > Secrets and variables > Actions.",
+        )
+    return CheckResult("secrets", True, f"Required secrets present: {', '.join(expected)}")
+
+
+def run_all_checks(cfg: Config, repo: str | None = None) -> list[CheckResult]:
+    """Run all security checks. Auto-detects repo if not provided."""
+    if shutil.which("gh") is None:
+        return [CheckResult("prerequisites", None, "gh CLI not found — install it to run security checks")]
+
+    if repo is None:
+        repo = detect_repo()
+    if repo is None:
+        return [CheckResult(
+            "prerequisites",
+            None,
+            "Could not detect repository. Run from a git repo with a GitHub remote, or pass --repo.",
+        )]
+
+    return [
+        check_branch_protection(repo, cfg.default_branch),
+        check_bot_permission(repo, cfg.bot_name),
+        check_secrets(repo, [cfg.bot_token_secret, cfg.claude_token_secret]),
+    ]

--- a/generator/src/continuous/cli.py
+++ b/generator/src/continuous/cli.py
@@ -6,8 +6,21 @@ from pathlib import Path
 
 import click
 
+from continuous.checks import CheckResult, run_all_checks
 from continuous.config import Config
 from continuous.workflows import generate_all
+
+
+def _print_check_results(results: list[CheckResult]) -> None:
+    """Print check results with pass/fail/skip indicators."""
+    for r in results:
+        if r.passed is True:
+            icon = click.style("PASS", fg="green")
+        elif r.passed is False:
+            icon = click.style("FAIL", fg="red")
+        else:
+            icon = click.style("SKIP", fg="yellow")
+        click.echo(f"  {icon}  {r.name} — {r.message}")
 
 
 @click.group()
@@ -43,3 +56,20 @@ def init(config_path: Path | None, dry_run: bool) -> None:
 
     if not dry_run:
         click.echo(f"\nGenerated {len(workflows)} workflow files.")
+        click.echo("Run `continuous check` to verify security prerequisites.")
+
+
+@main.command()
+@click.option("--config", "-c", "config_path", type=click.Path(exists=True, path_type=Path), default=None)
+@click.option("--repo", "-r", help="GitHub repo (owner/name). Auto-detected if omitted.")
+def check(config_path: Path | None, repo: str | None) -> None:
+    """Verify security prerequisites (branch protection, bot access, secrets)."""
+    cfg = Config.load(config_path)
+    results = run_all_checks(cfg, repo)
+
+    click.echo("Security checks:")
+    _print_check_results(results)
+
+    failures = [r for r in results if r.passed is False]
+    if failures:
+        raise SystemExit(1)

--- a/generator/tests/test_checks.py
+++ b/generator/tests/test_checks.py
@@ -1,0 +1,238 @@
+"""Tests for security checks module."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from continuous.checks import (
+    CheckResult,
+    check_bot_permission,
+    check_branch_protection,
+    check_secrets,
+    detect_repo,
+    run_all_checks,
+)
+from continuous.cli import main
+from continuous.config import Config
+
+
+def _make_completed(stdout: str = "", stderr: str = "", returncode: int = 0) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def _write_config(tmp_path: Path, content: str = 'bot_name = "test-bot"') -> Path:
+    cfg = tmp_path / ".config" / "continuous.toml"
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(content)
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# detect_repo
+# ---------------------------------------------------------------------------
+
+
+def test_detect_repo_success() -> None:
+    with patch("continuous.checks._gh", return_value=_make_completed("owner/repo\n")):
+        assert detect_repo() == "owner/repo"
+
+
+def test_detect_repo_failure() -> None:
+    with patch("continuous.checks._gh", return_value=_make_completed(returncode=1)):
+        assert detect_repo() is None
+
+
+def test_detect_repo_no_gh() -> None:
+    with patch("continuous.checks._gh", return_value=None):
+        assert detect_repo() is None
+
+
+# ---------------------------------------------------------------------------
+# check_branch_protection
+# ---------------------------------------------------------------------------
+
+
+def test_branch_protected() -> None:
+    with patch("continuous.checks._gh", return_value=_make_completed("true\n")):
+        result = check_branch_protection("owner/repo", "main")
+    assert result.passed is True
+    assert "protected" in result.message
+
+
+def test_branch_not_protected() -> None:
+    with patch("continuous.checks._gh", return_value=_make_completed("false\n")):
+        result = check_branch_protection("owner/repo", "main")
+    assert result.passed is False
+    assert "NOT protected" in result.message
+
+
+def test_branch_protection_api_error() -> None:
+    with patch("continuous.checks._gh", return_value=_make_completed(returncode=1, stderr="Not Found")):
+        result = check_branch_protection("owner/repo", "main")
+    assert result.passed is None
+    assert "API error" in result.message
+
+
+def test_branch_protection_no_gh() -> None:
+    with patch("continuous.checks._gh", return_value=None):
+        result = check_branch_protection("owner/repo", "main")
+    assert result.passed is None
+
+
+# ---------------------------------------------------------------------------
+# check_bot_permission
+# ---------------------------------------------------------------------------
+
+
+def test_bot_write_permission() -> None:
+    with patch("continuous.checks._gh", return_value=_make_completed("write\n")):
+        result = check_bot_permission("owner/repo", "my-bot")
+    assert result.passed is True
+    assert "write" in result.message
+
+
+def test_bot_admin_permission() -> None:
+    with patch("continuous.checks._gh", return_value=_make_completed("admin\n")):
+        result = check_bot_permission("owner/repo", "my-bot")
+    assert result.passed is False
+    assert "admin" in result.message
+    assert "bypass" in result.message
+
+
+def test_bot_permission_403() -> None:
+    with patch("continuous.checks._gh", return_value=_make_completed(returncode=1, stderr="HTTP 403")):
+        result = check_bot_permission("owner/repo", "my-bot")
+    assert result.passed is None
+    assert "admin access" in result.message
+
+
+# ---------------------------------------------------------------------------
+# check_secrets
+# ---------------------------------------------------------------------------
+
+
+def test_secrets_present() -> None:
+    with patch("continuous.checks._gh", return_value=_make_completed('["BOT_TOKEN","CLAUDE_CODE_OAUTH_TOKEN"]\n')):
+        result = check_secrets("owner/repo", ["BOT_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"])
+    assert result.passed is True
+
+
+def test_secrets_missing() -> None:
+    with patch("continuous.checks._gh", return_value=_make_completed('["BOT_TOKEN"]\n')):
+        result = check_secrets("owner/repo", ["BOT_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"])
+    assert result.passed is False
+    assert "CLAUDE_CODE_OAUTH_TOKEN" in result.message
+
+
+def test_secrets_api_error() -> None:
+    with patch("continuous.checks._gh", return_value=_make_completed(returncode=1, stderr="HTTP 403")):
+        result = check_secrets("owner/repo", ["BOT_TOKEN"])
+    assert result.passed is None
+
+
+def test_secrets_bad_json() -> None:
+    with patch("continuous.checks._gh", return_value=_make_completed("not json")):
+        result = check_secrets("owner/repo", ["BOT_TOKEN"])
+    assert result.passed is None
+
+
+# ---------------------------------------------------------------------------
+# run_all_checks
+# ---------------------------------------------------------------------------
+
+
+def test_run_all_checks_no_gh() -> None:
+    with patch("shutil.which", return_value=None):
+        results = run_all_checks(Config("bot", "main", "T1", "T2", [], {}))
+    assert len(results) == 1
+    assert results[0].passed is None
+    assert "gh CLI" in results[0].message
+
+
+def test_run_all_checks_no_repo() -> None:
+    with patch("shutil.which", return_value="/usr/bin/gh"), \
+         patch("continuous.checks.detect_repo", return_value=None):
+        results = run_all_checks(Config("bot", "main", "T1", "T2", [], {}))
+    assert len(results) == 1
+    assert "detect" in results[0].message
+
+
+def test_run_all_checks_with_explicit_repo() -> None:
+    """Explicit --repo skips auto-detection."""
+    def fake_gh(*args: str) -> subprocess.CompletedProcess[str]:
+        cmd = args[1] if len(args) > 1 else ""
+        if "branches" in cmd:
+            return _make_completed("true\n")
+        if "collaborators" in cmd:
+            return _make_completed("write\n")
+        if "secrets" in cmd:
+            return _make_completed('["T1","T2"]\n')
+        return _make_completed(returncode=1)
+
+    with patch("shutil.which", return_value="/usr/bin/gh"), \
+         patch("continuous.checks._gh", side_effect=fake_gh):
+        results = run_all_checks(Config("bot", "main", "T1", "T2", [], {}), repo="owner/repo")
+    assert len(results) == 3
+    assert all(r.passed is True for r in results)
+
+
+# ---------------------------------------------------------------------------
+# CLI: continuous check
+# ---------------------------------------------------------------------------
+
+
+def test_cli_check_all_pass(tmp_path: Path, monkeypatch: object) -> None:
+    _write_config(tmp_path)
+    monkeypatch.chdir(tmp_path)  # type: ignore[union-attr]
+
+    pass_results = [
+        CheckResult("branch-protection", True, "protected"),
+        CheckResult("bot-permission", True, "write"),
+        CheckResult("secrets", True, "present"),
+    ]
+    with patch("continuous.cli.run_all_checks", return_value=pass_results):
+        result = CliRunner().invoke(main, ["check"])
+    assert result.exit_code == 0
+    assert "PASS" in result.output
+
+
+def test_cli_check_failure_exits_1(tmp_path: Path, monkeypatch: object) -> None:
+    _write_config(tmp_path)
+    monkeypatch.chdir(tmp_path)  # type: ignore[union-attr]
+
+    results = [
+        CheckResult("branch-protection", False, "NOT protected"),
+    ]
+    with patch("continuous.cli.run_all_checks", return_value=results):
+        result = CliRunner().invoke(main, ["check"])
+    assert result.exit_code == 1
+    assert "FAIL" in result.output
+
+
+def test_cli_check_skips_exit_0(tmp_path: Path, monkeypatch: object) -> None:
+    """All skipped checks should not be treated as failures."""
+    _write_config(tmp_path)
+    monkeypatch.chdir(tmp_path)  # type: ignore[union-attr]
+
+    results = [CheckResult("prerequisites", None, "gh not found")]
+    with patch("continuous.cli.run_all_checks", return_value=results):
+        result = CliRunner().invoke(main, ["check"])
+    assert result.exit_code == 0
+    assert "SKIP" in result.output
+
+
+# ---------------------------------------------------------------------------
+# CLI: init reminder
+# ---------------------------------------------------------------------------
+
+
+def test_init_prints_check_reminder(tmp_path: Path, monkeypatch: object) -> None:
+    _write_config(tmp_path)
+    monkeypatch.chdir(tmp_path)  # type: ignore[union-attr]
+    result = CliRunner().invoke(main, ["init"])
+    assert result.exit_code == 0
+    assert "continuous check" in result.output


### PR DESCRIPTION
Adds runtime verification that the default branch is protected — the primary security boundary from docs/security-model.md. Two enforcement points:

**action.yaml preflight** — checks branch protection via GitHub API before running Claude. Hard fails if the default branch is unprotected, preventing the bot from operating without the merge restriction that caps its blast radius.

**`continuous check` CLI command** — local verification of three security prerequisites: branch protection on default branch, bot permission level (should be write, not admin), and required secrets. Degrades gracefully when `gh` isn't installed or the token lacks permission (checks show as SKIP, not FAIL).

`continuous init` now prints a reminder to run `continuous check` after generating workflows.

> _This was written by Claude Code on behalf of @max-sixty_