### PR TITLE
fix(notifications): skip comments already handled by tend-mention

### DIFF
--- a/plugins/tend-ci-runner/skills/notifications/SKILL.md
+++ b/plugins/tend-ci-runner/skills/notifications/SKILL.md
@@ -73,7 +73,25 @@ For each unread notification (oldest first):
 
 ### 4a. Determine if already handled
 
-Check whether the bot has already responded since the notification was
+**Check for concurrent `tend-mention` runs.** For notifications about
+issue/PR comments in `$GITHUB_REPOSITORY`, the `issue_comment` event also
+triggers `tend-mention`. If a `tend-mention` run started after the
+notification's `updated_at`, that workflow is already handling it — mark as
+read and skip to avoid duplicate responses and conflicting pushes.
+
+```bash
+# Check for tend-mention runs triggered after the notification
+RECENT_MENTION=$(gh run list --workflow tend-mention --limit 5 \
+  --json databaseId,status,createdAt \
+  --jq "[.[] | select(.createdAt > \"$NOTIF_UPDATED_AT\")] | length")
+if [ "$RECENT_MENTION" -gt 0 ]; then
+  # tend-mention is handling this — skip
+  gh api notifications/threads/{thread_id} -X PATCH
+  continue
+fi
+```
+
+**Check whether the bot has already responded** since the notification was
 generated:
 
 ```bash


### PR DESCRIPTION
## Summary

- Add concurrent `tend-mention` run check to the notifications skill's
  dedup step (4a), so it skips issue/PR comments that `tend-mention` is
  already handling

## Evidence

On PR [max-sixty/tend#109](https://github.com/max-sixty/tend/pull/109),
runs [23723478738](https://github.com/max-sixty/tend/actions/runs/23723478738)
(`tend-notifications`) and
[23723492882](https://github.com/max-sixty/tend/actions/runs/23723492882)
(`tend-mention`) both responded to the same maintainer comment. This
produced two duplicate "Done" comments (42 seconds apart) and conflicting
git pushes requiring rebase resolution.

**Root cause:** When a user comments on a PR, GitHub fires an
`issue_comment` event → `tend-mention` starts immediately. If
`tend-notifications` runs on schedule around the same time, it sees the
same comment as a notification. The existing dedup check (step 4a) only
looks for prior bot responses, but since both workflows start
concurrently, neither has responded yet when the other checks.

**Fix:** Before processing a notification, check if a `tend-mention` run
was triggered after the notification timestamp. If so, `tend-mention` is
handling it — mark as read and skip.

### Gate assessment

- **Evidence level:** Critical (duplicate user-visible comments, conflicting pushes)
- **Occurrences:** 1 (runs 23723478738 + 23723492882 on PR #109)
- **Change type:** Targeted fix (15 lines added to existing dedup step)
- **Related:** #91 covers a similar pattern for review events; this covers issue comments

## Test plan

- [ ] Verify `tend-notifications` skips notifications when a concurrent
  `tend-mention` run exists for the same event
- [ ] Verify `tend-notifications` still processes notifications that have
  no corresponding `tend-mention` run (e.g., `review_requested`, cross-repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
