### PR TITLE
nightly: default to PRs over issues, prompt for repo-specific overlay

### DIFF
--- a/plugins/tend/skills/tend-nightly/SKILL.md
+++ b/plugins/tend/skills/tend-nightly/SKILL.md
@@ -74,23 +74,28 @@ For each file, look for: bugs, stale documentation, dead code, simplification
 opportunities, missing tests, CLAUDE.md/skill drift. Spend roughly equal time
 per file.
 
-## Step 5: Report findings
+## Step 5: Fix findings
 
-Before creating issues, check for duplicates:
+Before acting on findings, check for duplicates and existing work:
 
 ```bash
 gh issue list --state open --json number,title
+gh pr list --state open --json number,title,headRefName
 ```
 
-For each finding (from both recent-commit review and rolling survey):
+The default action is a PR, not an issue. If there's a plausible fix, make
+it — explain uncertainty in the PR description.
 
-1. **Create a GitHub issue** — clear actionable title, include file location
-   and suggested fix
-2. **For confident fixes** (clear bugs, stale docs, obvious missing tests):
-   branch, fix, run full test suite, commit, push, create PR, poll CI.
-   **Every bug fix must include a regression test that would have failed before
-   the fix.** If a test is not feasible (e.g., pure documentation changes),
-   note why in the PR description.
+For each finding:
+
+1. **Create a PR** — branch, fix, run full test suite, commit, push, create
+   PR, poll CI. **Every bug fix must include a regression test that would have
+   failed before the fix.** If a test is not feasible (e.g., pure
+   documentation changes), note why in the PR description. When uncertain about
+   the approach, explain the trade-offs in the description.
+2. **Create an issue only when there's no obvious fix** — design questions,
+   problems needing maintainer input, or findings requiring investigation
+   beyond what the survey can provide.
 
 ## Step 6: Summary
 

--- a/plugins/tend/skills/tend-running-in-ci/SKILL.md
+++ b/plugins/tend/skills/tend-running-in-ci/SKILL.md
@@ -7,7 +7,18 @@ metadata:
 
 # Running in CI
 
-## First Steps — Read Context
+## First Steps — Load Repo-Specific Guidance
+
+Most repos have a project-specific overlay skill (typically `running-tend`)
+with conventions the generic tend skills don't know — test commands, labels,
+branch naming, survey scripts, codecov requirements. Check for one and load it
+before doing anything else:
+
+```bash
+ls .claude/skills/
+```
+
+## Read Context
 
 When triggered by a comment or issue, read the full context before responding.
 The prompt provides a URL — extract the PR/issue number from it.


### PR DESCRIPTION
The nightly was creating a GitHub issue for every finding, filling the tracker with actionable items that could just be PRs. Meanwhile, `tend-running-in-ci` never told the agent to load project-specific overlay skills, so conventions like labels, survey scripts, and test commands were silently skipped.

**tend-nightly** Step 5 now defaults to PRs. Issues are the fallback for findings with no obvious fix — design questions, maintainer input, or investigation beyond what the survey can provide.

**tend-running-in-ci** gets a new "First Steps" section that prompts the agent to `ls .claude/skills/` and load the project overlay (typically `running-tend`) before doing anything else.

> _This was written by Claude Code on behalf of @max-sixty_