### PR TITLE
test: add repo-local skill to verify auto-discovery in CI

### DIFF
--- a/.claude/skills/test-discovery/SKILL.md
+++ b/.claude/skills/test-discovery/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: test-discovery
+description: Test skill for verifying repo-local skill auto-discovery in CI. Use when testing skill discovery.
+---
+
+# Test Discovery
+
+This is a test skill to verify whether repo-local skills with proper YAML frontmatter are
+auto-discovered by Claude Code in CI environments (via claude-code-action).
+
+If this skill appears in the "following skills are available" system-reminder listing, auto-discovery
+works. If not, there is a gap in CI skill discovery that needs investigation.


### PR DESCRIPTION
## Summary

Adds a test skill at `.claude/skills/test-discovery/SKILL.md` with proper YAML frontmatter to verify whether Claude Code auto-discovers repo-local skills in CI.

## Context

Investigating [#139](https://github.com/max-sixty/tend/pull/139) — whether repo-local skills should auto-appear in the Skill tool's available skills list without manual `ls` discovery.

## Test plan

1. Merge this to main
2. Trigger a CI run (any workflow — nightly, notifications, or a comment on a PR)
3. Check the session log: does `test-discovery` appear in the system-reminder's available skills listing?
4. If yes → auto-discovery works when frontmatter is present → fix PRQL's `running-tend` skill by adding frontmatter
5. If no → auto-discovery doesn't work in CI regardless → investigate claude-code-action or Claude Code CLI

## Cleanup

This skill should be removed after testing, regardless of outcome.