### PR TITLE
docs: update README and DESIGN for post-refactor workflow layout

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -4,7 +4,7 @@
 
 Two Claude Code plugins, a GitHub composite action, and a generator that add
 Claude-powered CI to any repo. Handles PR review, issue triage, @bot mentions,
-CI fixes, nightly sweeps, and dependency updates.
+CI fixes, nightly sweeps, and weekly maintenance.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -15,16 +15,17 @@ Three sources of behavior:
 `.github/workflows/`. Each workflow handles everything GitHub needs before
 Claude runs: triggers, conditions (skip drafts, prevent bot self-loops),
 engagement verification, concurrency, permissions, checkout strategy, setup
-steps, and event-specific prompts. All six are enabled by default.
+steps, and event-specific prompts. All seven are enabled by default.
 
-| Workflow       | Trigger                              | Skill             |
-| -------------- | ------------------------------------ | ----------------- |
-| `tend-review`  | PR opened/updated, review submitted  | `review`          |
-| `tend-mention` | @bot mentions, engaged conversations | — (prompt-driven) |
-| `tend-triage`  | Issue opened                         | `triage`          |
-| `tend-ci-fix`  | CI fails on default branch           | `ci-fix`          |
-| `tend-nightly` | Daily schedule, manual dispatch      | `nightly`         |
-| `tend-weekly`  | Weekly schedule, manual dispatch     | `weekly`          |
+| Workflow              | Trigger                                       | Skill             |
+| --------------------- | --------------------------------------------- | ----------------- |
+| `tend-review`         | PR opened/updated                             | `review`          |
+| `tend-mention`        | @bot mentions, reviews, engaged conversations | — (prompt-driven) |
+| `tend-triage`         | Issue opened                                  | `triage`          |
+| `tend-ci-fix`         | CI fails on default branch                    | `ci-fix`          |
+| `tend-nightly`        | Daily schedule, manual dispatch               | `nightly`         |
+| `tend-weekly`         | Weekly schedule, manual dispatch              | `weekly`          |
+| `tend-notifications`  | Every 15 minutes, manual dispatch             | `notifications`   |
 
 Each workflow ends with `uses: max-sixty/tend@v1`, handing off to the action.
 


### PR DESCRIPTION
## Summary

- Fix `tend-review` trigger description in README: no longer handles `pull_request_review` events (moved to `tend-mention` in #102)
- Add `tend-notifications` workflow to the README table and update count from six to seven
- Fix DESIGN.md intro referencing "dependency updates" → "weekly maintenance" (renamed in #106)

No test changes — pure documentation fix.

## Test plan

- [x] `uv run pytest` passes (112 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)