### PR TITLE
fix(mention): guard against empty EVENT_TS in queue delay

### DIFF
--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -310,6 +310,10 @@ jobs:
       - name: Compute queue delay
         id: delay
         run: |
+          if [ -z "$EVENT_TS" ]; then
+            echo "seconds=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           event_epoch=$(date -d "$EVENT_TS" +%s)
           echo "seconds=$(( $(date +%s) - event_epoch ))" >> "$GITHUB_OUTPUT"
         env:
@@ -321,8 +325,9 @@ jobs:
           claude_code_oauth_token: {ct}
           bot_name: {bn}
           prompt: >-
-            This job started ${{{{ steps.delay.outputs.seconds }}}}s after the
-            triggering event (over ~40s means it was queued). Before acting,
+            ${{{{ steps.delay.outputs.seconds
+            && format('This job started {{0}}s after the triggering event (over ~40s means it was queued). ',
+            steps.delay.outputs.seconds) || '' }}}}Before acting,
             check recent comments: exit silently if the bot already responded
             to the trigger; handle any other unaddressed comments too.
 

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -11,7 +11,7 @@ from click.testing import CliRunner
 
 from tend.cli import main
 from tend.config import Config
-from tend.workflows import generate_all
+from tend.workflows import generate_all, generate_mention
 
 
 def _minimal_config(tmp_path: Path, extra: str = "") -> Path:
@@ -302,3 +302,38 @@ def test_mention_handle_has_queue_delay(tmp_path: Path) -> None:
     delay_idx = mention.content.index("Compute queue delay")
     tend_idx = mention.content.index("max-sixty/tend@v1")
     assert delay_idx < tend_idx, "delay step must precede tend action"
+
+
+def test_mention_queue_delay_guards_empty_event_ts(tmp_path: Path) -> None:
+    """date -d "" silently returns now on GNU; guard against empty EVENT_TS."""
+    cfg = Config.load(_minimal_config(tmp_path))
+    wf = generate_mention(cfg)
+    data = yaml.safe_load(wf.content)
+    delay_step = next(
+        s for s in data["jobs"]["handle"]["steps"] if s.get("id") == "delay"
+    )
+    script = delay_step["run"]
+    # Must bail before date -d when EVENT_TS is empty
+    assert 'if [ -z "$EVENT_TS" ]' in script
+    # date -d must only run after the guard
+    guard_pos = script.index('-z "$EVENT_TS"')
+    date_pos = script.index("date -d")
+    assert guard_pos < date_pos, "empty guard must precede date -d call"
+
+
+def test_mention_prompt_omits_delay_when_empty(tmp_path: Path) -> None:
+    """Prompt preamble must not hardcode delay text — it should be conditional
+    so an empty seconds output doesn't produce broken prose like 's after'."""
+    cfg = Config.load(_minimal_config(tmp_path))
+    wf = generate_mention(cfg)
+    data = yaml.safe_load(wf.content)
+    tend_step = next(
+        s
+        for s in data["jobs"]["handle"]["steps"]
+        if s.get("uses", "").startswith("max-sixty/tend@")
+    )
+    prompt = tend_step["with"]["prompt"]
+    # The delay text must be inside a format() conditional, not hardcoded
+    assert "format(" in prompt, "delay preamble must use conditional format()"
+    # "Before acting" must always appear (it's the unconditional part)
+    assert "Before acting" in prompt


### PR DESCRIPTION
GNU `date -d ""` silently returns the current time instead of failing. If a new event type is added to the mention workflow without updating the `EVENT_TS` fallback chain, the delay computes as ~0s — defeating the conversation-aware preamble that detects queued jobs.

The "Compute queue delay" step now checks for empty `EVENT_TS` before calling `date -d`, outputting `seconds=` (empty) and exiting cleanly. The prompt preamble uses a GitHub Actions `format()` conditional so it omits delay text entirely when seconds is empty, starting directly with "Before acting, ...".

Follow-up from #104/#105.

> _This was written by Claude Code on behalf of maximilian_