### PR TITLE
fix: improve bot check errors, add check to README, fix test types

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ claude_token = "MY_CLAUDE_TOKEN"
 
 ```bash
 uvx continuous init
+uvx continuous check          # verify branch protection, secrets, bot access
 git add .github/workflows/continuous-*.yaml .config/continuous.toml
 git commit -m "Add continuous workflows"
 git push

--- a/generator/src/continuous/checks.py
+++ b/generator/src/continuous/checks.py
@@ -72,6 +72,12 @@ def check_bot_permission(repo: str, bot_name: str) -> CheckResult:
     if result is None:
         return CheckResult("bot-permission", None, "gh CLI not found")
     if result.returncode != 0:
+        stderr = result.stderr.strip()
+        if "Not Found" in stderr or "404" in stderr:
+            return CheckResult(
+                "bot-permission", None,
+                f"Bot '{bot_name}' not found as a collaborator — check the bot_name in config",
+            )
         return CheckResult("bot-permission", None, "Could not check (may require admin access to read)")
 
     perm = result.stdout.strip()

--- a/generator/tests/test_checks.py
+++ b/generator/tests/test_checks.py
@@ -6,6 +6,7 @@ import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 from click.testing import CliRunner
 
 from continuous.checks import (
@@ -110,6 +111,14 @@ def test_bot_permission_403() -> None:
     assert "admin access" in result.message
 
 
+def test_bot_permission_404_wrong_username() -> None:
+    with patch("continuous.checks._gh", return_value=_make_completed(returncode=1, stderr="HTTP 404 Not Found")):
+        result = check_bot_permission("owner/repo", "typo-bot")
+    assert result.passed is None
+    assert "not found" in result.message.lower()
+    assert "typo-bot" in result.message
+
+
 # ---------------------------------------------------------------------------
 # check_secrets
 # ---------------------------------------------------------------------------
@@ -185,9 +194,9 @@ def test_run_all_checks_with_explicit_repo() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_cli_check_all_pass(tmp_path: Path, monkeypatch: object) -> None:
+def test_cli_check_all_pass(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _write_config(tmp_path)
-    monkeypatch.chdir(tmp_path)  # type: ignore[union-attr]
+    monkeypatch.chdir(tmp_path)
 
     pass_results = [
         CheckResult("branch-protection", True, "protected"),
@@ -200,9 +209,9 @@ def test_cli_check_all_pass(tmp_path: Path, monkeypatch: object) -> None:
     assert "PASS" in result.output
 
 
-def test_cli_check_failure_exits_1(tmp_path: Path, monkeypatch: object) -> None:
+def test_cli_check_failure_exits_1(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _write_config(tmp_path)
-    monkeypatch.chdir(tmp_path)  # type: ignore[union-attr]
+    monkeypatch.chdir(tmp_path)
 
     results = [
         CheckResult("branch-protection", False, "NOT protected"),
@@ -213,10 +222,10 @@ def test_cli_check_failure_exits_1(tmp_path: Path, monkeypatch: object) -> None:
     assert "FAIL" in result.output
 
 
-def test_cli_check_skips_exit_0(tmp_path: Path, monkeypatch: object) -> None:
+def test_cli_check_skips_exit_0(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """All skipped checks should not be treated as failures."""
     _write_config(tmp_path)
-    monkeypatch.chdir(tmp_path)  # type: ignore[union-attr]
+    monkeypatch.chdir(tmp_path)
 
     results = [CheckResult("prerequisites", None, "gh not found")]
     with patch("continuous.cli.run_all_checks", return_value=results):
@@ -230,9 +239,9 @@ def test_cli_check_skips_exit_0(tmp_path: Path, monkeypatch: object) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_init_prints_check_reminder(tmp_path: Path, monkeypatch: object) -> None:
+def test_init_prints_check_reminder(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _write_config(tmp_path)
-    monkeypatch.chdir(tmp_path)  # type: ignore[union-attr]
+    monkeypatch.chdir(tmp_path)
     result = CliRunner().invoke(main, ["init"])
     assert result.exit_code == 0
     assert "continuous check" in result.output

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from textwrap import dedent
 
+import pytest
 import yaml
 from click.testing import CliRunner
 
@@ -118,9 +119,9 @@ def test_watched_workflows(tmp_path: Path) -> None:
     assert '"lint"' in ci_fix.content
 
 
-def test_cli_init_dry_run(tmp_path: Path, monkeypatch: object) -> None:
+def test_cli_init_dry_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _minimal_config(tmp_path)
-    monkeypatch.chdir(tmp_path)  # type: ignore[union-attr]
+    monkeypatch.chdir(tmp_path)
     runner = CliRunner()
     result = runner.invoke(main, ["init", "--dry-run"])
     assert result.exit_code == 0
@@ -129,9 +130,9 @@ def test_cli_init_dry_run(tmp_path: Path, monkeypatch: object) -> None:
     assert not (tmp_path / ".github" / "workflows").exists()
 
 
-def test_cli_init_writes_files(tmp_path: Path, monkeypatch: object) -> None:
+def test_cli_init_writes_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _minimal_config(tmp_path)
-    monkeypatch.chdir(tmp_path)  # type: ignore[union-attr]
+    monkeypatch.chdir(tmp_path)
     runner = CliRunner()
     result = runner.invoke(main, ["init"])
     assert result.exit_code == 0


### PR DESCRIPTION
Three follow-up fixes from the security checks PR:

1. **Better bot 404 errors**: `check_bot_permission` now distinguishes 404 ("not found as a collaborator — check the bot_name in config") from 403 ("may require admin access"), surfacing bot_name typos early.

2. **README**: Added `uvx continuous check` to Quick Start Step 5 so new adopters see it in the setup flow.

3. **Test type annotations**: Fixed `monkeypatch: object` → `pytest.MonkeyPatch` across all test files, removing `# type: ignore[union-attr]` comments.

> _This was written by Claude Code on behalf of @max-sixty_