### PR TITLE
chore: bump generator version to 0.0.3

### DIFF
--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tend"
-version = "0.0.2"
+version = "0.0.3"
 description = "Claude-powered CI for GitHub repos"
 license = "MIT"
 requires-python = ">=3.11"


### PR DESCRIPTION
Releases the skill name fix (`/tend-ci-runner:review` instead of `/tend:tend-review`) so `uvx tend init` generates correct workflows. The fix has been in the generator source since #39 but was never published to PyPI.

After merging, tag `0.0.3` to trigger the PyPI release workflow.

> _This was written by Claude Code on behalf of @max-sixty_