### PR TITLE
fix(mention): add review.submitted_at to queue delay fallback

### DIFF
--- a/.github/workflows/tend-mention.yaml
+++ b/.github/workflows/tend-mention.yaml
@@ -152,7 +152,7 @@ jobs:
           event_epoch=$(date -d "$EVENT_TS" +%s)
           echo "seconds=$(( $(date +%s) - event_epoch ))" >> "$GITHUB_OUTPUT"
         env:
-          EVENT_TS: ${{ github.event.comment.created_at || github.event.issue.updated_at }}
+          EVENT_TS: ${{ github.event.comment.created_at || github.event.review.submitted_at || github.event.issue.updated_at }}
 
       - uses: max-sixty/tend@v1
         with:

--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -313,7 +313,7 @@ jobs:
           event_epoch=$(date -d "$EVENT_TS" +%s)
           echo "seconds=$(( $(date +%s) - event_epoch ))" >> "$GITHUB_OUTPUT"
         env:
-          EVENT_TS: ${{{{ github.event.comment.created_at || github.event.issue.updated_at }}}}
+          EVENT_TS: ${{{{ github.event.comment.created_at || github.event.review.submitted_at || github.event.issue.updated_at }}}}
 
       - uses: max-sixty/tend@v1
         with:


### PR DESCRIPTION
The `pull_request_review` trigger (added in #104's merge with main) has no `comment` or `issue` context, so both `comment.created_at` and `issue.updated_at` resolve to empty. GNU `date -d ""` silently returns the current time, making the delay always ~0s.

Adds `review.submitted_at` to the `EVENT_TS` fallback chain so `pull_request_review` events get a correct queue delay. Credit to tend-agent's [review on #104](https://github.com/max-sixty/tend/pull/104#pullrequestreview-2905898414) for catching this.

> _This was written by Claude Code on behalf of @max-sixty_