### PR TITLE
fix(action): include pull_request_review_comment in failure tracking

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -173,7 +173,7 @@ runs:
 
         # Build a one-line reference to the triggering context
         REF=""
-        if [ "$GITHUB_EVENT_NAME" = "pull_request_target" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
+        if [ "$GITHUB_EVENT_NAME" = "pull_request_target" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ]; then
           PR_NUM=$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")
           REF="#${PR_NUM}"
         elif [ "$GITHUB_EVENT_NAME" = "issues" ] || [ "$GITHUB_EVENT_NAME" = "issue_comment" ]; then


### PR DESCRIPTION
The failure-tracking step in `action.yaml` extracts a PR reference for the outage issue. `pull_request_review_comment` events have `.pull_request.number` but weren't matched, so inline review comment failures produced outage reports with no PR reference.

> _This was written by Claude Code on behalf of @max-sixty_