### PR TITLE
feat: add setup.raw for injecting arbitrary YAML steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,31 +124,24 @@ uses = ["./.github/actions/my-setup"]
 run = ["echo CARGO_TERM_COLOR=always >> $GITHUB_ENV"]
 ```
 
-`uses` and `run` entries are bare strings — there's no way to pass `with:`
-parameters to an action directly. For actions that need inputs (e.g.,
-`cargo-install`, `rust-cache`, `setup-node`), wrap them in a local composite
-action:
-
-```yaml
-# .github/actions/tend-setup/action.yaml
-name: tend-setup
-runs:
-  using: composite
-  steps:
-    - uses: cargo-bins/cargo-binstall@main
-    - run: cargo binstall cargo-insta --no-confirm
-      shell: bash
-    - uses: Swatinem/rust-cache@v2
-      with:
-        save-if: false
-```
-
-Then reference it as a single `uses` entry:
+For actions that need `with:` parameters, use `raw` — a multiline string of
+GitHub Actions YAML injected verbatim into the workflow steps:
 
 ```toml
 [setup]
-uses = ["./.github/actions/tend-setup"]
+uses = ["cargo-bins/cargo-binstall@main"]
+run = ["cargo binstall cargo-insta --no-confirm"]
+raw = """
+- uses: Swatinem/rust-cache@v2
+  with:
+    save-if: false
+"""
 ```
+
+`uses` and `run` entries are bare strings (no `with:` support). `raw` handles
+everything else. For very complex setups, a local composite action
+(`.github/actions/tend-setup/action.yaml`) referenced via `uses` is an
+alternative.
 
 ### Workflow overrides
 

--- a/generator/src/tend/config.py
+++ b/generator/src/tend/config.py
@@ -37,6 +37,7 @@ class Config:
     bot_token_secret: str
     claude_token_secret: str
     setup: list[SetupStep]
+    setup_raw: str
     workflows: dict[str, WorkflowConfig]
 
     @classmethod
@@ -71,10 +72,10 @@ class Config:
         secrets = raw.get("secrets", {})
 
         setup: list[SetupStep] = []
-        setup_raw = raw.get("setup", {})
-        for action in setup_raw.get("uses", []):
+        setup_section = raw.get("setup", {})
+        for action in setup_section.get("uses", []):
             setup.append(SetupStep(uses=action))
-        for cmd in setup_raw.get("run", []):
+        for cmd in setup_section.get("run", []):
             setup.append(SetupStep(run=cmd))
 
         workflows: dict[str, WorkflowConfig] = {}
@@ -104,5 +105,6 @@ class Config:
             bot_token_secret=secrets.get("bot_token", "BOT_TOKEN"),
             claude_token_secret=secrets.get("claude_token", "CLAUDE_CODE_OAUTH_TOKEN"),
             setup=setup,
+            setup_raw=setup_section.get("raw", ""),
             workflows=workflows,
         )

--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import textwrap
 from collections.abc import Callable
 from dataclasses import dataclass
 
@@ -18,6 +19,15 @@ def _claude_token(cfg: Config) -> str:
     return f"${{{{ secrets.{cfg.claude_token_secret} }}}}"
 
 
+def _reindent(text: str, indent: int) -> str:
+    """Dedent raw YAML and re-indent to `indent` spaces."""
+    stripped = textwrap.dedent(text).strip("\n")
+    if not stripped:
+        return ""
+    pad = " " * indent
+    return "\n".join(pad + line if line.strip() else line for line in stripped.splitlines())
+
+
 def _setup_yaml(cfg: Config, indent: int = 6) -> str:
     """Render setup steps as YAML, indented to `indent` spaces.
 
@@ -31,6 +41,8 @@ def _setup_yaml(cfg: Config, indent: int = 6) -> str:
             lines.append(f"{pad}- uses: {step.uses}")
         elif step.run:
             lines.append(f"{pad}- run: {step.run}")
+    if cfg.setup_raw:
+        lines.append(_reindent(cfg.setup_raw, indent))
     if not lines:
         return ""
     return "\n" + "\n".join(lines) + "\n"

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -157,6 +157,45 @@ def test_setup_after_pr_checkout_in_review(tmp_path: Path) -> None:
     assert setup_idx > checkout_idx, "Setup must come after PR checkout"
 
 
+def test_setup_raw_yaml_injected(tmp_path: Path) -> None:
+    extra = dedent("""\
+        [setup]
+        raw = \"\"\"
+        - uses: Swatinem/rust-cache@v2
+          with:
+            save-if: false
+        - run: cargo binstall cargo-insta --no-confirm
+          shell: bash
+        \"\"\"
+    """)
+    cfg = Config.load(_minimal_config(tmp_path, extra))
+    for wf in generate_all(cfg):
+        data = yaml.safe_load(wf.content)
+        assert isinstance(data, dict), f"{wf.filename} did not parse as valid YAML"
+        assert "Swatinem/rust-cache@v2" in wf.content, f"{wf.filename} missing raw uses step"
+        assert "save-if: false" in wf.content, f"{wf.filename} missing with parameter"
+        assert "cargo binstall" in wf.content, f"{wf.filename} missing raw run step"
+
+
+def test_setup_raw_combined_with_uses_and_run(tmp_path: Path) -> None:
+    extra = dedent("""\
+        [setup]
+        uses = ["./.github/actions/my-setup"]
+        run = ["echo FOO=bar >> $GITHUB_ENV"]
+        raw = \"\"\"
+        - uses: Swatinem/rust-cache@v2
+          with:
+            save-if: false
+        \"\"\"
+    """)
+    cfg = Config.load(_minimal_config(tmp_path, extra))
+    for wf in generate_all(cfg):
+        assert "./.github/actions/my-setup" in wf.content
+        assert "echo FOO=bar" in wf.content
+        assert "Swatinem/rust-cache@v2" in wf.content
+        assert "save-if: false" in wf.content
+
+
 def test_setup_after_pr_checkout_in_mention(tmp_path: Path) -> None:
     """Setup steps must run after PR checkout, not before."""
     extra = dedent("""\


### PR DESCRIPTION
For actions needing `with:` parameters (rust-cache, setup-node, etc.), the existing `uses` and `run` bare strings weren't sufficient. Previously the only workaround was a local composite action.

`setup.raw` is a multiline TOML string injected verbatim into workflow steps with correct indentation:

```toml
[setup]
raw = """
- uses: Swatinem/rust-cache@v2
  with:
    save-if: false
"""
```

Changes:
- `config.py`: Parse `setup.raw` field, rename `setup_raw` local to `setup_section` for clarity
- `workflows.py`: `_reindent()` dedents and re-indents raw YAML to the workflow step level
- `test_generate.py`: Tests for raw-only and combined (uses + run + raw) configs
- `README.md`: Document `raw` as the primary approach, composite action as fallback

> _This was written by Claude Code on behalf of maximilian_