### PR TITLE
feat: check merge restriction and org secrets in `tend check`

### DIFF
--- a/generator/src/tend/checks.py
+++ b/generator/src/tend/checks.py
@@ -25,14 +25,14 @@ class CheckResult:
     message: str
 
 
-def _gh(*args: str) -> subprocess.CompletedProcess[str] | None:
+def _gh(*args: str, input: str | None = None) -> subprocess.CompletedProcess[str] | None:
     """Run a gh CLI command. Returns None if gh is not installed."""
     gh = shutil.which("gh")
     if not gh:
         return None
     try:
         return subprocess.run(
-            [gh, *args], capture_output=True, text=True, timeout=30
+            [gh, *args], capture_output=True, text=True, timeout=30, input=input,
         )
     except subprocess.TimeoutExpired:
         return None
@@ -48,22 +48,67 @@ def detect_repo() -> str | None:
 
 
 def check_branch_protection(repo: str, branch: str) -> CheckResult:
-    """Check if the default branch is protected."""
+    """Check if the default branch is protected against bot merges.
+
+    Checks both that the branch is protected and that the protection actually
+    prevents the bot from merging (via required reviews or a restrict-updates
+    ruleset).
+    """
     result = _gh("api", f"repos/{repo}/branches/{branch}", "--jq", ".protected")
     if result is None:
         return CheckResult("branch-protection", None, "gh CLI not found")
     if result.returncode != 0:
         return CheckResult("branch-protection", None, f"API error: {result.stderr.strip()}")
 
-    if result.stdout.strip() == "true":
+    if result.stdout.strip() != "true":
+        return CheckResult(
+            "branch-protection",
+            False,
+            f"Default branch '{branch}' is NOT protected. "
+            "The bot must not be able to merge PRs — this is the primary security boundary. "
+            "Add a branch protection rule or ruleset. See docs/security-model.md.",
+        )
+
+    # Branch is protected — now check if the bot can still merge.
+    # A restrict-updates ruleset is sufficient (and preferred).
+    if _has_restrict_updates_ruleset(repo, branch):
+        return CheckResult("branch-protection", True, f"Default branch '{branch}' is protected (restrict-updates ruleset)")
+
+    # Fall back to checking branch protection rules for required reviews.
+    prot = _gh("api", f"repos/{repo}/branches/{branch}/protection")
+    if prot is None or prot.returncode != 0:
+        # Can't read details — branch is protected, assume OK.
         return CheckResult("branch-protection", True, f"Default branch '{branch}' is protected")
+
+    try:
+        data = json.loads(prot.stdout)
+    except json.JSONDecodeError:
+        return CheckResult("branch-protection", True, f"Default branch '{branch}' is protected")
+
+    reviews = data.get("required_pull_request_reviews")
+    if reviews and reviews.get("required_approving_review_count", 0) > 0:
+        return CheckResult("branch-protection", True, f"Default branch '{branch}' is protected (requires reviews)")
+
     return CheckResult(
         "branch-protection",
         False,
-        f"Default branch '{branch}' is NOT protected. "
-        "The bot must not be able to merge PRs — this is the primary security boundary. "
-        "Add a branch protection rule or ruleset. See docs/security-model.md.",
+        f"Default branch '{branch}' is protected but the bot can still merge PRs "
+        f"(required_approving_review_count is 0 and no restrict-updates ruleset found). "
+        "Either require at least 1 approving review, or add a 'Restrict updates' "
+        "ruleset with only admins bypassing. See docs/security-model.md.",
     )
+
+
+def _has_restrict_updates_ruleset(repo: str, branch: str) -> bool:
+    """Check if any active ruleset restricts updates to the branch."""
+    result = _gh("api", f"repos/{repo}/rulesets", "--jq",
+                 '[.[] | select(.enforcement == "active" and .target == "branch")] | length')
+    if result is None or result.returncode != 0:
+        return False
+    try:
+        return int(result.stdout.strip()) > 0
+    except ValueError:
+        return False
 
 
 def check_bot_permission(repo: str, bot_name: str) -> CheckResult:
@@ -92,7 +137,7 @@ def check_bot_permission(repo: str, bot_name: str) -> CheckResult:
 
 
 def check_secrets(repo: str, expected: list[str]) -> CheckResult:
-    """Check that required secrets exist in the repository."""
+    """Check that required secrets exist (repo-level, then org-level fallback)."""
     result = _gh("api", f"repos/{repo}/actions/secrets", "--jq", "[.secrets[].name]")
     if result is None:
         return CheckResult("secrets", None, "gh CLI not found")
@@ -100,11 +145,28 @@ def check_secrets(repo: str, expected: list[str]) -> CheckResult:
         return CheckResult("secrets", None, "Could not list secrets (may require admin access)")
 
     try:
-        secret_names = json.loads(result.stdout)
+        secret_names = set(json.loads(result.stdout))
     except json.JSONDecodeError:
         return CheckResult("secrets", None, "Could not parse secrets response")
 
     missing = [s for s in expected if s not in secret_names]
+
+    # Try org secrets for anything not found at repo level.
+    if missing:
+        org = repo.split("/")[0] if "/" in repo else None
+        if org:
+            org_secrets = _list_org_secrets(org)
+            if org_secrets is not None:
+                still_missing = [s for s in missing if s not in org_secrets]
+                found_at_org = [s for s in missing if s in org_secrets]
+                if found_at_org and not still_missing:
+                    return CheckResult(
+                        "secrets", True,
+                        f"Required secrets present (org-level: {', '.join(found_at_org)})",
+                    )
+                if found_at_org:
+                    missing = still_missing
+
     if missing:
         return CheckResult(
             "secrets",
@@ -113,6 +175,52 @@ def check_secrets(repo: str, expected: list[str]) -> CheckResult:
             "Add them in repo Settings > Secrets and variables > Actions.",
         )
     return CheckResult("secrets", True, f"Required secrets present: {', '.join(expected)}")
+
+
+def _list_org_secrets(org: str) -> set[str] | None:
+    """List org-level secret names. Returns None if inaccessible."""
+    result = _gh("api", f"orgs/{org}/actions/secrets", "--jq", "[.secrets[].name]")
+    if result is None or result.returncode != 0:
+        return None
+    try:
+        return set(json.loads(result.stdout))
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+RESTRICT_UPDATES_RULESET = json.dumps({
+    "name": "Merge access",
+    "target": "branch",
+    "enforcement": "active",
+    "conditions": {
+        "ref_name": {
+            "include": ["~DEFAULT_BRANCH"],
+            "exclude": [],
+        }
+    },
+    "rules": [{"type": "update"}],
+    "bypass_actors": [
+        {
+            "actor_id": 5,
+            "actor_type": "RepositoryRole",
+            "bypass_mode": "exempt",
+        }
+    ],
+})
+
+
+def fix_branch_protection(repo: str) -> CheckResult:
+    """Create a restrict-updates ruleset on the default branch.
+
+    Only admins (actor_id 5) can bypass. The bot (write role) cannot merge.
+    """
+    result = _gh("api", f"repos/{repo}/rulesets", "--method", "POST",
+                 "--input", "-", input=RESTRICT_UPDATES_RULESET)
+    if result is None:
+        return CheckResult("branch-protection", None, "gh CLI not found")
+    if result.returncode != 0:
+        return CheckResult("branch-protection", False, f"Failed to create ruleset: {result.stderr.strip()}")
+    return CheckResult("branch-protection", True, "Created 'Merge access' ruleset — only admins can merge")
 
 
 def run_all_checks(cfg: Config, repo: str | None = None) -> list[CheckResult]:

--- a/generator/src/tend/cli.py
+++ b/generator/src/tend/cli.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import click
 
-from tend.checks import CheckResult, run_all_checks
+from tend.checks import CheckResult, detect_repo, fix_branch_protection, run_all_checks
 from tend.config import Config
 from tend.workflows import generate_all
 
@@ -62,7 +62,8 @@ def init(config_path: Path | None, dry_run: bool) -> None:
 @main.command()
 @click.option("--config", "-c", "config_path", type=click.Path(exists=True, path_type=Path), default=None)
 @click.option("--repo", "-r", help="GitHub repo (owner/name). Auto-detected if omitted.")
-def check(config_path: Path | None, repo: str | None) -> None:
+@click.option("--fix", is_flag=True, help="Fix failing checks (creates rulesets, etc.)")
+def check(config_path: Path | None, repo: str | None, fix: bool) -> None:
     """Verify security prerequisites (branch protection, bot access, secrets)."""
     cfg = Config.load(config_path)
     results = run_all_checks(cfg, repo)
@@ -71,5 +72,35 @@ def check(config_path: Path | None, repo: str | None) -> None:
     _print_check_results(results)
 
     failures = [r for r in results if r.passed is False]
-    if failures:
+    if not failures:
+        return
+
+    if not fix:
+        raise SystemExit(1)
+
+    # Resolve repo for fix operations.
+    if repo is None:
+        repo = detect_repo()
+    if repo is None:
+        click.echo("Could not detect repo — pass --repo to fix.")
+        raise SystemExit(1)
+
+    fixed_any = False
+    for r in failures:
+        if r.name == "branch-protection" and "bot can still merge" in r.message:
+            click.echo()
+            click.echo("Creating 'Merge access' ruleset — only admins can merge to default branch...")
+            fix_result = fix_branch_protection(repo)
+            _print_check_results([fix_result])
+            if fix_result.passed:
+                fixed_any = True
+
+    if fixed_any:
+        click.echo()
+        click.echo("Re-running checks...")
+        results = run_all_checks(cfg, repo)
+        _print_check_results(results)
+        if any(r.passed is False for r in results):
+            raise SystemExit(1)
+    else:
         raise SystemExit(1)

--- a/skills/install-tend/SKILL.md
+++ b/skills/install-tend/SKILL.md
@@ -168,13 +168,33 @@ gh api "repos/$REPO/collaborators" --jq '.[].login'
 
 Skip if the bot is already a member of the org that owns the repo.
 
-## 8. Commit and push
+## 8. Create skill overlay (recommended)
+
+Create `.claude/skills/running-tend/SKILL.md` with tend-specific project
+guidance. This skill is loaded by tend workflows alongside the generic
+`tend-*` skills.
+
+**Do NOT duplicate CLAUDE.md.** The overlay should only contain information
+that tend workflows need beyond what CLAUDE.md already provides:
+
+- PR title conventions (prefix format, scope rules)
+- CI workflow names (which workflow tend-ci-fix watches)
+- Automerge behavior (which bot PRs get auto-merged)
+- Dependency management (Dependabot vs Renovate, tend-renovate enabled/disabled)
+
+Build commands, test commands, error conventions, code style, and project
+structure belong in CLAUDE.md — tend reads CLAUDE.md like any other Claude
+session.
+
+## 9. Commit and push
 
 Stage only the generated files:
 
 ```bash
-git add .config/tend.toml .github/workflows/tend-*.yaml
+git add .config/tend.toml .github/workflows/tend-*.yaml .claude/skills/running-tend/
 ```
+
+Also stage any setup actions created for tend (e.g., `.github/actions/tend-setup/`).
 
 Commit with co-author attribution. Do NOT push without explicit permission.
 
@@ -189,4 +209,5 @@ After completing all steps, present this checklist:
 - [ ] Bot PAT: `BOT_TOKEN` secret set (classic PAT, `repo` scope)
 - [ ] Ruleset: merge restriction on default branch, admin bypass
 - [ ] Bot access: write collaborator, invitation accepted
+- [ ] Skill overlay: `.claude/skills/running-tend/SKILL.md` (tend-specific only)
 - [ ] Committed and pushed


### PR DESCRIPTION
Found during PRQL setup: `tend check` had two gaps.

**Branch protection** only checked `"protected": true` but didn't verify the bot can't merge. On prql/prql, the branch was "protected" with 0 required reviews — the bot could self-merge its own PRs. Now checks for a restrict-updates ruleset or `required_approving_review_count > 0`, and `--fix` creates the ruleset automatically.

**Secrets** only checked repo-level. `PRQL_BOT_GITHUB_TOKEN` was an org secret, so the check false-failed. Now falls back to `orgs/{org}/actions/secrets` (requires `admin:org` scope, degrades gracefully without it).

Also adds step 9 to `install-tend` for creating the skill overlay, with guidance to keep it tend-specific and not duplicate CLAUDE.md.

> _This was written by Claude Code on behalf of @max-sixty_