### PR TITLE
fix: pin CLAUDE.md to base branch on fork PRs

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -126,6 +126,25 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.github_token }}
 
+    - name: Pin CLAUDE.md to base branch (fork PRs)
+      shell: bash
+      run: |
+        if [ "$GITHUB_EVENT_NAME" != "pull_request_target" ]; then
+          exit 0
+        fi
+        IS_FORK=$(jq -r '.pull_request.head.repo.fork // false' "$GITHUB_EVENT_PATH")
+        if [ "$IS_FORK" != "true" ]; then
+          exit 0
+        fi
+        DEFAULT_BRANCH=$(jq -r '.repository.default_branch' "$GITHUB_EVENT_PATH")
+        if git show "origin/${DEFAULT_BRANCH}:CLAUDE.md" > /tmp/base-claude.md 2>/dev/null; then
+          cp /tmp/base-claude.md CLAUDE.md
+          echo "Pinned CLAUDE.md to ${DEFAULT_BRANCH}"
+        else
+          rm -f CLAUDE.md
+          echo "No CLAUDE.md on ${DEFAULT_BRANCH} — removed fork version"
+        fi
+
     - name: Run Claude Code
       id: claude
       uses: anthropics/claude-code-action@v1

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -89,7 +89,7 @@ All workflows should pass the bot token to both paths.
 
 | Workflow | Injection surface | Attacker control | Mitigations |
 |----------|-------------------|-------------------|-------------|
-| **review** | PR diff content, review body on bot PRs | Full (any PR) / Medium (reviewers) | Fixed prompt, merge restriction |
+| **review** | PR diff content, review body on bot PRs | Full (any PR) / Medium (reviewers) | Fixed prompt, merge restriction, CLAUDE.md pinning (fork PRs) |
 | **triage** | Issue body | Partial (structured skill) | Fixed prompt, merge restriction, environment protection |
 | **mention** | Comment body on any issue/PR | Full | Fixed prompt, merge restriction, engagement verification |
 | **ci-fix** | Failed CI logs | Minimal (must break CI on default branch) | Fixed prompt, automatic trigger |
@@ -132,6 +132,18 @@ Two layers of detection:
 
 These are hardcoded in `action.yaml`. Because the check runs outside Claude's
 session, a prompt injection attack cannot instruct the bot to skip it.
+
+## CLAUDE.md pinning on fork PRs
+
+Claude Code loads `CLAUDE.md` into the system prompt. On `pull_request_target`,
+the checkout includes fork changes, so a fork PR that modifies `CLAUDE.md`
+injects instructions at system-prompt level — the same authority as the
+`system_prompt_append` conduct rules.
+
+The composite action detects fork PRs (via `GITHUB_EVENT_PATH`) and overwrites
+`CLAUDE.md` with the base branch version before running Claude. Same-repo PRs
+are unaffected — the branch's `CLAUDE.md` is used as-is, so changes to it can
+be reviewed normally.
 
 ## Future hardening
 


### PR DESCRIPTION
CLAUDE.md is loaded into the system prompt — same authority level as `system_prompt_append`. On `pull_request_target`, the checkout includes fork changes, so a fork PR that modifies CLAUDE.md injects instructions at system-prompt level that the conduct rules can't structurally override.

The composite action now detects fork PRs (via `GITHUB_EVENT_PATH`) and overwrites `CLAUDE.md` with the base branch version before running Claude. Same-repo PRs are unaffected — the branch's CLAUDE.md is used as-is, so changes can be reviewed normally.

> _This was written by Claude Code on behalf of @max-sixty_