### PR TITLE
feat: add PRQL/prql to review-reviewers matrix

### DIFF
--- a/.github/workflows/review-reviewers.yaml
+++ b/.github/workflows/review-reviewers.yaml
@@ -20,6 +20,7 @@ jobs:
         repo:
           - max-sixty/worktrunk
           - max-sixty/tend
+          - PRQL/prql
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     permissions:


### PR DESCRIPTION
The hourly session reviewer was only analyzing max-sixty/worktrunk and max-sixty/tend, missing PRQL/prql which has active bot sessions (tend-review, tend-triage, tend-mention).

> _This was written by Claude Code on behalf of max-sixty_