### PR TITLE
feat(mention): conversation-aware loading for queued handle jobs

### DIFF
--- a/.github/workflows/tend-mention.yaml
+++ b/.github/workflows/tend-mention.yaml
@@ -141,12 +141,25 @@ jobs:
 
       - uses: astral-sh/setup-uv@v6
 
+      - name: Compute queue delay
+        id: delay
+        run: |
+          event_epoch=$(date -d "$EVENT_TS" +%s)
+          echo "seconds=$(( $(date +%s) - event_epoch ))" >> "$GITHUB_OUTPUT"
+        env:
+          EVENT_TS: ${{ github.event.comment.created_at || github.event.issue.updated_at }}
+
       - uses: max-sixty/tend@v1
         with:
           github_token: ${{ secrets.BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           bot_name: tend-agent
           prompt: >-
+            This job started ${{ steps.delay.outputs.seconds }}s after the
+            triggering event (over ~40s means it was queued). Before acting,
+            check recent comments: exit silently if the bot already responded
+            to the trigger; handle any other unaddressed comments too.
+
             ${{ github.event_name == 'issues'
               && format('An issue was updated with a mention of you ({0}). Read it and respond.', github.event.issue.html_url)
               || (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@tend-agent')

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -417,11 +417,10 @@ With `cancel-in-progress: false`, when a third job arrives while one is running
 and one is pending, the **pending job is replaced** (cancelled) by the new
 arrival. The running job is unaffected.
 
-**Can a displaced job's mention be lost?** Yes. Each handle job receives only
-its own triggering comment's URL in the prompt — it does not scan the
-conversation for unprocessed mentions. So if mention B is displaced from the
-queue by mention C, mention B's request is dropped. Mention C processes only
-its own comment.
+**Can a displaced job's mention be lost?** The prompt preamble instructs the
+skill to scan recent conversation and pick up unaddressed comments, so mention
+C should self-heal mention B's dropped request. This is a soft mitigation — it
+depends on the skill following the instruction, not a hard guarantee.
 
 Example with three `@$bot_name` mentions arriving within seconds on the same PR:
 
@@ -434,24 +433,19 @@ This requires three genuine `should_run=true` mentions on the same PR/issue
 within the ~60-second window of handle job startup — uncommon but possible when
 multiple people are active on a PR.
 
-**Mitigation — conversation-aware loading** (not yet implemented):
+**Mitigation — conversation-aware loading:**
 
-The skill should review conversation state when it loads, not just its own
-triggering comment. Specifically it should be aware of two things:
+The prompt preamble instructs the skill to check recent conversation before
+acting. Specifically:
 
-1. **Other jobs may have already responded** to its triggering comment. If the
-   job was queued behind another run, that earlier run might have already handled
-   the mention. The skill should check before duplicating work.
-2. **Other unprocessed mentions may exist.** If a prior job was displaced from
-   the queue, its `@$bot_name` mention was never handled. The skill should scan
-   recent conversation for any unprocessed mentions and handle them — making the
-   system self-healing.
+1. **Dedup**: If the bot already responded to the triggering comment (a prior
+   queued run handled it), exit silently.
+2. **Self-heal**: If other comments warrant a response but have no bot reply
+   (a prior job was displaced from the queue), handle those too — oldest first.
 
-To help the skill judge how likely these scenarios are, the workflow could inject
-the **queue-to-run time delta** (time between job queued and job started) as an
-environment variable. A large delta signals the job was queued behind other runs,
-increasing the likelihood that the conversation state has changed since the
-triggering event.
+The workflow injects the **queue-to-run time delta** (seconds between event
+timestamp and job start) into the prompt. Over ~40s indicates the job was
+queued behind another run, making conversation drift more likely.
 
 ## What lives in the tend repo
 

--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -302,12 +302,25 @@ jobs:
           GH_TOKEN: {bt}
           PR_NUMBER: ${{{{ github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number }}}}
 {setup}
+      - name: Compute queue delay
+        id: delay
+        run: |
+          event_epoch=$(date -d "$EVENT_TS" +%s)
+          echo "seconds=$(( $(date +%s) - event_epoch ))" >> "$GITHUB_OUTPUT"
+        env:
+          EVENT_TS: ${{{{ github.event.comment.created_at || github.event.issue.updated_at }}}}
+
       - uses: max-sixty/tend@v1
         with:
           github_token: {bt}
           claude_code_oauth_token: {ct}
           bot_name: {bn}
           prompt: >-
+            This job started ${{{{ steps.delay.outputs.seconds }}}}s after the
+            triggering event (over ~40s means it was queued). Before acting,
+            check recent comments: exit silently if the bot already responded
+            to the trigger; handle any other unaddressed comments too.
+
             ${{{{ github.event_name == 'issues'
               && format('An issue was updated with a mention of you ({{0}}). Read it and respond.', github.event.issue.html_url)
               || (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@{bn}')

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -249,3 +249,21 @@ def test_setup_after_pr_checkout_in_mention(tmp_path: Path) -> None:
     checkout_idx = mention.content.index("Check out PR branch")
     setup_idx = mention.content.index("./.github/actions/my-setup")
     assert setup_idx > checkout_idx, "Setup must come after PR checkout"
+
+
+def test_mention_handle_has_queue_delay(tmp_path: Path) -> None:
+    """Handle job computes queue delay so the prompt can detect stale triggers."""
+    cfg = Config.load(_minimal_config(tmp_path))
+    workflows = {wf.filename: wf for wf in generate_all(cfg)}
+    mention = workflows["tend-mention.yaml"]
+    data = yaml.safe_load(mention.content)
+    handle_steps = data["jobs"]["handle"]["steps"]
+    delay_steps = [s for s in handle_steps if s.get("id") == "delay"]
+    assert len(delay_steps) == 1, "handle job must have a queue delay step"
+    assert "steps.delay.outputs.seconds" in mention.content, (
+        "prompt must reference queue delay"
+    )
+    # Delay step must come before the tend action (output must be available)
+    delay_idx = mention.content.index("Compute queue delay")
+    tend_idx = mention.content.index("max-sixty/tend@v1")
+    assert delay_idx < tend_idx, "delay step must precede tend action"


### PR DESCRIPTION
The mention handle job's concurrency group has queue depth 1. When a third mention arrives while one is running and one is pending, the pending job is displaced and its mention is lost (#93 documented this as a known limitation).

This adds a prompt preamble that instructs the skill to scan recent conversation before acting — exit silently if the trigger was already handled, pick up any unaddressed comments from displaced jobs. The workflow injects the queue-to-run time delta so the skill can gauge how likely conversation drift is (~40s+ means it was queued).

> _This was written by Claude Code on behalf of @max-sixty_
