### PR TITLE
feat: hint admin:org scope when org secret lookup returns 403

### DIFF
--- a/generator/src/tend/checks.py
+++ b/generator/src/tend/checks.py
@@ -152,10 +152,11 @@ def check_secrets(repo: str, expected: list[str]) -> CheckResult:
     missing = [s for s in expected if s not in secret_names]
 
     # Try org secrets for anything not found at repo level.
+    org_forbidden = False
     if missing:
         org = repo.split("/")[0] if "/" in repo else None
         if org:
-            org_secrets = _list_org_secrets(org)
+            org_secrets, org_forbidden = _list_org_secrets(org)
             if org_secrets is not None:
                 still_missing = [s for s in missing if s not in org_secrets]
                 found_at_org = [s for s in missing if s in org_secrets]
@@ -168,24 +169,32 @@ def check_secrets(repo: str, expected: list[str]) -> CheckResult:
                     missing = still_missing
 
     if missing:
-        return CheckResult(
-            "secrets",
-            False,
+        msg = (
             f"Missing secrets: {', '.join(missing)}. "
-            "Add them in repo Settings > Secrets and variables > Actions.",
+            "Add them in repo Settings > Secrets and variables > Actions."
         )
+        if org_forbidden:
+            msg += (
+                "\nNote: Could not check org-level secrets (HTTP 403). "
+                "If these secrets are set at the org level, grant the "
+                "admin:org scope: gh auth refresh -h github.com -s admin:org"
+            )
+        return CheckResult("secrets", False, msg)
     return CheckResult("secrets", True, f"Required secrets present: {', '.join(expected)}")
 
 
-def _list_org_secrets(org: str) -> set[str] | None:
-    """List org-level secret names. Returns None if inaccessible."""
+def _list_org_secrets(org: str) -> tuple[set[str] | None, bool]:
+    """List org-level secret names. Returns (secrets, permission_denied)."""
     result = _gh("api", f"orgs/{org}/actions/secrets", "--jq", "[.secrets[].name]")
-    if result is None or result.returncode != 0:
-        return None
+    if result is None:
+        return None, False
+    if result.returncode != 0:
+        forbidden = "HTTP 403" in result.stderr
+        return None, forbidden
     try:
-        return set(json.loads(result.stdout))
+        return set(json.loads(result.stdout)), False
     except (json.JSONDecodeError, TypeError):
-        return None
+        return None, False
 
 
 RESTRICT_UPDATES_RULESET = json.dumps({

--- a/generator/tests/test_checks.py
+++ b/generator/tests/test_checks.py
@@ -135,6 +135,18 @@ def test_secrets_missing() -> None:
         result = check_secrets("owner/repo", ["BOT_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"])
     assert result.passed is False
     assert "CLAUDE_CODE_OAUTH_TOKEN" in result.message
+    assert "admin:org" not in result.message
+
+
+def test_secrets_missing_with_org_403_hint() -> None:
+    """When org secrets return 403 and secrets are missing, include the hint."""
+    with patch("tend.checks._gh", return_value=_make_completed('["BOT_TOKEN"]\n')), \
+         patch("tend.checks._list_org_secrets", return_value=(None, True)):
+        result = check_secrets("owner/repo", ["BOT_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"])
+    assert result.passed is False
+    assert "CLAUDE_CODE_OAUTH_TOKEN" in result.message
+    assert "admin:org" in result.message
+    assert "gh auth refresh" in result.message
 
 
 def test_secrets_api_error() -> None:


### PR DESCRIPTION
When the gh token lacks `admin:org` scope, `_list_org_secrets` gets a 403 and returns `None` — `check_secrets` then reports secrets as missing with no explanation of why org-level lookup failed.

Now `_list_org_secrets` returns a `(secrets, permission_denied)` tuple distinguishing HTTP 403 from other failures. When secrets are missing and the org lookup was forbidden, `check_secrets` appends a remediation hint: `gh auth refresh -h github.com -s admin:org`. The hint only appears when secrets are actually missing — not when all are found at repo level.

> _This was written by Claude Code on behalf of @max-sixty_