### PR TITLE
feat: add fork privilege mode (triage + fork)

### DIFF
--- a/.config/tend.toml
+++ b/.config/tend.toml
@@ -1,4 +1,5 @@
 bot_name = "tend-agent"
+mode = "write"
 
 [workflows.ci-fix]
 watched_workflows = ["ci"]

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -55,6 +55,7 @@ Four pieces:
 
    ```toml
    bot_name = "worktrunk-bot"
+   mode = "fork"  # or "write"
 
    [secrets]
    bot_token = "WORKTRUNK_BOT_TOKEN"

--- a/action.yaml
+++ b/action.yaml
@@ -37,6 +37,9 @@ inputs:
   use_sticky_comment:
     default: "false"
     description: Use a sticky (updated) comment instead of new comments
+  mode:
+    default: "write"
+    description: "Privilege model: fork (triage + fork) or write (write + branch protection)"
   additional_permissions:
     default: "actions: read"
     description: Additional permissions for claude-code-action
@@ -47,6 +50,10 @@ runs:
     - name: Security preflight
       shell: bash
       run: |
+        if [ "$MODE" = "fork" ]; then
+          echo "Fork mode — branch protection not required (triage collaborator level is the security boundary)"
+          exit 0
+        fi
         DEFAULT_BRANCH=$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.default_branch')
         PROTECTED=$(gh api "repos/${GITHUB_REPOSITORY}/branches/${DEFAULT_BRANCH}" --jq '.protected')
         if [ "$PROTECTED" != "true" ]; then
@@ -56,6 +63,7 @@ runs:
         echo "Security preflight passed: default branch '${DEFAULT_BRANCH}' is protected"
       env:
         GH_TOKEN: ${{ inputs.github_token }}
+        MODE: ${{ inputs.mode }}
 
     - name: Install CI scripts
       shell: bash
@@ -89,6 +97,8 @@ runs:
     - name: Run Claude Code
       id: claude
       uses: anthropics/claude-code-action@v1
+      env:
+        TEND_MODE: ${{ inputs.mode }}
       with:
         show_full_output: ${{ inputs.show_full_output }}
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}

--- a/generator/src/tend/checks.py
+++ b/generator/src/tend/checks.py
@@ -123,8 +123,12 @@ def _has_restrict_updates_ruleset(repo: str, branch: str) -> bool:
         return False
 
 
-def check_bot_permission(repo: str, bot_name: str) -> CheckResult:
-    """Check the bot's permission level (should be write, not admin)."""
+def check_bot_permission(repo: str, bot_name: str, mode: str = "write") -> CheckResult:
+    """Check the bot's permission level.
+
+    In write mode: should be write, not admin.
+    In fork mode: should be triage (not write or admin — write is unnecessary risk).
+    """
     result = _gh("api", f"repos/{repo}/collaborators/{bot_name}/permission", "--jq", ".permission")
     if result is None:
         return CheckResult("bot-permission", None, "gh CLI not found")
@@ -143,8 +147,17 @@ def check_bot_permission(repo: str, bot_name: str) -> CheckResult:
             "bot-permission",
             False,
             f"Bot '{bot_name}' has admin permission — it can bypass branch protection. "
-            "Downgrade to write access.",
+            f"Downgrade to {'triage' if mode == 'fork' else 'write'} access.",
         )
+    if mode == "fork":
+        if perm in ("write", "maintain"):
+            return CheckResult(
+                "bot-permission",
+                False,
+                f"Bot '{bot_name}' has '{perm}' permission — fork mode only needs triage. "
+                "Downgrade to triage to reduce blast radius.",
+            )
+        return CheckResult("bot-permission", True, f"Bot '{bot_name}' has '{perm}' permission")
     return CheckResult("bot-permission", True, f"Bot '{bot_name}' has '{perm}' permission")
 
 
@@ -262,8 +275,14 @@ def run_all_checks(cfg: Config, repo: str | None = None) -> list[CheckResult]:
     if default_branch is None:
         return [CheckResult("prerequisites", None, f"Could not detect default branch for {repo}")]
 
-    return [
-        check_branch_protection(repo, default_branch),
-        check_bot_permission(repo, cfg.bot_name),
-        check_secrets(repo, [cfg.bot_token_secret, cfg.claude_token_secret]),
-    ]
+    checks = []
+    if cfg.mode == "fork":
+        checks.append(CheckResult(
+            "branch-protection", True,
+            "Fork mode — branch protection not required (triage collaborator level is the security boundary)",
+        ))
+    else:
+        checks.append(check_branch_protection(repo, default_branch))
+    checks.append(check_bot_permission(repo, cfg.bot_name, cfg.mode))
+    checks.append(check_secrets(repo, [cfg.bot_token_secret, cfg.claude_token_secret]))
+    return checks

--- a/generator/src/tend/config.py
+++ b/generator/src/tend/config.py
@@ -10,7 +10,8 @@ from pathlib import Path
 import click
 
 KNOWN_WORKFLOWS = {"review", "mention", "triage", "ci-fix", "nightly", "renovate"}
-KNOWN_TOP_LEVEL = {"bot_name", "secrets", "setup", "workflows"}
+KNOWN_TOP_LEVEL = {"bot_name", "mode", "secrets", "setup", "workflows"}
+VALID_MODES = ("fork", "write")
 _GITHUB_USERNAME = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$")
 
 
@@ -35,6 +36,7 @@ class WorkflowConfig:
 @dataclass
 class Config:
     bot_name: str
+    mode: str
     default_branch: str
     bot_token_secret: str
     claude_token_secret: str
@@ -60,6 +62,14 @@ class Config:
             raise click.ClickException(
                 f"bot_name '{bot_name}' is not a valid GitHub username "
                 "(only letters, digits, and hyphens)"
+            )
+
+        if "mode" not in raw:
+            raise click.ClickException("Missing required field: mode (must be 'fork' or 'write')")
+        mode = raw["mode"]
+        if mode not in VALID_MODES:
+            raise click.ClickException(
+                f"mode must be 'fork' or 'write', got '{mode}'"
             )
 
         unknown = set(raw.keys()) - KNOWN_TOP_LEVEL
@@ -106,6 +116,7 @@ class Config:
 
         return cls(
             bot_name=bot_name,
+            mode=mode,
             default_branch="main",
             bot_token_secret=secrets.get("bot_token", "BOT_TOKEN"),
             claude_token_secret=secrets.get("claude_token", "CLAUDE_CODE_OAUTH_TOKEN"),

--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -50,9 +50,10 @@ def _setup_yaml(cfg: Config, indent: int = 6) -> str:
     return "\n" + "\n".join(lines) + "\n"
 
 
-def _permissions(issues: bool = True) -> str:
+def _permissions(mode: str = "write", issues: bool = True) -> str:
+    contents = "read" if mode == "fork" else "write"
     lines = [
-        "      contents: write",
+        f"      contents: {contents}",
         "      pull-requests: write",
         "      id-token: write",
         "      actions: read",
@@ -60,6 +61,19 @@ def _permissions(issues: bool = True) -> str:
     if issues:
         lines.append("      issues: write")
     return "\n".join(lines)
+
+
+def _fork_remote_step(bot_name: str, bot_token: str, indent: int = 6) -> str:
+    """Generate a step that adds the bot's fork as a git remote."""
+    pad = " " * indent
+    return f"""\
+{pad}- name: Configure fork remote
+{pad}  run: |
+{pad}    REPO_NAME="${{GITHUB_REPOSITORY#*/}}"
+{pad}    git remote add fork "https://x-access-token:${{BOT_TOKEN}}@github.com/${{BOT_NAME}}/${{REPO_NAME}}.git"
+{pad}  env:
+{pad}    BOT_NAME: {bot_name}
+{pad}    BOT_TOKEN: {bot_token}"""
 
 
 def _escape(s: str) -> str:
@@ -108,7 +122,8 @@ def generate_review(cfg: Config) -> GeneratedWorkflow:
     bn = cfg.bot_name
 
     setup = _setup_yaml(cfg)
-    perms = _permissions()
+    perms = _permissions(cfg.mode)
+    fork_step = f"\n\n{_fork_remote_step(bn, bt)}\n" if cfg.mode == "fork" else ""
 
     content = f"""\
 {HEADER}
@@ -159,12 +174,13 @@ jobs:
         env:
           GH_TOKEN: {bt}
           PR_NUMBER: ${{{{ github.event.pull_request.number }}}}
-{setup}
+{fork_step}{setup}
       - uses: max-sixty/tend@v1
         with:
           github_token: {bt}
           claude_code_oauth_token: {ct}
           bot_name: {bn}
+          mode: {cfg.mode}
           use_sticky_comment: ${{{{ github.event_name == 'pull_request_target' }}}}
           prompt: >-
             ${{{{ github.event_name == 'pull_request_target'
@@ -188,7 +204,8 @@ def generate_mention(cfg: Config) -> GeneratedWorkflow:
     bn = cfg.bot_name
 
     setup = _setup_yaml(cfg)
-    perms = _permissions()
+    perms = _permissions(cfg.mode)
+    fork_step = f"\n\n{_fork_remote_step(bn, bt)}\n" if cfg.mode == "fork" else ""
     pr = "(github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number)"
 
     content = f"""\
@@ -327,12 +344,13 @@ jobs:
         env:
           GH_TOKEN: {bt}
           PR_NUMBER: ${{{{ github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number }}}}
-{setup}
+{fork_step}{setup}
       - uses: max-sixty/tend@v1
         with:
           github_token: {bt}
           claude_code_oauth_token: {ct}
           bot_name: {bn}
+          mode: {cfg.mode}
           prompt: >-
             ${{{{ github.event_name == 'issues'
               && format('An issue was updated with a mention of you ({{0}}). Read it and respond.', github.event.issue.html_url)
@@ -362,7 +380,8 @@ def generate_triage(cfg: Config) -> GeneratedWorkflow:
     bn = cfg.bot_name
 
     setup = _setup_yaml(cfg)
-    perms = _permissions()
+    perms = _permissions(cfg.mode)
+    fork_step = f"\n\n{_fork_remote_step(bn, bt)}\n" if cfg.mode == "fork" else ""
 
     content = f"""\
 {HEADER}
@@ -390,12 +409,13 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
           token: {bt}
-{setup}
+{fork_step}{setup}
       - uses: max-sixty/tend@v1
         with:
           github_token: {bt}
           claude_code_oauth_token: {ct}
           bot_name: {bn}
+          mode: {cfg.mode}
           prompt: |
             {prompt}
 """
@@ -424,7 +444,8 @@ def generate_ci_fix(cfg: Config) -> GeneratedWorkflow:
     bn = cfg.bot_name
 
     setup = _setup_yaml(cfg)
-    perms = _permissions(issues=False)
+    perms = _permissions(cfg.mode, issues=False)
+    fork_step = f"\n\n{_fork_remote_step(bn, bt)}\n" if cfg.mode == "fork" else ""
     watched_yaml = ", ".join(f'"{w}"' for w in watched)
     branches_yaml = ", ".join(f'"{b}"' for b in branches)
 
@@ -450,12 +471,13 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
           token: {bt}
-{setup}
+{fork_step}{setup}
       - uses: max-sixty/tend@v1
         with:
           github_token: {bt}
           claude_code_oauth_token: {ct}
           bot_name: {bn}
+          mode: {cfg.mode}
           prompt: |
             {prompt}
             - Run URL: ${{{{ github.event.workflow_run.html_url }}}}
@@ -478,7 +500,8 @@ def _generate_scheduled(cfg: Config, name: str, default_cron: str, default_promp
     bn = cfg.bot_name
 
     setup = _setup_yaml(cfg)
-    perms = _permissions()
+    perms = _permissions(cfg.mode)
+    fork_step = f"\n\n{_fork_remote_step(bn, bt)}\n" if cfg.mode == "fork" else ""
 
     prompt_lines = "\n".join(f"            {line}" for line in prompt.split("\n"))
     prompt_yaml = f"prompt: |\n{prompt_lines}"
@@ -503,12 +526,13 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
           token: {bt}
-{setup}
+{fork_step}{setup}
       - uses: max-sixty/tend@v1
         with:
           github_token: {bt}
           claude_code_oauth_token: {ct}
           bot_name: {bn}
+          mode: {cfg.mode}
           {prompt_yaml}
 """
     return GeneratedWorkflow(filename=f"tend-{name}.yaml", content=content)

--- a/generator/tests/test_checks.py
+++ b/generator/tests/test_checks.py
@@ -25,7 +25,7 @@ def _make_completed(stdout: str = "", stderr: str = "", returncode: int = 0) -> 
     return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
 
 
-def _write_config(tmp_path: Path, content: str = 'bot_name = "test-bot"') -> Path:
+def _write_config(tmp_path: Path, content: str = 'bot_name = "test-bot"\nmode = "write"') -> Path:
     cfg = tmp_path / ".config" / "tend.toml"
     cfg.parent.mkdir(parents=True, exist_ok=True)
     cfg.write_text(content)
@@ -174,7 +174,7 @@ def test_secrets_bad_json() -> None:
 
 def test_run_all_checks_no_gh() -> None:
     with patch("shutil.which", return_value=None):
-        results = run_all_checks(Config("bot", "main", "T1", "T2", [], {}))
+        results = run_all_checks(Config("bot", "write", "main", "T1", "T2", [], {}))
     assert len(results) == 1
     assert results[0].passed is None
     assert "gh CLI" in results[0].message
@@ -183,7 +183,7 @@ def test_run_all_checks_no_gh() -> None:
 def test_run_all_checks_no_repo() -> None:
     with patch("shutil.which", return_value="/usr/bin/gh"), \
          patch("tend.checks.detect_repo", return_value=None):
-        results = run_all_checks(Config("bot", "main", "T1", "T2", [], {}))
+        results = run_all_checks(Config("bot", "write", "main", "T1", "T2", [], {}))
     assert len(results) == 1
     assert "detect" in results[0].message
 
@@ -206,9 +206,53 @@ def test_run_all_checks_with_explicit_repo() -> None:
 
     with patch("shutil.which", return_value="/usr/bin/gh"), \
          patch("tend.checks._gh", side_effect=fake_gh):
-        results = run_all_checks(Config("bot", "main", "T1", "T2", [], {}), repo="owner/repo")
+        results = run_all_checks(Config("bot", "write", "main", "T1", "T2", [], {}), repo="owner/repo")
     assert len(results) == 3
     assert all(r.passed is True for r in results)
+
+
+# ---------------------------------------------------------------------------
+# Fork mode checks
+# ---------------------------------------------------------------------------
+
+
+def test_bot_write_permission_fails_in_fork_mode() -> None:
+    """In fork mode, write permission is too much — should fail."""
+    with patch("tend.checks._gh", return_value=_make_completed("write\n")):
+        result = check_bot_permission("owner/repo", "my-bot", mode="fork")
+    assert result.passed is False
+    assert "triage" in result.message
+
+
+def test_bot_triage_permission_passes_in_fork_mode() -> None:
+    with patch("tend.checks._gh", return_value=_make_completed("triage\n")):
+        result = check_bot_permission("owner/repo", "my-bot", mode="fork")
+    assert result.passed is True
+
+
+def test_fork_mode_skips_branch_protection() -> None:
+    """run_all_checks in fork mode skips branch protection check."""
+    def fake_gh(*args, **kwargs):
+        cmd = " ".join(args)
+        if args[1].startswith("repos/owner/repo") and ".default_branch" in " ".join(args):
+            return _make_completed("main\n")
+        if "collaborators" in cmd:
+            return _make_completed("triage\n")
+        if "secrets" in cmd:
+            return _make_completed('["T1","T2"]\n')
+        return _make_completed(returncode=1)
+
+    with patch("shutil.which", return_value="/usr/bin/gh"), \
+         patch("tend.checks._gh", side_effect=fake_gh):
+        results = run_all_checks(
+            Config("bot", "fork", "main", "T1", "T2", [], {}),
+            repo="owner/repo",
+        )
+    assert len(results) == 3
+    bp = results[0]
+    assert bp.name == "branch-protection"
+    assert bp.passed is True
+    assert "Fork mode" in bp.message
 
 
 # ---------------------------------------------------------------------------

--- a/generator/tests/test_config_edge_cases.py
+++ b/generator/tests/test_config_edge_cases.py
@@ -16,6 +16,9 @@ from tend.workflows import generate_all
 def _write_config(tmp_path: Path, content: str) -> Path:
     cfg = tmp_path / ".config" / "tend.toml"
     cfg.parent.mkdir(parents=True, exist_ok=True)
+    # Add mode after bot_name if not present (must be top-level, before sections)
+    if "mode" not in content and "bot_name" in content:
+        content = content.replace('bot_name', 'mode = "write"\nbot_name', 1)
     cfg.write_text(content)
     return cfg
 
@@ -37,11 +40,12 @@ def test_empty_toml_raises(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_bot_name_only(tmp_path: Path) -> None:
-    """Minimal config with just bot_name should produce valid defaults."""
-    path = _write_config(tmp_path, 'bot_name = "my-bot"')
+def test_minimal_config_defaults(tmp_path: Path) -> None:
+    """Minimal config (bot_name + mode) should produce valid defaults."""
+    path = _write_config(tmp_path, 'bot_name = "my-bot"\nmode = "write"')
     cfg = Config.load(path)
     assert cfg.bot_name == "my-bot"
+    assert cfg.mode == "write"
     assert cfg.bot_token_secret == "BOT_TOKEN"
     assert cfg.claude_token_secret == "CLAUDE_CODE_OAUTH_TOKEN"
     assert cfg.setup == []
@@ -460,6 +464,47 @@ def test_setup_steps_entry_both_keys(tmp_path: Path) -> None:
     with pytest.raises(ClickException, match="setup\\[0\\] must have exactly one"):
         Config.load(path)
 
+
+
+# ---------------------------------------------------------------------------
+# 12. Mode validation
+# ---------------------------------------------------------------------------
+
+
+def test_mode_missing_rejected(tmp_path: Path) -> None:
+    """mode is required — missing raises a clear error."""
+    cfg = tmp_path / ".config" / "tend.toml"
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text('bot_name = "my-bot"')
+    with pytest.raises(ClickException, match="Missing required field: mode"):
+        Config.load(cfg)
+
+
+def test_mode_fork(tmp_path: Path) -> None:
+    path = _write_config(tmp_path, dedent("""\
+        bot_name = "my-bot"
+        mode = "fork"
+    """))
+    cfg = Config.load(path)
+    assert cfg.mode == "fork"
+
+
+def test_mode_write(tmp_path: Path) -> None:
+    path = _write_config(tmp_path, dedent("""\
+        bot_name = "my-bot"
+        mode = "write"
+    """))
+    cfg = Config.load(path)
+    assert cfg.mode == "write"
+
+
+def test_mode_invalid_rejected(tmp_path: Path) -> None:
+    path = _write_config(tmp_path, dedent("""\
+        bot_name = "my-bot"
+        mode = "triage"
+    """))
+    with pytest.raises(ClickException, match="mode must be 'fork' or 'write'"):
+        Config.load(path)
 
 
 def test_workflow_disabled_boolean_shorthand_not_generated(tmp_path: Path) -> None:

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -17,7 +17,9 @@ from tend.workflows import generate_all
 def _minimal_config(tmp_path: Path, extra: str = "") -> Path:
     cfg = tmp_path / ".config" / "tend.toml"
     cfg.parent.mkdir(parents=True)
-    cfg.write_text(f'bot_name = "test-bot"\n{extra}')
+    # Default to write mode unless extra overrides it
+    mode_line = "" if "mode" in extra else 'mode = "write"\n'
+    cfg.write_text(f'bot_name = "test-bot"\n{mode_line}{extra}')
     return cfg
 
 
@@ -212,3 +214,67 @@ def test_setup_after_pr_checkout_in_mention(tmp_path: Path) -> None:
     checkout_idx = mention.content.index("Check out PR branch")
     setup_idx = mention.content.index("./.github/actions/my-setup")
     assert setup_idx > checkout_idx, "Setup must come after PR checkout"
+
+
+# ---------------------------------------------------------------------------
+# Fork mode
+# ---------------------------------------------------------------------------
+
+
+def test_fork_mode_adds_fork_remote_step(tmp_path: Path) -> None:
+    """Fork mode workflows include a step to configure the fork remote."""
+    cfg = Config.load(_minimal_config(tmp_path, 'mode = "fork"'))
+    for wf in generate_all(cfg):
+        assert "Configure fork remote" in wf.content, f"{wf.filename} missing fork remote step"
+        assert "git remote add fork" in wf.content, f"{wf.filename} missing git remote add"
+
+
+def test_write_mode_no_fork_remote_step(tmp_path: Path) -> None:
+    """Write mode workflows do not include fork remote step."""
+    cfg = Config.load(_minimal_config(tmp_path))
+    for wf in generate_all(cfg):
+        assert "Configure fork remote" not in wf.content, f"{wf.filename} has unexpected fork step"
+
+
+def test_fork_mode_contents_read(tmp_path: Path) -> None:
+    """Fork mode sets contents: read instead of contents: write."""
+    cfg = Config.load(_minimal_config(tmp_path, 'mode = "fork"'))
+    for wf in generate_all(cfg):
+        assert "contents: read" in wf.content, f"{wf.filename} missing contents: read"
+        assert "contents: write" not in wf.content, f"{wf.filename} has contents: write in fork mode"
+
+
+def test_fork_mode_passes_mode_to_action(tmp_path: Path) -> None:
+    """Fork mode passes mode: fork to the tend action."""
+    cfg = Config.load(_minimal_config(tmp_path, 'mode = "fork"'))
+    for wf in generate_all(cfg):
+        assert "mode: fork" in wf.content, f"{wf.filename} missing mode: fork"
+
+
+def test_write_mode_passes_mode_to_action(tmp_path: Path) -> None:
+    """Write mode passes mode: write to the tend action."""
+    cfg = Config.load(_minimal_config(tmp_path))
+    for wf in generate_all(cfg):
+        assert "mode: write" in wf.content, f"{wf.filename} missing mode: write"
+
+
+def test_fork_mode_valid_yaml(tmp_path: Path) -> None:
+    """Fork mode workflows produce valid YAML."""
+    cfg = Config.load(_minimal_config(tmp_path, 'mode = "fork"'))
+    for wf in generate_all(cfg):
+        data = yaml.safe_load(wf.content)
+        assert isinstance(data, dict), f"{wf.filename} did not parse as dict"
+
+
+def test_fork_mode_with_setup_steps(tmp_path: Path) -> None:
+    """Fork remote step appears before setup steps."""
+    extra = dedent("""\
+        mode = "fork"
+        setup = [{uses = "./.github/actions/my-setup"}]
+    """)
+    cfg = Config.load(_minimal_config(tmp_path, extra))
+    for wf in generate_all(cfg):
+        if "Configure fork remote" in wf.content and "./.github/actions/my-setup" in wf.content:
+            fork_idx = wf.content.index("Configure fork remote")
+            setup_idx = wf.content.index("./.github/actions/my-setup")
+            assert fork_idx < setup_idx, f"{wf.filename}: fork remote must come before setup"

--- a/plugins/tend-ci-runner/skills/ci-fix/SKILL.md
+++ b/plugins/tend-ci-runner/skills/ci-fix/SKILL.md
@@ -42,10 +42,10 @@ git add <files>
 git commit -m "fix: <description>
 
 Co-Authored-By: Claude <noreply@anthropic.com>"
-git push -u origin fix/ci-<run-id>
 ```
 
-Create the PR with `gh pr create`. PR body format:
+Push and create the PR using the fork-aware pattern from
+`/tend-ci-runner:running-in-ci` (check `$TEND_MODE`). PR body format:
 
 ```
 ## Problem

--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -88,9 +88,10 @@ it — explain uncertainty in the PR description.
 
 For each finding:
 
-1. **Create a PR** — branch, fix, run full test suite, commit, push, create
-   PR, poll CI. **Every bug fix must include a regression test that would have
-   failed before the fix.** If a test is not feasible (e.g., pure
+1. **Create a PR** — branch, fix, run full test suite, commit, push and create
+   PR using the fork-aware pattern from `/tend-ci-runner:running-in-ci` (check
+   `$TEND_MODE`), poll CI. **Every bug fix must include a regression test that
+   would have failed before the fix.** If a test is not feasible (e.g., pure
    documentation changes), note why in the PR description. When uncertain about
    the approach, explain the trade-offs in the description.
 2. **Create an issue only when there's no obvious fix** — design questions,

--- a/plugins/tend-ci-runner/skills/renovate/SKILL.md
+++ b/plugins/tend-ci-runner/skills/renovate/SKILL.md
@@ -27,7 +27,11 @@ If no dependency PRs are open, report "No dependency PRs to process" and exit.
 3. If the update is safe (patch/minor with green CI), approve and merge:
    ```bash
    gh pr review <number> --approve --body "Automated dependency update — CI passing, no breaking changes."
-   gh pr merge <number> --squash
+   # In fork mode (TEND_MODE=fork), skip the merge — the bot lacks merge
+   # permission. Leave it for a maintainer.
+   if [ "$TEND_MODE" != "fork" ]; then
+     gh pr merge <number> --squash
+   fi
    ```
 4. If CI is failing, comment with the failure summary and skip
 5. If a major version bump, comment noting it needs manual review and skip

--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -148,6 +148,8 @@ Flag duplicates — reuse is almost always better than a parallel implementation
 ### 5. Submit
 
 **If there are no issues, approve with an empty body — silence means correct.**
+In fork mode (`TEND_MODE=fork`), approvals don't count for required review
+policies — they're informational. Still submit them; they signal intent.
 
 ```bash
 gh pr review <number> --approve -b ""
@@ -364,6 +366,10 @@ Outdated comments (null line) are best-effort — skip if the original context
 can't be located.
 
 ### 8. Push mechanical fixes
+
+**Fork mode** (`TEND_MODE=fork`): The bot cannot push to human PR branches.
+Post inline suggestions only. For bot PRs (Dependabot, renovate), `gh pr
+checkout` configures tracking to the correct remote — bare `git push` works.
 
 **Bot PRs** (Dependabot, renovate, etc.): If the review found concrete, fixable
 issues and there's no human author to act on feedback, commit and push the fix

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -47,9 +47,39 @@ NEVER run commands that could expose secrets (`env`, `printenv`, `set`,
 environment variables, API keys, tokens, or credentials in responses or
 comments.
 
+## Fork Mode
+
+Check `$TEND_MODE` at the start of every task. When `TEND_MODE=fork`, the bot
+operates with triage access on the target repo and pushes to its own fork.
+A git remote named `fork` is pre-configured by the workflow.
+
+**Pushing new branches** (ci-fix, triage, nightly fix PRs):
+
+```bash
+if [ "$TEND_MODE" = "fork" ]; then
+  git push -u fork <branch>
+  BOT_LOGIN=$(gh api user --jq '.login')
+  gh pr create --repo "$GITHUB_REPOSITORY" --head "$BOT_LOGIN:<branch>" \
+    --title "..." --body "..."
+else
+  git push -u origin <branch>
+  gh pr create --title "..." --body "..."
+fi
+```
+
+**Limitations in fork mode:**
+
+- The bot cannot push to human PR branches — post inline suggestions instead
+- The bot cannot merge PRs (`gh pr merge` fails) — approve and leave for a
+  maintainer
+- Approvals don't count for required review policies (triage-level)
+- `origin` still points to the target repo — `git merge origin/main`, code
+  reading, and API calls work normally
+
 ## PR Creation
 
-When asked to create a PR, use `gh pr create` directly.
+When asked to create a PR, use `gh pr create` directly (or the fork pattern
+above when `TEND_MODE=fork`).
 
 Before creating a branch or PR, check for existing work:
 
@@ -66,9 +96,9 @@ Always use `git push` without specifying a remote — `gh pr checkout` configure
 tracking to the correct remote, including for fork PRs. Specifying `origin`
 explicitly can push to the wrong place.
 
-If pushing fails (fork PR with edits disabled), fall back to posting code
-snippets in a comment. Don't reference commit SHAs from temporary branches —
-post code inline.
+If pushing fails (fork PR with edits disabled, or fork mode on human PRs), fall
+back to posting code snippets in a comment. Don't reference commit SHAs from
+temporary branches — post code inline.
 
 ## CI Monitoring
 

--- a/plugins/tend-ci-runner/skills/triage/SKILL.md
+++ b/plugins/tend-ci-runner/skills/triage/SKILL.md
@@ -118,7 +118,8 @@ missing code. Before adding guidance to a skill:
 1. Fix the root cause (not just the symptom)
 2. Confirm the test now passes
 3. Run the full test suite and lints (use project test commands from CLAUDE.md)
-4. Create branch, commit, push, and create PR:
+4. Create branch, commit, and push using the fork-aware pattern from
+   `/tend-ci-runner:running-in-ci` (check `$TEND_MODE`):
    ```bash
    git checkout -b fix/issue-$ARGUMENTS
    git add -A
@@ -127,8 +128,11 @@ missing code. Before adding guidance to a skill:
    Closes #$ARGUMENTS
 
    Co-Authored-By: Claude <noreply@anthropic.com>"
-   git push -u origin fix/issue-$ARGUMENTS
-   gh pr create --title "fix: <description>" --body "## Problem
+   # Push and create PR — see running-in-ci "Fork Mode" section
+   ```
+   PR body format:
+   ```
+   ## Problem
    [What the issue reported and the root cause]
 
    ## Solution
@@ -138,7 +142,7 @@ missing code. Before adding guidance to a skill:
    [How the fix was verified — mention the reproduction test]
 
    ---
-   Closes #<issue-number> — automated triage"
+   Closes #<issue-number> — automated triage
    ```
 5. Monitor CI using the approach from /tend-ci-runner:running-in-ci.
 
@@ -152,12 +156,7 @@ git add -A
 git commit -m "test: add reproduction for #$ARGUMENTS
 
 Co-Authored-By: Claude <noreply@anthropic.com>"
-git push -u origin repro/issue-$ARGUMENTS
-gh pr create --title "test: reproduction for #$ARGUMENTS" --body "## Context
-Adds a failing test that reproduces #$ARGUMENTS. The fix is not yet included — this PR captures the reproduction so a maintainer can investigate.
-
----
-Automated triage for #<issue-number>"
+# Push and create PR — see running-in-ci "Fork Mode" section
 ```
 
 Note the PR number for the comment.


### PR DESCRIPTION
Adds a `mode` config field (required: `"fork"` or `"write"`) that controls how the bot interacts with the target repo.

Fork mode gives the bot triage access and its own fork. The generator adds a "Configure fork remote" step to each workflow, sets `contents: read` on GITHUB_TOKEN, skips the branch protection preflight, and passes `TEND_MODE=fork` to Claude's environment. Skills check `$TEND_MODE` to use the fork-aware push/PR pattern from `running-in-ci`.

Write mode is the existing behavior — bot has write access, branch protection is the security boundary.

Key files: `config.py` (required field + validation), `workflows.py` (fork remote step, permissions, mode passthrough), `action.yaml` (conditional preflight, TEND_MODE env), `checks.py` (triage permission check), `running-in-ci/SKILL.md` (fork push pattern), and updates to ci-fix/triage/review/renovate/nightly skills.

15 new tests covering mode validation, fork remote generation, YAML validity, permission checks, and step ordering.

> _This was written by Claude Code on behalf of maximilian_