### PR TITLE
Re-apply fork privilege mode with permission validation fix

### DIFF
--- a/.config/tend.toml
+++ b/.config/tend.toml
@@ -1,4 +1,5 @@
 bot_name = "tend-agent"
+mode = "write"
 protected_branches = ["v1"]
 
 [workflows.ci-fix]

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -55,6 +55,7 @@ Four pieces:
 
    ```toml
    bot_name = "worktrunk-bot"
+   mode = "fork"  # or "write"
 
    [secrets]
    bot_token = "WORKTRUNK_BOT_TOKEN"

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -32,6 +32,7 @@ Four pieces:
      allowed_non_write_users: { default: "*" }
      show_full_output: { default: "true" }
      use_sticky_comment: { default: "false" }
+     mode: { default: "write" }
      additional_permissions: { default: "actions: read" }
    ```
 
@@ -157,8 +158,7 @@ enforces this server-side regardless of the PAT's scope.
 ### Privilege models
 
 The `mode` field in `.config/tend.toml` selects between two privilege
-models (not yet implemented — currently only write + branch protection
-exists):
+models:
 
 | | **Triage + fork** | **Write + branch protection** |
 |---|---|---|

--- a/action.yaml
+++ b/action.yaml
@@ -37,6 +37,9 @@ inputs:
   use_sticky_comment:
     default: "false"
     description: Use a sticky (updated) comment instead of new comments
+  mode:
+    default: "write"
+    description: "Privilege model: fork (triage + fork) or write (write + branch protection)"
   additional_permissions:
     default: "actions: read"
     description: Additional permissions for claude-code-action
@@ -47,6 +50,10 @@ runs:
     - name: Security preflight
       shell: bash
       run: |
+        if [ "$MODE" = "fork" ]; then
+          echo "Fork mode — branch protection not required (triage collaborator level is the security boundary)"
+          exit 0
+        fi
         DEFAULT_BRANCH=$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.default_branch')
         PROTECTED=$(gh api "repos/${GITHUB_REPOSITORY}/branches/${DEFAULT_BRANCH}" --jq '.protected')
         if [ "$PROTECTED" != "true" ]; then
@@ -56,6 +63,7 @@ runs:
         echo "Security preflight passed: default branch '${DEFAULT_BRANCH}' is protected"
       env:
         GH_TOKEN: ${{ inputs.github_token }}
+        MODE: ${{ inputs.mode }}
 
     - name: Rate limit preflight
       shell: bash
@@ -139,6 +147,8 @@ runs:
     - name: Run Claude Code
       id: claude
       uses: anthropics/claude-code-action@v1
+      env:
+        TEND_MODE: ${{ inputs.mode }}
       with:
         show_full_output: ${{ inputs.show_full_output }}
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -1,10 +1,11 @@
 # CI Automation Security Model
 
-Tend gives an AI agent write access to a repository and runs it on
+Tend gives an AI agent access to a repository and runs it on
 attacker-controlled input (PR diffs, issue bodies, comments, CI logs). The
 agent needs enough access to be useful (push commits, post reviews, create
 PRs) but every capability is a capability an attacker inherits if they can
-hijack the session.
+hijack the session. The `mode` config field selects the privilege model —
+see DESIGN.md for the full comparison.
 
 A determined attacker with time and skill will eventually get the tokens —
 they're in memory during every workflow run, and Claude executes arbitrary
@@ -22,13 +23,15 @@ Three things an attacker wants, roughly in order of severity:
 1. **Merge malicious code to the default branch.** Game over — the attacker
    controls the repo. Everything else is damage limitation compared to this.
 
-2. **Exfiltrate tokens.** The bot token grants write access to the repo
-   (branches, PRs, comments). The Claude OAuth token grants billed API access.
-   With a long-lived PAT, the attacker keeps access indefinitely.
+2. **Exfiltrate tokens.** The bot token grants access to the repo — write
+   access in write mode, triage (comments/reviews only) in fork mode. The
+   Claude OAuth token grants billed API access. With a long-lived PAT, the
+   attacker keeps access indefinitely.
 
 3. **Hijack a single session.** Even without stealing tokens, an attacker who
-   controls what Claude does in one run can push malicious branches, post
-   misleading reviews, or create spam PRs.
+   controls what Claude does in one run can push malicious branches (write
+   mode) or branches to the fork (fork mode), post misleading reviews, or
+   create spam PRs.
 
 The attack surface varies by workflow. `tend-review` is the most exposed —
 the attacker controls the entire PR diff, which Claude reads and reasons
@@ -37,19 +40,30 @@ user-controlled input.
 
 | Workflow | Injection surface | Attacker control | Mitigations |
 |----------|-------------------|-------------------|-------------|
-| **review** | PR diff content, review body on bot PRs | Full (any PR) / Medium (reviewers) | Fixed prompt, merge restriction, CLAUDE.md pinning (fork PRs) |
-| **triage** | Issue body | Partial (structured skill) | Fixed prompt, merge restriction, environment protection |
-| **mention** | Comment body on any issue/PR | Full | Fixed prompt, merge restriction, engagement verification |
+| **review** | PR diff content, review body on bot PRs | Full (any PR) / Medium (reviewers) | Fixed prompt, privilege model, CLAUDE.md pinning (fork PRs) |
+| **triage** | Issue body | Partial (structured skill) | Fixed prompt, privilege model, environment protection |
+| **mention** | Comment body on any issue/PR | Full | Fixed prompt, privilege model, engagement verification |
 | **ci-fix** | Failed CI logs | Minimal (must break CI on default branch) | Fixed prompt, automatic trigger |
 | **renovate** | None | None | Fixed prompt, scheduled trigger |
 
 ## What we do
 
-**Merge restriction** is the primary security boundary. A GitHub ruleset (or
-branch protection) prevents the bot from merging to protected branches
-(default branch plus any in `protected_branches`) regardless of review status. The composite action refuses to start if the
-default branch isn't protected. Everything below is defense in depth — useful,
-but not load-bearing.
+**The privilege model** is the primary security boundary, selected by the
+`mode` config field.
+
+In **fork mode** (`mode = "fork"`), the bot has triage access on the target
+repo. Triage cannot push, merge, or modify workflows — GitHub enforces this
+server-side regardless of the PAT's scope. The bot pushes to its own fork
+and creates cross-fork PRs. No branch protection or rulesets are required.
+`tend check` verifies the bot has exactly triage access (not more, not less).
+
+In **write mode** (`mode = "write"`), the bot has write access. A merge
+restriction (ruleset or branch protection) prevents the bot from merging to
+protected branches regardless of review status. The composite action refuses
+to start if the default branch isn't protected. `tend check` verifies both
+the permission level and the branch protection configuration.
+
+Everything below is defense in depth — useful, but not load-bearing.
 
 **Config pinning.** `claude-code-action` restores `.claude/`, `.mcp.json`,
 `.claude.json`, `.gitmodules`, and `.ripgreprc` from the base branch on all
@@ -118,10 +132,12 @@ tricks that bypass the log filter. On GitHub-hosted runners, there's no way
 to restrict outbound network access.
 
 **Long-lived PAT exposure.** A classic PAT is valid until revoked and grants
-access to every repo the bot account can reach. A single successful
-exfiltration gives the attacker persistent, broad write access. The merge
-restriction limits what they can *do* with it, but they can still push
-branches, create PRs, and post comments indefinitely.
+access to every repo the bot account can reach. In write mode, a single
+successful exfiltration gives the attacker persistent, broad write access —
+the merge restriction limits what they can do, but they can still push
+branches, create PRs, and post comments indefinitely. In fork mode, the
+leaked PAT is limited to triage on the target repo (comments and reviews)
+plus write access to the bot's own fork — a much smaller blast radius.
 
 **Prompt injection without code execution.** Even without hijacking the
 tools, an attacker who controls what Claude reads can influence its behavior.
@@ -150,7 +166,9 @@ useful as a tripwire against unsophisticated attacks. Not yet implemented.
 can review the diff and post comments but can't execute code or push commits.
 This would close the "attacker-controlled code execution" gap entirely for
 fork PRs. The tradeoff: the bot can't suggest fixes on fork PRs, only
-review them.
+review them. Fork privilege mode (`mode = "fork"`) is orthogonal — it
+restricts what the *token* can do but doesn't restrict what *Claude* does
+locally. Both could be combined for maximum restriction on fork PRs.
 
 **Network isolation.** Self-hosted runners with outbound traffic restricted
 to GitHub API and Anthropic API endpoints would prevent token exfiltration via
@@ -214,11 +232,11 @@ consistent identity for reviews and comments and avoids the
 
 **If a token leaks:**
 
-| Token | Lifetime | If leaked, attacker can... | ...but cannot |
-|-------|----------|---------------------------|---------------|
-| Bot token (PAT) | Long-lived | Push to unprotected branches, create PRs, impersonate bot — **indefinitely** | Merge PRs (merge restriction), push to default branch, access release secrets (environment-protected) |
-| Bot token (App) | ~1 hour | Same as PAT, but only until token expires | Same + token auto-expires |
-| Claude OAuth | Long-lived | Run Claude sessions billed to the account | Access GitHub |
+| Token | Lifetime | If leaked (write mode) | If leaked (fork mode) |
+|-------|----------|------------------------|----------------------|
+| Bot token (PAT) | Long-lived | Push to unprotected branches, create PRs, impersonate bot — **indefinitely**. Cannot merge (merge restriction), push to default branch, or access release secrets (environment-protected). | Post comments/reviews on target repo, push to bot's fork only. Cannot push to target, merge, or modify workflows. |
+| Bot token (App) | ~1 hour | Same as PAT, but only until token expires | Same as PAT, but only until token expires |
+| Claude OAuth | Long-lived | Run Claude sessions billed to the account. Cannot access GitHub. | Same as write mode |
 
 `GITHUB_TOKEN` is ephemeral (single job) and automatically scoped by each
 workflow's `permissions:` block. Not a meaningful leak target.
@@ -275,5 +293,5 @@ Conversation-tab comments (`issue_comment`) are unaffected.
   `--append-system-prompt "You are operating in a GitHub Actions CI environment. Use /tend-ci-runner:running-in-ci before starting work."`.
 - **Token choice**: All Claude workflows use the bot token for consistent
   identity.
-- **`permissions:` block**: Set `contents: read` for read-only workflows.
+- **`permissions:` block**: Fork mode uses `contents: read` for all workflows (the bot pushes to its fork, not the target). Write mode uses `contents: write`.
 - **Sensitive secrets** must be in protected environments, never repo-level.

--- a/generator/src/tend/checks.py
+++ b/generator/src/tend/checks.py
@@ -181,8 +181,12 @@ def _ref_matches_patterns(
     return False
 
 
-def check_bot_permission(repo: str, bot_name: str) -> CheckResult:
-    """Check the bot's permission level (should be write, not admin)."""
+def check_bot_permission(repo: str, bot_name: str, mode: str = "write") -> CheckResult:
+    """Check the bot's permission level.
+
+    In write mode: should be write, not admin.
+    In fork mode: should be triage (not write or admin — write is unnecessary risk).
+    """
     result = _gh(
         "api",
         f"repos/{repo}/collaborators/{bot_name}/permission",
@@ -209,7 +213,18 @@ def check_bot_permission(repo: str, bot_name: str) -> CheckResult:
             "bot-permission",
             False,
             f"Bot '{bot_name}' has admin permission — it can bypass branch protection. "
-            "Downgrade to write access.",
+            f"Downgrade to {'triage' if mode == 'fork' else 'write'} access.",
+        )
+    if mode == "fork":
+        if perm in ("write", "maintain"):
+            return CheckResult(
+                "bot-permission",
+                False,
+                f"Bot '{bot_name}' has '{perm}' permission — fork mode only needs triage. "
+                "Downgrade to triage to reduce blast radius.",
+            )
+        return CheckResult(
+            "bot-permission", True, f"Bot '{bot_name}' has '{perm}' permission"
         )
     return CheckResult(
         "bot-permission", True, f"Bot '{bot_name}' has '{perm}' permission"
@@ -443,15 +458,25 @@ def run_all_checks(cfg: Config, repo: str | None = None) -> list[CheckResult]:
         cfg.allowed_repo_secrets
     )
 
-    results = [
-        check_branch_protection(repo, default_branch, default_branch=default_branch)
-    ]
-    for branch in cfg.protected_branches:
-        if branch != default_branch:
-            results.append(
-                check_branch_protection(repo, branch, default_branch=default_branch)
+    results = []
+    if cfg.mode == "fork":
+        results.append(
+            CheckResult(
+                "branch-protection",
+                True,
+                "Fork mode — branch protection not required (triage collaborator level is the security boundary)",
             )
-    results.append(check_bot_permission(repo, cfg.bot_name))
+        )
+    else:
+        results.append(
+            check_branch_protection(repo, default_branch, default_branch=default_branch)
+        )
+        for branch in cfg.protected_branches:
+            if branch != default_branch:
+                results.append(
+                    check_branch_protection(repo, branch, default_branch=default_branch)
+                )
+    results.append(check_bot_permission(repo, cfg.bot_name, cfg.mode))
     results.append(check_secrets(repo, [cfg.bot_token_secret, cfg.claude_token_secret]))
     results.append(check_repo_secret_allowlist(repo, allowed))
     return results

--- a/generator/src/tend/checks.py
+++ b/generator/src/tend/checks.py
@@ -223,8 +223,22 @@ def check_bot_permission(repo: str, bot_name: str, mode: str = "write") -> Check
                 f"Bot '{bot_name}' has '{perm}' permission — fork mode only needs triage. "
                 "Downgrade to triage to reduce blast radius.",
             )
+        if perm == "read":
+            return CheckResult(
+                "bot-permission",
+                False,
+                f"Bot '{bot_name}' has read permission — fork mode needs triage "
+                "(read cannot post comments or reviews). Upgrade to triage.",
+            )
         return CheckResult(
             "bot-permission", True, f"Bot '{bot_name}' has '{perm}' permission"
+        )
+    if perm in ("read", "triage"):
+        return CheckResult(
+            "bot-permission",
+            False,
+            f"Bot '{bot_name}' has '{perm}' permission — write mode needs write "
+            "(the bot must be able to push to branches). Upgrade to write.",
         )
     return CheckResult(
         "bot-permission", True, f"Bot '{bot_name}' has '{perm}' permission"

--- a/generator/src/tend/config.py
+++ b/generator/src/tend/config.py
@@ -10,7 +10,15 @@ from pathlib import Path
 import click
 
 KNOWN_WORKFLOWS = {"review", "mention", "triage", "ci-fix", "nightly", "renovate"}
-KNOWN_TOP_LEVEL = {"bot_name", "protected_branches", "secrets", "setup", "workflows"}
+KNOWN_TOP_LEVEL = {
+    "bot_name",
+    "mode",
+    "protected_branches",
+    "secrets",
+    "setup",
+    "workflows",
+}
+VALID_MODES = ("fork", "write")
 KNOWN_SECRETS_KEYS = {"bot_token", "claude_token", "allowed"}
 _GITHUB_USERNAME = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$")
 
@@ -36,6 +44,7 @@ class WorkflowConfig:
 @dataclass
 class Config:
     bot_name: str
+    mode: str
     default_branch: str
     protected_branches: list[str]
     bot_token_secret: str
@@ -64,6 +73,14 @@ class Config:
                 f"bot_name '{bot_name}' is not a valid GitHub username "
                 "(only letters, digits, and hyphens)"
             )
+
+        if "mode" not in raw:
+            raise click.ClickException(
+                "Missing required field: mode (must be 'fork' or 'write')"
+            )
+        mode = raw["mode"]
+        if mode not in VALID_MODES:
+            raise click.ClickException(f"mode must be 'fork' or 'write', got '{mode}'")
 
         unknown = set(raw.keys()) - KNOWN_TOP_LEVEL
         for key in sorted(unknown):
@@ -132,6 +149,7 @@ class Config:
 
         return cls(
             bot_name=bot_name,
+            mode=mode,
             default_branch="main",
             protected_branches=protected_branches,
             bot_token_secret=secrets.get("bot_token", "BOT_TOKEN"),

--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -52,9 +52,10 @@ def _setup_yaml(cfg: Config, indent: int = 6) -> str:
     return "\n" + "\n".join(lines) + "\n"
 
 
-def _permissions(issues: bool = True) -> str:
+def _permissions(mode: str = "write", issues: bool = True) -> str:
+    contents = "read" if mode == "fork" else "write"
     lines = [
-        "      contents: write",
+        f"      contents: {contents}",
         "      pull-requests: write",
         "      id-token: write",
         "      actions: read",
@@ -62,6 +63,19 @@ def _permissions(issues: bool = True) -> str:
     if issues:
         lines.append("      issues: write")
     return "\n".join(lines)
+
+
+def _fork_remote_step(bot_name: str, bot_token: str, indent: int = 6) -> str:
+    """Generate a step that adds the bot's fork as a git remote."""
+    pad = " " * indent
+    return f"""\
+{pad}- name: Configure fork remote
+{pad}  run: |
+{pad}    REPO_NAME="${{GITHUB_REPOSITORY#*/}}"
+{pad}    git remote add fork "https://x-access-token:${{BOT_TOKEN}}@github.com/${{BOT_NAME}}/${{REPO_NAME}}.git"
+{pad}  env:
+{pad}    BOT_NAME: {bot_name}
+{pad}    BOT_TOKEN: {bot_token}"""
 
 
 def _escape(s: str) -> str:
@@ -111,7 +125,8 @@ def generate_review(cfg: Config) -> GeneratedWorkflow:
     bn = cfg.bot_name
 
     setup = _setup_yaml(cfg)
-    perms = _permissions()
+    perms = _permissions(cfg.mode)
+    fork_step = f"\n\n{_fork_remote_step(bn, bt)}\n" if cfg.mode == "fork" else ""
 
     content = f"""\
 {HEADER}
@@ -162,12 +177,13 @@ jobs:
         env:
           GH_TOKEN: {bt}
           PR_NUMBER: ${{{{ github.event.pull_request.number }}}}
-{setup}
+{fork_step}{setup}
       - uses: max-sixty/tend@v1
         with:
           github_token: {bt}
           claude_code_oauth_token: {ct}
           bot_name: {bn}
+          mode: {cfg.mode}
           use_sticky_comment: ${{{{ github.event_name == 'pull_request_target' }}}}
           prompt: >-
             ${{{{ github.event_name == 'pull_request_target'
@@ -192,7 +208,8 @@ def generate_mention(cfg: Config) -> GeneratedWorkflow:
     bn = cfg.bot_name
 
     setup = _setup_yaml(cfg)
-    perms = _permissions()
+    perms = _permissions(cfg.mode)
+    fork_step = f"\n\n{_fork_remote_step(bn, bt)}\n" if cfg.mode == "fork" else ""
     pr = "(github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number)"
 
     content = f"""\
@@ -334,12 +351,13 @@ jobs:
         env:
           GH_TOKEN: {bt}
           PR_NUMBER: ${{{{ github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number }}}}
-{setup}
+{fork_step}{setup}
       - uses: max-sixty/tend@v1
         with:
           github_token: {bt}
           claude_code_oauth_token: {ct}
           bot_name: {bn}
+          mode: {cfg.mode}
           prompt: >-
             ${{{{ github.event_name == 'issues'
               && format('An issue was updated with a mention of you ({{0}}). Read it and respond.', github.event.issue.html_url)
@@ -370,7 +388,8 @@ def generate_triage(cfg: Config) -> GeneratedWorkflow:
     bn = cfg.bot_name
 
     setup = _setup_yaml(cfg)
-    perms = _permissions()
+    perms = _permissions(cfg.mode)
+    fork_step = f"\n\n{_fork_remote_step(bn, bt)}\n" if cfg.mode == "fork" else ""
 
     content = f"""\
 {HEADER}
@@ -398,12 +417,13 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
           token: {bt}
-{setup}
+{fork_step}{setup}
       - uses: max-sixty/tend@v1
         with:
           github_token: {bt}
           claude_code_oauth_token: {ct}
           bot_name: {bn}
+          mode: {cfg.mode}
           prompt: |
             {prompt}
 """
@@ -433,7 +453,8 @@ def generate_ci_fix(cfg: Config) -> GeneratedWorkflow:
     bn = cfg.bot_name
 
     setup = _setup_yaml(cfg)
-    perms = _permissions(issues=False)
+    perms = _permissions(cfg.mode, issues=False)
+    fork_step = f"\n\n{_fork_remote_step(bn, bt)}\n" if cfg.mode == "fork" else ""
     watched_yaml = ", ".join(f'"{w}"' for w in watched)
     branches_yaml = ", ".join(f'"{b}"' for b in branches)
 
@@ -459,12 +480,13 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
           token: {bt}
-{setup}
+{fork_step}{setup}
       - uses: max-sixty/tend@v1
         with:
           github_token: {bt}
           claude_code_oauth_token: {ct}
           bot_name: {bn}
+          mode: {cfg.mode}
           prompt: |
             {prompt}
             - Run URL: ${{{{ github.event.workflow_run.html_url }}}}
@@ -490,7 +512,8 @@ def _generate_scheduled(
     bn = cfg.bot_name
 
     setup = _setup_yaml(cfg)
-    perms = _permissions()
+    perms = _permissions(cfg.mode)
+    fork_step = f"\n\n{_fork_remote_step(bn, bt)}\n" if cfg.mode == "fork" else ""
 
     prompt_lines = "\n".join(f"            {line}" for line in prompt.split("\n"))
     prompt_yaml = f"prompt: |\n{prompt_lines}"
@@ -515,12 +538,13 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
           token: {bt}
-{setup}
+{fork_step}{setup}
       - uses: max-sixty/tend@v1
         with:
           github_token: {bt}
           claude_code_oauth_token: {ct}
           bot_name: {bn}
+          mode: {cfg.mode}
           {prompt_yaml}
 """
     return GeneratedWorkflow(filename=f"tend-{name}.yaml", content=content)

--- a/generator/tests/test_checks.py
+++ b/generator/tests/test_checks.py
@@ -34,7 +34,9 @@ def _make_completed(
     )
 
 
-def _write_config(tmp_path: Path, content: str = 'bot_name = "test-bot"') -> Path:
+def _write_config(
+    tmp_path: Path, content: str = 'bot_name = "test-bot"\nmode = "write"'
+) -> Path:
     cfg = tmp_path / ".config" / "tend.toml"
     cfg.parent.mkdir(parents=True, exist_ok=True)
     cfg.write_text(content)
@@ -491,7 +493,7 @@ def test_repo_secret_allowlist_bad_json() -> None:
 
 def test_run_all_checks_no_gh() -> None:
     with patch("shutil.which", return_value=None):
-        results = run_all_checks(Config("bot", "main", [], "T1", "T2", [], {}))
+        results = run_all_checks(Config("bot", "write", "main", [], "T1", "T2", [], {}))
     assert len(results) == 1
     assert results[0].passed is None
     assert "gh CLI" in results[0].message
@@ -502,7 +504,7 @@ def test_run_all_checks_no_repo() -> None:
         patch("shutil.which", return_value="/usr/bin/gh"),
         patch("tend.checks.detect_repo", return_value=None),
     ):
-        results = run_all_checks(Config("bot", "main", [], "T1", "T2", [], {}))
+        results = run_all_checks(Config("bot", "write", "main", [], "T1", "T2", [], {}))
     assert len(results) == 1
     assert "detect" in results[0].message
 
@@ -533,7 +535,7 @@ def test_run_all_checks_with_explicit_repo() -> None:
         patch("tend.checks._gh", side_effect=_fake_gh_all_pass),
     ):
         results = run_all_checks(
-            Config("bot", "main", [], "T1", "T2", [], {}), repo="owner/repo"
+            Config("bot", "write", "main", [], "T1", "T2", [], {}), repo="owner/repo"
         )
     assert all(r.passed is True for r in results)
 
@@ -545,7 +547,7 @@ def test_run_all_checks_allowlist_includes_bot_secrets() -> None:
         patch("tend.checks._gh", side_effect=_fake_gh_all_pass),
     ):
         results = run_all_checks(
-            Config("bot", "main", [], "T1", "T2", [], {}), repo="owner/repo"
+            Config("bot", "write", "main", [], "T1", "T2", [], {}), repo="owner/repo"
         )
     allowlist_check = [r for r in results if r.name == "repo-secret-allowlist"]
     assert len(allowlist_check) == 1
@@ -578,7 +580,7 @@ def test_run_all_checks_allowlist_catches_unexpected() -> None:
         patch("tend.checks._gh", side_effect=fake_gh_with_extra_secret),
     ):
         results = run_all_checks(
-            Config("bot", "main", [], "T1", "T2", [], {}), repo="owner/repo"
+            Config("bot", "write", "main", [], "T1", "T2", [], {}), repo="owner/repo"
         )
     allowlist_check = [r for r in results if r.name == "repo-secret-allowlist"]
     assert len(allowlist_check) == 1
@@ -593,7 +595,7 @@ def test_run_all_checks_with_protected_branches() -> None:
         patch("tend.checks._gh", side_effect=_fake_gh_all_pass),
     ):
         results = run_all_checks(
-            Config("bot", "main", ["v1", "v2"], "T1", "T2", [], {}),
+            Config("bot", "write", "main", ["v1", "v2"], "T1", "T2", [], {}),
             repo="owner/repo",
         )
     # default + v1 + v2 + bot-permission + secrets + allowlist = 6
@@ -615,7 +617,7 @@ def test_run_all_checks_deduplicates_default_branch() -> None:
         patch("tend.checks._gh", side_effect=_fake_gh_all_pass),
     ):
         results = run_all_checks(
-            Config("bot", "main", ["main", "v1"], "T1", "T2", [], {}),
+            Config("bot", "write", "main", ["main", "v1"], "T1", "T2", [], {}),
             repo="owner/repo",
         )
     # main (deduped) + v1 + bot-permission + secrets + allowlist = 5
@@ -626,6 +628,55 @@ def test_run_all_checks_deduplicates_default_branch() -> None:
         "branch-protection:main",
         "branch-protection:v1",
     }
+
+
+# ---------------------------------------------------------------------------
+# Fork mode checks
+# ---------------------------------------------------------------------------
+
+
+def test_bot_write_permission_fails_in_fork_mode() -> None:
+    """In fork mode, write permission is too much — should fail."""
+    with patch("tend.checks._gh", return_value=_make_completed("write\n")):
+        result = check_bot_permission("owner/repo", "my-bot", mode="fork")
+    assert result.passed is False
+    assert "triage" in result.message
+
+
+def test_bot_triage_permission_passes_in_fork_mode() -> None:
+    with patch("tend.checks._gh", return_value=_make_completed("triage\n")):
+        result = check_bot_permission("owner/repo", "my-bot", mode="fork")
+    assert result.passed is True
+
+
+def test_fork_mode_skips_branch_protection() -> None:
+    """run_all_checks in fork mode skips branch protection check."""
+
+    def fake_gh(*args, **kwargs):
+        cmd = " ".join(args)
+        if args[1].startswith("repos/owner/repo") and ".default_branch" in " ".join(
+            args
+        ):
+            return _make_completed("main\n")
+        if "collaborators" in cmd:
+            return _make_completed("triage\n")
+        if "secrets" in cmd:
+            return _make_completed('["T1","T2"]\n')
+        return _make_completed(returncode=1)
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/gh"),
+        patch("tend.checks._gh", side_effect=fake_gh),
+    ):
+        results = run_all_checks(
+            Config("bot", "fork", "main", [], "T1", "T2", [], {}),
+            repo="owner/repo",
+        )
+    assert len(results) == 4
+    bp = results[0]
+    assert bp.name == "branch-protection"
+    assert bp.passed is True
+    assert "Fork mode" in bp.message
 
 
 # ---------------------------------------------------------------------------

--- a/generator/tests/test_checks.py
+++ b/generator/tests/test_checks.py
@@ -635,6 +635,14 @@ def test_run_all_checks_deduplicates_default_branch() -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_bot_admin_permission_fails_in_fork_mode() -> None:
+    """In fork mode, admin error message recommends triage (not write)."""
+    with patch("tend.checks._gh", return_value=_make_completed("admin\n")):
+        result = check_bot_permission("owner/repo", "my-bot", mode="fork")
+    assert result.passed is False
+    assert "triage" in result.message
+
+
 def test_bot_write_permission_fails_in_fork_mode() -> None:
     """In fork mode, write permission is too much — should fail."""
     with patch("tend.checks._gh", return_value=_make_completed("write\n")):
@@ -647,6 +655,38 @@ def test_bot_triage_permission_passes_in_fork_mode() -> None:
     with patch("tend.checks._gh", return_value=_make_completed("triage\n")):
         result = check_bot_permission("owner/repo", "my-bot", mode="fork")
     assert result.passed is True
+
+
+def test_bot_maintain_permission_fails_in_fork_mode() -> None:
+    """In fork mode, maintain permission is too much — should fail."""
+    with patch("tend.checks._gh", return_value=_make_completed("maintain\n")):
+        result = check_bot_permission("owner/repo", "my-bot", mode="fork")
+    assert result.passed is False
+    assert "triage" in result.message
+
+
+def test_bot_read_permission_fails_in_fork_mode() -> None:
+    """In fork mode, read permission is insufficient — needs triage."""
+    with patch("tend.checks._gh", return_value=_make_completed("read\n")):
+        result = check_bot_permission("owner/repo", "my-bot", mode="fork")
+    assert result.passed is False
+    assert "triage" in result.message
+
+
+def test_bot_read_permission_fails_in_write_mode() -> None:
+    """In write mode, read permission is insufficient — needs write."""
+    with patch("tend.checks._gh", return_value=_make_completed("read\n")):
+        result = check_bot_permission("owner/repo", "my-bot", mode="write")
+    assert result.passed is False
+    assert "write" in result.message
+
+
+def test_bot_triage_permission_fails_in_write_mode() -> None:
+    """In write mode, triage permission is insufficient — needs write."""
+    with patch("tend.checks._gh", return_value=_make_completed("triage\n")):
+        result = check_bot_permission("owner/repo", "my-bot", mode="write")
+    assert result.passed is False
+    assert "write" in result.message
 
 
 def test_fork_mode_skips_branch_protection() -> None:

--- a/generator/tests/test_config_edge_cases.py
+++ b/generator/tests/test_config_edge_cases.py
@@ -16,6 +16,9 @@ from tend.workflows import generate_all
 def _write_config(tmp_path: Path, content: str) -> Path:
     cfg = tmp_path / ".config" / "tend.toml"
     cfg.parent.mkdir(parents=True, exist_ok=True)
+    # Add mode after bot_name if not present (must be top-level, before sections)
+    if "mode" not in content and "bot_name" in content:
+        content = content.replace("bot_name", 'mode = "write"\nbot_name', 1)
     cfg.write_text(content)
     return cfg
 
@@ -37,11 +40,12 @@ def test_empty_toml_raises(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_bot_name_only(tmp_path: Path) -> None:
-    """Minimal config with just bot_name should produce valid defaults."""
-    path = _write_config(tmp_path, 'bot_name = "my-bot"')
+def test_minimal_config_defaults(tmp_path: Path) -> None:
+    """Minimal config (bot_name + mode) should produce valid defaults."""
+    path = _write_config(tmp_path, 'bot_name = "my-bot"\nmode = "write"')
     cfg = Config.load(path)
     assert cfg.bot_name == "my-bot"
+    assert cfg.mode == "write"
     assert cfg.protected_branches == []
     assert cfg.bot_token_secret == "BOT_TOKEN"
     assert cfg.claude_token_secret == "CLAUDE_CODE_OAUTH_TOKEN"
@@ -582,6 +586,56 @@ def test_setup_steps_entry_both_keys(tmp_path: Path) -> None:
     """),
     )
     with pytest.raises(ClickException, match="setup\\[0\\] must have exactly one"):
+        Config.load(path)
+
+
+# ---------------------------------------------------------------------------
+# 12. Mode validation
+# ---------------------------------------------------------------------------
+
+
+def test_mode_missing_rejected(tmp_path: Path) -> None:
+    """mode is required — missing raises a clear error."""
+    cfg = tmp_path / ".config" / "tend.toml"
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text('bot_name = "my-bot"')
+    with pytest.raises(ClickException, match="Missing required field: mode"):
+        Config.load(cfg)
+
+
+def test_mode_fork(tmp_path: Path) -> None:
+    path = _write_config(
+        tmp_path,
+        dedent("""\
+        bot_name = "my-bot"
+        mode = "fork"
+    """),
+    )
+    cfg = Config.load(path)
+    assert cfg.mode == "fork"
+
+
+def test_mode_write(tmp_path: Path) -> None:
+    path = _write_config(
+        tmp_path,
+        dedent("""\
+        bot_name = "my-bot"
+        mode = "write"
+    """),
+    )
+    cfg = Config.load(path)
+    assert cfg.mode == "write"
+
+
+def test_mode_invalid_rejected(tmp_path: Path) -> None:
+    path = _write_config(
+        tmp_path,
+        dedent("""\
+        bot_name = "my-bot"
+        mode = "triage"
+    """),
+    )
+    with pytest.raises(ClickException, match="mode must be 'fork' or 'write'"):
         Config.load(path)
 
 

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -17,7 +17,9 @@ from tend.workflows import generate_all
 def _minimal_config(tmp_path: Path, extra: str = "") -> Path:
     cfg = tmp_path / ".config" / "tend.toml"
     cfg.parent.mkdir(parents=True)
-    cfg.write_text(f'bot_name = "test-bot"\n{extra}')
+    # Default to write mode unless extra overrides it
+    mode_line = "" if "mode" in extra else 'mode = "write"\n'
+    cfg.write_text(f'bot_name = "test-bot"\n{mode_line}{extra}')
     return cfg
 
 
@@ -233,3 +235,80 @@ def test_setup_after_pr_checkout_in_mention(tmp_path: Path) -> None:
     checkout_idx = mention.content.index("Check out PR branch")
     setup_idx = mention.content.index("./.github/actions/my-setup")
     assert setup_idx > checkout_idx, "Setup must come after PR checkout"
+
+
+# ---------------------------------------------------------------------------
+# Fork mode
+# ---------------------------------------------------------------------------
+
+
+def test_fork_mode_adds_fork_remote_step(tmp_path: Path) -> None:
+    """Fork mode workflows include a step to configure the fork remote."""
+    cfg = Config.load(_minimal_config(tmp_path, 'mode = "fork"'))
+    for wf in generate_all(cfg):
+        assert "Configure fork remote" in wf.content, (
+            f"{wf.filename} missing fork remote step"
+        )
+        assert "git remote add fork" in wf.content, (
+            f"{wf.filename} missing git remote add"
+        )
+
+
+def test_write_mode_no_fork_remote_step(tmp_path: Path) -> None:
+    """Write mode workflows do not include fork remote step."""
+    cfg = Config.load(_minimal_config(tmp_path))
+    for wf in generate_all(cfg):
+        assert "Configure fork remote" not in wf.content, (
+            f"{wf.filename} has unexpected fork step"
+        )
+
+
+def test_fork_mode_contents_read(tmp_path: Path) -> None:
+    """Fork mode sets contents: read instead of contents: write."""
+    cfg = Config.load(_minimal_config(tmp_path, 'mode = "fork"'))
+    for wf in generate_all(cfg):
+        assert "contents: read" in wf.content, f"{wf.filename} missing contents: read"
+        assert "contents: write" not in wf.content, (
+            f"{wf.filename} has contents: write in fork mode"
+        )
+
+
+def test_fork_mode_passes_mode_to_action(tmp_path: Path) -> None:
+    """Fork mode passes mode: fork to the tend action."""
+    cfg = Config.load(_minimal_config(tmp_path, 'mode = "fork"'))
+    for wf in generate_all(cfg):
+        assert "mode: fork" in wf.content, f"{wf.filename} missing mode: fork"
+
+
+def test_write_mode_passes_mode_to_action(tmp_path: Path) -> None:
+    """Write mode passes mode: write to the tend action."""
+    cfg = Config.load(_minimal_config(tmp_path))
+    for wf in generate_all(cfg):
+        assert "mode: write" in wf.content, f"{wf.filename} missing mode: write"
+
+
+def test_fork_mode_valid_yaml(tmp_path: Path) -> None:
+    """Fork mode workflows produce valid YAML."""
+    cfg = Config.load(_minimal_config(tmp_path, 'mode = "fork"'))
+    for wf in generate_all(cfg):
+        data = yaml.safe_load(wf.content)
+        assert isinstance(data, dict), f"{wf.filename} did not parse as dict"
+
+
+def test_fork_mode_with_setup_steps(tmp_path: Path) -> None:
+    """Fork remote step appears before setup steps."""
+    extra = dedent("""\
+        mode = "fork"
+        setup = [{uses = "./.github/actions/my-setup"}]
+    """)
+    cfg = Config.load(_minimal_config(tmp_path, extra))
+    for wf in generate_all(cfg):
+        if (
+            "Configure fork remote" in wf.content
+            and "./.github/actions/my-setup" in wf.content
+        ):
+            fork_idx = wf.content.index("Configure fork remote")
+            setup_idx = wf.content.index("./.github/actions/my-setup")
+            assert fork_idx < setup_idx, (
+                f"{wf.filename}: fork remote must come before setup"
+            )

--- a/plugins/tend-ci-runner/skills/ci-fix/SKILL.md
+++ b/plugins/tend-ci-runner/skills/ci-fix/SKILL.md
@@ -42,10 +42,10 @@ git add <files>
 git commit -m "fix: <description>
 
 Co-Authored-By: Claude <noreply@anthropic.com>"
-git push -u origin fix/ci-<run-id>
 ```
 
-Create the PR with `gh pr create`. PR body format:
+Push and create the PR using the fork-aware pattern from
+`/tend-ci-runner:running-in-ci` (check `$TEND_MODE`). PR body format:
 
 ```
 ## Problem

--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -92,9 +92,10 @@ it — explain uncertainty in the PR description.
 
 For each finding:
 
-1. **Create a PR** — branch, fix, run full test suite, commit, push, create
-   PR, poll CI. **Every bug fix must include a regression test that would have
-   failed before the fix.** If a test is not feasible (e.g., pure
+1. **Create a PR** — branch, fix, run full test suite, commit, push and create
+   PR using the fork-aware pattern from `/tend-ci-runner:running-in-ci` (check
+   `$TEND_MODE`), poll CI. **Every bug fix must include a regression test that
+   would have failed before the fix.** If a test is not feasible (e.g., pure
    documentation changes), note why in the PR description. When uncertain about
    the approach, explain the trade-offs in the description.
 2. **Create an issue only when there's no obvious fix** — design questions,

--- a/plugins/tend-ci-runner/skills/renovate/SKILL.md
+++ b/plugins/tend-ci-runner/skills/renovate/SKILL.md
@@ -27,7 +27,11 @@ If no dependency PRs are open, report "No dependency PRs to process" and exit.
 3. If the update is safe (patch/minor with green CI), approve and merge:
    ```bash
    gh pr review <number> --approve --body "Automated dependency update — CI passing, no breaking changes."
-   gh pr merge <number> --squash
+   # In fork mode (TEND_MODE=fork), skip the merge — the bot lacks merge
+   # permission. Leave it for a maintainer.
+   if [ "$TEND_MODE" != "fork" ]; then
+     gh pr merge <number> --squash
+   fi
    ```
 4. If CI is failing, comment with the failure summary and skip
 5. If a major version bump, comment noting it needs manual review and skip

--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -148,6 +148,8 @@ Flag duplicates — reuse is almost always better than a parallel implementation
 ### 5. Submit
 
 **If there are no issues, approve with an empty body — silence means correct.**
+In fork mode (`TEND_MODE=fork`), approvals don't count for required review
+policies — they're informational. Still submit them; they signal intent.
 
 ```bash
 gh pr review <number> --approve -b ""
@@ -364,6 +366,10 @@ Outdated comments (null line) are best-effort — skip if the original context
 can't be located.
 
 ### 8. Push mechanical fixes
+
+**Fork mode** (`TEND_MODE=fork`): The bot cannot push to human PR branches.
+Post inline suggestions only. For bot PRs (Dependabot, renovate), `gh pr
+checkout` configures tracking to the correct remote — bare `git push` works.
 
 **Bot PRs** (Dependabot, renovate, etc.): If the review found concrete, fixable
 issues and there's no human author to act on feedback, commit and push the fix

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -80,9 +80,39 @@ NEVER run commands that could expose secrets (`env`, `printenv`, `set`,
 environment variables, API keys, tokens, or credentials in responses or
 comments.
 
+## Fork Mode
+
+Check `$TEND_MODE` at the start of every task. When `TEND_MODE=fork`, the bot
+operates with triage access on the target repo and pushes to its own fork.
+A git remote named `fork` is pre-configured by the workflow.
+
+**Pushing new branches** (ci-fix, triage, nightly fix PRs):
+
+```bash
+if [ "$TEND_MODE" = "fork" ]; then
+  git push -u fork <branch>
+  BOT_LOGIN=$(gh api user --jq '.login')
+  gh pr create --repo "$GITHUB_REPOSITORY" --head "$BOT_LOGIN:<branch>" \
+    --title "..." --body "..."
+else
+  git push -u origin <branch>
+  gh pr create --title "..." --body "..."
+fi
+```
+
+**Limitations in fork mode:**
+
+- The bot cannot push to human PR branches — post inline suggestions instead
+- The bot cannot merge PRs (`gh pr merge` fails) — approve and leave for a
+  maintainer
+- Approvals don't count for required review policies (triage-level)
+- `origin` still points to the target repo — `git merge origin/main`, code
+  reading, and API calls work normally
+
 ## PR Creation
 
-When asked to create a PR, use `gh pr create` directly.
+When asked to create a PR, use `gh pr create` directly (or the fork pattern
+above when `TEND_MODE=fork`).
 
 Before creating a branch or PR, check for existing work:
 
@@ -99,9 +129,9 @@ Always use `git push` without specifying a remote — `gh pr checkout` configure
 tracking to the correct remote, including for fork PRs. Specifying `origin`
 explicitly can push to the wrong place.
 
-If pushing fails (fork PR with edits disabled), fall back to posting code
-snippets in a comment. Don't reference commit SHAs from temporary branches —
-post code inline.
+If pushing fails (fork PR with edits disabled, or fork mode on human PRs), fall
+back to posting code snippets in a comment. Don't reference commit SHAs from
+temporary branches — post code inline.
 
 ## Merging Upstream into PR Branches
 

--- a/plugins/tend-ci-runner/skills/triage/SKILL.md
+++ b/plugins/tend-ci-runner/skills/triage/SKILL.md
@@ -118,7 +118,8 @@ missing code. Before adding guidance to a skill:
 1. Fix the root cause (not just the symptom)
 2. Confirm the test now passes
 3. Run the full test suite and lints (use project test commands from CLAUDE.md)
-4. Create branch, commit, push, and create PR:
+4. Create branch, commit, and push using the fork-aware pattern from
+   `/tend-ci-runner:running-in-ci` (check `$TEND_MODE`):
    ```bash
    git checkout -b fix/issue-$ARGUMENTS
    git add -A
@@ -127,8 +128,11 @@ missing code. Before adding guidance to a skill:
    Closes #$ARGUMENTS
 
    Co-Authored-By: Claude <noreply@anthropic.com>"
-   git push -u origin fix/issue-$ARGUMENTS
-   gh pr create --title "fix: <description>" --body "## Problem
+   # Push and create PR — see running-in-ci "Fork Mode" section
+   ```
+   PR body format:
+   ```
+   ## Problem
    [What the issue reported and the root cause]
 
    ## Solution
@@ -138,7 +142,7 @@ missing code. Before adding guidance to a skill:
    [How the fix was verified — mention the reproduction test]
 
    ---
-   Closes #<issue-number> — automated triage"
+   Closes #<issue-number> — automated triage
    ```
 5. Monitor CI using the approach from /tend-ci-runner:running-in-ci.
 
@@ -152,12 +156,7 @@ git add -A
 git commit -m "test: add reproduction for #$ARGUMENTS
 
 Co-Authored-By: Claude <noreply@anthropic.com>"
-git push -u origin repro/issue-$ARGUMENTS
-gh pr create --title "test: reproduction for #$ARGUMENTS" --body "## Context
-Adds a failing test that reproduces #$ARGUMENTS. The fix is not yet included — this PR captures the reproduction so a maintainer can investigate.
-
----
-Automated triage for #<issue-number>"
+# Push and create PR — see running-in-ci "Fork Mode" section
 ```
 
 Note the PR number for the comment.


### PR DESCRIPTION
Re-applies the fork privilege mode from #85 (reverted in #86) with fixes.

This adds a second privilege model to tend's security architecture. The `mode` config field (`"fork"` or `"write"`) selects how the bot interacts with the target repo:

- **Fork mode** (`mode = "fork"`): Bot has triage access on the target repo — can comment and review but cannot push, merge, or modify workflows. Code changes go through the bot's fork as cross-fork PRs. The collaborator level is the security boundary; no branch protection required. Leaked PAT blast radius is limited to comments on the target and writes to the bot's own fork.
- **Write mode** (`mode = "write"`): Existing model. Bot has write access, branch protection/rulesets prevent merging. Leaked PAT gives persistent write access to all branches.

### What changed

**Generator** (`config.py`, `checks.py`, `workflows.py`):
- `mode` is a required config field — existing configs without it fail with a clear error
- Fork mode workflows use `contents: read` permission and add a "Configure fork remote" step
- `check_bot_permission` validates both upper and lower bounds: fork mode requires exactly triage, write mode requires at least write
- `run_all_checks` skips branch protection in fork mode (triage level is the boundary instead)

**Composite action** (`action.yaml`):
- New `mode` input (default: `"write"`)
- Security preflight skips branch protection check in fork mode
- `TEND_MODE` env var passed to Claude Code for runtime mode awareness

**Skills** (6 updated):
- `running-in-ci`: Fork mode section with push-to-fork pattern, limitations (can't push to human branches, can't merge)
- `review`, `ci-fix`, `triage`, `nightly`, `renovate`: Updated to reference fork-aware push/merge patterns

**Documentation**:
- `DESIGN.md`: Removed stale "not yet implemented" note, added `mode` to composite action inputs
- `docs/security-model.md`: Integrated fork mode into threat model, primary boundary description, token leak table, and mitigations

### Fixes relative to #85

The original PR only checked for over-privilege (admin) in `check_bot_permission`. A bot with "read" in fork mode would pass `tend check` but fail at runtime — can't post comments or reviews. Similarly, "read" or "triage" passed in write mode despite being insufficient to push.

Now both modes validate lower bounds:
- Fork: read → fail ("upgrade to triage"), triage → pass, write/maintain/admin → fail
- Write: read/triage → fail ("upgrade to write"), write/maintain → pass, admin → fail

5 new tests cover the added permission checks. 128 total tests pass.

## Test plan
- [x] 128 tests pass (5 new for permission validation)
- [x] All lints pass (ruff, typos, actionlint, uv-lock)

> _This was written by Claude Code on behalf of maximilian_