### PR TITLE
fix(skills): approve on trivial-change-skip when prior bot issues are resolved

### DIFF
--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -53,10 +53,11 @@ gh api "repos/$REPO/compare/$LAST_REVIEW_SHA...$HEAD_SHA" \
   --jq '{total: ([.files[] | .additions + .deletions] | add), files: [.files[] | "\(.filename)\t+\(.additions)/-\(.deletions)"]}'
 ```
 
-If the incremental changes are trivial, skip the full review **and do not submit a new
-approval** — the existing review stands. Go directly to step 7 to resolve any bot threads
-addressed by the new changes, then exit. Do NOT proceed to steps 2–6 (no review, no approval, no
-CI polling). Rough heuristic:
+If the incremental changes are trivial, skip the full review — go directly to step 7 to resolve
+any bot threads addressed by the new changes. After resolving threads: if the most recent bot
+review was a COMMENT that flagged issues, and those issues are now addressed, submit an APPROVE
+with an empty body so the PR isn't left in limbo. Otherwise do not submit a new review — the
+existing one stands. Do NOT proceed to steps 2–6. Rough heuristic:
 changes under ~20 added+deleted lines that don't introduce new functions, types, or control flow
 are typically trivial.
 


### PR DESCRIPTION
## Summary

- Fix the review skill's trivial-change-skip path to approve when prior bot-flagged issues are resolved, instead of unconditionally skipping approval.

## Evidence

**Run:** [23976359110](https://github.com/max-sixty/worktrunk/actions/runs/23976359110) (`tend-review` on `docs/cmux-integration`, PR max-sixty/worktrunk#1907)

The bot reviewed the PR and flagged a sync-test issue (COMMENTED review). It then pushed a fix commit itself. On the next run, the trivial-change-skip path fired correctly (only 4 lines changed in 1 file), but the instruction "do not submit a new approval — the existing review stands" meant the PR was left with zero approvals despite all concerns being addressed.

**Classification:** Structural — the old instruction deterministically prevents approval on the trivial-change-skip path regardless of the prior review's state. Replaying this scenario would always produce the same result.

**Root cause:** The trivial-change-skip instruction treated all prior reviews as equivalent. A prior APPROVE review doesn't need refreshing, but a prior COMMENT review that flagged issues does need an APPROVE once those issues are fixed.

## Gate assessment

| Gate | Assessment |
|---|---|
| Confidence | Structural failure, 1 clear occurrence — sufficient per gate rules |
| Magnitude | Targeted fix (rewording 1 paragraph, no new sections) — normal evidence bar |
| Historical evidence | No prior occurrences in tracking issue #133 |

## Change

Rewrote the trivial-change-skip paragraph to: resolve threads first (step 7), then check whether the prior bot review was a COMMENT with now-addressed issues → approve. Otherwise, keep the existing "do not submit a new review" behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)