### PR TITLE
chore: regenerate workflows with tend 0.0.10

### DIFF
--- a/.github/workflows/tend-mention.yaml
+++ b/.github/workflows/tend-mention.yaml
@@ -20,18 +20,17 @@ on:
 
 jobs:
   verify:
-    # Filter out bot's own reviews/comments at the job level. This is required
-    # (not just an optimization) because pull_request_review events on fork PRs
-    # do not have access to secrets, so the verify step's API calls would fail.
+    # Filter out fork PRs for review events — secrets are unavailable there
+    # (no _target variant exists). The notifications workflow polls for these.
     if: |
       (github.event_name == 'issues' &&
         contains(github.event.issue.body, '@tend-agent')) ||
       (github.event_name == 'issue_comment' &&
         github.event.comment.user.login != 'tend-agent') ||
       (github.event_name == 'pull_request_review_comment' &&
-        github.event.comment.user.login != 'tend-agent') ||
+        github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'pull_request_review' &&
-        github.event.review.user.login != 'tend-agent')
+        github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-24.04
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
@@ -93,7 +92,7 @@ jobs:
 
           echo "should_run=false" >> "$GITHUB_OUTPUT"
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}
           COMMENT_BODY: ${{ github.event.comment.body || github.event.review.body }}
           ISSUE_BODY: ${{ github.event.issue.body }}

--- a/.github/workflows/tend-mention.yaml
+++ b/.github/workflows/tend-mention.yaml
@@ -20,13 +20,18 @@ on:
 
 jobs:
   verify:
+    # Filter out bot's own reviews/comments at the job level. This is required
+    # (not just an optimization) because pull_request_review events on fork PRs
+    # do not have access to secrets, so the verify step's API calls would fail.
     if: |
       (github.event_name == 'issues' &&
         contains(github.event.issue.body, '@tend-agent')) ||
       (github.event_name == 'issue_comment' &&
         github.event.comment.user.login != 'tend-agent') ||
-      github.event_name == 'pull_request_review_comment' ||
-      github.event_name == 'pull_request_review'
+      (github.event_name == 'pull_request_review_comment' &&
+        github.event.comment.user.login != 'tend-agent') ||
+      (github.event_name == 'pull_request_review' &&
+        github.event.review.user.login != 'tend-agent')
     runs-on: ubuntu-24.04
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
@@ -88,7 +93,7 @@ jobs:
 
           echo "should_run=false" >> "$GITHUB_OUTPUT"
         env:
-          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
           COMMENT_BODY: ${{ github.event.comment.body || github.event.review.body }}
           ISSUE_BODY: ${{ github.event.issue.body }}

--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -199,18 +199,17 @@ on:
 
 jobs:
   verify:
-    # Filter out bot's own reviews/comments at the job level. This is required
-    # (not just an optimization) because pull_request_review events on fork PRs
-    # do not have access to secrets, so the verify step's API calls would fail.
+    # Filter out fork PRs for review events — secrets are unavailable there
+    # (no _target variant exists). The notifications workflow polls for these.
     if: |
       (github.event_name == 'issues' &&
         contains(github.event.issue.body, '@{bn}')) ||
       (github.event_name == 'issue_comment' &&
         github.event.comment.user.login != '{bn}') ||
       (github.event_name == 'pull_request_review_comment' &&
-        github.event.comment.user.login != '{bn}') ||
+        github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'pull_request_review' &&
-        github.event.review.user.login != '{bn}')
+        github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-24.04
     outputs:
       should_run: ${{{{ steps.check.outputs.should_run }}}}
@@ -272,7 +271,7 @@ jobs:
 
           echo "should_run=false" >> "$GITHUB_OUTPUT"
         env:
-          GH_TOKEN: ${{{{ github.token }}}}
+          GH_TOKEN: {bt}
           EVENT_NAME: ${{{{ github.event_name }}}}
           COMMENT_BODY: ${{{{ github.event.comment.body || github.event.review.body }}}}
           ISSUE_BODY: ${{{{ github.event.issue.body }}}}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
@@ -20,18 +20,17 @@ on:
 
 jobs:
   verify:
-    # Filter out bot's own reviews/comments at the job level. This is required
-    # (not just an optimization) because pull_request_review events on fork PRs
-    # do not have access to secrets, so the verify step's API calls would fail.
+    # Filter out fork PRs for review events ? secrets are unavailable there
+    # (no _target variant exists). The notifications workflow polls for these.
     if: |
       (github.event_name == 'issues' &&
         contains(github.event.issue.body, '@test-bot')) ||
       (github.event_name == 'issue_comment' &&
         github.event.comment.user.login != 'test-bot') ||
       (github.event_name == 'pull_request_review_comment' &&
-        github.event.comment.user.login != 'test-bot') ||
+        github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'pull_request_review' &&
-        github.event.review.user.login != 'test-bot')
+        github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-24.04
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
@@ -93,7 +92,7 @@ jobs:
 
           echo "should_run=false" >> "$GITHUB_OUTPUT"
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}
           COMMENT_BODY: ${{ github.event.comment.body || github.event.review.body }}
           ISSUE_BODY: ${{ github.event.issue.body }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
@@ -20,18 +20,17 @@ on:
 
 jobs:
   verify:
-    # Filter out bot's own reviews/comments at the job level. This is required
-    # (not just an optimization) because pull_request_review events on fork PRs
-    # do not have access to secrets, so the verify step's API calls would fail.
+    # Filter out fork PRs for review events ? secrets are unavailable there
+    # (no _target variant exists). The notifications workflow polls for these.
     if: |
       (github.event_name == 'issues' &&
         contains(github.event.issue.body, '@test-bot')) ||
       (github.event_name == 'issue_comment' &&
         github.event.comment.user.login != 'test-bot') ||
       (github.event_name == 'pull_request_review_comment' &&
-        github.event.comment.user.login != 'test-bot') ||
+        github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'pull_request_review' &&
-        github.event.review.user.login != 'test-bot')
+        github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-24.04
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
@@ -93,7 +92,7 @@ jobs:
 
           echo "should_run=false" >> "$GITHUB_OUTPUT"
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}
           COMMENT_BODY: ${{ github.event.comment.body || github.event.review.body }}
           ISSUE_BODY: ${{ github.event.issue.body }}

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -223,13 +223,13 @@ def test_mention_handles_pull_request_review(tmp_path: Path) -> None:
     )
     assert data[True]["pull_request_review"] == {"types": ["submitted"]}
 
-    # Verify job filters out bot's own reviews/comments — required because
-    # fork PRs don't have access to secrets (the verify step would fail)
+    # Verify job filters out fork PRs for review events — secrets are
+    # unavailable there. The notifications workflow polls for these.
     verify_if = data["jobs"]["verify"]["if"]
     assert "pull_request_review" in verify_if
     assert "issue_comment" in verify_if
     assert "comment.user.login" in verify_if
-    assert "review.user.login" in verify_if
+    assert "pull_request.head.repo.full_name" in verify_if
 
     # Handle job checks out PR branch for this event
     handle_steps = data["jobs"]["handle"]["steps"]


### PR DESCRIPTION
## Summary

- Regenerates `tend-mention.yaml` to match the current generator (0.0.10)
- Restores bot-author filters on `pull_request_review` and `pull_request_review_comment` events — required because fork PRs don't have access to secrets, so the verify step's API calls would fail without this filter
- Switches the verify step's `GH_TOKEN` from `secrets.BOT_TOKEN` to `github.token` for the same fork PR reason

These fixes were in the generator since #206 but the committed workflows were last regenerated with 0.0.9 (#196).

## Test plan

- [ ] CI passes
- [ ] `git diff` between committed file and `uvx tend@latest init --dry-run` output shows no differences

🤖 Generated with [Claude Code](https://claude.com/claude-code)