### PR TITLE
fix(check): use per-branch rules endpoint for ruleset detection

### DIFF
--- a/generator/src/tend/checks.py
+++ b/generator/src/tend/checks.py
@@ -10,7 +10,6 @@ gh is unavailable or the token lacks permission.
 
 from __future__ import annotations
 
-import fnmatch
 import json
 import shutil
 import subprocess
@@ -63,15 +62,12 @@ def detect_default_branch(repo: str) -> str | None:
     return None
 
 
-def check_branch_protection(
-    repo: str, branch: str, *, default_branch: str | None = None
-) -> CheckResult:
+def check_branch_protection(repo: str, branch: str) -> CheckResult:
     """Check if a branch is protected against bot merges.
 
     Checks both that the branch is protected and that the protection actually
     prevents the bot from merging (via required reviews or a restrict-updates
-    ruleset). Pass ``default_branch`` so ``~DEFAULT_BRANCH`` ruleset patterns
-    can be resolved.
+    ruleset).
     """
     name = f"branch-protection:{branch}"
     result = _gh("api", f"repos/{repo}/branches/{branch}", "--jq", ".protected")
@@ -91,7 +87,7 @@ def check_branch_protection(
 
     # Branch is protected — now check if the bot can still merge.
     # A restrict-updates ruleset is sufficient (and preferred).
-    if _has_restrict_updates_ruleset(repo, branch, default_branch=default_branch):
+    if _has_restrict_updates_ruleset(repo, branch):
         return CheckResult(
             name,
             True,
@@ -130,55 +126,24 @@ def check_branch_protection(
     )
 
 
-def _has_restrict_updates_ruleset(
-    repo: str, branch: str, *, default_branch: str | None = None
-) -> bool:
+def _has_restrict_updates_ruleset(repo: str, branch: str) -> bool:
     """Check if any active ruleset restricts updates to the branch.
 
-    Fetches rulesets and checks whether their ``conditions.ref_name.include``
-    patterns actually cover ``branch``. Supports ``~DEFAULT_BRANCH``, ``~ALL``,
-    exact refs, and fnmatch glob patterns.
+    Uses the branch rules endpoint, which returns the effective rules
+    for a branch with all pattern matching resolved by GitHub.  The list
+    endpoint (``/repos/{repo}/rulesets``) omits ``rules`` and ``conditions``,
+    so we query the per-branch endpoint instead.
     """
-    result = _gh(
-        "api",
-        f"repos/{repo}/rulesets",
-        "--jq",
-        '[.[] | select(.enforcement == "active" and .target == "branch" and (.rules[]? | .type == "update"))]',
-    )
+    result = _gh("api", f"repos/{repo}/rules/branches/{branch}")
     if result is None or result.returncode != 0:
         return False
     try:
-        rulesets = json.loads(result.stdout)
+        rules = json.loads(result.stdout)
     except (json.JSONDecodeError, ValueError):
         return False
-
-    ref = f"refs/heads/{branch}"
-    for ruleset in rulesets:
-        conditions = ruleset.get("conditions") or {}
-        ref_name = conditions.get("ref_name") or {}
-        include = ref_name.get("include") or []
-        exclude = ref_name.get("exclude") or []
-        if _ref_matches_patterns(
-            ref, include, default_branch
-        ) and not _ref_matches_patterns(ref, exclude, default_branch):
-            return True
-    return False
-
-
-def _ref_matches_patterns(
-    ref: str, patterns: list[str], default_branch: str | None
-) -> bool:
-    """Check if a ref matches any GitHub ruleset pattern."""
-    for pattern in patterns:
-        if pattern == "~ALL":
-            return True
-        if pattern == "~DEFAULT_BRANCH":
-            if default_branch and ref == f"refs/heads/{default_branch}":
-                return True
-            continue
-        if fnmatch.fnmatch(ref, pattern):
-            return True
-    return False
+    if not isinstance(rules, list):
+        return False
+    return any(r.get("type") == "update" for r in rules)
 
 
 def check_bot_permission(repo: str, bot_name: str) -> CheckResult:
@@ -443,14 +408,10 @@ def run_all_checks(cfg: Config, repo: str | None = None) -> list[CheckResult]:
         cfg.allowed_repo_secrets
     )
 
-    results = [
-        check_branch_protection(repo, default_branch, default_branch=default_branch)
-    ]
+    results = [check_branch_protection(repo, default_branch)]
     for branch in cfg.protected_branches:
         if branch != default_branch:
-            results.append(
-                check_branch_protection(repo, branch, default_branch=default_branch)
-            )
+            results.append(check_branch_protection(repo, branch))
     results.append(check_bot_permission(repo, cfg.bot_name))
     results.append(check_secrets(repo, [cfg.bot_token_secret, cfg.claude_token_secret]))
     results.append(check_repo_secret_allowlist(repo, allowed))

--- a/generator/tests/test_checks.py
+++ b/generator/tests/test_checks.py
@@ -13,7 +13,6 @@ from click.testing import CliRunner
 from tend.checks import (
     CheckResult,
     _has_restrict_updates_ruleset,
-    _ref_matches_patterns,
     _restrict_updates_ruleset,
     check_bot_permission,
     check_branch_protection,
@@ -41,23 +40,9 @@ def _write_config(tmp_path: Path, content: str = 'bot_name = "test-bot"') -> Pat
     return cfg
 
 
-def _make_ruleset(include: list[str], exclude: list[str] | None = None) -> str:
-    """Build a JSON array with one active update ruleset targeting given patterns."""
-    return json.dumps(
-        [
-            {
-                "enforcement": "active",
-                "target": "branch",
-                "rules": [{"type": "update"}],
-                "conditions": {
-                    "ref_name": {
-                        "include": include,
-                        "exclude": exclude or [],
-                    }
-                },
-            }
-        ]
-    )
+def _make_branch_rules(*rule_types: str) -> str:
+    """Build a JSON array of branch rules (as returned by /rules/branches/{branch})."""
+    return json.dumps([{"type": t} for t in rule_types])
 
 
 # ---------------------------------------------------------------------------
@@ -86,16 +71,16 @@ def test_detect_repo_no_gh() -> None:
 
 
 def test_branch_protected() -> None:
-    ruleset = _make_ruleset(["~DEFAULT_BRANCH"])
+    branch_rules = _make_branch_rules("update")
 
     def fake_gh(*args, **kwargs):
-        cmd = " ".join(args)
-        if "rulesets" in cmd:
-            return _make_completed(ruleset)
+        url = args[1]
+        if "rules/branches" in url:
+            return _make_completed(branch_rules)
         return _make_completed("true\n")
 
     with patch("tend.checks._gh", side_effect=fake_gh):
-        result = check_branch_protection("owner/repo", "main", default_branch="main")
+        result = check_branch_protection("owner/repo", "main")
     assert result.passed is True
     assert "protected" in result.message
 
@@ -133,87 +118,59 @@ def test_branch_protection_result_name_includes_branch() -> None:
 
 
 # ---------------------------------------------------------------------------
-# _ref_matches_patterns
-# ---------------------------------------------------------------------------
-
-
-def test_ref_matches_exact() -> None:
-    assert _ref_matches_patterns("refs/heads/v1", ["refs/heads/v1"], None) is True
-
-
-def test_ref_no_match() -> None:
-    assert _ref_matches_patterns("refs/heads/v1", ["refs/heads/main"], None) is False
-
-
-def test_ref_matches_default_branch_macro() -> None:
-    assert _ref_matches_patterns("refs/heads/main", ["~DEFAULT_BRANCH"], "main") is True
-
-
-def test_ref_default_branch_macro_no_match() -> None:
-    """~DEFAULT_BRANCH should not match non-default branches."""
-    assert _ref_matches_patterns("refs/heads/v1", ["~DEFAULT_BRANCH"], "main") is False
-
-
-def test_ref_matches_all_macro() -> None:
-    assert _ref_matches_patterns("refs/heads/anything", ["~ALL"], None) is True
-
-
-def test_ref_matches_glob() -> None:
-    assert (
-        _ref_matches_patterns("refs/heads/release/v1", ["refs/heads/release/*"], None)
-        is True
-    )
-
-
-# ---------------------------------------------------------------------------
 # _has_restrict_updates_ruleset
 # ---------------------------------------------------------------------------
 
 
-def test_non_update_ruleset_is_not_detected() -> None:
-    """An empty jq result (no matching rulesets) should yield False."""
+def test_no_rules_for_branch() -> None:
+    """No rules at all for this branch → False."""
     with patch("tend.checks._gh", return_value=_make_completed("[]\n")):
         assert _has_restrict_updates_ruleset("owner/repo", "main") is False
 
 
-def test_update_ruleset_covering_default_branch() -> None:
-    """A ruleset targeting ~DEFAULT_BRANCH should match when checking the default branch."""
-    data = _make_ruleset(["~DEFAULT_BRANCH"])
+def test_update_rule_present() -> None:
+    """Branch rules include an update rule → True."""
+    data = _make_branch_rules("update")
     with patch("tend.checks._gh", return_value=_make_completed(data)):
-        assert (
-            _has_restrict_updates_ruleset("owner/repo", "main", default_branch="main")
-            is True
-        )
+        assert _has_restrict_updates_ruleset("owner/repo", "main") is True
 
 
-def test_update_ruleset_not_covering_branch() -> None:
-    """A ruleset targeting only ~DEFAULT_BRANCH should NOT match a non-default branch."""
-    data = _make_ruleset(["~DEFAULT_BRANCH"])
+def test_only_non_update_rules() -> None:
+    """Branch has rules but none are update → False."""
+    data = _make_branch_rules("deletion", "required_linear_history")
     with patch("tend.checks._gh", return_value=_make_completed(data)):
-        assert (
-            _has_restrict_updates_ruleset("owner/repo", "v1", default_branch="main")
-            is False
-        )
+        assert _has_restrict_updates_ruleset("owner/repo", "main") is False
 
 
-def test_update_ruleset_with_explicit_branch() -> None:
-    """A ruleset targeting refs/heads/v1 should match v1."""
-    data = _make_ruleset(["~DEFAULT_BRANCH", "refs/heads/v1"])
+def test_update_rule_among_others() -> None:
+    """Update rule mixed with other rules → True."""
+    data = _make_branch_rules("deletion", "update", "required_signatures")
     with patch("tend.checks._gh", return_value=_make_completed(data)):
-        assert (
-            _has_restrict_updates_ruleset("owner/repo", "v1", default_branch="main")
-            is True
-        )
+        assert _has_restrict_updates_ruleset("owner/repo", "main") is True
 
 
-def test_update_ruleset_excluded_branch() -> None:
-    """A branch in the exclude list should not match, even if include covers it."""
-    data = _make_ruleset(["~ALL"], exclude=["refs/heads/v1"])
-    with patch("tend.checks._gh", return_value=_make_completed(data)):
-        assert (
-            _has_restrict_updates_ruleset("owner/repo", "v1", default_branch="main")
-            is False
-        )
+def test_branch_rules_api_error() -> None:
+    """API error → False (graceful degradation)."""
+    with patch(
+        "tend.checks._gh",
+        return_value=_make_completed(returncode=1, stderr="Not Found"),
+    ):
+        assert _has_restrict_updates_ruleset("owner/repo", "main") is False
+
+
+def test_branch_rules_no_gh() -> None:
+    """gh CLI not found → False."""
+    with patch("tend.checks._gh", return_value=None):
+        assert _has_restrict_updates_ruleset("owner/repo", "main") is False
+
+
+def test_branch_rules_non_list_response() -> None:
+    """API returns a JSON object instead of an array → False."""
+    with patch(
+        "tend.checks._gh",
+        return_value=_make_completed('{"message": "Not Found"}'),
+    ):
+        assert _has_restrict_updates_ruleset("owner/repo", "main") is False
 
 
 # ---------------------------------------------------------------------------
@@ -507,21 +464,21 @@ def test_run_all_checks_no_repo() -> None:
     assert "detect" in results[0].message
 
 
-_ALL_PASS_RULESET = _make_ruleset(["~ALL"])
+_BRANCH_HAS_UPDATE_RULE = _make_branch_rules("update")
 
 
 def _fake_gh_all_pass(*args, **kwargs) -> subprocess.CompletedProcess[str]:
     """Simulate a gh CLI where all checks pass for owner/repo."""
-    cmd = " ".join(args)
-    if args[1] == "repos/owner/repo" and "--jq" in args and ".default_branch" in args:
+    url = args[1]
+    if url == "repos/owner/repo" and "--jq" in args and ".default_branch" in args:
         return _make_completed("main\n")
-    if "rulesets" in cmd:
-        return _make_completed(_ALL_PASS_RULESET)
-    if "branches" in cmd:
+    if "rules/branches" in url:
+        return _make_completed(_BRANCH_HAS_UPDATE_RULE)
+    if "branches" in url:
         return _make_completed("true\n")
-    if "collaborators" in cmd:
+    if "collaborators" in url:
         return _make_completed("write\n")
-    if "secrets" in cmd:
+    if "secrets" in url:
         return _make_completed('["T1","T2"]\n')
     return _make_completed(returncode=1)
 
@@ -556,20 +513,16 @@ def test_run_all_checks_allowlist_catches_unexpected() -> None:
     """Unexpected repo-level secret is flagged."""
 
     def fake_gh_with_extra_secret(*args, **kwargs) -> subprocess.CompletedProcess[str]:
-        cmd = " ".join(args)
-        if (
-            args[1] == "repos/owner/repo"
-            and "--jq" in args
-            and ".default_branch" in args
-        ):
+        url = args[1]
+        if url == "repos/owner/repo" and "--jq" in args and ".default_branch" in args:
             return _make_completed("main\n")
-        if "rulesets" in cmd:
-            return _make_completed(_ALL_PASS_RULESET)
-        if "branches" in cmd:
+        if "rules/branches" in url:
+            return _make_completed(_BRANCH_HAS_UPDATE_RULE)
+        if "branches" in url:
             return _make_completed("true\n")
-        if "collaborators" in cmd:
+        if "collaborators" in url:
             return _make_completed("write\n")
-        if "secrets" in cmd:
+        if "secrets" in url:
             return _make_completed('["T1","T2","PYPI_TOKEN"]\n')
         return _make_completed(returncode=1)
 


### PR DESCRIPTION
The rulesets list endpoint (`/repos/{repo}/rulesets`) returns only summary fields — it omits `rules` and `conditions`. The old code applied a `--jq` filter checking `.rules[]?` on this response, which silently produced nothing (the `?` operator suppresses missing-field errors), so `tend check` always reported "no restrict-updates ruleset found" regardless of what rulesets existed.

Switched `_has_restrict_updates_ruleset` to query `/repos/{repo}/rules/branches/{branch}` instead, which returns the effective rules for a branch with all pattern matching (`~DEFAULT_BRANCH`, `~ALL`, excludes, globs) resolved server-side. This also removes `_ref_matches_patterns` and the `fnmatch` import — ~40 lines of client-side pattern matching that was re-implementing GitHub's logic.

> _This was written by Claude Code on behalf of @max-sixty_