### PR TITLE
fix(skills): align nightly issue-closing with repo-authorization policy

### DIFF
--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nightly
-description: Nightly code quality sweep — resolves bot PR conflicts, reviews recent commits, surveys existing code, and closes resolved issues.
+description: Nightly code quality sweep — resolves bot PR conflicts, reviews recent commits, surveys existing code, and checks resolved issues.
 metadata:
   internal: true
 ---
@@ -52,7 +52,7 @@ Read the project's CLAUDE.md before reviewing. Apply the review checklist below 
 focusing on changes rather than unchanged code. Also check whether CLAUDE.md itself needs updating
 to reflect the new code (e.g., new file paths, changed commands, removed patterns).
 
-## Step 3: Check existing issues and close resolved ones
+## Step 3: Check existing issues
 
 ```bash
 gh issue list --state open --json number,title
@@ -60,7 +60,9 @@ gh pr list --state open --json number,title,headRefName
 ```
 
 For each open issue, check whether recent commits or the current codebase state already resolve
-it. If resolved, comment briefly and close with `gh issue close`. Skip partially unresolved issues.
+it. If resolved, comment with the evidence (commits, CI runs, or code state that resolves the
+issue). Only close the issue with `gh issue close` if the repo's guidance (e.g., `running-tend`
+skill) explicitly authorizes closing issues. Otherwise, leave it open for a maintainer to close.
 
 ## Step 4: Rolling survey
 


### PR DESCRIPTION
## Summary

The nightly skill's Step 3 ("Check existing issues and close resolved ones") unconditionally instructs `gh issue close` for resolved issues. This conflicts with the policy established in #155 (aa5fa74), which defaults to not closing issues unless the repo's guidance explicitly authorizes it.

**Evidence:** Run [24068363424](https://github.com/PRQL/prql/actions/runs/24068363424) on PRQL/prql closed issue PRQL/prql#5778 without authorization — PRQL/prql has no `.claude` directory or `running-tend` skill authorizing closures.

**Root cause:** #155 updated `running-in-ci` and `review-reviewers` but missed the nightly skill, which has its own explicit close instruction in Step 3.

**Fix:** Nightly now comments with evidence of resolution but only closes the issue if the repo's `running-tend` skill (or equivalent) explicitly authorizes closing.

**Gate assessment:**
- Evidence level: High (structural — deterministic instruction conflict)
- Classification: Structural — every nightly run follows Step 3's explicit close instruction
- Change type: Targeted fix (modify existing instruction)
- Historical evidence: 1 post-policy occurrence (this run); pre-policy closings were correct under the old rules

## Test plan

- [ ] Nightly on a repo without close authorization → comments with evidence but leaves issue open
- [ ] Nightly on a repo whose `running-tend` authorizes closing → closes as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)