### PR TITLE
fix: unique artifact names for matrix workflow jobs

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -99,11 +99,21 @@ runs:
           --append-system-prompt "${{ inputs.system_prompt_append }}"
           --plugin-dir ${{ github.action_path }}
 
+    - name: Compute artifact name
+      if: always()
+      id: artifact
+      shell: bash
+      run: |
+        # Use INVOCATION_ID (unique per job in matrix workflows) to avoid
+        # artifact name collisions when the action runs in multiple matrix jobs
+        suffix="${INVOCATION_ID:+"-${INVOCATION_ID:0:8}"}"
+        echo "name=claude-session-logs${suffix}" >> "$GITHUB_OUTPUT"
+
     - name: Upload session logs
       if: always()
       uses: actions/upload-artifact@v7
       with:
-        name: claude-session-logs
+        name: ${{ steps.artifact.outputs.name }}
         path: /home/runner/.claude/projects/
         retention-days: 30
         if-no-files-found: warn

--- a/skills/tend-review-reviewers/SKILL.md
+++ b/skills/tend-review-reviewers/SKILL.md
@@ -117,7 +117,7 @@ text alone, which lacks sufficient context to judge relatedness:
 
 ```bash
 # Each tracking entry has a Run ID — use it to pull the actual logs
-gh -R $ARGUMENTS run download <run-id> --name claude-session-logs --dir /tmp/logs/<run-id>/
+gh -R $ARGUMENTS run download <run-id> --pattern 'claude-session-logs*' --dir /tmp/logs/<run-id>/
 ```
 
 Trace the original decision chain in the session JSONL to confirm the historical
@@ -187,7 +187,7 @@ If empty, report "no runs to review" and exit.
 ## Step 2: Download and analyze session logs
 
 ```bash
-gh -R $ARGUMENTS run download <run-id> --name claude-session-logs --dir /tmp/logs/<run-id>/
+gh -R $ARGUMENTS run download <run-id> --pattern 'claude-session-logs*' --dir /tmp/logs/<run-id>/
 ```
 
 Skip runs without artifacts. Find JSONL files under `/tmp/logs/` and extract:

--- a/skills/tend-running-in-ci/SKILL.md
+++ b/skills/tend-running-in-ci/SKILL.md
@@ -204,7 +204,7 @@ The primary evidence for diagnosing bot behavior is the session log artifact —
 not console output (`show_full_output` defaults to `false`).
 
 ```bash
-gh run download <run-id> -n claude-session-logs -D /tmp/session-logs-<run-id>
+gh run download <run-id> --pattern 'claude-session-logs*' -D /tmp/session-logs-<run-id>
 ```
 
 The artifact contains JSONL files. Each line has a `type` field (`user`,


### PR DESCRIPTION
## Summary

- Fix artifact name collision in matrix workflows — `upload-artifact@v7`
  rejects duplicate names, and both matrix jobs were uploading
  `claude-session-logs`
- Append truncated `INVOCATION_ID` (unique per job) as a suffix
- Update skill download commands to use `--pattern 'claude-session-logs*'`
  glob matching

## Evidence

Every `review-reviewers` run since #9 introduced the matrix strategy has
failed on the worktrunk job with:

```
Failed to CreateArtifact: (409) Conflict: an artifact with this name
already exists on the workflow run
```

10+ consecutive failures observed across
[run 23459876242](https://github.com/max-sixty/tend/actions/runs/23459876242),
[run 23457407012](https://github.com/max-sixty/tend/actions/runs/23457407012),
and all prior hourly runs.

**Gate assessment:**
- Evidence level: Critical (consistent infrastructure failure, 10+ occurrences)
- Change type: Targeted fix (3 files, minimal logic change)
- Both gates pass

## Test plan

- [ ] Verify next `review-reviewers` run completes both matrix jobs
  without artifact conflict
- [ ] Verify session log download still works with `--pattern` matching

🤖 Generated with [Claude Code](https://claude.com/claude-code)
