### PR TITLE
fix(skills): add running-in-ci setup step to ci-fix skill

### DIFF
--- a/plugins/tend-ci-runner/skills/ci-fix/SKILL.md
+++ b/plugins/tend-ci-runner/skills/ci-fix/SKILL.md
@@ -14,6 +14,12 @@ CI has failed on the default branch. Diagnose the root cause, fix it, and create
 
 ## Workflow
 
+### 0. Load environment skills
+
+Load `/tend-ci-runner:running-in-ci` first — it contains CI security rules, polling conventions,
+and comment formatting guidance. It will also prompt you to load any repo-specific skills (e.g.,
+`running-tend`).
+
 ### 1. Check for existing fixes
 
 ```bash
@@ -61,5 +67,5 @@ Automated fix for [failed run](run-url)
 
 ### 4. Monitor CI
 
-Poll CI using the approach from `/tend-ci-runner:running-in-ci`. If CI fails, diagnose with
+Poll CI using the approach from `running-in-ci` (loaded in step 0). If CI fails, diagnose with
 `gh run view <run-id> --log-failed`, fix, commit, push, and repeat.


### PR DESCRIPTION
## Summary

The ci-fix skill was the only CI skill missing the "Load `/tend-ci-runner:running-in-ci` first" setup step that review, triage, and notifications all have. Without it, the bot never loads CI environment rules — including polling conventions and the prohibition on `gh run watch`.

## Evidence

**Run [23977801254](https://github.com/PRQL/prql/actions/runs/23977801254)** (tend-ci-fix on PRQL/prql): The bot correctly diagnosed a transient GitHub Actions artifact upload timeout and re-ran the failed job. But while waiting for the re-run, it:

- Made **115 tool calls** (79 Bash, 36 Read) — the vast majority were redundant status checks
- Launched **15 separate background sleep/poll commands** instead of a single polling loop
- Used `gh run watch` — explicitly forbidden by running-in-ci
- Never loaded `running-in-ci` or the repo-local `running-tend` skill

The root cause is structural: the ci-fix skill doesn't tell the bot to load running-in-ci. Compare:

| Skill | Has "Load running-in-ci first" step |
|---|---|
| review | Yes (step 0) |
| triage | Yes (step 1) |
| notifications | Yes (step 1) |
| **ci-fix** | **No — only a vague reference in step 4** |

## Gate assessment

- **Evidence level**: High — structural gap (deterministic)
- **Classification**: Structural — the skill omits the setup instruction; replaying 10 times would reproduce the same omission
- **Change type**: Targeted fix — adds 5 lines matching the pattern used by all other skills
- **Historical evidence**: 1 direct observation (sufficient for structural + targeted fix)

## Fix

Adds a "Step 0: Load environment skills" section to ci-fix, matching the pattern in review, triage, and notifications. Also clarifies the step 4 reference to say "loaded in step 0" instead of a slash-command path.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)