### PR TITLE
feat: review-reviewers targets multiple repos via matrix

### DIFF
--- a/.github/workflows/review-reviewers.yaml
+++ b/.github/workflows/review-reviewers.yaml
@@ -1,6 +1,13 @@
 name: review-reviewers
-# Hourly analysis of Claude CI session logs from adopter repos.
-# Currently monitors worktrunk only.
+# Hourly analysis of Claude CI session logs from adopter repos to improve tend.
+#
+# Each matrix entry is a repo to analyze. The job checks out the tend repo
+# (for creating improvement PRs/issues) and uses TARGET_REPO_TOKEN to read
+# the target repo's CI data.
+#
+# TODO: Move repo list to a config file so adding a repo doesn't require a workflow change
+# TODO: Cross-repo pattern detection — correlate findings across repos
+# TODO: Add tend itself (max-sixty/tend) once it has sufficient CI history
 on:
   schedule:
     - cron: '47 * * * *'
@@ -8,6 +15,12 @@ on:
 
 jobs:
   review-reviewers:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - repo: max-sixty/worktrunk
+            token_secret: WORKTRUNK_BOT_TOKEN
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     permissions:
@@ -19,17 +32,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          repository: max-sixty/worktrunk
-          ref: main
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.WORKTRUNK_BOT_TOKEN }}
-
-      - uses: ./.github/actions/claude-setup
+          token: ${{ secrets.BOT_TOKEN }}
 
       - uses: max-sixty/tend@v1
         with:
-          github_token: ${{ secrets.WORKTRUNK_BOT_TOKEN }}
+          github_token: ${{ secrets.BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          bot_name: worktrunk-bot
-          prompt: /tend:tend-review-reviewers
+          bot_name: continuous-bot
+          prompt: /tend:tend-review-reviewers ${{ matrix.repo }}
+        env:
+          TARGET_REPO_TOKEN: ${{ secrets[matrix.token_secret] }}

--- a/scripts/list-recent-runs.sh
+++ b/scripts/list-recent-runs.sh
@@ -7,6 +7,10 @@
 # not *end* time — a run started 2h ago may have just finished, and a run
 # started 50min ago may still be running. See #1301 for details.
 #
+# Environment variables:
+#   TARGET_REPO       - Query a different repo (default: current repo)
+#   TARGET_REPO_TOKEN - Auth token for the target repo (default: GH_TOKEN)
+#
 # Output: JSON array of {databaseId, conclusion, createdAt, updatedAt} objects.
 
 set -euo pipefail
@@ -14,10 +18,20 @@ set -euo pipefail
 # Prevent gh from emitting ANSI color codes in non-TTY contexts.
 export NO_COLOR=1
 
-# Dynamically discover CD workflows. Accepts a prefix argument (default: "cd-").
+# Use target repo token if provided.
+if [ -n "${TARGET_REPO_TOKEN:-}" ]; then
+  export GH_TOKEN="$TARGET_REPO_TOKEN"
+fi
+
+repo_args=()
+if [ -n "${TARGET_REPO:-}" ]; then
+  repo_args=(-R "$TARGET_REPO")
+fi
+
+# Dynamically discover tend workflows. Accepts a prefix argument (default: "tend-").
 # Usage: ./list-recent-runs.sh [prefix]
-PREFIX="${1:-cd-}"
-mapfile -t WORKFLOWS < <(gh workflow list --json name --jq ".[].name | select(startswith(\"$PREFIX\"))")
+PREFIX="${1:-tend-}"
+mapfile -t WORKFLOWS < <(gh workflow list "${repo_args[@]}" --json name --jq ".[].name | select(startswith(\"$PREFIX\"))")
 
 CREATED_SINCE=$(date -d '3 hours ago' +%Y-%m-%dT%H:%M:%S)
 COMPLETED_AFTER=$(date -d '1 hour ago' +%s)
@@ -26,6 +40,7 @@ all_runs="[]"
 
 for wf in "${WORKFLOWS[@]}"; do
   runs=$(gh run list \
+    "${repo_args[@]}" \
     --workflow "${wf}" \
     --created ">=${CREATED_SINCE}" \
     --json databaseId,conclusion,createdAt,updatedAt \

--- a/skills/tend-review-reviewers/SKILL.md
+++ b/skills/tend-review-reviewers/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: tend-review-reviewers
 description: Hourly analysis of Claude CI session logs — identifies behavioral problems, skill gaps, and workflow issues.
+argument-hint: "<owner/repo>"
 metadata:
   internal: true
 ---
@@ -9,6 +10,27 @@ metadata:
 
 Analyze Claude-powered CI runs from the past hour. Identify behavioral problems,
 skill gaps, and workflow issues — then create PRs or issues to fix them.
+
+## Target repo
+
+**Target repo:** $ARGUMENTS
+
+Analysis targets an adopter repo whose CI runs are analyzed. Findings result in
+PRs/issues on the current repo (tend) to improve skills and workflows.
+
+Two tokens are available:
+- `GH_TOKEN` (default) — authenticates to tend for creating issues/PRs
+- `TARGET_REPO_TOKEN` (env var, set by workflow) — authenticates to the target
+  repo for reading CI data
+
+For commands that access the target repo (downloading artifacts, querying runs
+and PRs), override the token and specify the repo:
+
+```bash
+GH_TOKEN="$TARGET_REPO_TOKEN" gh -R $ARGUMENTS run download ...
+```
+
+For commands that create issues/PRs on tend, use regular `gh` commands.
 
 ## Confidence and magnitude gates
 
@@ -106,7 +128,7 @@ text alone, which lacks sufficient context to judge relatedness:
 
 ```bash
 # Each tracking entry has a Run ID — use it to pull the actual logs
-gh run download <run-id> --name claude-session-logs --dir /tmp/logs/<run-id>/
+GH_TOKEN="$TARGET_REPO_TOKEN" gh -R $ARGUMENTS run download <run-id> --name claude-session-logs --dir /tmp/logs/<run-id>/
 ```
 
 Trace the original decision chain in the session JSONL to confirm the historical
@@ -161,16 +183,19 @@ trace incidents to session logs.
 
 ## Step 1: Find recent runs
 
-Run `.github/scripts/list-recent-runs.sh` for recently completed Claude CI runs.
-If empty, report "no runs to review" and exit.
+List recently completed Claude CI runs on the target repo:
 
-Include `review-reviewers` runs — self-analysis is intentional so
-we can catch bugs in the reviewer itself.
+```bash
+TARGET_REPO=$ARGUMENTS .github/scripts/list-recent-runs.sh
+```
+
+The script uses `TARGET_REPO` and `TARGET_REPO_TOKEN` from the environment.
+If empty, report "no runs to review" and exit.
 
 ## Step 2: Download and analyze session logs
 
 ```bash
-gh run download <run-id> --name claude-session-logs --dir /tmp/logs/<run-id>/
+GH_TOKEN="$TARGET_REPO_TOKEN" gh -R $ARGUMENTS run download <run-id> --name claude-session-logs --dir /tmp/logs/<run-id>/
 ```
 
 Skip runs without artifacts. Find JSONL files under `/tmp/logs/` and extract:
@@ -193,8 +218,8 @@ was the outcome?
 For `tend-review` runs, compare what the bot said against what happened next:
 
 ```bash
-HEAD_BRANCH=$(gh run view <run-id> --json headBranch --jq '.headBranch')
-PR_NUMBER=$(gh pr list --head "$HEAD_BRANCH" --state all --json number --jq '.[0].number')
+HEAD_BRANCH=$(GH_TOKEN="$TARGET_REPO_TOKEN" gh -R $ARGUMENTS run view <run-id> --json headBranch --jq '.headBranch')
+PR_NUMBER=$(GH_TOKEN="$TARGET_REPO_TOKEN" gh -R $ARGUMENTS pr list --head "$HEAD_BRANCH" --state all --json number --jq '.[0].number')
 ```
 
 Check for subsequent commits that undid something the bot approved (gap in


### PR DESCRIPTION
The hourly review-reviewers workflow checked out worktrunk directly and created PRs/issues there. Since the workflow's purpose is improving tend's skills, it should create PRs on tend and read CI data from adopter repos remotely.

Now the workflow checks out tend and uses a matrix strategy for target repos (starting with worktrunk). Two tokens: `GH_TOKEN` for tend operations, `TARGET_REPO_TOKEN` for target repo CI data. The script and skill use `-R` and token overrides for target repo commands; issue/PR creation stays on tend with default auth.

TODOs in the workflow for future improvements: config-file-based repo list, cross-repo pattern detection, adding tend itself as a target.

> _This was written by Claude Code on behalf of maximilian_