### PR TITLE
fix(review): require one-sentence summary in approval body

### DIFF
--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -147,10 +147,17 @@ Flag duplicates — reuse is almost always better than a parallel implementation
 
 ### 5. Submit
 
-**If there are no issues, approve with an empty body — silence means correct.**
+**If there are no issues, approve with a one-sentence summary of what you
+checked.** Don't list every file — just state the nature of the change and
+your key verification (e.g., "Config parsing change with good edge-case
+coverage; tests pass."). This tells the author and future readers that a real
+review happened, not just an auto-approval.
 
 ```bash
-gh pr review <number> --approve -b ""
+cat > /tmp/approve-body.md << 'EOF'
+<one-sentence summary>
+EOF
+gh pr review <number> --approve -F /tmp/approve-body.md
 ```
 
 If there are actionable findings, submit as a review with inline suggestions
@@ -207,8 +214,7 @@ ALREADY_POSTED=$(gh api "repos/$REPO/pulls/<number>/reviews" \
 
 Post exactly one review per run. Always give a verdict: **approve** or
 **comment** (never "request changes"). Use `gh pr review` for reviews, not
-`gh pr comment`. Note: `--comment` requires a non-empty body — if there's
-nothing to say, use the approve-with-empty-body pattern.
+`gh pr comment`.
 
 **Inline suggestions are mandatory for concrete fixes.** Whenever there's a
 concrete fix (typos, doc updates, naming, missing imports, minor refactors),


### PR DESCRIPTION
## Summary

- Replace the "approve with empty body" instruction with a requirement for a
  one-sentence summary of what was checked
- Remove the fallback reference to the empty-body pattern in posting mechanics

## Evidence

**4 occurrences** (1 historical + 3 this hour) of empty approval bodies where
the bot performed thorough internal analysis but communicated none of it:

| Run | PR | Branch | Observation |
|---|---|---|---|
| 23575296165 | worktrunk#1746 | (historical) | Verified shortcode unused, checked all refs — posted `-b ""` |
| 23614232417 | #75 | protected-branches | Identified `branch` param ignored in ruleset check, ran 84 tests — posted `-b ""` |
| 23614705569 | #76 | secrets | Analyzed security allowlist logic, ran 100 tests — posted `-b ""` |
| 23614762732 | #77 | lazy-attacker | Read security threat model, verified structure — posted `-b ""` |

**Root cause:** The review skill at line 150 explicitly instructs `approve with
an empty body — silence means correct` with a code block showing `-b ""`.

**Gate assessment:**
- Evidence level: High (consistent pattern — 100% of review sessions)
- Occurrences: 4 (1 historical + 3 this hour, threshold for High: 2–3)
- Change type: Targeted fix (replace one instruction + code block)
- Both gates pass

## Change

The fix replaces the empty-body instruction with guidance to include a
one-sentence summary (e.g., "Config parsing change with good edge-case
coverage; tests pass."). Uses `-F /tmp/approve-body.md` instead of `-b ""`
to follow the shell-quoting best practices already in the running-in-ci skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)