### PR TITLE
fix: ban --watch flags in CI skills to prevent hangs

### DIFF
--- a/skills/tend-review/SKILL.md
+++ b/skills/tend-review/SKILL.md
@@ -270,8 +270,8 @@ array indices to object keys, which GitHub rejects.
 
 ### 6. Monitor CI
 
-After approving or staying silent, monitor CI using the approach from
-/tend:tend-running-in-ci.
+After approving or staying silent, monitor CI using the polling approach from
+/tend:tend-running-in-ci. **NEVER use `--watch` flags** — they hang forever.
 
 - **All required checks passed** -> done.
 - **A check failed** and it's related to the PR -> post a follow-up COMMENT

--- a/skills/tend-running-in-ci/SKILL.md
+++ b/skills/tend-running-in-ci/SKILL.md
@@ -87,8 +87,9 @@ exit 1
    fix, commit, push, repeat.
 3. Report completion only after all required checks pass.
 
-Never report "done" before CI passes. Avoid `gh run watch` and
-`gh pr checks --watch` — both can hang indefinitely.
+Never report "done" before CI passes. **NEVER use `gh run watch` or
+`gh pr checks --watch`** — both hang indefinitely and will consume the
+entire job timeout. Always poll with `gh pr checks` in a loop instead.
 
 Before dismissing local test failures as "pre-existing", check main branch CI:
 


### PR DESCRIPTION
The tend-review job on PR #14 hung for 60 minutes because Claude used `gh pr checks --watch`, which blocks indefinitely — especially when the only check is the review job watching itself.

The `tend-running-in-ci` skill already said "Avoid" these flags, but Claude ignored the soft guidance. Changed to a hard ban with explanation of consequences in both `tend-running-in-ci` and `tend-review`.

> _This was written by Claude Code on behalf of max-sixty_