### PR TITLE
fix(skills): remove long-running qualifier from recheck-before-posting

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -187,12 +187,9 @@ Reply in context rather than creating new top-level comments:
 
 ## Recheck Before Posting
 
-Long-running tasks (triage, review, CI diagnosis) can take minutes. By the time you're ready to
-comment, new discussion may have arrived that changes the context — a human may have already
-answered, the author may have pushed a fix, or new information may make your response redundant or
-wrong.
-
-**Before posting any comment or review**, re-fetch the current conversation state:
+**Before posting any comment or review**, re-fetch the current conversation state. Other
+participants may comment while you work — even in short sessions, context can change between when
+you read a thread and when you reply:
 
 ```bash
 # For issues


### PR DESCRIPTION
## Summary

- Remove the qualifying "Long-running tasks..." framing from the Recheck Before Posting section in `running-in-ci`
- Lead with the unconditional rule instead of context that implies it only applies to slow sessions

## Evidence

**Skipped recheck-before-posting** (20+ occurrences across monthly tracking issues [#12](https://github.com/max-sixty/tend/issues/12)):

The recheck section opened with "Long-running tasks (triage, review, CI diagnosis) can take minutes..." — this framing gives the model a reasoning escape hatch for short sessions. Mention sessions (typically <2 minutes) consistently skip the recheck, while review sessions (which have their own explicit pre-posting verification in the review skill) follow it reliably.

Latest occurrence: Run [23739555730](https://github.com/max-sixty/worktrunk/actions/runs/23739555730) — tend-mention session on issue #1806 posted a reply without rechecking conversation state.

**Classification**: The root cause is structural — the qualifying language deterministically provides a reason to skip for short sessions. The model's reasoning traces show it either doesn't reach the bold instruction (stops at the qualifying context) or reasons the step away as unnecessary for quick replies.

**Gate assessment**:
- Evidence level: High (20+ occurrences)
- Failure type: Structural (qualifying framing provides escape hatch)
- Change type: Removal/simplification (shortening the section, removing the qualifying paragraph)
- Both gates pass

**Complementary to PR #90**, which adds explicit recheck steps to the triage skill. This PR fixes the general guidance that all session types load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)