### PR TITLE
fix: use tend: plugin prefix for skill invocations

### DIFF
--- a/.github/workflows/review-reviewers.yaml
+++ b/.github/workflows/review-reviewers.yaml
@@ -32,4 +32,4 @@ jobs:
           github_token: ${{ secrets.WORKTRUNK_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           bot_name: worktrunk-bot
-          prompt: /tend-review-reviewers
+          prompt: /tend:tend-review-reviewers

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -26,7 +26,7 @@ Four pieces:
      prompt: { required: true }
      model: { default: "opus" }
      allowed_tools: { default: "Bash,Edit,Read,Write,Glob,Grep,WebSearch,WebFetch,Task,Skill" }
-     system_prompt_append: { default: "...Use /tend-running-in-ci..." }
+     system_prompt_append: { default: "...Use /tend:tend-running-in-ci..." }
      allowed_bots: { default: "*" }
      allowed_non_write_users: { default: "*" }
      show_full_output: { default: "true" }
@@ -111,7 +111,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           bot_name: worktrunk-bot
           prompt: >-
-            ${{ format('/tend-review {0}', github.event.pull_request.number) }}
+            ${{ format('/tend:tend-review {0}', github.event.pull_request.number) }}
 ```
 
 ## What the generator owns vs what the adopter owns

--- a/action.yaml
+++ b/action.yaml
@@ -23,7 +23,7 @@ inputs:
     default: "Bash,Edit,Read,Write,Glob,Grep,WebSearch,WebFetch,Task,Skill"
     description: Comma-separated list of allowed tools
   system_prompt_append:
-    default: "You are operating in a GitHub Actions CI environment. Use /tend-running-in-ci before starting work."
+    default: "You are operating in a GitHub Actions CI environment. Use /tend:tend-running-in-ci before starting work."
     description: Text appended to the system prompt
   allowed_bots:
     default: "*"

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -143,7 +143,7 @@ Individual inline comments from a review also fire as separate
 - **Adding `allowed_non_write_users`** to a workflow with user-controlled
   prompts requires security review.
 - **All Claude workflows** must include
-  `--append-system-prompt "You are operating in a GitHub Actions CI environment. Use /tend-running-in-ci before starting work."`.
+  `--append-system-prompt "You are operating in a GitHub Actions CI environment. Use /tend:tend-running-in-ci before starting work."`.
 - **Token choice**: All Claude workflows use the bot token for consistent
   identity.
 - **`permissions:` block**: Set `contents: read` for read-only workflows.

--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -81,7 +81,7 @@ def _escape_braces(prompt: str, placeholder: str) -> tuple[str, bool]:
 
 def generate_review(cfg: Config) -> GeneratedWorkflow:
     wf = cfg.workflows.get("review", WorkflowConfig())
-    raw_prompt = wf.prompt or "/tend-review {pr_number}"
+    raw_prompt = wf.prompt or "/tend:tend-review {pr_number}"
     format_body, needs_format = _escape_braces(raw_prompt, "pr_number")
     escaped = _escape(format_body)
     if needs_format:
@@ -339,7 +339,7 @@ jobs:
 
 def generate_triage(cfg: Config) -> GeneratedWorkflow:
     wf = cfg.workflows.get("triage", WorkflowConfig())
-    prompt = (wf.prompt or "/tend-triage {issue_number}").replace(
+    prompt = (wf.prompt or "/tend:tend-triage {issue_number}").replace(
         "{issue_number}", "${{ github.event.issue.number }}"
     )
     bt = _bot_token(cfg)
@@ -396,7 +396,7 @@ jobs:
 def generate_ci_fix(cfg: Config) -> GeneratedWorkflow:
     wf = cfg.workflows.get("ci-fix", WorkflowConfig())
     watched = wf.watched_workflows if wf.watched_workflows is not None else ["ci"]
-    prompt = (wf.prompt or "/tend-ci-fix {run_id}").replace(
+    prompt = (wf.prompt or "/tend:tend-ci-fix {run_id}").replace(
         "{run_id}", "${{ github.event.workflow_run.id }}"
     )
     bt = _bot_token(cfg)
@@ -498,11 +498,11 @@ jobs:
 
 
 def generate_nightly(cfg: Config) -> GeneratedWorkflow:
-    return _generate_scheduled(cfg, "nightly", "17 6 * * *", "/tend-nightly")
+    return _generate_scheduled(cfg, "nightly", "17 6 * * *", "/tend:tend-nightly")
 
 
 def generate_renovate(cfg: Config) -> GeneratedWorkflow:
-    return _generate_scheduled(cfg, "renovate", "17 9 * * 0", "/tend-renovate")
+    return _generate_scheduled(cfg, "renovate", "17 9 * * 0", "/tend:tend-renovate")
 
 
 # ---------------------------------------------------------------------------

--- a/skills/tend-ci-fix/SKILL.md
+++ b/skills/tend-ci-fix/SKILL.md
@@ -63,5 +63,5 @@ Automated fix for [failed run](run-url)
 
 ### 4. Monitor CI
 
-Poll CI using the approach from `/tend-running-in-ci`. If CI fails, diagnose with
+Poll CI using the approach from `/tend:tend-running-in-ci`. If CI fails, diagnose with
 `gh run view <run-id> --log-failed`, fix, commit, push, and repeat.

--- a/skills/tend-nightly/SKILL.md
+++ b/skills/tend-nightly/SKILL.md
@@ -24,7 +24,7 @@ For each conflicted PR, dispatch a subagent to:
 2. Merge the default branch: `git merge origin/main`
 3. Resolve conflicts (read files, understand both sides), `git add`,
    `git commit --no-edit`
-4. Push and poll CI using the approach from `/tend-running-in-ci`
+4. Push and poll CI using the approach from `/tend:tend-running-in-ci`
 5. If conflicts are too complex, `git merge --abort` and comment explaining
    manual resolution is needed
 

--- a/skills/tend-review/SKILL.md
+++ b/skills/tend-review/SKILL.md
@@ -271,7 +271,7 @@ array indices to object keys, which GitHub rejects.
 ### 6. Monitor CI
 
 After approving or staying silent, monitor CI using the approach from
-/tend-running-in-ci.
+/tend:tend-running-in-ci.
 
 - **All required checks passed** -> done.
 - **A check failed** and it's related to the PR -> post a follow-up COMMENT

--- a/skills/tend-triage/SKILL.md
+++ b/skills/tend-triage/SKILL.md
@@ -14,7 +14,7 @@ Triage a newly opened GitHub issue.
 
 ## Step 1: Setup
 
-Load `/tend-running-in-ci` first (CI environment rules, security).
+Load `/tend:tend-running-in-ci` first (CI environment rules, security).
 
 Follow the AD FONTES principle throughout: reproduce before fixing, evidence
 before speculation, test before committing.
@@ -140,7 +140,7 @@ missing code. Before adding guidance to a skill:
    ---
    Closes #<issue-number> — automated triage"
    ```
-5. Monitor CI using the approach from /tend-running-in-ci.
+5. Monitor CI using the approach from /tend:tend-running-in-ci.
 
 ### If reproduction test works but fix is not confident
 
@@ -172,7 +172,7 @@ automation alone.
 characterize something as "known" unless you find prior issues or documentation
 about it. Don't speculate beyond the code you read.
 
-Use the heredoc pattern from `/tend-running-in-ci` for `--body` arguments to avoid
+Use the heredoc pattern from `/tend:tend-running-in-ci` for `--body` arguments to avoid
 shell quoting issues.
 
 Choose the appropriate template:


### PR DESCRIPTION
Plugin skills require the `plugin-name:` prefix. Update all skill references from `/tend-*` to `/tend:tend-*` so Claude Code resolves them through the plugin.

Updated: action.yaml system prompt, generator workflow prompts, skill cross-references, review-reviewers workflow, security docs.

All 64 generator tests pass.

> _This was written by Claude Code on behalf of maximilian_