### PR TITLE
fix: use v1 branch instead of floating tag

### DIFF
--- a/.github/workflows/update-action-tag.yaml
+++ b/.github/workflows/update-action-tag.yaml
@@ -1,11 +1,11 @@
-name: Update action tag
+name: Update action branch
 
 on:
   push:
     branches: [main]
 
 jobs:
-  update-tag:
+  update-branch:
     runs-on: ubuntu-latest
     if: github.repository == 'max-sixty/tend'
     permissions:
@@ -13,7 +13,5 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Move v1 tag to HEAD
-        run: |
-          git tag -f v1
-          git push -f origin v1
+      - name: Update v1 branch to match main
+        run: git push origin HEAD:refs/heads/v1


### PR DESCRIPTION
Floating tags cause `git fetch` failures ("would clobber existing tag") for anyone with a local clone. Switches to a branch, which is the convention for GitHub Actions major-version refs (`actions/checkout@v4` is a branch). GitHub Actions resolves `@v1` identically either way.

The remote `v1` tag has been deleted and replaced with a `v1` branch already — this PR updates the workflow to push to the branch instead of force-pushing a tag.

> _This was written by Claude Code on behalf of @max-sixty_