### PR TITLE
fix: correct jq queries in debug-ci-session against real session logs

### DIFF
--- a/plugins/install-tend/skills/debug-ci-session/SKILL.md
+++ b/plugins/install-tend/skills/debug-ci-session/SKILL.md
@@ -52,7 +52,10 @@ gh run view "$RUN_ID" -R "$REPO" --log-failed
 
 ## Parse session logs
 
-Each JSONL line has a `type` field: `user`, `assistant`, or `system`.
+Each JSONL line has a `type` field. The main message types are `user` and
+`assistant` (with `.message.content`). Other types (`system`, `progress`,
+`queue-operation`, `last-prompt`) carry metadata — ignore them for most
+debugging.
 
 ### Overview — what happened
 
@@ -104,10 +107,10 @@ jq -r 'select(.type == "assistant") | .message.content[]? |
   select(.type == "tool_use" and (.name == "Write" or .name == "Edit")) |
   "\(.name): \(.input.file_path)"' "$FILE"
 
-# GitHub API calls (gh commands)
+# GitHub API calls (gh commands, including inside variable assignments)
 jq -r 'select(.type == "assistant") | .message.content[]? |
   select(.type == "tool_use" and .name == "Bash") |
-  .input.command | select(startswith("gh ") or contains("| gh "))' "$FILE"
+  .input.command | select(test("\\bgh\\b"))' "$FILE"
 ```
 
 ### Searching for specific behavior


### PR DESCRIPTION
Tested all jq queries in `debug-ci-session` against real session log artifacts (3 sessions from worktrunk and tend repos, 6-122 lines each). Two fixes:

- **Type documentation**: real sessions have `user`, `assistant`, `progress`, `queue-operation`, `last-prompt`, `system` — not just three types. Updated to document the main message types (`user`/`assistant` with `.message.content`) and note the rest as metadata.
- **gh commands query**: `\bgh\b` regex replaces `startswith`/`contains` filter that missed `gh` calls inside variable assignments and multi-line scripts (caught 14/14 vs 5/14 on a real review session).

> _This was written by Claude Code on behalf of @max-sixty_