### PR TITLE
fix(skills): set BOT_LOGIN/NOTIF_UPDATED_AT in notifications dedup check

### DIFF
--- a/plugins/tend-ci-runner/skills/notifications/SKILL.md
+++ b/plugins/tend-ci-runner/skills/notifications/SKILL.md
@@ -71,16 +71,21 @@ For each unread notification (oldest first):
 
 ### 4a. Determine if already handled
 
-Check whether the bot has already responded since the notification was generated:
+Check whether the bot has already responded since the notification was generated. `BOT_LOGIN`
+and `NOTIF_UPDATED_AT` are not pre-populated by the workflow — set them explicitly before the jq
+call (`NOTIF_UPDATED_AT` is the `updated_at` field from the notification fetched in step 1):
 
 ```bash
+BOT_LOGIN=$(gh api user --jq '.login')
+NOTIF_UPDATED_AT=<updated_at from the notification>
+
 # For issues
 gh api repos/{owner}/{repo}/issues/{number}/comments \
-  --jq '[.[] | select(.user.login == env.BOT_LOGIN and .created_at > env.NOTIF_UPDATED_AT)] | length'
+  --jq "[.[] | select(.user.login == \"$BOT_LOGIN\" and .created_at > \"$NOTIF_UPDATED_AT\")] | length"
 
 # For PRs — also check reviews
 gh api repos/{owner}/{repo}/pulls/{number}/reviews \
-  --jq '[.[] | select(.user.login == env.BOT_LOGIN and .submitted_at > env.NOTIF_UPDATED_AT)] | length'
+  --jq "[.[] | select(.user.login == \"$BOT_LOGIN\" and .submitted_at > \"$NOTIF_UPDATED_AT\")] | length"
 ```
 
 If the bot already responded after the notification timestamp, mark the notification as read and


### PR DESCRIPTION
## Summary

The `tend-ci-runner:notifications` skill's step-4a dedup check referenced `env.BOT_LOGIN` and `env.NOTIF_UPDATED_AT` inside jq expressions, but neither variable is set anywhere — not by the `tend-notifications` workflow, not by the action, and not by the skill itself. Jq's `env.FOO` returns an empty string when the variable is unset, so `.user.login == env.BOT_LOGIN` matches no comment authors and the dedup check always returns 0. The bot would re-respond to notifications it had already handled.

The fix aligns notifications with every other skill in the plugin (`review`, `nightly`, `review-runs`, `review-reviewers`, `running-in-ci`), all of which explicitly run `BOT_LOGIN=$(gh api user --jq '.login')` and interpolate `"$BOT_LOGIN"` into the `--jq` string.

## Evidence

Review-reviewers run [24011340336](https://github.com/max-sixty/tend/actions/runs/24011340336) analyzed 4 `tend-notifications` runs on max-sixty/worktrunk from the past hour. All four found zero unread notifications and exited cleanly — so the broken dedup path was not exercised end-to-end. But session `37929ff6-303a-41e8-9fb7-19e8b84e2b1a` on run [24011296643](https://github.com/max-sixty/worktrunk/actions/runs/24011296643) incidentally ran a diagnostic:

```
$ echo "BOT_LOGIN=$BOT_LOGIN"; echo "GITHUB_REPOSITORY=$GITHUB_REPOSITORY"; gh api user --jq .login
BOT_LOGIN=
GITHUB_REPOSITORY=max-sixty/worktrunk
worktrunk-bot
```

`BOT_LOGIN` is empty; `gh api user --jq .login` returns the actual login only when invoked explicitly. This confirms the env var is not pre-populated.

A grep of the repo for `BOT_LOGIN` shows that [every other skill](https://github.com/max-sixty/tend/blob/main/plugins/tend-ci-runner/skills/review/SKILL.md#L32) sets it explicitly with `BOT_LOGIN=$(gh api user --jq '.login')` and uses shell interpolation `"$BOT_LOGIN"`; only `notifications/SKILL.md` lines 79 and 83 used the unset `env.BOT_LOGIN` pattern. `NOTIF_UPDATED_AT` had the same issue on the same lines.

## Gate assessment

- **Evidence level**: Critical (clearly wrong — the jq filter cannot match any author with an empty `BOT_LOGIN`, so dedup is broken on every non-empty notification queue).
- **Occurrences**: 1 (sufficient for Critical).
- **Classification**: Structural — deterministic failure every time the step-4a code runs with the default (unset) env.
- **Change type**: Targeted fix (3 added lines, 3 modified lines in one file).
- **Passes Gate 1 (confidence)**: Yes — Critical needs only 1 occurrence, and the broken code is directly visible in the skill file.
- **Passes Gate 2 (magnitude)**: Yes — smallest possible fix (set the vars, switch jq interpolation style to match sibling skills). No new sections, no restructuring.

## Relationship to #151

[#151](https://github.com/max-sixty/tend/pull/151) also edits `notifications/SKILL.md`, but only reorders when `running-in-ci` is loaded; it does not touch step 4a. The two changes are in different parts of the file and compose cleanly.

## Runs analyzed

| Run | Session | Notifications | Outcome |
|---|---|---|---|
| [24011296643](https://github.com/max-sixty/worktrunk/actions/runs/24011296643) | 37929ff6 | 0 | Clean no-op (also ran the BOT_LOGIN diagnostic quoted above) |
| [24010902156](https://github.com/max-sixty/worktrunk/actions/runs/24010902156) | 2b94c568 | 0 | Clean no-op |
| [24010621878](https://github.com/max-sixty/worktrunk/actions/runs/24010621878) | 384fe132 | 0 | Clean no-op |
| [24010335710](https://github.com/max-sixty/worktrunk/actions/runs/24010335710) | 3e38e8a2 | 0 | Clean no-op |

The broken dedup path was not exercised in any of these, which is why the bug has gone unnoticed — it only trips when notifications are actually present and the bot has already responded to the subject.
