### PR TITLE
fix(check): return SKIP instead of FAIL when ruleset API is unreachable

### DIFF
--- a/generator/src/tend/checks.py
+++ b/generator/src/tend/checks.py
@@ -87,7 +87,8 @@ def check_branch_protection(repo: str, branch: str) -> CheckResult:
 
     # Branch is protected — now check if the bot can still merge.
     # A restrict-updates ruleset is sufficient (and preferred).
-    if _has_restrict_updates_ruleset(repo, branch):
+    ruleset = _has_restrict_updates_ruleset(repo, branch)
+    if ruleset is True:
         return CheckResult(
             name,
             True,
@@ -116,6 +117,16 @@ def check_branch_protection(repo: str, branch: str) -> CheckResult:
             f"Branch '{branch}' is protected (requires reviews)",
         )
 
+    # Neither required reviews nor a confirmed restrict-updates ruleset.
+    if ruleset is None:
+        # Ruleset check was inconclusive — don't false-positive.
+        return CheckResult(
+            name,
+            None,
+            f"Branch '{branch}' is protected but could not verify rulesets "
+            "(insufficient API permissions). Check rulesets manually.",
+        )
+
     return CheckResult(
         name,
         False,
@@ -126,23 +137,23 @@ def check_branch_protection(repo: str, branch: str) -> CheckResult:
     )
 
 
-def _has_restrict_updates_ruleset(repo: str, branch: str) -> bool:
+def _has_restrict_updates_ruleset(repo: str, branch: str) -> bool | None:
     """Check if any active ruleset restricts updates to the branch.
 
-    Uses the branch rules endpoint, which returns the effective rules
-    for a branch with all pattern matching resolved by GitHub.  The list
-    endpoint (``/repos/{repo}/rulesets``) omits ``rules`` and ``conditions``,
-    so we query the per-branch endpoint instead.
+    Returns True if found, False if confirmed absent, None if unable to check.
+
+    Uses the per-branch rules endpoint which resolves patterns like
+    ~DEFAULT_BRANCH.
     """
     result = _gh("api", f"repos/{repo}/rules/branches/{branch}")
     if result is None or result.returncode != 0:
-        return False
+        return None
     try:
         rules = json.loads(result.stdout)
     except (json.JSONDecodeError, ValueError):
-        return False
+        return None
     if not isinstance(rules, list):
-        return False
+        return None
     return any(r.get("type") == "update" for r in rules)
 
 

--- a/generator/tests/test_checks.py
+++ b/generator/tests/test_checks.py
@@ -108,6 +108,28 @@ def test_branch_protection_no_gh() -> None:
     assert result.passed is None
 
 
+def test_branch_protected_ruleset_inconclusive_skips() -> None:
+    """Branch is protected, no reviews, ruleset check inconclusive → SKIP not FAIL."""
+    protection_data = json.dumps(
+        {"required_pull_request_reviews": {"required_approving_review_count": 0}}
+    )
+
+    def fake_gh(*args, **kwargs):
+        url = args[1]
+        if url == "repos/owner/repo/branches/main" and ".protected" in args:
+            return _make_completed("true\n")
+        if "rules/branches" in url:
+            return _make_completed(returncode=1, stderr="HTTP 403")
+        if "branches/main/protection" in url:
+            return _make_completed(protection_data)
+        return _make_completed(returncode=1)
+
+    with patch("tend.checks._gh", side_effect=fake_gh):
+        result = check_branch_protection("owner/repo", "main")
+    assert result.passed is None
+    assert "could not verify rulesets" in result.message
+
+
 def test_branch_protection_result_name_includes_branch() -> None:
     """Each branch gets a distinct check name for identification."""
     with patch("tend.checks._gh", return_value=_make_completed("false\n")):
@@ -150,27 +172,27 @@ def test_update_rule_among_others() -> None:
 
 
 def test_branch_rules_api_error() -> None:
-    """API error → False (graceful degradation)."""
+    """API error → None (inconclusive)."""
     with patch(
         "tend.checks._gh",
         return_value=_make_completed(returncode=1, stderr="Not Found"),
     ):
-        assert _has_restrict_updates_ruleset("owner/repo", "main") is False
+        assert _has_restrict_updates_ruleset("owner/repo", "main") is None
 
 
 def test_branch_rules_no_gh() -> None:
-    """gh CLI not found → False."""
+    """gh CLI not found → None (can't check either endpoint)."""
     with patch("tend.checks._gh", return_value=None):
-        assert _has_restrict_updates_ruleset("owner/repo", "main") is False
+        assert _has_restrict_updates_ruleset("owner/repo", "main") is None
 
 
 def test_branch_rules_non_list_response() -> None:
-    """API returns a JSON object instead of an array → False."""
+    """API returns a JSON object instead of an array → None."""
     with patch(
         "tend.checks._gh",
         return_value=_make_completed('{"message": "Not Found"}'),
     ):
-        assert _has_restrict_updates_ruleset("owner/repo", "main") is False
+        assert _has_restrict_updates_ruleset("owner/repo", "main") is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`_has_restrict_updates_ruleset` returned `False` on any API error, so `check_branch_protection` reported "no restrict-updates ruleset found" when the `/rules/branches/{branch}` endpoint was unreachable (e.g., insufficient token permissions). Changed return type to `bool | None` — the caller now reports SKIP instead of FAIL when inconclusive, eliminating the false positive.

> _This was written by Claude Code on behalf of maximilian_