### PR TITLE
fix: replace broken INVOCATION_ID with artifact_suffix input

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -31,6 +31,9 @@ inputs:
   allowed_non_write_users:
     default: "*"
     description: Non-write users allowed to trigger workflows
+  artifact_suffix:
+    default: ""
+    description: Suffix appended to session log artifact name (use for matrix jobs to avoid collisions)
   show_full_output:
     default: "true"
     description: Show full Claude output in workflow logs
@@ -99,21 +102,11 @@ runs:
           --append-system-prompt "${{ inputs.system_prompt_append }}"
           --plugin-dir ${{ github.action_path }}/plugins/tend
 
-    - name: Compute artifact name
-      if: always()
-      id: artifact
-      shell: bash
-      run: |
-        # Use INVOCATION_ID (unique per job in matrix workflows) to avoid
-        # artifact name collisions when the action runs in multiple matrix jobs
-        suffix="${INVOCATION_ID:+"-${INVOCATION_ID:0:8}"}"
-        echo "name=claude-session-logs${suffix}" >> "$GITHUB_OUTPUT"
-
     - name: Upload session logs
       if: always()
       uses: actions/upload-artifact@v7
       with:
-        name: ${{ steps.artifact.outputs.name }}
+        name: claude-session-logs${{ inputs.artifact_suffix && format('-{0}', inputs.artifact_suffix) || '' }}
         path: /home/runner/.claude/projects/
         retention-days: 30
         if-no-files-found: warn


### PR DESCRIPTION
## Summary

`INVOCATION_ID` is not a GitHub Actions environment variable — it's a systemd
concept. The suffix added in #13 was always empty, so both matrix jobs in
`review-reviewers` still upload artifacts named `claude-session-logs`, causing a
409 Conflict on the second job. Every hourly run has failed since #13 merged (5+
consecutive failures on 2026-03-24 alone).

This PR:
- Removes the broken `Compute artifact name` step and `INVOCATION_ID` logic
- Adds an `artifact_suffix` input to `action.yaml` (defaults to empty for
  non-matrix workflows)
- When set, the artifact name becomes `claude-session-logs-<suffix>`

## Remaining workflow change (needs `workflow` scope)

The `review-reviewers.yaml` workflow also needs updating to pass the suffix.
This change couldn't be pushed because the bot token lacks the `workflow` scope.
Apply manually:

```diff
--- a/.github/workflows/review-reviewers.yaml
+++ b/.github/workflows/review-reviewers.yaml
@@ -35,6 +35,12 @@ jobs:
           fetch-tags: true
           token: ${{ secrets.BOT_TOKEN }}
 
+      - name: Compute artifact suffix
+        id: suffix
+        shell: bash
+        run: echo "value=${REPO//\//-}" >> "$GITHUB_OUTPUT"
+        env:
+          REPO: ${{ matrix.repo }}
+
       - uses: max-sixty/tend@v1
         with:
           github_token: ${{ secrets.BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           bot_name: continuous-bot
+          artifact_suffix: ${{ steps.suffix.outputs.value }}
           prompt: /tend:tend-review-reviewers ${{ matrix.repo }}
```

This produces artifact names like `claude-session-logs-max-sixty-worktrunk` and
`claude-session-logs-max-sixty-tend`, avoiding the collision.

## Evidence

| Run ID | Time (UTC) | Conclusion |
|---|---|---|
| 23491281568 | 13:13 | failure (artifact collision) |
| 23488329082 | 12:00 | failure (artifact collision) |
| 23486322266 | 11:07 | failure (artifact collision) |
| 23483936695 | 10:07 | failure (artifact collision) |
| 23481521089 | 09:07 | failure (artifact collision) |

All failures show the same `upload-artifact` 409 error on the `max-sixty/worktrunk`
matrix job.

## Gate assessment

- **Evidence level**: Critical (every run fails, missing session data from worktrunk)
- **Occurrences**: 5+ today, ongoing since #13 merged
- **Change type**: Targeted fix (replace one broken mechanism with a working one)
- Both gates passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
