### PR TITLE
fix(skills): include COMMENTED reviews in pre-flight dedup check

### DIFF
--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -33,13 +33,12 @@ BOT_LOGIN=$(gh api user --jq '.login')
 HEAD_SHA=$(gh pr view <number> --json commits --jq '.commits[-1].oid')
 PR_AUTHOR=$(gh pr view <number> --json author --jq '.author.login')
 
-# Find the bot's most recent substantive review (any state).
-# Include reviews with a non-empty body OR approvals (LGTM uses --approve -b "").
-# Uses "| length > 0" instead of "!= \"\"" to avoid bash ! history expansion.
+# Find the bot's most recent review (any state counts — COMMENTED reviews carry
+# inline comments even when the body is empty).
 # IMPORTANT: `gh pr view --json reviews` returns `.commit.oid` (NOT `.commit_id`).
 # The REST API (`gh api .../reviews`) uses `.commit_id` — don't confuse the two.
 LAST_REVIEW_SHA=$(gh pr view <number> --json reviews \
-  --jq "[.reviews[] | select(.author.login == \"$BOT_LOGIN\" and ((.body | length) > 0 or .state == \"APPROVED\"))] | last | .commit.oid // empty")
+  --jq "[.reviews[] | select(.author.login == \"$BOT_LOGIN\")] | last | .commit.oid // empty")
 ```
 
 If `LAST_REVIEW_SHA == HEAD_SHA`, this commit has already been reviewed — exit silently. The only


### PR DESCRIPTION
## Summary

The `LAST_REVIEW_SHA` pre-flight filter in the review skill skipped COMMENTED reviews with empty bodies — but these reviews are substantive because they carry inline comments. This caused the bot to redo full analysis on commits it had already reviewed.

- Simplify the filter to match any bot review regardless of body or state
- COMMENTED reviews (inline-comment-only) are now correctly detected as prior reviews

## Evidence

**Run [23949079715](https://github.com/max-sixty/tend/actions/runs/23949079715)** on PR #141: the bot had already posted a COMMENTED review with inline comments (commit 9aca0ae). A subsequent tend-review run missed it because the jq filter required `(.body | length) > 0 or .state == "APPROVED"` — a COMMENTED review with empty body matched neither condition. The bot did a full re-analysis before discovering (via a different API call) that the commit was already reviewed.

**Classification:** Structural — the jq filter deterministically excludes this review type. Every COMMENTED review with inline comments (and no body text) would be missed.

**Gate assessment:**
- Evidence level: High (structural gap, 1 occurrence sufficient for targeted fix)
- Change type: Removal/simplification (fewer filter conditions, smaller jq expression)
- Both gates passed

## Test plan

- [ ] Verify on a PR where the bot previously left inline comments (COMMENTED review, empty body) — the next tend-review run should detect `LAST_REVIEW_SHA == HEAD_SHA` and skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)