### PR TITLE
fix(skills): add dedup check for inline review comment replies

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -208,8 +208,8 @@ appeared:
 ### Dedup check for inline review comment replies
 
 A single PR review can fire both `pull_request_review` and `pull_request_review_comment` events,
-triggering concurrent workflow runs. Before replying to an inline review comment, check whether
-the bot already replied:
+triggering separate workflow runs (serialized by the concurrency group, not truly concurrent).
+Before replying to an inline review comment, check whether the bot already replied:
 
 ```bash
 BOT_LOGIN=$(gh api user --jq '.login')


### PR DESCRIPTION
## Summary

- Add explicit dedup guidance for inline review comment replies in the `running-in-ci` skill
- When replying to a review comment, the bot must now check for existing bot replies to the same `in_reply_to_id` before posting

**Root cause:** A single PR review fires both `pull_request_review` and `pull_request_review_comment` events. The `handle` job's concurrency group correctly serializes these runs (the second queues until the first completes). However, the existing "Recheck Before Posting" section only checks total comment/review counts — too coarse to detect that the bot already replied to a specific inline comment. The second run's finer-grained check used a non-existent `GET /replies` endpoint that returned a 404, and the fallback output was ambiguous, making the bot conclude "No existing replies."

**Evidence:** On [max-sixty/worktrunk PR #1890](https://github.com/max-sixty/worktrunk/pull/1890), runs [23933934456](https://github.com/max-sixty/worktrunk/actions/runs/23933934456) (`pull_request_review`, handle 04:34:16–04:36:35) and [23933934467](https://github.com/max-sixty/worktrunk/actions/runs/23933934467) (`pull_request_review_comment`, handle 04:36:38–04:38:29) were correctly serialized by the concurrency group, but the second run's recheck failed to detect the first's reply and posted a duplicate.

**Gate assessment:**
- Evidence level: High — structural issue (the `/replies` GET endpoint always 404s, making the fallback output always ambiguous)
- Classification: Structural — deterministic cause, will recur whenever dual events fire
- Change type: Targeted fix — adds one subsection with an explicit, correct API command
- Prior near-miss: [PRQL/prql runs 23831453414/23831453468](https://github.com/PRQL/prql/actions/runs/23831453414) had the same dual-trigger but avoided duplication due to timing

## Test plan

- [ ] Verify the skill file parses correctly (valid markdown, consistent structure)
- [ ] In future dual-event scenarios (`pull_request_review` + `pull_request_review_comment`), the second run should detect the first's reply and exit silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)
