### PR TITLE
fix(ci): distinguish structural vs stochastic failures in review-reviewers

### DIFF
--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -58,12 +58,34 @@ Rate the proposed change:
 needs less justification than a new paragraph. Prefer small, targeted fixes over
 broad rewrites.
 
+### Structural vs. stochastic failures
+
+Before applying the gates, classify each failure:
+
+- **Structural**: the failure has a deterministic cause that guidance can
+  prevent — e.g., "the checkout differs between `pull_request_target` and
+  `issue_comment` events, so grepping always finds stale content." These
+  failures will recur every time the same conditions arise. One clear
+  occurrence is sufficient evidence for a targeted fix.
+
+- **Stochastic**: the failure is a probabilistic model behavior — e.g., "the
+  model was too agreeable when challenged" or "the model forgot to check X."
+  The same model might handle the next identical situation correctly without
+  any guidance change. These need significantly more evidence (5+ occurrences)
+  because adding guidance for a one-off stochastic lapse adds noise that can
+  degrade performance on other tasks.
+
+The test: "If I replayed this exact scenario 10 times, would the failure
+occur every time (structural) or only sometimes (stochastic)?" When in doubt,
+classify as stochastic and wait for more evidence.
+
 ### Applying the gates
 
 For each finding, state:
 1. The evidence level and occurrence count (current hour + historical)
-2. The proposed change type
-3. Whether it passes both gates
+2. Whether the failure is structural or stochastic
+3. The proposed change type
+4. Whether it passes both gates
 
 Only proceed to Step 5 for findings that pass both gates.
 


### PR DESCRIPTION
## Summary

- Revert the re-verify-before-conceding guidance added to running-in-ci
  (thin evidence for a stochastic behavior)
- Add "Structural vs. stochastic failures" subsection to review-reviewers
  gates, requiring findings to be classified before proposing guidance changes

Structural failures (deterministic cause, always recurs in the same scenario)
can justify action with fewer occurrences. Stochastic failures (model judgment
calls) need 5+ occurrences to avoid over-constraining behavior based on
one-off lapses.

## Evidence

Same incident as before (PR #104 capitulation), but the response is now
correctly scoped: rather than adding guidance for a single stochastic event,
we raise the evidence bar so future review-reviewers runs distinguish
reproducible mechanical failures from probabilistic model behavior.

## Test plan

- [x] Verify the new subsection renders correctly in the skill markdown
- [ ] Monitor future review-reviewers runs for correct classification

🤖 Generated with [Claude Code](https://claude.com/claude-code)
