### PR TITLE
fix(review): skip re-review when bot pushes to already-approved PR

### DIFF
--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -44,6 +44,23 @@ LAST_REVIEW_SHA=$(gh pr view <number> --json reviews \
 If `LAST_REVIEW_SHA == HEAD_SHA`, this commit has already been reviewed — exit silently. The only
 exception: an unanswered conversation question directed at the bot (check below).
 
+**Bot-authored commits on third-party PRs:** If the bot already approved (`LAST_REVIEW_STATE` is
+`APPROVED`) and the latest commit was authored by the bot itself, exit silently — the bot pushed a
+fix (from a prior review or notification run) and there's nothing new to review. This prevents
+redundant approvals when each bot push triggers a new review run.
+
+```bash
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+BOT_LOGIN=$(gh api user --jq '.login')
+LAST_REVIEW_STATE=$(gh pr view <number> --json reviews \
+  --jq "[.reviews[] | select(.author.login == \"$BOT_LOGIN\")] | last | .state // empty")
+LATEST_COMMIT_AUTHOR=$(gh api "repos/$REPO/commits/$HEAD_SHA" \
+  --jq '.author.login // .committer.login // empty')
+```
+
+If `LAST_REVIEW_STATE == "APPROVED"` and `LATEST_COMMIT_AUTHOR == BOT_LOGIN` and
+`PR_AUTHOR != BOT_LOGIN`, exit silently.
+
 If the bot reviewed a previous commit (`LAST_REVIEW_SHA` exists but differs from `HEAD_SHA`),
 check the incremental changes:
 


### PR DESCRIPTION
## Summary

- Add pre-flight check to skip review when the bot pushes a commit to a PR it already approved
- Prevents redundant approval spam on third-party PRs (Dependabot, renovate) where the bot iterates on CI fixes

## Evidence

**Run ID:** [24044816094](https://github.com/PRQL/prql/actions/runs/24044816094) (tend-notifications on PRQL/prql)

On [PRQL/prql#5774](https://github.com/PRQL/prql/pull/5774) (Dependabot cargo patch bump), a maintainer asked `@prql-bot fix CI`. The notifications handler pushed multiple fix commits. Each push triggered a new `tend-review` run, producing **5 bot approvals** on the same PR:

| Review | Timestamp | Source run | Status |
|---|---|---|---|
| 1 | 17:21:41Z | Initial review | success |
| 2 | 18:41:00Z | [24045334184](https://github.com/PRQL/prql/actions/runs/24045334184) | cancelled |
| 3 | 18:44:03Z | [24045467036](https://github.com/PRQL/prql/actions/runs/24045467036) | cancelled |
| 4 | 18:52:37Z | [24045654923](https://github.com/PRQL/prql/actions/runs/24045654923) | cancelled |
| 5 | 18:57:57Z | [24045947651](https://github.com/PRQL/prql/actions/runs/24045947651) | success |

Cancelled runs still managed to approve before the cancellation signal arrived. Run 24045654923 also pushed a code fix from within a review context.

**Root cause:** The pre-flight check sees a new HEAD (the bot's own commit) and proceeds with an incremental review, which re-approves because the changes are trivial.

**Classification:** Structural — recurs whenever the bot pushes to a PR it already reviewed. Gate 1: High confidence (4 redundant approvals in one incident). Gate 2: Targeted fix (14 lines of guidance added to pre-flight).

## Test plan

- [ ] Verify on next Dependabot PR where bot pushes a fix: only 1 approval should appear
- [ ] Verify bot still reviews new human-authored commits normally (PR_AUTHOR != BOT_LOGIN check)
- [ ] Verify self-authored PR reviews still work (condition excludes PR_AUTHOR == BOT_LOGIN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
