### PR TITLE
fix: add backward-compat aliases for pre-0.0.2 skill names

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,6 +18,11 @@
       "name": "tend-ci-runner",
       "description": "Internal CI skills loaded by tend's GitHub Action. Not for manual installation.",
       "source": "./plugins/tend-ci-runner"
+    },
+    {
+      "name": "tend",
+      "description": "Legacy alias for tend-ci-runner. Resolves pre-0.0.2 skill names (e.g. /tend:tend-review).",
+      "source": "./plugins/tend-compat"
     }
   ]
 }

--- a/action.yaml
+++ b/action.yaml
@@ -85,6 +85,7 @@ runs:
         claude plugin marketplace add https://github.com/max-sixty/tend.git
         claude plugin install install-tend@tend
         claude plugin install tend-ci-runner@tend
+        claude plugin install tend@tend
 
     - name: Run Claude Code
       id: claude

--- a/plugins/tend-compat/.claude-plugin/plugin.json
+++ b/plugins/tend-compat/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "tend",
+  "version": "0.1.0",
+  "description": "Legacy alias for tend-ci-runner. Resolves pre-0.0.2 skill names like /tend:tend-review.",
+  "author": {
+    "name": "Maximilian Roos",
+    "url": "https://github.com/max-sixty"
+  },
+  "repository": "https://github.com/max-sixty/tend",
+  "license": "MIT"
+}

--- a/plugins/tend-compat/skills/tend-ci-fix
+++ b/plugins/tend-compat/skills/tend-ci-fix
@@ -1,0 +1,1 @@
+../../tend-ci-runner/skills/ci-fix

--- a/plugins/tend-compat/skills/tend-nightly
+++ b/plugins/tend-compat/skills/tend-nightly
@@ -1,0 +1,1 @@
+../../tend-ci-runner/skills/nightly

--- a/plugins/tend-compat/skills/tend-renovate
+++ b/plugins/tend-compat/skills/tend-renovate
@@ -1,0 +1,1 @@
+../../tend-ci-runner/skills/renovate

--- a/plugins/tend-compat/skills/tend-review
+++ b/plugins/tend-compat/skills/tend-review
@@ -1,0 +1,1 @@
+../../tend-ci-runner/skills/review

--- a/plugins/tend-compat/skills/tend-review-reviewers
+++ b/plugins/tend-compat/skills/tend-review-reviewers
@@ -1,0 +1,1 @@
+../../tend-ci-runner/skills/review-reviewers

--- a/plugins/tend-compat/skills/tend-running-in-ci
+++ b/plugins/tend-compat/skills/tend-running-in-ci
@@ -1,0 +1,1 @@
+../../tend-ci-runner/skills/running-in-ci

--- a/plugins/tend-compat/skills/tend-triage
+++ b/plugins/tend-compat/skills/tend-triage
@@ -1,0 +1,1 @@
+../../tend-ci-runner/skills/triage


### PR DESCRIPTION
## Summary

- Adds a `tend-compat` plugin registered as `tend` in the marketplace, containing symlinks from old skill names (`tend-review`, `tend-triage`, etc.) to the real `tend-ci-runner` skills
- Updates `action.yaml` to install the compat plugin alongside `tend-ci-runner`

## Root cause

The plugin rename from `tend` → `tend-ci-runner` in #39 changed both the plugin name and skill names (e.g. `tend-review` → `review`). Adopter workflows generated before v0.0.2 reference `/tend:tend-review` — a plugin called `tend` with a skill called `tend-review`.

When the `v1` tag auto-moved (#49), adopter runs started failing silently: the workflow reports `success` but Claude receives `"Unknown skill: tend:tend-review"` and performs no review.

## Evidence

All 4 `tend-review` runs on `max-sixty/worktrunk` in the past hour failed identically:

| Run | PR | Error |
|---|---|---|
| [23558948684](https://github.com/max-sixty/worktrunk/actions/runs/23558948684) | #1713 | `Unknown skill: tend:tend-review` |
| [23558265657](https://github.com/max-sixty/worktrunk/actions/runs/23558265657) | #1667 | `Unknown skill: tend:tend-review` |
| [23558140064](https://github.com/max-sixty/worktrunk/actions/runs/23558140064) | #1713 | `Unknown skill: tend:tend-review` |
| [23558023083](https://github.com/max-sixty/worktrunk/actions/runs/23558023083) | #1667 | `Unknown skill: tend:tend-review` |

Session logs confirm zero assistant messages — Claude never ran. The earlier run at 17:12 UTC ([23554107050](https://github.com/max-sixty/worktrunk/actions/runs/23554107050)) still worked because the `v1` tag hadn't moved yet.

**Gate assessment**: Critical evidence (clearly wrong outcome — PRs going completely unreviewed), 4 occurrences. Targeted fix (new compat plugin with symlinks).

## Adopter action

Adopter repos should still regenerate workflows with `uvx tend init` to use the canonical `/tend-ci-runner:review` names. This compat layer prevents silent failures in the interim.

## Test plan

- [ ] Verify symlinks resolve correctly when the plugin is installed via `claude plugin install tend@tend`
- [ ] Confirm `/tend:tend-review` resolves to the review skill content
- [ ] Run a test review on worktrunk after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
