### PR TITLE
fix(review): preserve approval when codecov failure is structural

### DIFF
--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -307,6 +307,10 @@ exit 1
   ```
   Skip if already dismissed. **Do not push fixes on human-authored PRs** — post the analysis and
   offer to fix, then wait for the author to accept.
+- **A coverage check failed** but the uncovered lines are structurally untestable (interactive
+  prompts, platform-specific paths) and the same pattern exists in surrounding code -> **do not
+  dismiss**. Post a COMMENT noting the gap is pre-existing and structural, but keep the approval.
+  Only dismiss when the coverage failure represents a real testing gap the author should address.
 - **A check failed** and it's a transient flake (unrelated to the PR changes) ->
   1. **Re-run the failed jobs:**
      ```bash


### PR DESCRIPTION
## Summary

- Add a third CI outcome case to the review skill: when `codecov/patch` fails but the uncovered lines are structurally untestable (interactive prompts, platform-specific paths) and the same pattern exists in surrounding code, **keep the approval** instead of dismissing it.

## Evidence

**6 occurrences** across max-sixty/worktrunk reviews (tracking issue #12), including:

- **Run 23784704657** (PR #1834, `feat/install-statusline`): Bot approved, codecov failed at 66.66% on interactive prompt lines (113–134 of `plugins.rs`). Bot correctly identified the gap matches existing `handle_claude_install`/`handle_claude_uninstall` patterns — then dismissed anyway per current instructions. PR was merged by the human regardless. The bot actually dismissed **twice** on this PR across two review cycles.

- **Run 23771421550** (PR #1820): Similar pattern — structural coverage gap, dismissal, human override.

- **4 additional prior occurrences** documented in tracking issue #12.

**Classification**: Structural — the current instruction deterministically causes dismissal whenever codecov fails, with no exception for pre-existing/untestable gaps. The bot's analysis is correct (it identifies the gap as structural) but the action (dismiss) contradicts its own finding.

**Gate assessment**: 6 occurrences (structural) + targeted fix (4-line addition) = passes both confidence and magnitude gates.

## Test plan

- [ ] Verify the new guidance is clear: bot should distinguish "real coverage gap the author should fix" from "structural gap matching existing patterns"
- [ ] Monitor next codecov-failing review on worktrunk to confirm bot keeps approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)