### PR TITLE
fix(review): skip APPROVE when incremental commits are bot-authored

### DIFF
--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -60,8 +60,9 @@ gh api "repos/$REPO/compare/$LAST_REVIEW_SHA...$HEAD_SHA" \
 pushed from `tend-notifications`, `tend-ci-fix`, or a prior mention run), do not submit a new
 APPROVE regardless of whether the changes are trivial — self-approval of your own commits is not
 an independent review signal. Leave any existing approval in place. If you find a genuine new
-issue in the bot-authored code, post it as a COMMENT; otherwise exit silently and proceed to step
-6 to monitor CI. This guards against the re-approval loop where each bot-pushed fix triggers
+issue in the bot-authored code, post it as a COMMENT; otherwise exit silently. Either way,
+proceed to step 7 to resolve any prior bot threads addressed by the fix, then to step 6 to
+monitor CI. This guards against the re-approval loop where each bot-pushed fix triggers
 `tend-review`, which then ratifies its own commit.
 
 If the incremental changes are trivial, skip the full review — go directly to step 7 to resolve

--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -45,13 +45,24 @@ If `LAST_REVIEW_SHA == HEAD_SHA`, this commit has already been reviewed — exit
 exception: an unanswered conversation question directed at the bot (check below).
 
 If the bot reviewed a previous commit (`LAST_REVIEW_SHA` exists but differs from `HEAD_SHA`),
-check the incremental changes:
+check the incremental changes **and their authors**:
 
 ```bash
 REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+BOT_LOGIN=$(gh api user --jq '.login')
 gh api "repos/$REPO/compare/$LAST_REVIEW_SHA...$HEAD_SHA" \
-  --jq '{total: ([.files[] | .additions + .deletions] | add), files: [.files[] | "\(.filename)\t+\(.additions)/-\(.deletions)"]}'
+  --jq '{total: ([.files[] | .additions + .deletions] | add),
+         files: [.files[] | "\(.filename)\t+\(.additions)/-\(.deletions)"],
+         authors: ([.commits[].author.login] | unique)}'
 ```
+
+**Bot-authored incremental commits**: If every author in `authors` is the bot itself (i.e. a fix
+pushed from `tend-notifications`, `tend-ci-fix`, or a prior mention run), do not submit a new
+APPROVE regardless of whether the changes are trivial — self-approval of your own commits is not
+an independent review signal. Leave any existing approval in place. If you find a genuine new
+issue in the bot-authored code, post it as a COMMENT; otherwise exit silently and proceed to step
+6 to monitor CI. This guards against the re-approval loop where each bot-pushed fix triggers
+`tend-review`, which then ratifies its own commit.
 
 If the incremental changes are trivial, skip the full review — go directly to step 7 to resolve
 any bot threads addressed by the new changes. After resolving threads: if the most recent bot


### PR DESCRIPTION
## Summary

- Add an explicit pre-flight check to the `/tend-ci-runner:review` skill: when every commit since `LAST_REVIEW_SHA` was authored by the bot itself, do not submit a new APPROVE — leave any existing approval in place.
- Guards against the re-approval loop where a bot-pushed fix (from `tend-notifications`, `tend-ci-fix`, or a mention run) triggers `tend-review`, which then ratifies its own commit.

## Evidence

### Incident: [max-sixty/worktrunk#2041](https://github.com/max-sixty/worktrunk/pull/2041) (merged)

Timeline on the `logs` branch (PR by `max-sixty`):

| Time | Commit | Actor | Review result |
|---|---|---|---|
| 23:10:40Z | d4e3e8b | worktrunk-bot review #1 | COMMENTED — flagged 2 real issues |
| 23:17:58Z | d6456bc | worktrunk-bot review #2 | COMMENTED — acknowledged trash-sweep fix |
| 23:30:31Z | f96b126 | worktrunk-bot review #3 | **APPROVED** (empty body) |
| 23:32:17Z | **c30d804** | **worktrunk-bot push** (fix from `tend-notifications` [run 24218351323](https://github.com/max-sixty/worktrunk/actions/runs/24218351323)) | — |
| 23:36:57Z | c30d804 | worktrunk-bot review #4 | **APPROVED** (empty body) — **self-review of own commit** |

[tend-review run 24218513196](https://github.com/max-sixty/worktrunk/actions/runs/24218513196) session transcript shows the bot reasoning:

> The bot already approved at `f96b1260`. The new commit is trivial — just one line change in `state.rs` using `to_slash_lossy()` for Windows path consistency. Let me verify the change is correct, check threads, and **re-approve**.

The skill's existing trivial-change branch already says _"Otherwise do not submit a new review — the existing one stands"_, but the bot re-approved anyway. This ended with the bot holding 4 reviews on the PR, the last of which approved its own commit.

### Related prior attempt: #154 (closed)

[PR #154](https://github.com/max-sixty/tend/pull/154) tried to fix a similar pattern on [PRQL/prql#5774](https://github.com/PRQL/prql/pull/5774) (5 redundant approvals) by skipping the review entirely. That was rejected — a review IS still needed, because bot-pushed commits can still introduce issues worth catching. This PR takes the narrower approach suggested in that thread: still review, just do not re-APPROVE.

## Gate assessment

- **Classification**: structural — any bot push to a PR the bot has already approved can repeat this.
- **Confidence**: High. 1 fresh occurrence (PR #2041) plus the prior incident documented in #154. Skill already has indirect guidance ("existing one stands") that was violated; the new check makes it keyed on commit authorship instead of an ambiguous triviality judgment.
- **Magnitude**: Targeted fix (13 added lines in one skill file, no code changes).
- **Both gates pass.**

## Test plan

- [ ] Next time `tend-notifications` or `tend-ci-fix` pushes a fix to a human PR that the bot has already approved, verify the follow-up `tend-review` run does not submit a second APPROVE.
- [ ] Verify normal human-authored incremental review paths are unchanged (commits from the human PR author still get reviewed and approved as before).
- [ ] Verify self-authored PRs (`PR_AUTHOR == BOT_LOGIN`) continue to work with the existing separate guidance.