### PR TITLE
feat(mention): cover pull_request_review events

### DIFF
--- a/.github/workflows/tend-mention.yaml
+++ b/.github/workflows/tend-mention.yaml
@@ -7,6 +7,8 @@ on:
   issue_comment:
     types: [created, edited]
   # Works for same-repo PRs only; secrets unavailable on fork PRs (no _target variant exists)
+  pull_request_review:
+    types: [submitted]
   pull_request_review_comment:
     types: [created, edited]
 
@@ -19,7 +21,9 @@ jobs:
       (github.event_name == 'issue_comment' &&
         github.event.comment.user.login != 'tend-agent') ||
       (github.event_name == 'pull_request_review_comment' &&
-        github.event.comment.user.login != 'tend-agent')
+        github.event.comment.user.login != 'tend-agent') ||
+      (github.event_name == 'pull_request_review' &&
+        github.event.review.user.login != 'tend-agent')
     runs-on: ubuntu-24.04
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
@@ -83,7 +87,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.BOT_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}
-          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_BODY: ${{ github.event.comment.body || github.event.review.body }}
           ISSUE_BODY: ${{ github.event.issue.body }}
           ISSUE_OR_PR_NUMBER: ${{ github.event.issue.number }}
           ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
@@ -127,7 +131,8 @@ jobs:
       - name: Check out PR branch
         if: |
           (github.event_name == 'issue_comment' && github.event.issue.pull_request.url != '') ||
-          github.event_name == 'pull_request_review_comment'
+          github.event_name == 'pull_request_review_comment' ||
+          github.event_name == 'pull_request_review'
         run: |
           PR_STATE=$(gh pr view "$PR_NUMBER" --json state --jq '.state')
           if [ "$PR_STATE" = "OPEN" ]; then
@@ -153,6 +158,10 @@ jobs:
                 && format('You were mentioned in an inline review comment on PR #{0} ({1}, review comment ID {2}). Read the full PR context (description, diff, recent comments, CI status) and respond. If they are requesting changes, make the changes, commit, and push. Reply in the review thread using `gh api repos/{3}/pulls/{0}/comments/{2}/replies -f body="..."` — do not create a new top-level comment.', (github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number), github.event.comment.html_url, github.event.comment.id, github.repository))
               || (github.event_name == 'pull_request_review_comment'
                 && format('A user left an inline review comment on a PR where you previously participated (PR #{0}, {1}, review comment ID {2}). Read the full context. Only respond if the comment is directed at you or requests changes. Reply in the review thread using `gh api repos/{3}/pulls/{0}/comments/{2}/replies -f body="..."`.', (github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number), github.event.comment.html_url, github.event.comment.id, github.repository))
+              || (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@tend-agent')
+                && format('A review was submitted on PR #{0} that mentions you ({1}). Read the review and full PR context (description, diff, comments, CI status), then respond. If changes were requested, make them, commit, and push.', github.event.pull_request.number, github.event.review.html_url))
+              || (github.event_name == 'pull_request_review'
+                && format('A review was submitted on a PR where you previously participated (PR #{0}, {1}). Read the review and full PR context. If the review requests changes or asks questions, respond appropriately. If the review approves or is between humans, exit silently.', github.event.pull_request.number, github.event.review.html_url))
               || (contains(github.event.comment.body, '@tend-agent')
                 && format('You were mentioned in a comment ({0}). Read the full issue or PR (description, diff, recent comments, CI status) and respond. If they are requesting changes, make the changes, commit, and push.', github.event.comment.html_url))
               || format('A user commented on an issue/PR where you previously participated ({0}). Read the full context. Only respond if the comment is directed at you, asks a question you can help with, or requests changes you can make. A comment that responds to concerns you raised in a review is directed at you — briefly acknowledge that the concerns are resolved (or explain why they are not). If the conversation is between humans, exit silently.', github.event.comment.html_url)

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -354,6 +354,7 @@ consumes no resources.
 | **mention** (verify) | `issues` (edited) | Issue body contains `@$bot_name` and editor is not bot | Bot's own edits; edits that don't mention bot |
 | **mention** (verify) | `issue_comment` | Comment author is not bot | Bot's own comments (prevents loops) |
 | **mention** (verify) | `pull_request_review_comment` | Comment author is not bot | Bot's own inline comments |
+| **mention** (verify) | `pull_request_review` (submitted) | Reviewer is not bot | Bot's own reviews |
 | **mention** (handle) | — | Verify job output `should_run == true` | Events where verify determined no engagement (Layer 2) |
 | **triage** | `issues` (opened) | Issue author is not bot | Bot-opened issues (prevents self-triage loop) |
 | **ci-fix** | `workflow_run` | Triggering workflow concluded with failure | Successful CI runs |
@@ -367,7 +368,7 @@ order):
 
 1. **Issue edits** (`issues` event): always `true` (the GHA condition already
    confirmed `@$bot_name` is in the body).
-2. **Direct mention**: comment body contains `@$bot_name` → `true`.
+2. **Direct mention**: comment or review body contains `@$bot_name` → `true`.
 3. **Non-mention on an issue** (not a PR): bot authored the issue, or `@$bot_name`
    appears in the issue body, or bot has previously commented → `true`.
    Otherwise → `false`.

--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -174,6 +174,8 @@ on:
   issue_comment:
     types: [created, edited]
   # Works for same-repo PRs only; secrets unavailable on fork PRs (no _target variant exists)
+  pull_request_review:
+    types: [submitted]
   pull_request_review_comment:
     types: [created, edited]
 
@@ -186,7 +188,9 @@ jobs:
       (github.event_name == 'issue_comment' &&
         github.event.comment.user.login != '{bn}') ||
       (github.event_name == 'pull_request_review_comment' &&
-        github.event.comment.user.login != '{bn}')
+        github.event.comment.user.login != '{bn}') ||
+      (github.event_name == 'pull_request_review' &&
+        github.event.review.user.login != '{bn}')
     runs-on: ubuntu-24.04
     outputs:
       should_run: ${{{{ steps.check.outputs.should_run }}}}
@@ -250,7 +254,7 @@ jobs:
         env:
           GH_TOKEN: {bt}
           EVENT_NAME: ${{{{ github.event_name }}}}
-          COMMENT_BODY: ${{{{ github.event.comment.body }}}}
+          COMMENT_BODY: ${{{{ github.event.comment.body || github.event.review.body }}}}
           ISSUE_BODY: ${{{{ github.event.issue.body }}}}
           ISSUE_OR_PR_NUMBER: ${{{{ github.event.issue.number }}}}
           ISSUE_AUTHOR: ${{{{ github.event.issue.user.login }}}}
@@ -290,7 +294,8 @@ jobs:
       - name: Check out PR branch
         if: |
           (github.event_name == 'issue_comment' && github.event.issue.pull_request.url != '') ||
-          github.event_name == 'pull_request_review_comment'
+          github.event_name == 'pull_request_review_comment' ||
+          github.event_name == 'pull_request_review'
         run: |
           PR_STATE=$(gh pr view "$PR_NUMBER" --json state --jq '.state')
           if [ "$PR_STATE" = "OPEN" ]; then
@@ -314,6 +319,10 @@ jobs:
                 && format('You were mentioned in an inline review comment on PR #{{0}} ({{1}}, review comment ID {{2}}). Read the full PR context (description, diff, recent comments, CI status) and respond. If they are requesting changes, make the changes, commit, and push. Reply in the review thread using `gh api repos/{{3}}/pulls/{{0}}/comments/{{2}}/replies -f body="..."` — do not create a new top-level comment.', {pr}, github.event.comment.html_url, github.event.comment.id, github.repository))
               || (github.event_name == 'pull_request_review_comment'
                 && format('A user left an inline review comment on a PR where you previously participated (PR #{{0}}, {{1}}, review comment ID {{2}}). Read the full context. Only respond if the comment is directed at you or requests changes. Reply in the review thread using `gh api repos/{{3}}/pulls/{{0}}/comments/{{2}}/replies -f body="..."`.', {pr}, github.event.comment.html_url, github.event.comment.id, github.repository))
+              || (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@{bn}')
+                && format('A review was submitted on PR #{{0}} that mentions you ({{1}}). Read the review and full PR context (description, diff, comments, CI status), then respond. If changes were requested, make them, commit, and push.', github.event.pull_request.number, github.event.review.html_url))
+              || (github.event_name == 'pull_request_review'
+                && format('A review was submitted on a PR where you previously participated (PR #{{0}}, {{1}}). Read the review and full PR context. If the review requests changes or asks questions, respond appropriately. If the review approves or is between humans, exit silently.', github.event.pull_request.number, github.event.review.html_url))
               || (contains(github.event.comment.body, '@{bn}')
                 && format('You were mentioned in a comment ({{0}}). Read the full issue or PR (description, diff, recent comments, CI status) and respond. If they are requesting changes, make the changes, commit, and push.', github.event.comment.html_url))
               || format('A user commented on an issue/PR where you previously participated ({{0}}). Read the full context. Only respond if the comment is directed at you, asks a question you can help with, or requests changes you can make. A comment that responds to concerns you raised in a review is directed at you — briefly acknowledge that the concerns are resolved (or explain why they are not). If the conversation is between humans, exit silently.', github.event.comment.html_url)

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -210,6 +210,41 @@ def test_setup_raw_interleaved_with_steps(tmp_path: Path) -> None:
         assert uses_idx < raw_idx < run_idx, f"{wf.filename}: wrong order"
 
 
+def test_mention_handles_pull_request_review(tmp_path: Path) -> None:
+    """pull_request_review (submitted) must be covered by tend-mention so the bot
+    responds when a reviewer submits a formal review on an engaged PR."""
+    cfg = Config.load(_minimal_config(tmp_path))
+    workflows = {wf.filename: wf for wf in generate_all(cfg)}
+    mention = workflows["tend-mention.yaml"]
+    data = yaml.safe_load(mention.content)
+
+    # Event trigger present
+    assert "pull_request_review" in data[True], (
+        "tend-mention must listen for pull_request_review events"
+    )
+    assert data[True]["pull_request_review"] == {"types": ["submitted"]}
+
+    # Verify job filters on reviewer identity
+    verify_if = data["jobs"]["verify"]["if"]
+    assert "pull_request_review" in verify_if
+    assert "github.event.review.user.login" in verify_if
+
+    # Handle job checks out PR branch for this event
+    handle_steps = data["jobs"]["handle"]["steps"]
+    checkout_step = next(
+        s for s in handle_steps if s.get("name") == "Check out PR branch"
+    )
+    assert "pull_request_review" in checkout_step["if"]
+
+    # Prompt includes review-specific branches
+    tend_step = next(
+        s for s in handle_steps if s.get("uses", "").startswith("max-sixty/tend@")
+    )
+    prompt = tend_step["with"]["prompt"]
+    assert "github.event.review.html_url" in prompt
+    assert "github.event.review.body" in prompt
+
+
 def test_mention_verify_no_concurrency(tmp_path: Path) -> None:
     """verify job must not have concurrency — a non-mention comment can cancel
     an explicit @bot mention if both arrive on the same PR within seconds (#93)."""


### PR DESCRIPTION
The previous commit removed `pull_request_review` from `tend-review` but didn't add it to `tend-mention`, leaving a gap: a reviewer submitting a formal review with feedback only in the review body (no inline comments) produces a `pull_request_review` event that no workflow handles.

Adds `pull_request_review: [submitted]` to `tend-mention` — verify filter on `review.user.login`, `COMMENT_BODY` coalesces `comment.body || review.body` for mention detection, PR checkout, and two prompt branches (direct mention vs engagement-based).

> _This was written by Claude Code on behalf of @max-sixty_