### PR TITLE
fix(review): propose project PRs for missing CI deps instead of ad-hoc installs

### DIFF
--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -299,9 +299,10 @@ exit 1
 
 - **All required checks passed** -> done.
 - **A check failed** and it's related to the PR -> post a follow-up COMMENT review with analysis
-  and inline suggestions, then dismiss the bot's approval. **Do not install tools** (coverage
-  runners like `cargo-llvm-cov`, linters, etc.) to reproduce failures locally — analyze the
-  failure from the check output, PR diff, and source code reading:
+  and inline suggestions, then dismiss the bot's approval. If the failure is because the CI job
+  is missing a tool or dependency (e.g., a coverage runner, linter), don't install it ad-hoc —
+  propose a PR to the project adding it consistent with the project's existing conventions.
+  Analyze the failure from the check output, PR diff, and source code reading:
   ```bash
   # Use PUT, not POST — the dismiss endpoint requires it
   gh api "repos/$REPO/pulls/<number>/reviews/$REVIEW_ID/dismissals" \


### PR DESCRIPTION
## Summary

- When the bot encounters a CI failure caused by a missing tool or dependency, instead of installing it ad-hoc (wasting CI time) or being blanket-prohibited from installing anything, it should **propose a PR to the project** adding the dependency consistent with the project's existing conventions.

## Evidence

**Finding:** Bot installs `cargo-llvm-cov` in CI to investigate codecov/patch failures, wasting CI minutes and sometimes causing session cancellation from compilation timeouts.

**Gate assessment:**
- **Evidence level:** Medium (stochastic — bot sometimes analyzes the diff correctly, sometimes improvises tool installation)
- **Occurrences:** 7 total (5 historical in tracking issue #12 + 2 this hour on runs [23779254077](https://github.com/max-sixty/worktrunk/actions/runs/23779254077) and [23779671239](https://github.com/max-sixty/worktrunk/actions/runs/23779671239), both reviewing PR max-sixty/worktrunk#1830)
- **Classification:** Stochastic (5+ threshold met)
- **Change type:** Targeted fix (one sentence addition to existing step)
- **Both gates pass**

## Test plan

- [ ] Verify the review skill still reads coherently at Step 6
- [ ] Monitor next codecov failure review to confirm bot proposes a project PR rather than installing tools ad-hoc

🤖 Generated with [Claude Code](https://claude.com/claude-code)
