### PR TITLE
docs: fix stale file tree in DESIGN.md

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -439,24 +439,26 @@ tend/
 ├── .claude-plugin/
 │   └── marketplace.json        # Lists both plugins
 ├── plugins/
-│   ├── install-tend/           # User-facing plugin (setup skill)
+│   ├── install-tend/           # User-facing plugin (setup + debug skills)
 │   │   ├── .claude-plugin/
 │   │   │   └── plugin.json
 │   │   └── skills/
+│   │       ├── debug-ci-session/
 │   │       └── install-tend/
-│   └── tend/                   # CI plugin (all CI skills)
+│   └── tend-ci-runner/         # CI plugin (all CI skills)
 │       ├── .claude-plugin/
 │       │   └── plugin.json
+│       ├── scripts/            # Helper scripts (survey, run listing)
 │       └── skills/
-│           ├── tend-running-in-ci/
-│           ├── tend-review/
-│           ├── tend-triage/
-│           ├── tend-ci-fix/
-│           ├── tend-nightly/
-│           ├── tend-weekly/
-│           └── tend-review-reviewers/
+│           ├── ci-fix/
+│           ├── nightly/
+│           ├── notifications/
+│           ├── review/
+│           ├── review-reviewers/
+│           ├── running-in-ci/
+│           ├── triage/
+│           └── weekly/
 ├── action.yaml                 # Composite action (the interface)
-├── scripts/                    # Helper scripts installed by the action
 ├── generator/                  # Python package (uvx tend init)
 │   ├── pyproject.toml
 │   └── src/tend/


### PR DESCRIPTION
The file tree in the "What lives in the tend repo" section had drifted from the actual structure: `plugins/tend/` should be `plugins/tend-ci-runner/`, skill directories had a spurious `tend-` prefix, `scripts/` was shown at repo root instead of inside the plugin, and `notifications` and `debug-ci-session` skills were missing.

> _This was written by Claude Code on behalf of maximilian_