### PR TITLE
chore: release 0.0.4

### DIFF
--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tend"
-version = "0.0.3"
+version = "0.0.4"
 description = "Claude-powered CI for GitHub repos"
 license = "MIT"
 requires-python = ">=3.11"

--- a/generator/uv.lock
+++ b/generator/uv.lock
@@ -132,7 +132,7 @@ wheels = [
 
 [[package]]
 name = "tend"
-version = "0.0.3"
+version = "0.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Bumps generator version to 0.0.4 and syncs lockfile. The tag push triggers the PyPI release workflow.

31 commits since 0.0.3, including notification polling, review event handling, ruleset detection fixes, and CI improvements.

> _This was written by Claude Code on behalf of maximilian_