### PR TITLE
docs: document fork PR inline comment limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,27 @@ Repos using `anthropics/claude-code-action` should delete that workflow — tend
 replaces it. Update team members to @-mention the bot account instead of
 `@claude`. Verify no other workflows reference `anthropics/claude-code-action`.
 
+## Limitations
+
+### Inline review comments on fork PRs
+
+GitHub has no event type that provides secret access for inline code review
+comments on fork PRs. The `pull_request_review_comment` event fires, but
+[secrets are unavailable for workflows triggered from forks][gh-secrets-forks].
+Unlike `pull_request` (which has `pull_request_target` as a secrets-safe
+equivalent), there is no `pull_request_review_comment_target` — GitHub has
+[no plans to add one][gh-discussion-55940].
+
+In practice this means `tend-mention` cannot respond to inline review comments
+on fork PRs. Conversation-tab comments work fine — the `issue_comment` event
+always runs in the base repository context with full secret access.
+
+**Workaround:** comment on the conversation tab instead of inline when
+interacting with the bot on a fork PR.
+
+[gh-secrets-forks]: https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#using-secrets-in-a-workflow
+[gh-discussion-55940]: https://github.com/orgs/community/discussions/55940
+
 ## Security
 
 See [docs/security-model.md](docs/security-model.md).

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -122,17 +122,28 @@ secrets.
 GitHub treats PRs as a superset of issues. Comments on a PR arrive via
 different event types depending on where they're posted:
 
-- **Conversation tab** → `issue_comment` event. The PR is at
+- **Conversation tab** → `issue_comment` event. Runs in base repo context —
+  secrets available even for fork PRs. The PR is at
   `github.event.issue.pull_request`. The PR number is
   `github.event.issue.number`.
-- **Files changed (inline)** → `pull_request_review_comment` event. The PR is
-  at `github.event.pull_request`. There is no `github.event.issue`.
-- **Review submission** → `pull_request_review` event (type: `submitted`). The
-  review is at `github.event.review`. The PR is at
-  `github.event.pull_request`.
+- **Files changed (inline)** → `pull_request_review_comment` event. Runs in
+  fork context — no secret access for fork PRs (same restriction as
+  `pull_request`). The PR is at `github.event.pull_request`. There is no
+  `github.event.issue`.
+- **Review submission** → `pull_request_review` event (type: `submitted`). Same
+  fork restriction as `pull_request_review_comment`. The review is at
+  `github.event.review`. The PR is at `github.event.pull_request`.
 
 Individual inline comments from a review also fire as separate
 `pull_request_review_comment` events.
+
+GitHub provides `pull_request_target` as a secrets-safe equivalent of
+`pull_request`, but no such variant exists for `pull_request_review_comment` or
+`pull_request_review` ([community discussion][gh-55940]). This means
+`tend-mention` cannot respond to inline review comments on fork PRs.
+Conversation-tab comments (`issue_comment`) are unaffected.
+
+[gh-55940]: https://github.com/orgs/community/discussions/55940
 
 ## Rules for modifying workflows
 


### PR DESCRIPTION
GitHub provides no secrets-safe event type for inline review comments on fork PRs. `pull_request_review_comment` runs in the fork context without secret access, and unlike `pull_request` (which has `pull_request_target`), there is no `_target` variant — GitHub has [no plans to add one](https://github.com/orgs/community/discussions/55940).

This adds a Limitations section to the README explaining the workaround (use conversation-tab comments instead), and enriches the security model's event type reference with fork-context details for each event.

> _This was written by Claude Code on behalf of @max-sixty_