### PR TITLE
fix: recheck for new comments before posting in CI

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -136,6 +136,35 @@ Reply in context rather than creating new top-level comments:
 - **Conversation comments** (`#issuecomment-`): Post a regular comment (GitHub
   doesn't support threading).
 
+## Recheck Before Posting
+
+Long-running tasks (triage, review, CI diagnosis) can take minutes. By the time
+you're ready to comment, new discussion may have arrived that changes the
+context — a human may have already answered, the author may have pushed a fix,
+or new information may make your response redundant or wrong.
+
+**Before posting any comment or review**, re-fetch the current conversation
+state:
+
+```bash
+# For issues
+gh issue view <number> --json comments --jq '.comments | length'
+
+# For PRs (comments + reviews)
+gh pr view <number> --json comments,reviews \
+  --jq '{comments: (.comments | length), reviews: (.reviews | length)}'
+```
+
+Compare with the count you saw when you first read the context. If new comments
+or reviews appeared:
+
+1. **Read the new comments** to understand what changed.
+2. **Adjust or skip your response.** If someone already answered, don't repeat
+   them. If the author resolved the issue, acknowledge that instead of posting
+   a stale analysis. If new information contradicts your findings, update your
+   response before posting.
+3. **If your response is now entirely redundant, don't post it.**
+
 ## Comment Formatting
 
 Keep comments concise. Put supporting detail inside `<details>` tags — the


### PR DESCRIPTION
## Problem

The bot posts stale comments after long-running tasks (triage, review, CI diagnosis) without checking whether new discussion arrived while it was working. This leads to redundant or contextually wrong responses — e.g., posting an analysis after a human already answered, or suggesting a fix after the author already pushed one.

Reported in #52 with [a concrete example](https://github.com/max-sixty/worktrunk/issues/1719#issuecomment-4124360570).

## Solution

Adds a "Recheck Before Posting" section to the `running-in-ci` shared skill. This is the right location because `running-in-ci` is co-loaded by all CI workflows (triage, review, ci-fix, nightly), so the guidance applies everywhere without duplication.

The guidance instructs the bot to:
1. Re-fetch the comment/review count before posting
2. Compare with the count seen at initial context read
3. Read any new comments and adjust or skip the response accordingly

## Testing

This is a skill text change (prompt guidance), not code — no unit tests apply. The fix was verified by confirming no other co-loaded skill already contains this guidance, and that `running-in-ci` is the canonical shared skill for all CI workflows.

---
Closes #52 — automated triage
