### PR TITLE
fix(skills): extract shared review checklist and remove project-specific examples

### DIFF
--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -48,11 +48,9 @@ git diff ${OLDEST}^..HEAD
 git log --since='24 hours ago' --format='%h %s' main
 ```
 
-Read the project's CLAUDE.md before reviewing (same as Step 4). Review for: bugs, inconsistencies
-with existing patterns, missing/outdated documentation, missing test coverage, dead code,
-non-canonical patterns. Also check whether the changes introduce code that violates CLAUDE.md
-conventions, or whether CLAUDE.md itself needs updating to reflect the new code (e.g., new file
-paths, changed commands, removed patterns).
+Read the project's CLAUDE.md before reviewing. Apply the review checklist below to the diff,
+focusing on changes rather than unchanged code. Also check whether CLAUDE.md itself needs updating
+to reflect the new code (e.g., new file paths, changed commands, removed patterns).
 
 ## Step 3: Check existing issues and close resolved ones
 
@@ -74,9 +72,11 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/todays-survey-files.sh
 ```
 
 Before reviewing files, read the project's CLAUDE.md and any project-specific skills or review
-criteria it references. These define the conventions that surveyed code should follow.
+criteria it references. Apply the review checklist below to each file in full.
 
-For each file, check against both general quality and project-specific conventions:
+## Review checklist
+
+Used by both Step 2 (applied to recent diffs) and Step 4 (applied to full files).
 
 **General quality:**
 - Bugs, logic errors, unhandled edge cases
@@ -86,8 +86,7 @@ For each file, check against both general quality and project-specific conventio
 - Missing test coverage for non-trivial logic
 
 **Convention compliance (from CLAUDE.md and project skills):**
-- Code patterns that violate stated conventions (e.g., compatibility layers, defensive programming,
-  wrapper functions, feature flags — whatever the project's CLAUDE.md prohibits)
+- Code patterns that violate conventions stated in the project's CLAUDE.md
 - Stale CLAUDE.md entries — conventions that reference renamed files, deleted functions, or
   outdated patterns
 - Skills that have drifted from actual project behavior (instructions that no longer match how the


### PR DESCRIPTION
Follow-up to #134. Extracts the review checklist that Steps 2 and 4 of the nightly skill both use into its own section, so both steps reference one canonical list instead of duplicating criteria. Also removes the illustrative examples from the convention compliance bullet ("e.g., compatibility layers, defensive programming...") — the bot reads the actual project CLAUDE.md before reviewing, so hardcoded examples from one style of CLAUDE.md could mislead on repos with different conventions.

> _This was written by Claude Code on behalf of @max-sixty_