### PR TITLE
fix: prevent --allow-unrelated-histories and fix v1 branch sync

### DIFF
--- a/.github/workflows/update-action-branch.yaml
+++ b/.github/workflows/update-action-branch.yaml
@@ -12,6 +12,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Update v1 branch to match main
         run: git push origin HEAD:refs/heads/v1

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -70,6 +70,31 @@ If pushing fails (fork PR with edits disabled), fall back to posting code
 snippets in a comment. Don't reference commit SHAs from temporary branches —
 post code inline.
 
+## Merging Upstream into PR Branches
+
+When asked to merge the default branch into a PR branch:
+
+1. **Never use `--allow-unrelated-histories`.** If `git merge` fails because
+   git can't find a merge base, the checkout is broken — investigate rather than
+   forcing the merge. `--allow-unrelated-histories` treats both sides as
+   disconnected, creating add/add conflicts in every file.
+
+2. **Handle untracked file conflicts properly.** If `git merge origin/main`
+   fails because untracked files would be overwritten by tracked files, stash
+   them first — don't delete them:
+   ```bash
+   git stash --include-untracked
+   git merge origin/main
+   git stash pop
+   ```
+
+3. **Verify merge base exists** before merging:
+   ```bash
+   git merge-base origin/main HEAD
+   ```
+   If this fails, the branch history is disconnected. Re-checkout the PR with
+   full history (`fetch-depth: 0`) before retrying.
+
 ## CI Monitoring
 
 After pushing, wait for CI before reporting completion.


### PR DESCRIPTION
## Summary

- Add merge guidance to the `running-in-ci` skill: never use `--allow-unrelated-histories`, stash untracked files before merging, verify merge base exists
- Fix `update-action-branch.yaml` to use `fetch-depth: 0` — the default shallow clone can't fast-forward push, which is why v1 is currently 6 commits behind main

## Context

The bot was observed using `--allow-unrelated-histories` when merging upstream into PR branches ([worktrunk #1667](https://github.com/max-sixty/worktrunk/pull/1667)), causing add/add conflicts in every file. The root cause was untracked files blocking the merge, followed by the bot reaching for `--allow-unrelated-histories` as a recovery strategy.

The v1 branch sync issue is a separate bug: `actions/checkout` defaults to `fetch-depth: 1`, and a shallow clone can't verify fast-forward ancestry, so `git push origin HEAD:refs/heads/v1` is rejected.

## Test plan

- [ ] Verify CI passes
- [ ] After merge, confirm the update-action-branch workflow succeeds and v1 catches up to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)