### PR TITLE
fix: use full clone in v1 branch update workflow

### DIFF
--- a/.github/workflows/update-action-branch.yaml
+++ b/.github/workflows/update-action-branch.yaml
@@ -12,6 +12,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Update v1 branch to match main
         run: git push origin HEAD:refs/heads/v1


### PR DESCRIPTION
## Summary

- Adds `fetch-depth: 0` to the checkout step in the v1 branch update workflow so git has full history to prove the fast-forward push

## Root cause

The "Update action branch" workflow uses a shallow clone (default `fetch-depth: 1`), which only has the tip commit. When pushing `HEAD:refs/heads/v1`, git cannot prove to the remote that the push is a fast-forward without the common ancestor in local history. The remote rejects with:

```
! [rejected]        HEAD -> v1 (fetch first)
error: failed to push some refs to 'https://github.com/max-sixty/tend'
hint: Updates were rejected because the remote contains work that you do not
hint: have locally.
```

This broke the v1 auto-update when PR #55 merged, keeping `v1` stuck at `fbf397e` while main advanced to `9466b6a`. The compat fix (PR #54) — which unblocks all adopter review runs — cannot reach adopters until v1 is updated.

## Evidence

- **Failed run**: [23561357476](https://github.com/max-sixty/tend/actions/runs/23561357476) — `git push origin HEAD:refs/heads/v1` rejected
- **v1 status**: 4 commits behind main, 0 ahead (confirmed via GitHub compare API)
- **Impact**: All `tend-review` runs on adopter repos (e.g. max-sixty/worktrunk) continue failing with `Unknown skill: tend:tend-review` because v1 still points to pre-compat code

## Gate assessment

- **Evidence level**: Critical — clearly wrong outcome (v1 update mechanism is completely broken, preventing fixes from reaching adopters)
- **Occurrences**: 1 (the first and only run of this workflow since PR #55 merged)
- **Change type**: Targeted fix (add one parameter to checkout step)
- **Passes both gates**: Yes

## Test plan

- [ ] Merge this PR to trigger the workflow on the push-to-main event
- [ ] Verify the "Update action branch" workflow succeeds
- [ ] Confirm v1 branch SHA matches main after workflow completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)