### PR TITLE
fix(skills): verify newly-added CI jobs pass, not just required checks

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -158,6 +158,12 @@ exit 1
    push, repeat.
 3. Report completion only after all required checks pass.
 
+**When your push adds or modifies CI jobs**, also verify those specific jobs pass — don't rely
+solely on `--required`. Newly added jobs are typically not yet required. After the required-checks
+loop completes, run `gh pr checks <number>` (without `--required`) and confirm any job you
+created or changed has passed. If it failed, diagnose and fix before reporting success. Do not
+assume a new job "didn't run" based on path filters — check the actual results.
+
 Before dismissing local test failures as "pre-existing", check main branch CI:
 
 ```bash


### PR DESCRIPTION
## Summary

- Add guidance to the CI monitoring section to verify newly-created or modified CI jobs pass, not just pre-existing required checks.

## Evidence

**Run IDs:** [24116374057](https://github.com/PRQL/prql/actions/runs/24116374057) (tend-mention), [24116452569](https://github.com/PRQL/prql/actions/runs/24116452569) (tend-review)

**Target repo:** PRQL/prql, PR [#5779](https://github.com/PRQL/prql/pull/5779)

**What happened:** The mention run responded to a maintainer request by adding a `test-devcontainer` job to `tests.yaml`. The new job failed (`uv` not in PATH in the devcontainer CI environment). However, the bot's CI polling loop only checked `--required` checks (`pre-commit.ci`), so it reported "CI passed." The subsequent review run also polled only required checks and concluded "no issues found." Both sessions incorrectly reasoned the new job "likely didn't run" due to path filters — it did run and failed.

**Root cause:** The `running-in-ci` skill's CI monitoring section instructs bots to poll `gh pr checks --required`. Newly added CI jobs aren't required, so their failures are invisible to this polling. The bot has no guidance to check its own newly-created jobs.

**Fix:** Add a paragraph after the required-checks instructions telling bots to also verify any jobs they created or modified, using `gh pr checks` without `--required`.

## Gate assessment

- **Evidence level:** Critical — the bot reported CI success while its own change broke CI
- **Failure type:** Structural — the `--required` flag deterministically excludes new non-required jobs; will recur every time the bot adds a CI job
- **Change type:** Targeted fix (6 lines added to existing section)
- **Historical evidence:** First observation, but structural failures need only 1 occurrence

🤖 Generated with [Claude Code](https://claude.com/claude-code)