### PR TITLE
simplify: remove TARGET_REPO_TOKEN, use GH_TOKEN for all repos

### DIFF
--- a/.github/workflows/review-reviewers.yaml
+++ b/.github/workflows/review-reviewers.yaml
@@ -2,8 +2,8 @@ name: review-reviewers
 # Hourly analysis of Claude CI session logs from adopter repos to improve tend.
 #
 # Each matrix entry is a repo to analyze. The job checks out the tend repo
-# (for creating improvement PRs/issues) and uses TARGET_REPO_TOKEN to read
-# the target repo's CI data.
+# (for creating improvement PRs/issues). BOT_TOKEN is sufficient for reading
+# CI data from public adopter repos.
 #
 # TODO: Move repo list to a config file so adding a repo doesn't require a workflow change
 # TODO: Cross-repo pattern detection — correlate findings across repos
@@ -17,11 +17,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - repo: max-sixty/worktrunk
-            token_secret: WORKTRUNK_BOT_TOKEN
-          - repo: max-sixty/tend
-            token_secret: BOT_TOKEN
+        repo:
+          - max-sixty/worktrunk
+          - max-sixty/tend
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     permissions:
@@ -43,5 +41,3 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           bot_name: continuous-bot
           prompt: /tend:tend-review-reviewers ${{ matrix.repo }}
-        env:
-          TARGET_REPO_TOKEN: ${{ secrets[matrix.token_secret] }}

--- a/scripts/list-recent-runs.sh
+++ b/scripts/list-recent-runs.sh
@@ -8,8 +8,7 @@
 # started 50min ago may still be running. See #1301 for details.
 #
 # Environment variables:
-#   TARGET_REPO       - Query a different repo (default: current repo)
-#   TARGET_REPO_TOKEN - Auth token for the target repo (default: GH_TOKEN)
+#   TARGET_REPO - Query a different repo (default: current repo)
 #
 # Output: JSON array of {databaseId, conclusion, createdAt, updatedAt} objects.
 
@@ -17,11 +16,6 @@ set -euo pipefail
 
 # Prevent gh from emitting ANSI color codes in non-TTY contexts.
 export NO_COLOR=1
-
-# Use target repo token if provided.
-if [ -n "${TARGET_REPO_TOKEN:-}" ]; then
-  export GH_TOKEN="$TARGET_REPO_TOKEN"
-fi
 
 repo_args=()
 if [ -n "${TARGET_REPO:-}" ]; then

--- a/skills/tend-review-reviewers/SKILL.md
+++ b/skills/tend-review-reviewers/SKILL.md
@@ -18,19 +18,8 @@ skill gaps, and workflow issues — then create PRs or issues to fix them.
 Analysis targets an adopter repo whose CI runs are analyzed. Findings result in
 PRs/issues on the current repo (tend) to improve skills and workflows.
 
-Two tokens are available:
-- `GH_TOKEN` (default) — authenticates to tend for creating issues/PRs
-- `TARGET_REPO_TOKEN` (env var, set by workflow) — authenticates to the target
-  repo for reading CI data
-
-For commands that access the target repo (downloading artifacts, querying runs
-and PRs), override the token and specify the repo:
-
-```bash
-GH_TOKEN="$TARGET_REPO_TOKEN" gh -R $ARGUMENTS run download ...
-```
-
-For commands that create issues/PRs on tend, use regular `gh` commands.
+Use `-R $ARGUMENTS` for commands that access the target repo (downloading
+artifacts, querying runs and PRs). Commands without `-R` default to tend.
 
 ## Confidence and magnitude gates
 
@@ -128,7 +117,7 @@ text alone, which lacks sufficient context to judge relatedness:
 
 ```bash
 # Each tracking entry has a Run ID — use it to pull the actual logs
-GH_TOKEN="$TARGET_REPO_TOKEN" gh -R $ARGUMENTS run download <run-id> --name claude-session-logs --dir /tmp/logs/<run-id>/
+gh -R $ARGUMENTS run download <run-id> --name claude-session-logs --dir /tmp/logs/<run-id>/
 ```
 
 Trace the original decision chain in the session JSONL to confirm the historical
@@ -198,7 +187,7 @@ If empty, report "no runs to review" and exit.
 ## Step 2: Download and analyze session logs
 
 ```bash
-GH_TOKEN="$TARGET_REPO_TOKEN" gh -R $ARGUMENTS run download <run-id> --name claude-session-logs --dir /tmp/logs/<run-id>/
+gh -R $ARGUMENTS run download <run-id> --name claude-session-logs --dir /tmp/logs/<run-id>/
 ```
 
 Skip runs without artifacts. Find JSONL files under `/tmp/logs/` and extract:
@@ -221,8 +210,8 @@ was the outcome?
 For `tend-review` runs, compare what the bot said against what happened next:
 
 ```bash
-HEAD_BRANCH=$(GH_TOKEN="$TARGET_REPO_TOKEN" gh -R $ARGUMENTS run view <run-id> --json headBranch --jq '.headBranch')
-PR_NUMBER=$(GH_TOKEN="$TARGET_REPO_TOKEN" gh -R $ARGUMENTS pr list --head "$HEAD_BRANCH" --state all --json number --jq '.[0].number')
+HEAD_BRANCH=$(gh -R $ARGUMENTS run view <run-id> --json headBranch --jq '.headBranch')
+PR_NUMBER=$(gh -R $ARGUMENTS pr list --head "$HEAD_BRANCH" --state all --json number --jq '.[0].number')
 ```
 
 Check for subsequent commits that undid something the bot approved (gap in


### PR DESCRIPTION
BOT_TOKEN is already set as GH_TOKEN by claude-code-action and can read public repos. The per-repo token override added in #9 was premature — removed it from the workflow, script, and skill. Matrix is now a flat list of repos.

> _This was written by Claude Code on behalf of maximilian_