### PR TITLE
fix(install): ask user for skill overlay preferences instead of inventing them

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,9 +177,9 @@ Tend reads `CLAUDE.md` like any other Claude session. Put build/test/lint
 commands and project conventions there.
 
 For tend-specific guidance that doesn't belong in CLAUDE.md, add a skill overlay
-at `.claude/skills/running-tend/SKILL.md`. This is for things only relevant to
-CI: PR title conventions, which CI workflow names tend-ci-fix watches, automerge
-rules, dependency management preferences. Don't duplicate CLAUDE.md content.
+at `.claude/skills/running-tend/SKILL.md`. The main use is recording which CI
+workflow names tend-ci-fix watches. Other project-specific conventions (PR title
+format, label policies) can be added if relevant.
 
 ## Migrating from claude-code-action
 

--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -228,17 +228,25 @@ Create `.claude/skills/running-tend/SKILL.md` with tend-specific project
 guidance. This skill is loaded by tend workflows alongside the generic
 `tend-*` skills.
 
-**Do NOT duplicate CLAUDE.md.** The overlay should only contain information
-that tend workflows need beyond what CLAUDE.md already provides:
+**Do NOT duplicate CLAUDE.md** and **do NOT invent project conventions.**
 
-- PR title conventions (prefix format, scope rules)
-- CI workflow names (which workflow tend-ci-fix watches)
-- Automerge behavior (which bot PRs get auto-merged)
-- Dependency management (Dependabot vs Renovate, tend-weekly enabled/disabled)
+Ask the user whether they have tend-specific preferences that differ
+from defaults. Examples of things that vary between projects:
 
-Build commands, test commands, error conventions, code style, and project
-structure belong in CLAUDE.md — tend reads CLAUDE.md like any other Claude
-session.
+- PR title format (e.g., conventional commits, Jira ticket prefix)
+- Labels the bot should apply to its PRs
+- Review request routing (specific teams or people)
+- Target branch if not the default branch
+
+If the user has preferences, add them. Otherwise create a placeholder:
+
+```markdown
+No project-specific tend preferences yet. Add guidance here as
+needed — this file is loaded by tend workflows alongside CLAUDE.md.
+```
+
+Build commands, test commands, code style, and project structure belong
+in CLAUDE.md — tend reads it like any other Claude session.
 
 ## 9. Commit and push
 

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -10,9 +10,9 @@ metadata:
 ## First Steps — Load Repo-Specific Guidance
 
 Most repos have a project-specific overlay skill (typically `running-tend`)
-with conventions the generic tend skills don't know — test commands, labels,
-branch naming, survey scripts, codecov requirements. Check for one and load it
-before doing anything else:
+with project-specific CI context — which workflows tend-ci-fix watches, PR
+title conventions, label policies. Check for one and load it before doing
+anything else:
 
 ```bash
 ls .claude/skills/


### PR DESCRIPTION
The old step 8 "Create skill overlay" listed topics as blanks to fill in, so Claude invented project conventions rather than documenting real ones. On numbagg, this produced "PR titles: Use conventional commit prefixes" (project doesn't use them) and "Bot PRs for dependency bumps can be auto-merged" (never confirmed with the user).

Now the step asks the user what preferences they have, provides examples of things that genuinely vary between projects, and creates a placeholder if none. Also removes all automerge references (banned by security) and aligns the `running-in-ci` overlay description.

> _This was written by Claude Code on behalf of max-sixty_