### PR TITLE
feat: support protecting branches beyond the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,19 @@ bot_name = "my-project-bot"
 
 Only overrides from defaults are needed.
 
+### Protected branches
+
+The default branch is always protected. To protect additional branches (e.g.,
+release branches), list them explicitly:
+
+```toml
+protected_branches = ["v1", "v2"]
+```
+
+`tend check` verifies branch protection on all listed branches. `tend check
+--fix` creates a single ruleset covering the default branch and all extra
+branches.
+
 ### Secrets
 
 Two repo secrets are required:

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -8,9 +8,10 @@ the principles; each adopting repo should document its specific configuration
 
 Two layers protect a repository, in order of importance:
 
-1. **Merge restriction** — only designated admins can merge to the default
-   branch, enforced by a ruleset or branch protection. The bot has write access
-   (not admin) and cannot merge regardless of review status.
+1. **Merge restriction** — only designated admins can merge to protected
+   branches (default branch plus any in `protected_branches`), enforced by a
+   ruleset or branch protection. The bot has write access (not admin) and
+   cannot merge regardless of review status.
 2. **Environment protection** — release secrets (registry tokens, signing keys)
    are in a protected GitHub Environment requiring deployment approval,
    preventing exfiltration via modified workflows.

--- a/generator/src/tend/checks.py
+++ b/generator/src/tend/checks.py
@@ -1,7 +1,7 @@
 """Security checks for tend setup.
 
 Verifies the repository has the security prerequisites described in
-docs/security-model.md: branch protection on the default branch, bot
+docs/security-model.md: branch protection on configured branches, bot
 permission level, and required secrets.
 
 Uses the `gh` CLI for GitHub API access. Checks degrade gracefully when
@@ -53,7 +53,7 @@ def detect_repo() -> str | None:
     return None
 
 
-def _detect_default_branch(repo: str) -> str | None:
+def detect_default_branch(repo: str) -> str | None:
     """Detect the default branch for a repo via the GitHub API."""
     result = _gh("api", f"repos/{repo}", "--jq", ".default_branch")
     if result and result.returncode == 0:
@@ -63,25 +63,24 @@ def _detect_default_branch(repo: str) -> str | None:
 
 
 def check_branch_protection(repo: str, branch: str) -> CheckResult:
-    """Check if the default branch is protected against bot merges.
+    """Check if a branch is protected against bot merges.
 
     Checks both that the branch is protected and that the protection actually
     prevents the bot from merging (via required reviews or a restrict-updates
     ruleset).
     """
+    name = f"branch-protection:{branch}"
     result = _gh("api", f"repos/{repo}/branches/{branch}", "--jq", ".protected")
     if result is None:
-        return CheckResult("branch-protection", None, "gh CLI not found")
+        return CheckResult(name, None, "gh CLI not found")
     if result.returncode != 0:
-        return CheckResult(
-            "branch-protection", None, f"API error: {result.stderr.strip()}"
-        )
+        return CheckResult(name, None, f"API error: {result.stderr.strip()}")
 
     if result.stdout.strip() != "true":
         return CheckResult(
-            "branch-protection",
+            name,
             False,
-            f"Default branch '{branch}' is NOT protected. "
+            f"Branch '{branch}' is NOT protected. "
             "The bot must not be able to merge PRs — this is the primary security boundary. "
             "Add a branch protection rule or ruleset. See docs/security-model.md.",
         )
@@ -90,43 +89,37 @@ def check_branch_protection(repo: str, branch: str) -> CheckResult:
     # A restrict-updates ruleset is sufficient (and preferred).
     if _has_restrict_updates_ruleset(repo, branch):
         return CheckResult(
-            "branch-protection",
+            name,
             True,
-            f"Default branch '{branch}' is protected (restrict-updates ruleset)",
+            f"Branch '{branch}' is protected (restrict-updates ruleset)",
         )
 
     # Fall back to checking branch protection rules for required reviews.
     prot = _gh("api", f"repos/{repo}/branches/{branch}/protection")
     if prot is None or prot.returncode != 0:
         # Can't read details — branch is protected, assume OK.
-        return CheckResult(
-            "branch-protection", True, f"Default branch '{branch}' is protected"
-        )
+        return CheckResult(name, True, f"Branch '{branch}' is protected")
 
     try:
         data = json.loads(prot.stdout)
     except json.JSONDecodeError:
-        return CheckResult(
-            "branch-protection", True, f"Default branch '{branch}' is protected"
-        )
+        return CheckResult(name, True, f"Branch '{branch}' is protected")
 
     if not isinstance(data, dict):
-        return CheckResult(
-            "branch-protection", True, f"Default branch '{branch}' is protected"
-        )
+        return CheckResult(name, True, f"Branch '{branch}' is protected")
 
     reviews = data.get("required_pull_request_reviews")
     if reviews and reviews.get("required_approving_review_count", 0) > 0:
         return CheckResult(
-            "branch-protection",
+            name,
             True,
-            f"Default branch '{branch}' is protected (requires reviews)",
+            f"Branch '{branch}' is protected (requires reviews)",
         )
 
     return CheckResult(
-        "branch-protection",
+        name,
         False,
-        f"Default branch '{branch}' is protected but the bot can still merge PRs "
+        f"Branch '{branch}' is protected but the bot can still merge PRs "
         f"(required_approving_review_count is 0 and no restrict-updates ruleset found). "
         "Either require at least 1 approving review, or add a 'Restrict updates' "
         "ruleset with only admins bypassing. See docs/security-model.md.",
@@ -250,34 +243,48 @@ def _list_org_secrets(org: str) -> tuple[set[str] | None, bool]:
         return None, False
 
 
-RESTRICT_UPDATES_RULESET = json.dumps(
-    {
-        "name": "Merge access",
-        "target": "branch",
-        "enforcement": "active",
-        "conditions": {
-            "ref_name": {
-                "include": ["~DEFAULT_BRANCH"],
-                "exclude": [],
-            }
-        },
-        "rules": [{"type": "update"}],
-        "bypass_actors": [
-            {
-                "actor_id": 5,
-                "actor_type": "RepositoryRole",
-                "bypass_mode": "exempt",
-            }
-        ],
-    }
-)
+def _restrict_updates_ruleset(extra_branches: list[str]) -> str:
+    """Build the JSON body for a restrict-updates ruleset.
 
-
-def fix_branch_protection(repo: str) -> CheckResult:
-    """Create a restrict-updates ruleset on the default branch.
-
-    Only admins (actor_id 5) can bypass. The bot (write role) cannot merge.
+    Always includes ~DEFAULT_BRANCH. Extra branches are added as
+    refs/heads/<name> patterns.
     """
+    include = ["~DEFAULT_BRANCH"] + [f"refs/heads/{b}" for b in extra_branches]
+    return json.dumps(
+        {
+            "name": "Merge access",
+            "target": "branch",
+            "enforcement": "active",
+            "conditions": {
+                "ref_name": {
+                    "include": include,
+                    "exclude": [],
+                }
+            },
+            "rules": [{"type": "update"}],
+            "bypass_actors": [
+                {
+                    "actor_id": 5,
+                    "actor_type": "RepositoryRole",
+                    "bypass_mode": "exempt",
+                }
+            ],
+        }
+    )
+
+
+def fix_branch_protection(
+    repo: str,
+    default_branch: str,
+    extra_branches: list[str] | None = None,
+) -> CheckResult:
+    """Create a restrict-updates ruleset covering protected branches.
+
+    Always covers the default branch. Extra branches from config are included
+    in the same ruleset. Only admins (actor_id 5) can bypass.
+    """
+    extra = [b for b in (extra_branches or []) if b != default_branch]
+    body = _restrict_updates_ruleset(extra)
     result = _gh(
         "api",
         f"repos/{repo}/rulesets",
@@ -285,20 +292,22 @@ def fix_branch_protection(repo: str) -> CheckResult:
         "POST",
         "--input",
         "-",
-        input=RESTRICT_UPDATES_RULESET,
+        input=body,
     )
+    name = f"branch-protection:{default_branch}"
     if result is None:
-        return CheckResult("branch-protection", None, "gh CLI not found")
+        return CheckResult(name, None, "gh CLI not found")
     if result.returncode != 0:
         return CheckResult(
-            "branch-protection",
+            name,
             False,
             f"Failed to create ruleset: {result.stderr.strip()}",
         )
+    branches = [default_branch] + extra
     return CheckResult(
-        "branch-protection",
+        name,
         True,
-        "Created 'Merge access' ruleset — only admins can merge",
+        f"Created 'Merge access' ruleset — only admins can merge ({', '.join(branches)})",
     )
 
 
@@ -324,7 +333,7 @@ def run_all_checks(cfg: Config, repo: str | None = None) -> list[CheckResult]:
             )
         ]
 
-    default_branch = _detect_default_branch(repo)
+    default_branch = detect_default_branch(repo)
     if default_branch is None:
         return [
             CheckResult(
@@ -332,8 +341,10 @@ def run_all_checks(cfg: Config, repo: str | None = None) -> list[CheckResult]:
             )
         ]
 
-    return [
-        check_branch_protection(repo, default_branch),
-        check_bot_permission(repo, cfg.bot_name),
-        check_secrets(repo, [cfg.bot_token_secret, cfg.claude_token_secret]),
-    ]
+    results = [check_branch_protection(repo, default_branch)]
+    for branch in cfg.protected_branches:
+        if branch != default_branch:
+            results.append(check_branch_protection(repo, branch))
+    results.append(check_bot_permission(repo, cfg.bot_name))
+    results.append(check_secrets(repo, [cfg.bot_token_secret, cfg.claude_token_secret]))
+    return results

--- a/generator/src/tend/cli.py
+++ b/generator/src/tend/cli.py
@@ -7,7 +7,13 @@ from pathlib import Path
 
 import click
 
-from tend.checks import CheckResult, detect_repo, fix_branch_protection, run_all_checks
+from tend.checks import (
+    CheckResult,
+    detect_default_branch,
+    detect_repo,
+    fix_branch_protection,
+    run_all_checks,
+)
 from tend.config import Config
 from tend.workflows import generate_all
 
@@ -121,16 +127,23 @@ def check(config_path: Path | None, repo: str | None, fix: bool) -> None:
         raise SystemExit(1)
 
     fixed_any = False
-    for r in failures:
-        if r.name == "branch-protection" and "bot can still merge" in r.message:
-            click.echo()
-            click.echo(
-                "Creating 'Merge access' ruleset — only admins can merge to default branch..."
-            )
-            fix_result = fix_branch_protection(repo)
-            _print_check_results([fix_result])
-            if fix_result.passed:
-                fixed_any = True
+    bp_fixable = [
+        r
+        for r in failures
+        if r.name.startswith("branch-protection:")
+        and "bot can still merge" in r.message
+    ]
+    if bp_fixable:
+        branches_desc = ", ".join(r.name.split(":", 1)[1] for r in bp_fixable)
+        click.echo()
+        click.echo(
+            f"Creating 'Merge access' ruleset — only admins can merge ({branches_desc})..."
+        )
+        default_branch = detect_default_branch(repo) or "main"
+        fix_result = fix_branch_protection(repo, default_branch, cfg.protected_branches)
+        _print_check_results([fix_result])
+        if fix_result.passed:
+            fixed_any = True
 
     if fixed_any:
         click.echo()

--- a/generator/src/tend/config.py
+++ b/generator/src/tend/config.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import click
 
 KNOWN_WORKFLOWS = {"review", "mention", "triage", "ci-fix", "nightly", "renovate"}
-KNOWN_TOP_LEVEL = {"bot_name", "secrets", "setup", "workflows"}
+KNOWN_TOP_LEVEL = {"bot_name", "protected_branches", "secrets", "setup", "workflows"}
 _GITHUB_USERNAME = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$")
 
 
@@ -36,6 +36,7 @@ class WorkflowConfig:
 class Config:
     bot_name: str
     default_branch: str
+    protected_branches: list[str]
     bot_token_secret: str
     claude_token_secret: str
     setup: list[SetupStep]
@@ -65,6 +66,14 @@ class Config:
         unknown = set(raw.keys()) - KNOWN_TOP_LEVEL
         for key in sorted(unknown):
             click.echo(f"Warning: unknown config key '{key}'", err=True)
+
+        protected_branches = raw.get("protected_branches", [])
+        if not isinstance(protected_branches, list) or not all(
+            isinstance(b, str) and b for b in protected_branches
+        ):
+            raise click.ClickException(
+                "protected_branches must be a list of non-empty strings"
+            )
 
         secrets = raw.get("secrets", {})
 
@@ -110,6 +119,7 @@ class Config:
         return cls(
             bot_name=bot_name,
             default_branch="main",
+            protected_branches=protected_branches,
             bot_token_secret=secrets.get("bot_token", "BOT_TOKEN"),
             claude_token_secret=secrets.get("claude_token", "CLAUDE_CODE_OAUTH_TOKEN"),
             setup=setup,

--- a/generator/tests/test_checks.py
+++ b/generator/tests/test_checks.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 from unittest.mock import patch
@@ -12,6 +13,7 @@ from click.testing import CliRunner
 from tend.checks import (
     CheckResult,
     _has_restrict_updates_ruleset,
+    _restrict_updates_ruleset,
     check_bot_permission,
     check_branch_protection,
     check_secrets,
@@ -98,6 +100,15 @@ def test_branch_protection_no_gh() -> None:
     assert result.passed is None
 
 
+def test_branch_protection_result_name_includes_branch() -> None:
+    """Each branch gets a distinct check name for identification."""
+    with patch("tend.checks._gh", return_value=_make_completed("false\n")):
+        main_result = check_branch_protection("owner/repo", "main")
+        v1_result = check_branch_protection("owner/repo", "v1")
+    assert main_result.name == "branch-protection:main"
+    assert v1_result.name == "branch-protection:v1"
+
+
 # ---------------------------------------------------------------------------
 # _has_restrict_updates_ruleset
 # ---------------------------------------------------------------------------
@@ -115,6 +126,27 @@ def test_update_ruleset_is_detected() -> None:
     """A ruleset containing a type:update rule should be detected."""
     with patch("tend.checks._gh", return_value=_make_completed("1\n")):
         assert _has_restrict_updates_ruleset("owner/repo", "main") is True
+
+
+# ---------------------------------------------------------------------------
+# _restrict_updates_ruleset
+# ---------------------------------------------------------------------------
+
+
+def test_ruleset_default_branch_only() -> None:
+    """No extra branches — ruleset targets only ~DEFAULT_BRANCH."""
+    body = json.loads(_restrict_updates_ruleset([]))
+    assert body["conditions"]["ref_name"]["include"] == ["~DEFAULT_BRANCH"]
+
+
+def test_ruleset_with_extra_branches() -> None:
+    """Extra branches are added as refs/heads/<name> patterns."""
+    body = json.loads(_restrict_updates_ruleset(["v1", "v2"]))
+    assert body["conditions"]["ref_name"]["include"] == [
+        "~DEFAULT_BRANCH",
+        "refs/heads/v1",
+        "refs/heads/v2",
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -213,7 +245,7 @@ def test_secrets_bad_json() -> None:
 
 def test_run_all_checks_no_gh() -> None:
     with patch("shutil.which", return_value=None):
-        results = run_all_checks(Config("bot", "main", "T1", "T2", [], {}))
+        results = run_all_checks(Config("bot", "main", [], "T1", "T2", [], {}))
     assert len(results) == 1
     assert results[0].passed is None
     assert "gh CLI" in results[0].message
@@ -224,41 +256,80 @@ def test_run_all_checks_no_repo() -> None:
         patch("shutil.which", return_value="/usr/bin/gh"),
         patch("tend.checks.detect_repo", return_value=None),
     ):
-        results = run_all_checks(Config("bot", "main", "T1", "T2", [], {}))
+        results = run_all_checks(Config("bot", "main", [], "T1", "T2", [], {}))
     assert len(results) == 1
     assert "detect" in results[0].message
 
 
+def _fake_gh_all_pass(*args, **kwargs) -> subprocess.CompletedProcess[str]:
+    """Simulate a gh CLI where all checks pass for owner/repo."""
+    cmd = " ".join(args)
+    if args[1] == "repos/owner/repo" and "--jq" in args and ".default_branch" in args:
+        return _make_completed("main\n")
+    if "rulesets" in cmd:
+        return _make_completed("1\n")
+    if "branches" in cmd:
+        return _make_completed("true\n")
+    if "collaborators" in cmd:
+        return _make_completed("write\n")
+    if "secrets" in cmd:
+        return _make_completed('["T1","T2"]\n')
+    return _make_completed(returncode=1)
+
+
 def test_run_all_checks_with_explicit_repo() -> None:
     """Explicit --repo skips auto-detection."""
-
-    def fake_gh(*args, **kwargs) -> subprocess.CompletedProcess[str]:
-        cmd = " ".join(args)
-        if (
-            args[1] == "repos/owner/repo"
-            and "--jq" in args
-            and ".default_branch" in args
-        ):
-            return _make_completed("main\n")
-        if "rulesets" in cmd:
-            return _make_completed("1\n")
-        if "branches" in cmd:
-            return _make_completed("true\n")
-        if "collaborators" in cmd:
-            return _make_completed("write\n")
-        if "secrets" in cmd:
-            return _make_completed('["T1","T2"]\n')
-        return _make_completed(returncode=1)
-
     with (
         patch("shutil.which", return_value="/usr/bin/gh"),
-        patch("tend.checks._gh", side_effect=fake_gh),
+        patch("tend.checks._gh", side_effect=_fake_gh_all_pass),
     ):
         results = run_all_checks(
-            Config("bot", "main", "T1", "T2", [], {}), repo="owner/repo"
+            Config("bot", "main", [], "T1", "T2", [], {}), repo="owner/repo"
         )
     assert len(results) == 3
     assert all(r.passed is True for r in results)
+
+
+def test_run_all_checks_with_protected_branches() -> None:
+    """Protected branches produce additional branch-protection checks."""
+    with (
+        patch("shutil.which", return_value="/usr/bin/gh"),
+        patch("tend.checks._gh", side_effect=_fake_gh_all_pass),
+    ):
+        results = run_all_checks(
+            Config("bot", "main", ["v1", "v2"], "T1", "T2", [], {}),
+            repo="owner/repo",
+        )
+    # default + v1 + v2 + bot-permission + secrets = 5
+    assert len(results) == 5
+    bp_results = [r for r in results if r.name.startswith("branch-protection:")]
+    assert len(bp_results) == 3
+    assert {r.name for r in bp_results} == {
+        "branch-protection:main",
+        "branch-protection:v1",
+        "branch-protection:v2",
+    }
+    assert all(r.passed is True for r in results)
+
+
+def test_run_all_checks_deduplicates_default_branch() -> None:
+    """If protected_branches includes the default branch, it's not checked twice."""
+    with (
+        patch("shutil.which", return_value="/usr/bin/gh"),
+        patch("tend.checks._gh", side_effect=_fake_gh_all_pass),
+    ):
+        results = run_all_checks(
+            Config("bot", "main", ["main", "v1"], "T1", "T2", [], {}),
+            repo="owner/repo",
+        )
+    # main (deduped) + v1 + bot-permission + secrets = 4
+    assert len(results) == 4
+    bp_results = [r for r in results if r.name.startswith("branch-protection:")]
+    assert len(bp_results) == 2
+    assert {r.name for r in bp_results} == {
+        "branch-protection:main",
+        "branch-protection:v1",
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/generator/tests/test_config_edge_cases.py
+++ b/generator/tests/test_config_edge_cases.py
@@ -42,10 +42,64 @@ def test_bot_name_only(tmp_path: Path) -> None:
     path = _write_config(tmp_path, 'bot_name = "my-bot"')
     cfg = Config.load(path)
     assert cfg.bot_name == "my-bot"
+    assert cfg.protected_branches == []
     assert cfg.bot_token_secret == "BOT_TOKEN"
     assert cfg.claude_token_secret == "CLAUDE_CODE_OAUTH_TOKEN"
     assert cfg.setup == []
     assert cfg.workflows == {}
+
+
+# ---------------------------------------------------------------------------
+# 2b. protected_branches
+# ---------------------------------------------------------------------------
+
+
+def test_protected_branches_parsed(tmp_path: Path) -> None:
+    path = _write_config(
+        tmp_path,
+        dedent("""\
+        bot_name = "my-bot"
+        protected_branches = ["v1", "v2"]
+    """),
+    )
+    cfg = Config.load(path)
+    assert cfg.protected_branches == ["v1", "v2"]
+
+
+def test_protected_branches_empty_list(tmp_path: Path) -> None:
+    path = _write_config(
+        tmp_path,
+        dedent("""\
+        bot_name = "my-bot"
+        protected_branches = []
+    """),
+    )
+    cfg = Config.load(path)
+    assert cfg.protected_branches == []
+
+
+def test_protected_branches_non_list_rejected(tmp_path: Path) -> None:
+    path = _write_config(
+        tmp_path,
+        dedent("""\
+        bot_name = "my-bot"
+        protected_branches = "v1"
+    """),
+    )
+    with pytest.raises(ClickException, match="protected_branches must be a list"):
+        Config.load(path)
+
+
+def test_protected_branches_empty_string_rejected(tmp_path: Path) -> None:
+    path = _write_config(
+        tmp_path,
+        dedent("""\
+        bot_name = "my-bot"
+        protected_branches = ["v1", ""]
+    """),
+    )
+    with pytest.raises(ClickException, match="non-empty strings"):
+        Config.load(path)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Repos often have important branches beyond the default — release branches like `v1`, maintenance branches. Previously `tend check` only verified the default branch was protected.

Adds a `protected_branches` config field:

```toml
bot_name = "tend-agent"
protected_branches = ["v1", "v2"]
```

`tend check` now verifies branch protection on all listed branches (plus the default, always). `tend check --fix` creates a single GitHub ruleset covering everything. The action.yaml runtime preflight stays default-branch-only as a safety net.

Known limitation: `_has_restrict_updates_ruleset` doesn't filter by which branches a ruleset targets (pre-existing — the function queries all rulesets in the repo). A ruleset covering only `main` could produce a false positive for `v1`. Since `--fix` creates a single ruleset covering all configured branches, this mainly matters for manually-configured rulesets.

> _This was written by Claude Code on behalf of @max-sixty_