### PR TITLE
Set up tend-agent for this repo

### DIFF
--- a/.config/tend.toml
+++ b/.config/tend.toml
@@ -1,5 +1,1 @@
-bot_name = "tend-bot"
-
-# TODO: Generate PAT for tend-bot (classic, repo scope) and set as BOT_TOKEN secret
-# TODO: Accept collaborator invitation as tend-bot
-# TODO: Verify oauth-token.sh token exchange end-to-end (rate limited during initial testing)
+bot_name = "tend-agent"

--- a/.github/workflows/tend-ci-fix.yaml
+++ b/.github/workflows/tend-ci-fix.yaml
@@ -29,7 +29,7 @@ jobs:
         with:
           github_token: ${{ secrets.BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          bot_name: tend-bot
+          bot_name: tend-agent
           prompt: |
             /tend:tend-ci-fix ${{ github.event.workflow_run.id }}
             - Run URL: ${{ github.event.workflow_run.html_url }}

--- a/.github/workflows/tend-mention.yaml
+++ b/.github/workflows/tend-mention.yaml
@@ -13,12 +13,12 @@ jobs:
   verify:
     if: |
       (github.event_name == 'issues' &&
-        contains(github.event.issue.body, '@tend-bot') &&
-        github.event.issue.user.login != 'tend-bot') ||
+        contains(github.event.issue.body, '@tend-agent') &&
+        github.event.issue.user.login != 'tend-agent') ||
       (github.event_name == 'issue_comment' &&
-        github.event.comment.user.login != 'tend-bot') ||
+        github.event.comment.user.login != 'tend-agent') ||
       (github.event_name == 'pull_request_review_comment' &&
-        github.event.comment.user.login != 'tend-bot')
+        github.event.comment.user.login != 'tend-agent')
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number }}
       cancel-in-progress: true
@@ -35,7 +35,7 @@ jobs:
             exit 0
           fi
 
-          if [ -n "$COMMENT_BODY" ] && printf '%s\n' "$COMMENT_BODY" | grep -qF '@tend-bot'; then
+          if [ -n "$COMMENT_BODY" ] && printf '%s\n' "$COMMENT_BODY" | grep -qF '@tend-agent'; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -45,14 +45,14 @@ jobs:
             ISSUE_NUMBER="$ISSUE_OR_PR_NUMBER"
 
             if [ -z "$PR_URL" ]; then
-              if [ "$ISSUE_AUTHOR" = "tend-bot" ]; then
+              if [ "$ISSUE_AUTHOR" = "tend-agent" ]; then
                 echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
               fi
-              if printf '%s\n' "$ISSUE_BODY" | grep -qF '@tend-bot'; then
+              if printf '%s\n' "$ISSUE_BODY" | grep -qF '@tend-agent'; then
                 echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
               fi
               BOT_COMMENTS=$(gh api "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments" \
-                --jq '[.[] | select(.user.login == "tend-bot")] | length')
+                --jq '[.[] | select(.user.login == "tend-agent")] | length')
               if [ "$BOT_COMMENTS" -gt "0" ]; then
                 echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
               fi
@@ -65,18 +65,18 @@ jobs:
           fi
 
           PR_AUTHOR=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json author --jq '.author.login')
-          if [ "$PR_AUTHOR" = "tend-bot" ]; then
+          if [ "$PR_AUTHOR" = "tend-agent" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
           fi
 
           BOT_REVIEWS=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
-            --jq '[.[] | select(.user.login == "tend-bot")] | length')
+            --jq '[.[] | select(.user.login == "tend-agent")] | length')
           if [ "$BOT_REVIEWS" -gt "0" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
           fi
 
           BOT_COMMENTS=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
-            --jq '[.[] | select(.user.login == "tend-bot")] | length')
+            --jq '[.[] | select(.user.login == "tend-agent")] | length')
           if [ "$BOT_COMMENTS" -gt "0" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
           fi
@@ -96,7 +96,7 @@ jobs:
         if: |
           steps.check.outputs.should_run == 'true'
           && github.event.comment
-          && contains(github.event.comment.body, '@tend-bot')
+          && contains(github.event.comment.body, '@tend-agent')
         run: |
           gh api "repos/$REPO/issues/comments/$COMMENT_ID/reactions" -f content=eyes 2>/dev/null || \
           gh api "repos/$REPO/pulls/comments/$COMMENT_ID/reactions" -f content=eyes 2>/dev/null || true
@@ -142,15 +142,15 @@ jobs:
         with:
           github_token: ${{ secrets.BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          bot_name: tend-bot
+          bot_name: tend-agent
           prompt: >-
             ${{ github.event_name == 'issues'
               && format('An issue was updated with a mention of you ({0}). Read it and respond.', github.event.issue.html_url)
-              || (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@tend-bot')
+              || (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@tend-agent')
                 && format('You were mentioned in an inline review comment on PR #{0} ({1}, review comment ID {2}). Read the full PR context (description, diff, recent comments, CI status) and respond. If they are requesting changes, make the changes, commit, and push. Reply in the review thread using `gh api repos/{3}/pulls/{0}/comments/{2}/replies -f body="..."` — do not create a new top-level comment.', (github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number), github.event.comment.html_url, github.event.comment.id, github.repository))
               || (github.event_name == 'pull_request_review_comment'
                 && format('A user left an inline review comment on a PR where you previously participated (PR #{0}, {1}, review comment ID {2}). Read the full context. Only respond if the comment is directed at you or requests changes. Reply in the review thread using `gh api repos/{3}/pulls/{0}/comments/{2}/replies -f body="..."`.', (github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number), github.event.comment.html_url, github.event.comment.id, github.repository))
-              || (contains(github.event.comment.body, '@tend-bot')
+              || (contains(github.event.comment.body, '@tend-agent')
                 && format('You were mentioned in a comment ({0}). Read the full issue or PR (description, diff, recent comments, CI status) and respond. If they are requesting changes, make the changes, commit, and push.', github.event.comment.html_url))
               || format('A user commented on an issue/PR where you previously participated ({0}). Read the full context. Only respond if the comment is directed at you, asks a question you can help with, or requests changes you can make. If the conversation is between humans, exit silently.', github.event.comment.html_url)
             }}

--- a/.github/workflows/tend-nightly.yaml
+++ b/.github/workflows/tend-nightly.yaml
@@ -28,6 +28,6 @@ jobs:
         with:
           github_token: ${{ secrets.BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          bot_name: tend-bot
+          bot_name: tend-agent
           prompt: |
             /tend:tend-nightly

--- a/.github/workflows/tend-renovate.yaml
+++ b/.github/workflows/tend-renovate.yaml
@@ -28,6 +28,6 @@ jobs:
         with:
           github_token: ${{ secrets.BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          bot_name: tend-bot
+          bot_name: tend-agent
           prompt: |
             /tend:tend-renovate

--- a/.github/workflows/tend-review.yaml
+++ b/.github/workflows/tend-review.yaml
@@ -13,8 +13,8 @@ jobs:
       (github.event_name == 'pull_request_target' &&
         github.event.pull_request.draft == false) ||
       (github.event_name == 'pull_request_review' &&
-        github.event.pull_request.user.login == 'tend-bot' &&
-        github.event.review.user.login != 'tend-bot' &&
+        github.event.pull_request.user.login == 'tend-agent' &&
+        github.event.review.user.login != 'tend-agent' &&
         (github.event.review.state != 'approved' || github.event.review.body))
     concurrency:
       group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number }}
@@ -56,7 +56,7 @@ jobs:
         with:
           github_token: ${{ secrets.BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          bot_name: tend-bot
+          bot_name: tend-agent
           use_sticky_comment: ${{ github.event_name == 'pull_request_target' }}
           prompt: >-
             ${{ github.event_name == 'pull_request_target'

--- a/.github/workflows/tend-triage.yaml
+++ b/.github/workflows/tend-triage.yaml
@@ -13,7 +13,7 @@ jobs:
   triage:
     if: >-
       github.event.issue.user.type != 'Bot' &&
-      github.event.issue.user.login != 'tend-bot'
+      github.event.issue.user.login != 'tend-agent'
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     permissions:
@@ -34,6 +34,6 @@ jobs:
         with:
           github_token: ${{ secrets.BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          bot_name: tend-bot
+          bot_name: tend-agent
           prompt: |
             /tend:tend-triage ${{ github.event.issue.number }}

--- a/skills/install-tend/SKILL.md
+++ b/skills/install-tend/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: install-tend
-description: Sets up tend (Claude-powered CI) on a GitHub repo. Creates config, generates workflows, configures secrets and branch protection via API, guides bot account and PAT creation via browser. Use when setting up tend on a new repo or when asked to install/configure tend.
+description: Sets up tend (Claude-powered CI) on a GitHub repo. Creates config, generates workflows, configures secrets and branch protection via API, creates bot account and PAT via Chrome. Use when setting up tend on a new repo or when asked to install/configure tend.
 argument-hint: "[bot-name]"
 ---
 
@@ -10,27 +10,31 @@ Set up tend on the current repo.
 
 **Bot name:** $ARGUMENTS (or ask the user if not provided)
 
-Follow each step in order. Skip steps that are already done.
-
-## 1. Prerequisites
-
-Verify before proceeding:
+Follow each step in order. Skip steps that are already done — check each
+prerequisite before acting. Derive `REPO` once at the start:
 
 ```bash
 gh auth status
-git remote -v
-```
-
-- `gh` must be authenticated
-- Repo must have a GitHub remote (need owner/repo for API calls)
-
-Derive `OWNER/REPO` from the remote for later steps:
-
-```bash
 REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
 ```
 
-## 2. Create config
+## Chrome automation
+
+Steps 3, 5, and 7 require a browser (account creation, PAT generation,
+invitation acceptance). Use Chrome automation tools for all of these:
+
+1. Call `tabs_context_mcp` to connect
+2. Create a tab or reuse an existing one
+3. Navigate, interact with forms, and verify outcomes
+
+If Chrome is unavailable, fall back to giving the user URLs and waiting for
+confirmation.
+
+For any step where the browser must be logged in as the bot account, verify
+the logged-in user by clicking the avatar menu and checking the username
+before proceeding.
+
+## 1. Create config
 
 Create `.config/tend.toml`:
 
@@ -46,158 +50,125 @@ Ask the user about overrides. Only add what differs from defaults:
   for ci-fix (default watches `"ci"`)
 - **Default branch** — only needed if not `main`
 
-## 3. Generate workflows
+## 2. Generate workflows
 
 ```bash
 uvx tend init
 ```
 
-Verify 6 workflow files appear in `.github/workflows/tend-*.yaml`.
+Verify workflow files appear in `.github/workflows/tend-*.yaml`.
 
-## 4. Bot account
-
-Check if the bot account exists:
+## 3. Bot account
 
 ```bash
 gh api users/<bot-name> --jq '.login,.id' 2>/dev/null && echo "EXISTS" || echo "NOT FOUND"
 ```
 
-If it doesn't exist, the user must create it. Open Chrome to the signup page:
+If the account doesn't exist:
 
-```
-Navigate to: https://github.com/signup
-```
+1. If the user hasn't chosen a name yet, check availability of candidates
+   using `gh api users/<name>` (404 = available). Suggest options.
+2. Navigate Chrome to `https://github.com/signup`. The user must create the
+   account themselves (account creation is a prohibited action for Claude).
+3. If a verification code is needed, use jean-claude to search for the
+   GitHub email: `jean-claude gmail search "from:github subject:code" -n 1`
+4. After confirmation, re-verify via API.
 
-Tell the user: "Create the bot account `<bot-name>` in this browser tab, then
-tell me when it's done." Wait for confirmation, then verify:
+## 4. Claude OAuth token
 
-```bash
-gh api users/<bot-name> --jq '.login,.id'
-```
-
-## 5. Claude OAuth token
-
-The `CLAUDE_CODE_OAUTH_TOKEN` is an OAuth access token from Claude's auth
-service. It uses the user's Claude subscription (Max/Team) for billing —
-this is NOT an API key from console.anthropic.com.
-
-Check if already set:
+An OAuth access token from Claude's auth service — uses the user's Claude
+subscription (Max/Team) for billing. Not an API key from console.anthropic.com.
 
 ```bash
-gh secret list --repo OWNER/REPO --json name --jq '.[].name' | grep -q CLAUDE_CODE_OAUTH_TOKEN && echo "SET" || echo "NOT SET"
+gh secret list --repo "$REPO" --json name --jq '.[].name' | grep -q CLAUDE_CODE_OAUTH_TOKEN && echo "SET" || echo "NOT SET"
 ```
 
-If not set, obtain the token using the `${CLAUDE_SKILL_DIR}/scripts/oauth-token.sh`
-script. This runs a standard OAuth 2.0 PKCE flow against claude.ai and
-prints the access token:
+If not set, obtain the token via `${CLAUDE_SKILL_DIR}/scripts/oauth-token.sh`
+(OAuth 2.0 PKCE flow, opens browser, token valid for 1 year):
 
 ```bash
 TOKEN=$("${CLAUDE_SKILL_DIR}/scripts/oauth-token.sh")
-echo "$TOKEN" | gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo OWNER/REPO
+echo "$TOKEN" | gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo "$REPO"
 ```
 
-The script opens a browser for the user to sign in with their Claude account.
-The token is valid for 1 year.
+## 5. Bot PAT and secret
 
-## 6. Bot PAT and secret
+The bot needs a classic PAT with `repo` scope. Use Chrome:
 
-The bot account needs a classic PAT with `repo` scope for GitHub API access.
-This must be done while logged in as the bot.
-
-Open Chrome to the token creation page:
-
-```
-Navigate to: https://github.com/settings/tokens/new?scopes=repo&description=tend-ci
-```
-
-Tell the user: "Log in as `<bot-name>` and generate the token. Copy the token
-value and paste it here when ready."
-
-Once the user provides the PAT, set it as a repo secret:
+1. Verify the browser is logged in as `<bot-name>` (click avatar, check
+   username). If not, tell the user to log in as the bot first.
+2. Navigate to
+   `https://github.com/settings/tokens/new?scopes=repo&description=tend-ci`
+3. The URL pre-fills the note and `repo` scope. Set expiration to
+   "No expiration" via the dropdown.
+4. Click "Generate token" (scroll to bottom of page).
+5. Read the token from the resulting page using `get_page_text`.
+6. Set as repo secret:
 
 ```bash
-echo "<pat-value>" | gh secret set BOT_TOKEN --repo OWNER/REPO
+echo "<pat-value>" | gh secret set BOT_TOKEN --repo "$REPO"
 ```
 
 Verify both secrets exist:
 
 ```bash
-gh secret list --repo OWNER/REPO
+gh secret list --repo "$REPO"
 ```
 
-## 7. Branch protection
+## 6. Branch protection
 
-Check existing rulesets first — skip if one already protects the default branch:
+Check existing rulesets — skip if one already protects the default branch:
 
 ```bash
-gh api "repos/$REPO/rulesets" --jq '.[] | {name, enforcement, target}'
+gh api "repos/$REPO/rulesets" --jq '.[] | {name, enforcement}'
 ```
 
-If none exist, create a "Restrict updates" ruleset. This blocks all pushes
-and merges to the default branch — only admins can bypass. The bot (write
-role) cannot merge regardless of review status.
-
-The merge restriction itself is the security boundary — not required reviews.
-Required reviews create problems for solo maintainers (CODEOWNERS deadlock)
-and are unnecessary when only admins can merge.
+If none exist, create a ruleset restricting pushes/merges to the default
+branch. Only admins can bypass — the bot (write role) cannot merge.
 
 ```bash
-cat > /tmp/tend-ruleset.json << 'EOF'
+gh api "repos/$REPO/rulesets" --method POST --input - << 'EOF'
 {
   "name": "Merge access",
   "target": "branch",
   "enforcement": "active",
   "conditions": {
-    "ref_name": {
-      "include": ["~DEFAULT_BRANCH"],
-      "exclude": []
-    }
+    "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] }
   },
-  "rules": [
-    {
-      "type": "update"
-    }
-  ],
-  "bypass_actors": [
-    {
-      "actor_id": 5,
-      "actor_type": "RepositoryRole",
-      "bypass_mode": "exempt"
-    }
-  ]
+  "rules": [{ "type": "update" }],
+  "bypass_actors": [{
+    "actor_id": 5,
+    "actor_type": "RepositoryRole",
+    "bypass_mode": "exempt"
+  }]
 }
 EOF
-
-REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
-gh api "repos/$REPO/rulesets" --method POST --input /tmp/tend-ruleset.json
 ```
 
 - `type: update` — restricts who can push to or merge into the branch
 - `actor_id: 5` = Repository Admin role
-- `bypass_mode: exempt` — silently skips the rule for admins (no checkbox)
-- The bot account must have **write** access (not admin)
+- `bypass_mode: exempt` — silently skips the rule for admins
 
-## 8. Add bot as collaborator
-
-The bot needs write access to push branches and create PRs:
+## 7. Add bot as collaborator
 
 ```bash
-REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
 gh api "repos/$REPO/collaborators/<bot-name>" -X PUT -f permission=push
 ```
 
-The bot must accept the invitation. Open Chrome:
+The bot must accept the invitation. Use Chrome:
 
-```
-Navigate to: https://github.com/notifications
-```
+1. Navigate to `https://github.com/<owner>/<repo>/invitations` (not
+   `/notifications` — invitations don't appear there for new accounts).
+2. Click "Accept invitation".
+3. Verify via API:
 
-Tell the user: "Log in as `<bot-name>` and accept the repository invitation,
-then tell me when done."
+```bash
+gh api "repos/$REPO/collaborators" --jq '.[].login'
+```
 
 Skip if the bot is already a member of the org that owns the repo.
 
-## 9. Commit and push
+## 8. Commit and push
 
 Stage only the generated files:
 
@@ -212,10 +183,10 @@ Commit with co-author attribution. Do NOT push without explicit permission.
 After completing all steps, present this checklist:
 
 - [ ] Config: `.config/tend.toml` created
-- [ ] Workflows: 6 files in `.github/workflows/`
+- [ ] Workflows: generated in `.github/workflows/`
 - [ ] Bot account: `<bot-name>` exists on GitHub
-- [ ] Claude token: `CLAUDE_CODE_OAUTH_TOKEN` set (via OAuth script)
-- [ ] Bot PAT: `BOT_TOKEN` set (classic PAT with `repo` scope)
-- [ ] Ruleset: "Restrict updates" on default branch, admin bypass (exempt mode)
+- [ ] Claude token: `CLAUDE_CODE_OAUTH_TOKEN` secret set
+- [ ] Bot PAT: `BOT_TOKEN` secret set (classic PAT, `repo` scope)
+- [ ] Ruleset: merge restriction on default branch, admin bypass
 - [ ] Bot access: write collaborator, invitation accepted
 - [ ] Committed and pushed


### PR DESCRIPTION
Configures tend-agent as the bot account for this repo and improves the install-tend skill based on running through the setup process end-to-end.

**Setup completed:**
- Bot account `tend-agent` created, added as collaborator with write access
- `BOT_TOKEN` (no-expiry classic PAT, `repo` scope) and `CLAUDE_CODE_OAUTH_TOKEN` secrets set
- "Merge access" ruleset already in place
- Config updated to `bot_name = "tend-agent"`, workflows regenerated

**Skill improvements** (from running the skill and hitting real issues):
- Added Chrome automation section — PAT creation, invitation acceptance, login verification
- Use `/<owner>/<repo>/invitations` for accepting invites (notifications page doesn't show them for new accounts)
- Added jean-claude integration for fetching GitHub verification codes from email
- Added bot name availability checking before account creation
- Removed stale TODOs from config

> _This was written by Claude Code on behalf of max-sixty_