### PR TITLE
feat: add runtime rate limit preflight

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -57,6 +57,54 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.github_token }}
 
+    - name: Rate limit preflight
+      shell: bash
+      run: |
+        REPO="${GITHUB_REPOSITORY}"
+        BOT="${{ inputs.bot_name }}"
+        # GNU date — runs on Ubuntu (GitHub Actions runners)
+        TWENTY_MIN_AGO=$(date -u -d '20 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
+        TODAY=$(date -u +%Y-%m-%d)
+        YESTERDAY=$(date -u -d 'yesterday' +%Y-%m-%d)
+        SIX_DAYS_AGO=$(date -u -d '6 days ago' +%Y-%m-%d)
+
+        # Burst check: too many in the last 20 minutes
+        RECENT_PRS=$(gh api "repos/$REPO/pulls?state=all&sort=created&direction=desc&per_page=30" \
+          --jq "[.[] | select(.user.login == \"$BOT\" and .created_at > \"$TWENTY_MIN_AGO\")] | length" || echo 0)
+        RECENT_ISSUES=$(gh api "repos/$REPO/issues?creator=$BOT&state=all&sort=created&direction=desc&per_page=30" \
+          --jq "[.[] | select(.pull_request == null and .created_at > \"$TWENTY_MIN_AGO\")] | length" || echo 0)
+
+        # Spike check: abnormal daily volume vs 6-day baseline
+        # search/issues covers both issues and PRs
+        TODAY_POSTS=$(gh api "search/issues?q=author:${BOT}+repo:${REPO}+created:${TODAY}" \
+          --jq '.total_count' || echo 0)
+        PAST_POSTS=$(gh api "search/issues?q=author:${BOT}+repo:${REPO}+created:${SIX_DAYS_AGO}..${YESTERDAY}" \
+          --jq '.total_count' || echo 0)
+        # spike_limit = 10 + 2 * daily_avg = 10 + 2 * (past_posts / 6) = 10 + past_posts / 3
+        SPIKE_LIMIT=$((10 + PAST_POSTS / 3))
+
+        echo "Rate limit: burst=${RECENT_PRS} PRs, ${RECENT_ISSUES} issues (20min); today=${TODAY_POSTS} (limit: ${SPIKE_LIMIT})"
+
+        ABORT=false
+        if [ "$RECENT_PRS" -gt 10 ]; then
+          echo "::error::Rate limit: bot created ${RECENT_PRS} PRs in the last 20 minutes (limit: 10)"
+          ABORT=true
+        fi
+        if [ "$RECENT_ISSUES" -gt 10 ]; then
+          echo "::error::Rate limit: bot created ${RECENT_ISSUES} issues in the last 20 minutes (limit: 10)"
+          ABORT=true
+        fi
+        if [ "$TODAY_POSTS" -gt "$SPIKE_LIMIT" ]; then
+          echo "::error::Rate limit: bot created ${TODAY_POSTS} items today, above spike limit of ${SPIKE_LIMIT} (baseline: ${PAST_POSTS} over past 6 days)"
+          ABORT=true
+        fi
+        if [ "$ABORT" = true ]; then
+          exit 1
+        fi
+        echo "Rate limit check passed"
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+
     - name: Install CI scripts
       shell: bash
       run: |

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -108,6 +108,31 @@ code — it's exfiltrating other secrets:
 This is why release secrets must be in a protected environment, not repo-level
 secrets.
 
+## Runtime rate limits
+
+The composite action aborts if recent bot activity exceeds any limit,
+before starting Claude. This catches runaway loops (e.g., triage creating a
+fix PR whose CI failure triggers ci-fix, which creates another PR) and
+prompt injection that tricks the bot into creating PRs or issues in bulk.
+
+Two layers of detection:
+
+- **Burst** — caps creation rate over a short window (20 minutes). Catches
+  tight loops that produce many artifacts quickly.
+- **Spike** — compares today's total against the daily average of the previous
+  6 days. The formula `10 + 2 × daily_avg` adapts to each repo's normal
+  activity level: a repo that averages 0 posts/day trips at 11, while one
+  averaging 15/day trips at 41.
+
+| Check | Limit | Layer |
+|-------|-------|-------|
+| PRs created in last 20 min | 10 | Burst |
+| Issues created in last 20 min | 10 | Burst |
+| Items created today | 10 + 2× daily avg (past 6 days) | Spike |
+
+These are hardcoded in `action.yaml`. Because the check runs outside Claude's
+session, a prompt injection attack cannot instruct the bot to skip it.
+
 ## Future hardening
 
 - Migrate from PAT to GitHub App for ephemeral tokens (~1 hour vs indefinite)


### PR DESCRIPTION
Adds a preflight step to the composite action that checks recent bot activity before starting Claude. Two detection layers:

- **Burst** — caps PRs and issues created in the last 20 minutes (limit 10 each). Catches tight loops like triage→fix→CI-fail→ci-fix→fix.
- **Spike** — compares today's total items against the daily average of the previous 6 days, using `10 + 2× daily_avg` as the threshold. Adapts to each repo's normal activity level.

Runs outside Claude's session (in `action.yaml` as a composite step), so prompt injection cannot instruct the bot to skip it. Falls back to 0 on API errors — branch protection remains the primary security boundary.

> _This was written by Claude Code on behalf of @max-sixty_