### PR TITLE
fix(review): reinforce background CI polling in review skill

### DIFF
--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -272,9 +272,10 @@ array indices to object keys, which GitHub rejects.
 ### 6. Monitor CI
 
 After approving or staying silent, monitor CI using the polling approach from
-/tend-ci-runner:running-in-ci. **Exclude the `tend-review` check** (your own
-workflow) from the poll — it will always show as pending while you're running.
-**NEVER use `--watch` flags** — they hang forever.
+/tend-ci-runner:running-in-ci. **Use `run_in_background: true`** for the polling
+loop — foreground polling blocks the session for 10–30 minutes. **Exclude the
+`tend-review` check** (your own workflow) from the poll — it will always show as
+pending while you're running. **NEVER use `--watch` flags** — they hang forever.
 
 - **All required checks passed** -> done.
 - **A check failed** and it's related to the PR -> post a follow-up COMMENT


### PR DESCRIPTION
## Summary

- Reinforce `run_in_background: true` for CI polling in the review skill's Step 6

The `running-in-ci` skill already prescribes background polling, but the review
skill's Step 6 ("Monitor CI") didn't mention it. In practice, review sessions
consistently use foreground sequential `sleep` calls, blocking the runner for
10–30 minutes per review.

## Evidence

**5+ sessions** across multiple days exhibited foreground CI polling:

| Run | Session type | Impact |
|---|---|---|
| 23479136808 | Self-blocking CI poll | ~10 min wasted (polled own workflow) |
| 23576202335 | Dependabot review | ~30 min foreground (15 sequential polls for non-required check) |
| 23578601418 | Re-review (PR #1736) | ~10 min foreground (no actionable outcome) |
| 23578576282 | Re-review (PR #1745) | ~10 min foreground (no actionable outcome) |
| 23581268549 | Self-authored PR review | ~14 min foreground (6 sequential `sleep 120`/`sleep 180` calls) |

**Gate assessment:**
- Evidence level: High (consistent pattern, 5+ occurrences)
- Change type: Targeted fix (one sentence added)
- Both gates pass

## Test plan

- [ ] Verify next review session uses `run_in_background: true` for CI polling

🤖 Generated with [Claude Code](https://claude.com/claude-code)