### PR TITLE
fix: skip tracking comment update when no new findings

### DIFF
--- a/plugins/tend/skills/tend-review-reviewers/SKILL.md
+++ b/plugins/tend/skills/tend-review-reviewers/SKILL.md
@@ -129,6 +129,11 @@ gates.
 
 ### Recording below-threshold findings
 
+**Only update the tracking issue when you have new below-threshold findings to
+record.** If a run has no new findings (no sessions to analyze, or all sessions
+were clean), skip the tracking comment entirely — do not append "no new findings"
+entries, as these add noise without evidence value.
+
 After analysis, find **the bot's existing comment** on the tracking issue and
 **append** new findings to it. If no bot comment exists yet, create one. This
 avoids notification spam from hourly runs.


### PR DESCRIPTION
## Summary

The review-reviewers skill instructs bots to append findings to a monthly
tracking issue, but doesn't say to skip updating when there are no new findings.
Every hourly run — even those with no sessions or clean sessions — appends a
"no new findings" entry. This has bloated the tracking comment on #12 to 34KB
with 29 run entries, where the majority are empty noise like:

```
## Run 23496877984 — 2026-03-24T15:14Z
No completed runs with session logs...
### No new below-threshold findings
Previously recorded observations remain unchanged (7 findings, none at threshold)
```

This makes it harder to scan for actual historical evidence when evaluating gates.

## Fix

Add explicit guidance before the "append" instructions: only update the tracking
comment when there are actual new below-threshold findings to record. Empty runs
should skip the tracking comment entirely.

## Gate assessment

- **Evidence level**: High — consistent pattern, 20+ occurrences across all runs
  since tracking issue #12 was created
- **Change type**: Targeted fix (4 lines of guidance added)
- **Historical evidence**: 29 run entries in tracking comment, majority are
  "no new findings" noise entries (verified by reading issue #12 comment
  `4113696426`)
- Both gates passed

## Sessions analyzed this run

| Run | Workflow | Repo | Assessment |
|---|---|---|---|
| 23494523814 | tend-review (PR #34) | tend | Correct — reviewed artifact_suffix fix, correctly skipped self-approval |
| 23494122035 | review-reviewers | tend→worktrunk | Correct — no sessions in window, reported all clear |
| 23496877984 | review-reviewers | tend→worktrunk | Correct — found skipped runs, reported all clear |
| 23496995775 | tend-mention | tend | Skipped (no artifacts) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
