### PR TITLE
fix(review): add inline comment 422 recovery to prevent duplicate reviews

### DIFF
--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -258,6 +258,24 @@ object keys, which GitHub rejects.
      parser may consume it as a delimiter, corrupting the result. Either shrink the range to avoid
      the fence or push a commit.
 
+#### Recovering from inline comment 422 errors
+
+GitHub returns `422 Unprocessable Entity` with "Line could not be resolved" when inline comment line numbers don't map to valid positions in the diff. This happens most often on large or complex diffs. **Do not retry by posting a second review** — the first `POST` to the reviews endpoint already created a review record (with the body but without the failed inline comments), so a second attempt creates a duplicate.
+
+Instead, when a 422 occurs on inline comments:
+
+1. **Move the failed inline comments into the review body** as fenced code blocks with file paths.
+2. **Edit the existing review** rather than creating a new one:
+   ```bash
+   # Find the review that was just created (body posted, inline comments rejected)
+   REVIEW_ID=$(gh api "repos/$REPO/pulls/<number>/reviews" \
+     --jq "[.[] | select(.user.login == \"$BOT_LOGIN\" and .commit_id == \"$HEAD_SHA\")] | last | .id")
+   # Update its body to include the failed inline suggestions
+   gh api "repos/$REPO/pulls/<number>/reviews/$REVIEW_ID" \
+     -X PUT -F body=@/tmp/updated-review-body.md
+   ```
+3. If editing fails, **do not post another review** — the body-only review is sufficient.
+
 ### 6. Monitor CI
 
 After approving or staying silent, poll CI in **a single background loop** — do not launch


### PR DESCRIPTION
## Summary

- Add 422 error recovery guidance to the review skill's inline comment posting section
- Instructs the bot to edit the existing review instead of creating a duplicate when inline comments fail with "Line could not be resolved"

## Evidence

**Pattern**: When posting inline review comments via the GitHub API, large or complex diffs cause `422 Unprocessable Entity` ("Line could not be resolved") errors. The bot recovers by posting a second body-only review, creating duplicate reviews on the PR.

**Occurrences**: 3 confirmed (structural failure — deterministic for certain diff shapes)

| Run | Repo | PR | Session |
|---|---|---|---|
| [23572156158](https://github.com/max-sixty/tend/actions/runs/23572156158) | tend | #68 | Historical — graceful recovery noted |
| [23744513271](https://github.com/max-sixty/worktrunk/actions/runs/23744513271) | worktrunk | #1807 | First review attempt — 422 on inline, fell back to body-only, then posted second review |
| [23745509515](https://github.com/max-sixty/worktrunk/actions/runs/23745509515) | worktrunk | #1807 | Re-review — same 422 failure, same duplicate review pattern |

**Root cause**: The first `POST` to the reviews endpoint creates a review record with the body even when inline comments are rejected. The bot then retries with a second review, producing two reviews on the same commit.

**Classification**: Structural — the 422 is deterministic for diffs where line numbers don't map cleanly to diff hunks. The duplicate review is a consequence of the recovery strategy, not model randomness.

**Fix**: Add a "Recovering from inline comment 422 errors" subsection to the posting mechanics guidance. Instructs the bot to edit the existing review (PUT) rather than creating a new one (POST), and to move failed inline comments into the review body as fenced code blocks.

## Gate assessment

- **Evidence level**: High (consistent pattern across multiple sessions)
- **Failure type**: Structural (deterministic for certain diff shapes)
- **Change type**: Targeted fix (new subsection in existing guidance)
- **Passes Gate 1**: Yes (3 occurrences, threshold 2–3 for High evidence)
- **Passes Gate 2**: Yes (targeted fix with normal evidence bar)

## Test plan

- [ ] Verify the next large-diff review that hits a 422 edits the existing review instead of creating a duplicate
- [ ] Confirm no regressions in normal inline comment posting (the new guidance only applies on 422)

🤖 Generated with [Claude Code](https://claude.com/claude-code)