### PR TITLE
fix(skills): clarify repo-local skills are invoked unprefixed

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -14,6 +14,10 @@ CI context — which workflows tend-ci-fix watches, PR title conventions, label 
 `running-tend` skill is listed in your available skills, load it with the Skill tool before doing
 anything else.
 
+Repo-local skills are invoked by their unprefixed name — `Skill: running-tend`, not
+`Skill: tend-ci-runner:running-tend` (that prefix is reserved for this plugin's own skills, and
+trying it returns `Unknown skill`).
+
 Repo-local skills must have YAML frontmatter (`name` + `description`) to be auto-discovered.
 
 ## Conduct


### PR DESCRIPTION
## Summary

Adds one sentence to `running-in-ci` clarifying that the repo-local overlay skill (`running-tend`) is invoked by its unprefixed name. The model has been repeatedly guessing `Skill: tend-ci-runner:running-tend` first — by analogy with the other plugin skills it sees listed as `tend-ci-runner:*` — getting `Unknown skill`, and then recovering on the next call. A one-line clarification steers it to the correct form directly.

## Evidence

Observed in three PRQL/prql runs and tracked in #133:

| Run | Session | Behavior |
|---|---|---|
| [23987040416](https://github.com/PRQL/prql/actions/runs/23987040416) | `6b59cf32-…` | `Skill: tend-ci-runner:running-tend` → `Unknown skill`, then `Skill: running-tend` → success |
| [23989155925](https://github.com/max-sixty/worktrunk/actions/runs/23989155925) | (worktrunk) | Same pattern — qualified prefix first, unqualified second |
| [23988967434](https://github.com/PRQL/prql/actions/runs/23988967434) | `5cf03886-…` | Same pattern — this run |

Tracking issue entries: #133 (2026-04-04T21:00Z and 22:45Z comments).

## Gate assessment

- **Evidence level**: High — 3 occurrences across two adopter repos, all deterministic (same wrong-then-right pattern).
- **Classification**: Structural — the model sees `tend-ci-runner:*` skills in its available-skills list and reasonably infers the repo-local overlay uses the same prefix. Guidance can deterministically prevent this.
- **Change type**: Targeted fix — four lines added, no restructuring.
- **Gate 1 (confidence)**: Passes (3 occurrences, structural).
- **Gate 2 (magnitude)**: Passes (small addition, proportionate).

## Run context

This PR is from review-reviewers run $GITHUB_RUN_ID analyzing PRQL/prql runs. Other runs in the window (self-authored PR #5770 review, issue #5769 mention response, clean notification polls) were correct — detailed in the summary comment on #133.
