### PR TITLE
fix(install): run claude setup-token in tmux for TTY

### DIFF
--- a/plugins/install-tend/skills/install-tend/scripts/oauth-token.sh
+++ b/plugins/install-tend/skills/install-tend/scripts/oauth-token.sh
@@ -11,15 +11,35 @@ if ! command -v claude &>/dev/null; then
   exit 1
 fi
 
-# claude setup-token runs the OAuth PKCE flow (opens browser, exchanges token).
-# It's a TUI app — redirect to a file (piping breaks it).
 TMPFILE=$(mktemp)
 trap 'rm -f "$TMPFILE"' EXIT
 
->&2 echo "Running claude setup-token (approve in browser)..."
-claude setup-token > "$TMPFILE" 2>&1
+# claude setup-token is a TUI that starts a localhost server for the OAuth PKCE
+# callback. It requires a real TTY — without one the server doesn't bind and the
+# browser gets "can't connect to localhost". Claude Code's Bash tool has no TTY.
+#
+# Strategy: if tmux is available, use it to provide a PTY. Otherwise, tell the
+# caller to run the command in their own terminal.
+if command -v tmux &>/dev/null; then
+  SESSION="oauth-token-$$"
+  trap 'rm -f "$TMPFILE"; tmux kill-session -t "$SESSION" 2>/dev/null || true' EXIT
 
-# Extract the token (sk-ant-oat01-...) from the TUI output
+  >&2 echo "Running claude setup-token (approve in browser)..."
+
+  # tmux provides a PTY; macOS script(1) captures raw output to the file.
+  tmux new-session -d -s "$SESSION" \
+    "script -q '$TMPFILE' claude setup-token; tmux wait-for -S '$SESSION'"
+  tmux wait-for "$SESSION"
+else
+  >&2 echo "Error: tmux not found — claude setup-token needs a TTY."
+  >&2 echo "Run this command in your terminal, then paste the token back:"
+  >&2 echo ""
+  >&2 echo "  claude setup-token"
+  >&2 echo ""
+  exit 1
+fi
+
+# Extract the token (sk-ant-oat01-...) from the captured output
 TOKEN=$(grep -o 'sk-ant-oat01-[A-Za-z0-9_-]*' "$TMPFILE" | head -1)
 
 if [ -z "$TOKEN" ]; then


### PR DESCRIPTION
`claude setup-token` is a TUI that starts a localhost server for the OAuth PKCE callback. It requires a real TTY — without one the server doesn't bind and the browser gets "can't connect to localhost". Claude Code's Bash tool provides sockets instead of a TTY, so `script` alone fails (`tcgetattr: Operation not supported on socket`).

Fix: use tmux to provide a PTY. `tmux new-session -d` creates a detached session with a real PTY, then `script` inside tmux captures the raw output. `tmux wait-for` synchronizes completion. Falls back to telling the user to run `claude setup-token` in their own terminal if tmux isn't available.

> _This was written by Claude Code on behalf of max-sixty_