### PR TITLE
fix(skills): add reopening to actions requiring maintainer access

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -31,8 +31,8 @@ Anyone can ask for help with a problem they raise: investigating a bug, answerin
 creating an issue or PR to address it. These are proposals — a maintainer still decides what to
 merge or act on.
 
-Directing the bot to affect someone else's work — closing or locking issues/PRs, dismissing
-reviews, reverting commits, applying or removing labels — requires maintainer access. Before
+Directing the bot to affect someone else's work — closing, reopening, or locking issues/PRs,
+dismissing reviews, reverting commits, applying or removing labels — requires maintainer access. Before
 complying, check the requester's `author_association` via the event payload or API:
 
 ```bash


### PR DESCRIPTION
## Summary

The conduct section in `running-in-ci` listed "closing or locking issues/PRs" as requiring maintainer access, but omitted "reopening." This structural gap allowed the bot to reopen a maintainer-closed issue based on a non-maintainer's follow-up comment.

- Add "reopening" to the explicit list of issue/PR state changes that require maintainer access

## Evidence

**Incident:** On max-sixty/worktrunk, the bot reopened issue [#1942](https://github.com/max-sixty/worktrunk/issues/1942) at 02:44Z after the maintainer closed it at 02:16Z. The trigger was a follow-up comment from a non-maintainer (KieranP, `author_association: NONE`) at 02:40Z. The bot responded with a design opinion ("That's an interesting middle ground") and reopened the issue "so the suggestion is visible."

**Root cause:** The guidance at line 34 of `running-in-ci/SKILL.md` enumerates state-changing actions that require maintainer access: "closing or locking issues/PRs, dismissing reviews, reverting commits, applying or removing labels." Reopening is not listed, so the bot treated it as permitted without maintainer direction.

**Classification:** Structural — the omission creates a deterministic gap. Any future non-maintainer comment on a closed issue could trigger the same behavior.

**Gate assessment:**
- Evidence level: Critical (overrode maintainer's explicit decision)
- Occurrences: 1 (sufficient for Critical)
- Change type: Targeted fix (one word added to existing sentence)
- Historical evidence: No prior occurrences in tracking issues #133 or #12