### PR TITLE
fix(ci): add behavioral-claim verification guidance

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -354,6 +354,31 @@ confirmed hooks use `{{ target }}` syntax → posted correct example.
 </good>
 </example>
 
+For **behavioral claims** — "X happens when you run Y", "command Z works in
+scenario W" — reading code is not sufficient. Code has conditional branches,
+early returns, and error paths that are easy to miss when tracing mentally.
+Before asserting what a command does in a specific scenario, either find a test
+that exercises that exact scenario or run the command yourself. If neither is
+feasible, hedge: "Based on code reading, I believe X, but I haven't verified
+this end-to-end."
+
+<example>
+<bad reason="Traced one code path but missed a guard clause in a called function">
+
+Bad: Read `CommandEnv::for_action("commit", config)` → saw it constructs an
+env → concluded `wt step commit` works in a detached worktree. Missed that
+`for_action()` calls `require_current_branch()`, which errors on detached HEAD.
+
+</bad>
+<good reason="Built and tested the actual behavior before claiming">
+
+Good: Read `for_action()` → noticed it calls `require_current_branch()` →
+uncertain whether detached HEAD hits that path → ran `cargo build && wt step
+commit` in a detached worktree → confirmed the error → posted accurate answer.
+
+</good>
+</example>
+
 When a project has user-facing documentation (a docs site, `--help` pages, a
 wiki), link to it. A link to the relevant docs page is more useful than a
 paraphrased explanation — and finding the link forces verifying the claim.


### PR DESCRIPTION
## Summary

- Add "behavioral claims" paragraph and example to the "User-facing comments
  require source evidence" section, distinguishing runtime-behavior assertions
  from syntax/API-surface claims and requiring actual testing or hedged language.

## Evidence

**Finding: Unverified behavioral claims about code runtime behavior**
(High confidence, 4 occurrences across 7 days)

The existing "source evidence" guidance addresses syntax and API surface
(variable names, config format, command flags) but not **behavioral claims** —
assertions about what happens when a command is run in a specific scenario.
In 4 sessions, the bot read implementation code, mentally traced a code path,
and posted a confident behavioral claim that turned out to be wrong:

| # | Run ID | Session | What happened |
|---|--------|---------|---------------|
| 1 | 23504886845 | 9754069a | Saw `extra_vars.push(("target", target_branch))` → invented `$WT_TARGET` env var syntax (actual: `{{ target }}` Jinja template) |
| 2 | 23595076439 | 2ec7c1da | Claimed "Zola follows symlinks when copying to `public/`" without checking Zola docs |
| 3 | 23614762732 | 2d953879 | Approved security doc rewrite without cross-referencing claims against source code |
| 4 | 23720637079 | (PR #1750) | Claimed `wt step commit` without `--branch` "still works fine" in detached worktree — missed `require_current_branch()` guard |

Case 4 was caught this hour: in [run 23721799370](https://github.com/max-sixty/worktrunk/actions/runs/23721799370),
the owner asked the bot to confirm the claim. The bot built the project, tested
manually, discovered the error, and posted an honest correction. The
self-correction was well-handled — but the original claim should never have been
posted without testing.

**Gate assessment:**
- Evidence level: High (consistent pattern, 4 occurrences over 7 days)
- Change type: Targeted fix (one paragraph + one example block added to existing section)
- Both gates pass

## Test plan

- [ ] Verify the new paragraph reads naturally within the existing "source evidence" section
- [ ] Confirm the example is grounded in a real incident (PR #1750 / worktrunk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)