### PR TITLE
docs: document secrets.allowed in setup skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,19 @@ bot_token = "MY_BOT_PAT"
 claude_token = "MY_CLAUDE_TOKEN"
 ```
 
+`tend check` flags any repo-level secret not in an explicit allowlist (the bot
+tokens above are always allowed). Repos with additional legitimate repo-level
+secrets — coverage tokens, linter keys — must list them:
+
+```toml
+[secrets]
+allowed = ["CODECOV_TOKEN"]
+```
+
+Release secrets (registry tokens, signing keys) should never be repo-level.
+Store them in a protected GitHub Environment instead — see
+`docs/security-model.md`.
+
 ### Setup steps
 
 Build tools, caches, and environment variables run before Claude in every

--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -56,6 +56,16 @@ overriding the default name rather than creating a duplicate:
 bot_token = "GH_BOT_TOKEN"
 ```
 
+If the secret list shows non-bot repo-level secrets (e.g., `CODECOV_TOKEN`,
+`SENTRY_DSN`), add them to `secrets.allowed` so `tend check` doesn't flag them.
+Any secret not in the allowlist triggers a warning — release secrets (registry
+tokens, signing keys) should be in a protected environment, not listed here:
+
+```toml
+[secrets]
+allowed = ["CODECOV_TOKEN"]
+```
+
 Discover existing CI workflows so tend-ci-fix can watch them:
 
 ```bash


### PR DESCRIPTION
Follow-up to #76. The setup skill now guides users to add `secrets.allowed` entries for legitimate repo-level secrets during initial configuration.

> _This was written by Claude Code on behalf of @max-sixty_