### PR TITLE
fix: use claude-code-action native plugin inputs

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -126,14 +126,6 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.github_token }}
 
-    - name: Install tend CI plugin
-      shell: bash
-      run: |
-        npm install -g @anthropic-ai/claude-code
-        claude plugin marketplace add https://github.com/max-sixty/tend.git
-        claude plugin install install-tend@tend
-        claude plugin install tend-ci-runner@tend
-
     - name: Run Claude Code
       id: claude
       uses: anthropics/claude-code-action@v1
@@ -149,6 +141,10 @@ runs:
         use_sticky_comment: ${{ inputs.use_sticky_comment }}
         additional_permissions: ${{ inputs.additional_permissions }}
         prompt: ${{ inputs.prompt }}
+        plugin_marketplaces: https://github.com/max-sixty/tend.git
+        plugins: |
+          install-tend@tend
+          tend-ci-runner@tend
         claude_args: |
           --model ${{ inputs.model }}
           --allowedTools ${{ inputs.allowed_tools }}


### PR DESCRIPTION
The `Install tend CI plugin` shell step installed plugins into a standalone Claude CLI instance. `claude-code-action` creates its own settings file on startup, but the plugins happened to persist on the filesystem and were still discoverable — so this worked by accident.

Replace the shell step with `claude-code-action`'s native `plugin_marketplaces` and `plugins` inputs so plugin installation is reliable rather than depending on filesystem side effects.

**Note on worktrunk#1736:** The silent review failure there was caused by the wrong skill name in the worktrunk config (`/tend:tend-review` instead of `/tend-ci-runner:review`). Claude resolved the skill client-side, found nothing, and returned "Unknown skill" with zero tokens. This action.yaml change wouldn't have fixed that — the worktrunk config needs updating separately.

> _This was written by Claude Code on behalf of @max-sixty_