### PR TITLE
fix(action): rewrite legacy skill names in prompt

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -136,6 +136,20 @@ runs:
           echo "No CLAUDE.md on ${DEFAULT_BRANCH} — removed fork version"
         fi
 
+    - name: Normalize prompt
+      id: prompt
+      shell: bash
+      run: |
+        # Rewrite legacy skill names: /tend:tend-X → /tend-ci-runner:X
+        # Pre-v0.0.2 workflows used the old plugin name; the generator now
+        # emits /tend-ci-runner:*, but adopter repos may not have regenerated.
+        PROMPT="${ORIG_PROMPT//\/tend:tend-/\/tend-ci-runner:}"
+        echo "value<<TEND_PROMPT_EOF" >> "$GITHUB_OUTPUT"
+        echo "$PROMPT" >> "$GITHUB_OUTPUT"
+        echo "TEND_PROMPT_EOF" >> "$GITHUB_OUTPUT"
+      env:
+        ORIG_PROMPT: ${{ inputs.prompt }}
+
     - name: Run Claude Code
       id: claude
       uses: anthropics/claude-code-action@v1
@@ -150,7 +164,7 @@ runs:
         trigger_phrase: "@${{ inputs.bot_name }}"
         use_sticky_comment: ${{ inputs.use_sticky_comment }}
         additional_permissions: ${{ inputs.additional_permissions }}
-        prompt: ${{ inputs.prompt }}
+        prompt: ${{ steps.prompt.outputs.value }}
         plugin_marketplaces: https://github.com/max-sixty/tend.git
         plugins: |
           install-tend@tend


### PR DESCRIPTION
## Summary

- Add a prompt normalization step in `action.yaml` that rewrites legacy skill
  names (`/tend:tend-*` → `/tend-ci-runner:*`) before passing to Claude Code

## Evidence

**Critical finding — 8+ occurrences.** Both `tend-review` runs on PRQL/prql
this hour (runs
[23694627681](https://github.com/PRQL/prql/actions/runs/23694627681),
[23694428832](https://github.com/PRQL/prql/actions/runs/23694428832)) failed
with `Unknown skill: tend:tend-review`. The sessions lasted <1 second, no
review was posted, yet the jobs reported `success`. PR
[PRQL/prql#5753](https://github.com/PRQL/prql/pull/5753) and PR
[PRQL/prql#5752](https://github.com/PRQL/prql/pull/5752) were both merged
without bot review.

6+ additional occurrences were recorded in tracking issue #12 across prior
hourly runs (worktrunk and PRQL/prql). PR #54 attempted a compat plugin
approach but was closed.

### Root cause

The plugin rename from `tend` → `tend-ci-runner` in #39 changed skill names
(`tend-review` → `review`). The generator was updated to emit
`/tend-ci-runner:review`, but adopter repos whose workflows were generated
before v0.0.2 still reference `/tend:tend-review`.

### Fix

A lightweight prompt rewrite step: `${PROMPT//\/tend:tend-/\/tend-ci-runner:}`.
This runs before `claude-code-action` and transparently maps old names to new
ones. No compat plugin needed, no changes required in adopter repos.

### Gate assessment

- **Evidence level**: Critical (reviews silently skipped, PRs merged unreviewed)
- **Occurrences**: 8+ (2 this hour + 6+ historical in #12)
- **Change type**: Targeted fix (one new step in action.yaml)
- **Passes both gates**: Yes

## Test plan

- [ ] CI passes on this PR
- [ ] After merging and updating the `v1` tag, verify PRQL/prql `tend-review`
  runs load the `tend-ci-runner:review` skill successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)