### PR TITLE
fix(install): use script(1) instead of tmux for oauth-token PTY

### DIFF
--- a/plugins/install-tend/skills/install-tend/scripts/oauth-token.sh
+++ b/plugins/install-tend/skills/install-tend/scripts/oauth-token.sh
@@ -11,36 +11,30 @@ if ! command -v claude &>/dev/null; then
   exit 1
 fi
 
-TMPFILE=$(mktemp)
-trap 'rm -f "$TMPFILE"' EXIT
-
 # claude setup-token is a TUI that starts a localhost server for the OAuth PKCE
 # callback. It requires a real TTY — without one the server doesn't bind and the
 # browser gets "can't connect to localhost". Claude Code's Bash tool has no TTY.
 #
-# Strategy: if tmux is available, use it to provide a PTY. Otherwise, tell the
-# caller to run the command in their own terminal.
-if command -v tmux &>/dev/null; then
-  SESSION="oauth-token-$$"
-  trap 'rm -f "$TMPFILE"; tmux kill-session -t "$SESSION" 2>/dev/null || true' EXIT
+# Fix: script(1) creates a PTY for the child, but fails with "tcgetattr:
+# Operation not supported on socket" when its own stdin is a socket (as in
+# Claude Code). Redirecting stdin from /dev/null avoids this — the child
+# still gets a real PTY.
+TMPFILE=$(mktemp)
+trap 'rm -f "$TMPFILE"' EXIT
 
-  >&2 echo "Running claude setup-token (approve in browser)..."
-
-  # tmux provides a PTY; macOS script(1) captures raw output to the file.
-  tmux new-session -d -s "$SESSION" \
-    "script -q '$TMPFILE' claude setup-token; tmux wait-for -S '$SESSION'"
-  tmux wait-for "$SESSION"
+>&2 echo "Running claude setup-token (approve in browser)..."
+if [[ "$(uname)" == "Darwin" ]]; then
+  script -q "$TMPFILE" claude setup-token < /dev/null
 else
-  >&2 echo "Error: tmux not found — claude setup-token needs a TTY."
-  >&2 echo "Run this command in your terminal, then paste the token back:"
-  >&2 echo ""
-  >&2 echo "  claude setup-token"
-  >&2 echo ""
-  exit 1
+  script -qec "claude setup-token" "$TMPFILE" < /dev/null
 fi
 
-# Extract the token (sk-ant-oat01-...) from the captured output
-TOKEN=$(grep -o 'sk-ant-oat01-[A-Za-z0-9_-]*' "$TMPFILE" | head -1)
+# Extract the token (sk-ant-oat01-...) from the captured output.
+# script(1) captures raw terminal output — ANSI codes and line wraps at the PTY
+# width (default 80 cols) can split the token across lines. Strip escape codes
+# and newlines so the full token is one continuous string for grep.
+TOKEN=$(sed $'s/\033\\[[^a-zA-Z]*[a-zA-Z]//g' "$TMPFILE" | tr -d '\r\n' \
+  | grep -o 'sk-ant-oat01-[A-Za-z0-9_-]*' | head -1)
 
 if [ -z "$TOKEN" ]; then
   >&2 echo "Error: Could not extract token from output"


### PR DESCRIPTION
Follow-up to #113. Replaces the tmux-based approach with plain `script(1) < /dev/null`.

The `tcgetattr: Operation not supported on socket` error happens because Claude Code's Bash tool connects stdin via a socket. Redirecting script's stdin from `/dev/null` avoids this — `tcgetattr` on `/dev/null` returns `ENOTTY` which `script` handles gracefully, while the child process still gets a real PTY.

Also fixes token extraction: strips ANSI escape codes and joins lines before grep, since `script` captures raw terminal output and long tokens wrap at the default 80-column PTY width (confirmed by live test — a 108-char token was truncated to 80 chars without this fix).

Handles both macOS (`script -q <file> <cmd>`) and Linux (`script -qec <cmd> <file>`) syntax.

> _This was written by Claude Code on behalf of max-sixty_