### PR TITLE
fix: handle non-dict response from branch protection API

### DIFF
--- a/generator/src/tend/checks.py
+++ b/generator/src/tend/checks.py
@@ -85,6 +85,9 @@ def check_branch_protection(repo: str, branch: str) -> CheckResult:
     except json.JSONDecodeError:
         return CheckResult("branch-protection", True, f"Default branch '{branch}' is protected")
 
+    if not isinstance(data, dict):
+        return CheckResult("branch-protection", True, f"Default branch '{branch}' is protected")
+
     reviews = data.get("required_pull_request_reviews")
     if reviews and reviews.get("required_approving_review_count", 0) > 0:
         return CheckResult("branch-protection", True, f"Default branch '{branch}' is protected (requires reviews)")

--- a/generator/tests/test_checks.py
+++ b/generator/tests/test_checks.py
@@ -168,7 +168,7 @@ def test_secrets_bad_json() -> None:
 
 def test_run_all_checks_no_gh() -> None:
     with patch("shutil.which", return_value=None):
-        results = run_all_checks(Config("bot", "main", "T1", "T2", [], {}))
+        results = run_all_checks(Config("bot", "main", "T1", "T2", [], "", {}))
     assert len(results) == 1
     assert results[0].passed is None
     assert "gh CLI" in results[0].message
@@ -177,7 +177,7 @@ def test_run_all_checks_no_gh() -> None:
 def test_run_all_checks_no_repo() -> None:
     with patch("shutil.which", return_value="/usr/bin/gh"), \
          patch("tend.checks.detect_repo", return_value=None):
-        results = run_all_checks(Config("bot", "main", "T1", "T2", [], {}))
+        results = run_all_checks(Config("bot", "main", "T1", "T2", [], "", {}))
     assert len(results) == 1
     assert "detect" in results[0].message
 
@@ -196,7 +196,7 @@ def test_run_all_checks_with_explicit_repo() -> None:
 
     with patch("shutil.which", return_value="/usr/bin/gh"), \
          patch("tend.checks._gh", side_effect=fake_gh):
-        results = run_all_checks(Config("bot", "main", "T1", "T2", [], {}), repo="owner/repo")
+        results = run_all_checks(Config("bot", "main", "T1", "T2", [], "", {}), repo="owner/repo")
     assert len(results) == 3
     assert all(r.passed is True for r in results)
 


### PR DESCRIPTION
The GitHub API can return a boolean (e.g., `true`) instead of a dict for the `/repos/{owner}/{repo}/branches/{branch}/protection` endpoint. `json.loads("true")` parses to Python `True`, and calling `.get()` on a bool raises `AttributeError`.

Added an `isinstance(data, dict)` guard after JSON parsing — non-dict responses are treated like the existing "can't read details" fallback (branch is protected, assume OK). Also fixed `Config` constructor calls in tests that were missing the `setup_raw` positional argument.

> _This was written by Claude Code on behalf of @max-sixty_