### PR TITLE
fix(skills): rotate tracking comments before hitting GitHub size limit

### DIFF
--- a/plugins/tend-ci-runner/shared/review-gates.md
+++ b/plugins/tend-ci-runner/shared/review-gates.md
@@ -123,16 +123,24 @@ EXISTING_COMMENT=$(gh api "repos/$REPO/issues/$TRACKING_NUMBER/comments" \
   --jq "[.[] | select(.user.login == \"$BOT_LOGIN\")] | last | .id // empty")
 ```
 
-If `EXISTING_COMMENT` is non-empty, download existing body, append new findings, then PATCH. Never
-replace the body — prior entries contain per-run evidence needed for gate evaluation.
+If `EXISTING_COMMENT` is non-empty, check its size before appending. GitHub rejects comment bodies
+over 65536 characters — start a new comment when the existing one is too large.
 
 ```bash
 gh api "repos/$REPO/issues/comments/$EXISTING_COMMENT" --jq '.body' > /tmp/existing.md
-cat /tmp/existing.md /tmp/findings.md > /tmp/combined.md
-gh api "repos/$REPO/issues/comments/$EXISTING_COMMENT" -X PATCH -F body=@/tmp/combined.md
+EXISTING_SIZE=$(wc -c < /tmp/existing.md)
+if [ "$EXISTING_SIZE" -lt 50000 ]; then
+  cat /tmp/existing.md /tmp/findings.md > /tmp/combined.md
+  gh api "repos/$REPO/issues/comments/$EXISTING_COMMENT" -X PATCH -F body=@/tmp/combined.md
+else
+  # Comment approaching limit — start a new one
+  gh api "repos/$REPO/issues/$TRACKING_NUMBER/comments" -F body=@/tmp/findings.md
+fi
 ```
 
-Otherwise create a new comment.
+Never replace the body — prior entries contain per-run evidence needed for gate evaluation.
+
+If `EXISTING_COMMENT` is empty, create a new comment.
 
 Format each finding under a `## Run <run-id>` heading:
 


### PR DESCRIPTION
## Summary

- Adds a size check before appending to tracking issue comments — if the existing comment is approaching GitHub's 65536-char limit (threshold: 50K), start a new comment instead of appending
- Preserves all prior evidence in the old comment; new comment continues accumulation cleanly

## Evidence

**Run ID**: [23983423605](https://github.com/max-sixty/tend/actions/runs/23983423605) (review-reviewers on max-sixty/tend, 2026-04-04T16:59Z)

The bot tried to PATCH the tracking comment on issue #133, which had grown to 259,612 characters over 4 days of hourly runs. GitHub rejected the update with a 422 error. The bot recovered by creating a new comment, but the failed API call is avoidable.

**Root cause**: The `review-gates.md` guidance instructs unconditional append-to-single-comment. Monthly rotation isn't granular enough for repos with frequent runs — the comment can exceed GitHub's limit well within a single month.

**Gate assessment**:
- Evidence level: High (structural — deterministic failure when comment exceeds 65K chars)
- Classification: Structural (will recur every month on any active repo)
- Change type: Targeted fix (adds a size guard to existing code block)
- Historical evidence: 1 occurrence (sufficient for structural + targeted fix)

## Test plan

- [ ] Verify the size check logic: comments under 50K append normally, comments over 50K trigger a new comment
- [ ] Confirm the `wc -c` output is numeric and comparable with `-lt` in bash

🤖 Generated with [Claude Code](https://claude.com/claude-code)
