### PR TITLE
simplify: fold setup_raw into setup array, detect default branch at init

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,24 +89,24 @@ setup = [
 ]
 ```
 
-For actions that need `with:` parameters, use `setup_raw` — a multiline string of
-GitHub Actions YAML injected verbatim into the workflow steps:
+For actions that need `with:` parameters, use `{raw = "..."}` — a multiline
+string of GitHub Actions YAML injected verbatim:
 
 ```toml
 setup = [
   {uses = "cargo-bins/cargo-binstall@main"},
   {run = "cargo binstall cargo-insta --no-confirm"},
-]
-setup_raw = """
+  {raw = """
 - uses: Swatinem/rust-cache@v2
   with:
     save-if: false
-"""
+"""},
+]
 ```
 
-`setup` entries are `{uses = "..."}` or `{run = "..."}` (no `with:` support).
-`setup_raw` handles everything else. For very complex setups, a local composite
-action (`.github/actions/tend-setup/action.yaml`) referenced via `uses` is an
+Each entry is `{uses = "..."}`, `{run = "..."}`, or `{raw = "..."}`. For very
+complex setups, a local composite action
+(`.github/actions/tend-setup/action.yaml`) referenced via `uses` is an
 alternative.
 
 ### Workflow overrides

--- a/generator/src/tend/cli.py
+++ b/generator/src/tend/cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import click
@@ -9,6 +10,23 @@ import click
 from tend.checks import CheckResult, detect_repo, fix_branch_protection, run_all_checks
 from tend.config import Config
 from tend.workflows import generate_all
+
+
+def _detect_default_branch() -> str:
+    """Detect the default branch from git remote."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "origin/HEAD"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0:
+            # Returns "origin/main" or "origin/master" — strip the remote prefix
+            ref = result.stdout.strip()
+            if "/" in ref:
+                return ref.split("/", 1)[1]
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    return "main"
 
 
 def _print_check_results(results: list[CheckResult]) -> None:
@@ -34,6 +52,7 @@ def main() -> None:
 def init(config_path: Path | None, dry_run: bool) -> None:
     """Generate workflow files from config. Idempotent — always overwrites."""
     cfg = Config.load(config_path)
+    cfg.default_branch = _detect_default_branch()
     outdir = Path(".github/workflows")
 
     workflows = generate_all(cfg)

--- a/generator/src/tend/config.py
+++ b/generator/src/tend/config.py
@@ -10,16 +10,17 @@ from pathlib import Path
 import click
 
 KNOWN_WORKFLOWS = {"review", "mention", "triage", "ci-fix", "nightly", "renovate"}
-KNOWN_TOP_LEVEL = {"bot_name", "secrets", "setup", "setup_raw", "workflows"}
+KNOWN_TOP_LEVEL = {"bot_name", "secrets", "setup", "workflows"}
 _GITHUB_USERNAME = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$")
 
 
 @dataclass
 class SetupStep:
-    """A single project setup step — either a `uses:` action or a `run:` command."""
+    """A single project setup step — `uses:`, `run:`, or `raw:` YAML."""
 
     uses: str = ""
     run: str = ""
+    raw: str = ""
 
 
 @dataclass
@@ -28,15 +29,16 @@ class WorkflowConfig:
     prompt: str = ""
     cron: str = ""
     watched_workflows: list[str] | None = None
+    branches: list[str] | None = None
 
 
 @dataclass
 class Config:
     bot_name: str
+    default_branch: str
     bot_token_secret: str
     claude_token_secret: str
     setup: list[SetupStep]
-    setup_raw: str
     workflows: dict[str, WorkflowConfig]
 
     @classmethod
@@ -70,20 +72,15 @@ class Config:
         for i, entry in enumerate(raw.get("setup", [])):
             if not isinstance(entry, dict):
                 raise click.ClickException(
-                    f"setup[{i}] must be a table with 'uses' or 'run'"
+                    f"setup[{i}] must be a table with 'uses', 'run', or 'raw'"
                 )
-            if "uses" in entry and "run" in entry:
+            keys = {"uses", "run", "raw"} & entry.keys()
+            if len(keys) != 1:
                 raise click.ClickException(
-                    f"setup[{i}] must have 'uses' or 'run', not both"
+                    f"setup[{i}] must have exactly one of 'uses', 'run', or 'raw'"
                 )
-            if "uses" in entry:
-                setup.append(SetupStep(uses=entry["uses"]))
-            elif "run" in entry:
-                setup.append(SetupStep(run=entry["run"]))
-            else:
-                raise click.ClickException(
-                    f"setup[{i}] must have 'uses' or 'run'"
-                )
+            key = keys.pop()
+            setup.append(SetupStep(**{key: entry[key]}))
 
         workflows: dict[str, WorkflowConfig] = {}
         for name, wf_raw in raw.get("workflows", {}).items():
@@ -102,15 +99,16 @@ class Config:
                     prompt=wf_raw.get("prompt", ""),
                     cron=wf_raw.get("cron", ""),
                     watched_workflows=watched,
+                    branches=wf_raw.get("branches"),
                 )
             else:
                 workflows[name] = WorkflowConfig(enabled=bool(wf_raw))
 
         return cls(
             bot_name=bot_name,
+            default_branch="main",
             bot_token_secret=secrets.get("bot_token", "BOT_TOKEN"),
             claude_token_secret=secrets.get("claude_token", "CLAUDE_CODE_OAUTH_TOKEN"),
             setup=setup,
-            setup_raw=raw.get("setup_raw", ""),
             workflows=workflows,
         )

--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -41,8 +41,8 @@ def _setup_yaml(cfg: Config, indent: int = 6) -> str:
             lines.append(f"{pad}- uses: {step.uses}")
         elif step.run:
             lines.append(f"{pad}- run: {step.run}")
-    if cfg.setup_raw:
-        lines.append(_reindent(cfg.setup_raw, indent))
+        elif step.raw:
+            lines.append(_reindent(step.raw, indent))
     if not lines:
         return ""
     return "\n" + "\n".join(lines) + "\n"
@@ -406,6 +406,7 @@ jobs:
 def generate_ci_fix(cfg: Config) -> GeneratedWorkflow:
     wf = cfg.workflows.get("ci-fix", WorkflowConfig())
     watched = wf.watched_workflows if wf.watched_workflows is not None else ["ci"]
+    branches = wf.branches if wf.branches is not None else [cfg.default_branch]
     prompt = (wf.prompt or "/tend:tend-ci-fix {run_id}").replace(
         "{run_id}", "${{ github.event.workflow_run.id }}"
     )
@@ -416,6 +417,7 @@ def generate_ci_fix(cfg: Config) -> GeneratedWorkflow:
     setup = _setup_yaml(cfg)
     perms = _permissions(issues=False)
     watched_yaml = ", ".join(f'"{w}"' for w in watched)
+    branches_yaml = ", ".join(f'"{b}"' for b in branches)
 
     content = f"""\
 {HEADER}
@@ -424,12 +426,11 @@ on:
   workflow_run:
     workflows: [{watched_yaml}]
     types: [completed]
+    branches: [{branches_yaml}]
 
 jobs:
   fix-ci:
-    if: >-
-      github.event.workflow_run.conclusion == 'failure' &&
-      github.event.workflow_run.head_branch == github.event.repository.default_branch
+    if: github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     permissions:

--- a/generator/tests/test_checks.py
+++ b/generator/tests/test_checks.py
@@ -174,7 +174,7 @@ def test_secrets_bad_json() -> None:
 
 def test_run_all_checks_no_gh() -> None:
     with patch("shutil.which", return_value=None):
-        results = run_all_checks(Config("bot", "T1", "T2", [], "", {}))
+        results = run_all_checks(Config("bot", "main", "T1", "T2", [], {}))
     assert len(results) == 1
     assert results[0].passed is None
     assert "gh CLI" in results[0].message
@@ -183,7 +183,7 @@ def test_run_all_checks_no_gh() -> None:
 def test_run_all_checks_no_repo() -> None:
     with patch("shutil.which", return_value="/usr/bin/gh"), \
          patch("tend.checks.detect_repo", return_value=None):
-        results = run_all_checks(Config("bot", "T1", "T2", [], "", {}))
+        results = run_all_checks(Config("bot", "main", "T1", "T2", [], {}))
     assert len(results) == 1
     assert "detect" in results[0].message
 
@@ -206,7 +206,7 @@ def test_run_all_checks_with_explicit_repo() -> None:
 
     with patch("shutil.which", return_value="/usr/bin/gh"), \
          patch("tend.checks._gh", side_effect=fake_gh):
-        results = run_all_checks(Config("bot", "T1", "T2", [], "", {}), repo="owner/repo")
+        results = run_all_checks(Config("bot", "main", "T1", "T2", [], {}), repo="owner/repo")
     assert len(results) == 3
     assert all(r.passed is True for r in results)
 

--- a/generator/tests/test_config_edge_cases.py
+++ b/generator/tests/test_config_edge_cases.py
@@ -421,12 +421,12 @@ def test_setup_steps_empty_list(tmp_path: Path) -> None:
 
 
 def test_setup_steps_entry_missing_key(tmp_path: Path) -> None:
-    """setup entry without uses or run is rejected."""
+    """setup entry without uses, run, or raw is rejected."""
     path = _write_config(tmp_path, dedent("""\
         bot_name = "my-bot"
         setup = [{name = "oops"}]
     """))
-    with pytest.raises(ClickException, match="setup\\[0\\] must have 'uses' or 'run'"):
+    with pytest.raises(ClickException, match="setup\\[0\\] must have exactly one"):
         Config.load(path)
 
 
@@ -436,7 +436,7 @@ def test_setup_steps_entry_both_keys(tmp_path: Path) -> None:
         bot_name = "my-bot"
         setup = [{uses = "action", run = "cmd"}]
     """))
-    with pytest.raises(ClickException, match="setup\\[0\\] must have 'uses' or 'run', not both"):
+    with pytest.raises(ClickException, match="setup\\[0\\] must have exactly one"):
         Config.load(path)
 
 

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -106,6 +106,18 @@ def test_watched_workflows(tmp_path: Path) -> None:
     assert '"build"' in ci_fix.content
     assert '"test"' in ci_fix.content
     assert '"lint"' in ci_fix.content
+    assert 'branches: ["main"]' in ci_fix.content
+
+
+def test_ci_fix_custom_branches(tmp_path: Path) -> None:
+    extra = dedent("""\
+        [workflows.ci-fix]
+        branches = ["main", "release"]
+    """)
+    cfg = Config.load(_minimal_config(tmp_path, extra))
+    workflows = {wf.filename: wf for wf in generate_all(cfg)}
+    ci_fix = workflows["tend-ci-fix.yaml"]
+    assert 'branches: ["main", "release"]' in ci_fix.content
 
 
 def test_cli_init_dry_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -144,15 +156,17 @@ def test_setup_after_pr_checkout_in_review(tmp_path: Path) -> None:
 
 
 def test_setup_raw_yaml_injected(tmp_path: Path) -> None:
-    extra = dedent("""\
-        setup_raw = \"\"\"
+    extra = dedent('''\
+        setup = [
+          {raw = """
         - uses: Swatinem/rust-cache@v2
           with:
             save-if: false
         - run: cargo binstall cargo-insta --no-confirm
           shell: bash
-        \"\"\"
-    """)
+        """},
+        ]
+    ''')
     cfg = Config.load(_minimal_config(tmp_path, extra))
     for wf in generate_all(cfg):
         data = yaml.safe_load(wf.content)
@@ -162,30 +176,29 @@ def test_setup_raw_yaml_injected(tmp_path: Path) -> None:
         assert "cargo binstall" in wf.content, f"{wf.filename} missing raw run step"
 
 
-def test_setup_raw_combined_with_steps(tmp_path: Path) -> None:
-    extra = dedent("""\
+def test_setup_raw_interleaved_with_steps(tmp_path: Path) -> None:
+    extra = dedent('''\
         setup = [
           {uses = "./.github/actions/my-setup"},
-          {run = "echo FOO=bar >> $GITHUB_ENV"},
-        ]
-        setup_raw = \"\"\"
+          {raw = """
         - uses: Swatinem/rust-cache@v2
           with:
             save-if: false
-        \"\"\"
-    """)
+        """},
+          {run = "echo FOO=bar >> $GITHUB_ENV"},
+        ]
+    ''')
     cfg = Config.load(_minimal_config(tmp_path, extra))
     for wf in generate_all(cfg):
         assert "./.github/actions/my-setup" in wf.content
-        assert "echo FOO=bar" in wf.content
         assert "Swatinem/rust-cache@v2" in wf.content
         assert "save-if: false" in wf.content
-        # raw steps must come after uses and run steps
+        assert "echo FOO=bar" in wf.content
+        # Order preserved: uses, raw, run
         uses_idx = wf.content.index("./.github/actions/my-setup")
-        run_idx = wf.content.index("echo FOO=bar")
         raw_idx = wf.content.index("Swatinem/rust-cache@v2")
-        assert uses_idx < raw_idx, f"{wf.filename}: raw before uses"
-        assert run_idx < raw_idx, f"{wf.filename}: raw before run"
+        run_idx = wf.content.index("echo FOO=bar")
+        assert uses_idx < raw_idx < run_idx, f"{wf.filename}: wrong order"
 
 
 def test_setup_after_pr_checkout_in_mention(tmp_path: Path) -> None:


### PR DESCRIPTION
Setup entries now support three types — `{uses}`, `{run}`, and `{raw}`. Raw YAML entries can be interleaved with structured steps:

```toml
setup = [
  {uses = "cargo-bins/cargo-binstall@main"},
  {raw = """
- uses: Swatinem/rust-cache@v2
  with:
    save-if: false
"""},
  {run = "cargo binstall cargo-insta --no-confirm"},
]
```

This replaces the separate `setup_raw` top-level key, which forced raw YAML to always come after all structured steps.

The ci-fix workflow's `branches:` filter is now populated by detecting the default branch from git at `tend init` time (`git rev-parse --abbrev-ref origin/HEAD`, falling back to `"main"`). Override with config:

```toml
[workflows.ci-fix]
branches = ["main", "release"]
```

Follows #18 (merged).

> _This was written by Claude Code on behalf of @max-sixty_