### PR TITLE
fix(review): skip CI polling on trivial re-review path

### DIFF
--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -56,7 +56,8 @@ gh api "repos/$REPO/compare/$LAST_REVIEW_SHA...$HEAD_SHA" \
 
 If the incremental changes are trivial, skip the full review **and do not submit a new
 approval** — the existing review stands. Go directly to step 7 to resolve any bot threads
-addressed by the new changes, then exit. Do NOT proceed to steps 2, 3, or 4. Rough heuristic:
+addressed by the new changes, then exit. Do NOT proceed to steps 2–6 (no review, no approval, no
+CI polling). Rough heuristic:
 changes under ~20 added+deleted lines that don't introduce new functions, types, or control flow
 are typically trivial.
 


### PR DESCRIPTION
## Summary

- Clarify that the trivial re-review skip path exits after step 7 (thread resolution) — no CI polling (step 6)

The instruction previously said "Do NOT proceed to steps 2, 3, or 4" but omitted step 6 (CI monitoring). The bot consistently interpreted this as permission to poll CI after resolving threads, spending ~10 minutes on reviews where it had already decided to post nothing.

## Evidence

| Run | Workflow | Behavior |
|---|---|---|
| [23786853890](https://github.com/max-sixty/worktrunk/actions/runs/23786853890) | tend-review (PR #1840 re-review) | Classified 77-line change as trivial, skipped review, then polled CI for 10 min — no action taken on results |
| [23786370577](https://github.com/max-sixty/worktrunk/actions/runs/23786370577) | tend-review (PR #1840 re-review) | Same pattern — CI polling consumed session time, session truncated before it could report a CI failure it had diagnosed |

**Failure type**: Structural — the bot reads "Do NOT proceed to steps 2, 3, or 4" and infers steps 5-6 are still active. Changing to "steps 2–6" closes the gap.

**Gate assessment**: High confidence (2 occurrences, structural pattern), targeted fix (one-line clarification). Passes both gates.

## Test plan

- [ ] Verify next trivial re-review on worktrunk exits after thread resolution without CI polling

🤖 Generated with [Claude Code](https://claude.com/claude-code)