### PR TITLE
feat: auto-move v1 tag on push to main

### DIFF
--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -2,7 +2,7 @@ name: Release to PyPI
 
 on:
   push:
-    tags: ["*"]
+    tags: ["[0-9]*"]
 
 jobs:
   build:

--- a/.github/workflows/update-action-tag.yaml
+++ b/.github/workflows/update-action-tag.yaml
@@ -1,0 +1,19 @@
+name: Update action tag
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  update-tag:
+    runs-on: ubuntu-latest
+    if: github.repository == 'max-sixty/tend'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Move v1 tag to HEAD
+        run: |
+          git tag -f v1
+          git push -f origin v1


### PR DESCRIPTION
The `v1` tag was 31 commits behind main — consuming repos using `max-sixty/tend@v1` were stuck on a stale action.yaml.

Adds a workflow that force-updates the `v1` tag to HEAD on every push to main, matching the standard GitHub Actions convention (e.g. how `actions/checkout@v6` tracks the latest v6.x). Narrows the pypi-release trigger from `["*"]` to `["[0-9]*"]` so moving `v1` doesn't trigger a spurious PyPI release.

> _This was written by Claude Code on behalf of @max-sixty_