### PR TITLE
fix(mention): load triage skill before proposing bug fixes

### DIFF
--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -353,6 +353,8 @@ jobs:
                 && format('You were mentioned in a comment ({{0}}). Read the full issue or PR (description, diff, recent comments, CI status) and respond. If they are requesting changes, make the changes, commit, and push.', github.event.comment.html_url))
               || format('A user commented on an issue/PR where you previously participated ({{0}}). Read the full context. Only respond if the comment is directed at you, asks a question you can help with, or requests changes you can make. A comment that responds to concerns you raised in a review is directed at you — briefly acknowledge that the concerns are resolved (or explain why they are not). If the conversation is between humans, exit silently.', github.event.comment.html_url)
             }}}}
+
+            If you are going to propose a code fix for a bug, load /tend-ci-runner:triage first — it contains reproduction and testing gates that apply to all fix attempts, not just initial triage.
 """
     return GeneratedWorkflow(filename="tend-mention.yaml", content=content)
 


### PR DESCRIPTION
## Summary

- The mention workflow handles follow-up comments on issues/PRs but didn't load the triage skill, so the bot could propose fixes without reproduction or a failing test
- Adds prompt guidance telling the bot to load `/tend-ci-runner:triage` before proposing any code fix for a bug — ensuring the reproduction and testing gates apply universally
- Implements Option A from the diagnosis in #159

Closes #159
