### PR TITLE
fix(skills): strengthen repo-specific skill loading instruction

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -9,13 +9,15 @@ metadata:
 
 ## First Steps — Load Repo-Specific Guidance
 
-Most repos have a project-specific overlay skill (typically `running-tend`) with project-specific
-CI context — which workflows tend-ci-fix watches, PR title conventions, label policies. Check for
-one and load it before doing anything else:
+**REQUIRED — do this before any other action.** Most repos have a project-specific overlay skill
+(typically `running-tend`) with project-specific CI context — which workflows tend-ci-fix watches,
+PR title conventions, label policies.
 
-```bash
-ls .claude/skills/
-```
+1. Run `ls .claude/skills/` to discover available skills.
+2. For each skill listed, call the Skill tool to load it.
+3. Only then proceed with the task.
+
+Skipping this step causes downstream problems — wrong PR title format, missed CI conventions, etc.
 
 ## Conduct
 


### PR DESCRIPTION
## Summary

The `running-in-ci` skill tells the bot to load repo-specific skills (like `running-tend`) before doing anything else, but ~20% of runs skip this step. The current prose instruction ("check for one and load it before doing anything else") is easily glossed over. This PR strengthens it with a bold **REQUIRED** marker, numbered steps, and a brief explanation of downstream consequences.

## Evidence

5 occurrences of the bot running `ls .claude/skills/`, seeing `running-tend` in the output, and then proceeding without loading it:

| # | Run ID | Repo | Workflow | Date |
|---|--------|------|----------|------|
| 1 | [23844508205](https://github.com/PRQL/prql/actions/runs/23844508205) | PRQL/prql | tend-notifications | 2026-04-01 |
| 2 | [23846949253](https://github.com/PRQL/prql/actions/runs/23846949253) | PRQL/prql | tend-notifications | 2026-04-01 |
| 3 | [23851983395](https://github.com/PRQL/prql/actions/runs/23851983395) | PRQL/prql | tend-notifications | 2026-04-01 |
| 4 | [23873966768](https://github.com/PRQL/prql/actions/runs/23873966768) | PRQL/prql | tend-notifications | 2026-04-01 |
| 5 | [23902137850](https://github.com/PRQL/prql/actions/runs/23902137850) | PRQL/prql | tend-notifications | 2026-04-02 |

In all cases, the bot correctly ran `ls .claude/skills/` and saw `running-tend` listed, but skipped the Skill tool call to load it. No impact in these specific cases (all zero-notification runs), but for reviews/mentions/nightlies this causes missed PR conventions and CI structure context.

## Gate assessment

- **Evidence level**: Medium (stochastic behavior — same model loads skill ~80% of the time)
- **Occurrences**: 5 (meets stochastic threshold of 5+)
- **Failure type**: Stochastic — identical instructions succeed in concurrent runs
- **Change type**: Targeted fix — reformats existing instruction, no new content
- **Both gates pass**

## Change

Replaces the single-paragraph instruction with a bold **REQUIRED** marker, explicit numbered steps (ls, load, then proceed), and a brief consequence note. No new concepts or sections added.