### PR TITLE
feat: add tend self-analysis, support multiple script prefixes

### DIFF
--- a/.github/workflows/review-reviewers.yaml
+++ b/.github/workflows/review-reviewers.yaml
@@ -7,7 +7,6 @@ name: review-reviewers
 #
 # TODO: Move repo list to a config file so adding a repo doesn't require a workflow change
 # TODO: Cross-repo pattern detection — correlate findings across repos
-# TODO: Add tend itself (max-sixty/tend) once it has sufficient CI history
 on:
   schedule:
     - cron: '47 * * * *'
@@ -21,6 +20,8 @@ jobs:
         include:
           - repo: max-sixty/worktrunk
             token_secret: WORKTRUNK_BOT_TOKEN
+          - repo: max-sixty/tend
+            token_secret: BOT_TOKEN
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     permissions:

--- a/scripts/list-recent-runs.sh
+++ b/scripts/list-recent-runs.sh
@@ -28,10 +28,19 @@ if [ -n "${TARGET_REPO:-}" ]; then
   repo_args=(-R "$TARGET_REPO")
 fi
 
-# Dynamically discover tend workflows. Accepts a prefix argument (default: "tend-").
-# Usage: ./list-recent-runs.sh [prefix]
-PREFIX="${1:-tend-}"
-mapfile -t WORKFLOWS < <(gh workflow list "${repo_args[@]}" --json name --jq ".[].name | select(startswith(\"$PREFIX\"))")
+# Dynamically discover workflows by prefix. Multiple prefixes supported.
+# Usage: ./list-recent-runs.sh [prefix ...]
+if [ $# -eq 0 ]; then
+  PREFIXES=("tend-")
+else
+  PREFIXES=("$@")
+fi
+
+WORKFLOWS=()
+for prefix in "${PREFIXES[@]}"; do
+  mapfile -t matches < <(gh workflow list "${repo_args[@]}" --json name --jq ".[].name | select(startswith(\"$prefix\"))")
+  WORKFLOWS+=("${matches[@]}")
+done
 
 CREATED_SINCE=$(date -d '3 hours ago' +%Y-%m-%dT%H:%M:%S)
 COMPLETED_AFTER=$(date -d '1 hour ago' +%s)

--- a/skills/tend-review-reviewers/SKILL.md
+++ b/skills/tend-review-reviewers/SKILL.md
@@ -189,7 +189,10 @@ List recently completed Claude CI runs on the target repo:
 TARGET_REPO=$ARGUMENTS .github/scripts/list-recent-runs.sh
 ```
 
-The script uses `TARGET_REPO` and `TARGET_REPO_TOKEN` from the environment.
+The script discovers `tend-*` workflows by default. Pass additional prefixes
+as arguments to include other workflows (e.g., `review-reviewers` when
+analyzing tend itself).
+
 If empty, report "no runs to review" and exit.
 
 ## Step 2: Download and analyze session logs


### PR DESCRIPTION
Add `max-sixty/tend` to the review-reviewers matrix so the hourly analysis covers tend's own CI runs (self-improvement loop). The script now accepts multiple prefix arguments to discover non-`tend-` prefixed workflows like `review-reviewers`.

Also created the `v1` tag so `max-sixty/tend@v1` resolves — this was blocking all CI.

> _This was written by Claude Code on behalf of maximilian_