### PR TITLE
Use 'release' environment for PyPI publishing

### DIFF
--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -40,7 +40,7 @@ jobs:
   pypi:
     needs: build
     runs-on: ubuntu-latest
-    environment: pypi
+    environment: release
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
Consistent with worktrunk's environment naming — use `release` instead of `pypi` for the GitHub Actions environment in `pypi-release.yaml`. Updated the PyPI trusted publisher config to match.

> _This was written by Claude Code on behalf of @max-sixty_