### PR TITLE
docs(review-reviewers): mark bot re-approval as a non-issue

### DIFF
--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -26,6 +26,22 @@ that follows tend's defaults but contradicts repo-specific guidance is a problem
 Frame your analysis around this hierarchy: did the bot follow the repo's guidance? Only fall back
 to evaluating against tend's defaults for behaviors the repo doesn't address.
 
+## Non-issues: do not flag these
+
+Some patterns look suspicious but are intentional. Before drafting a finding, check this list —
+flagging expected behaviors creates maintainer churn and costs trust.
+
+- **`tend-review` re-approving after the bot pushed a fix commit.** The reviewer role is
+  independent of commit and PR authorship. Re-reviewing (and re-approving) after
+  `tend-notifications`, `tend-ci-fix`, or a mention run pushes a fix is expected behavior, not a
+  re-approval loop. Two prior PRs attempted authorship-keyed guards and were both closed by the
+  maintainer as solving a non-problem — [#154](https://github.com/max-sixty/tend/pull/154)
+  ("skip re-review when bot pushes to already-approved PR") and
+  [#212](https://github.com/max-sixty/tend/pull/212) ("skip APPROVE when incremental commits are
+  bot-authored"). If you observe stacked approvals from concurrent runs that raced with
+  concurrency-group cancellation, that is a *concurrency* issue (the cancelled runs managed to
+  POST before the SIGTERM arrived) — do not propose changes to review's approval rules.
+
 ## Target repo
 
 **Target repo:** $ARGUMENTS

--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -61,6 +61,11 @@ existing one stands. Do NOT proceed to steps 2–6. Rough heuristic:
 changes under ~20 added+deleted lines that don't introduce new functions, types, or control flow
 are typically trivial.
 
+**Commit and PR authorship do not affect review behavior.** Apply the same trivial-vs-substantive
+heuristic regardless of who pushed the new commits. When `tend-notifications` or `tend-ci-fix`
+pushes a fix to a human-authored PR, reviewing (and re-approving) the updated state is expected —
+the reviewer role is independent of commit authorship.
+
 Then read all previous bot feedback and conversation:
 
 ```bash


### PR DESCRIPTION
## Summary

- Add a **"Non-issues: do not flag these"** section to `review-reviewers/SKILL.md` so the hourly judgment doesn't keep re-discovering the same non-problem.
- Document in `review/SKILL.md` that commit and PR authorship don't affect review behavior — reviewing/re-approving after a bot-pushed fix is expected.

## Evidence — two prior rejections of the same fix

`review-reviewers` has now made two attempts to guard `tend-review` from re-approving on bot-pushed fix commits. Both were closed by the maintainer as solving a non-problem.

| PR | Title | Closed | Maintainer feedback |
|---|---|---|---|
| [#154](https://github.com/max-sixty/tend/pull/154) | `fix(review): skip re-review when bot pushes to already-approved PR` | 2026-04-07 | "but presumably this does require a new review, no? why is this case special?" |
| [#212](https://github.com/max-sixty/tend/pull/212) | `fix(review): skip APPROVE when incremental commits are bot-authored` | 2026-04-10 01:07Z | "this is totally fine — we should *not* treat a bot PR differently from any other PR. We should make that clear in our docs" |

The second rejection explicitly asked for the principle to be documented. This PR does that.

## Root cause

Run [24219300860](https://github.com/max-sixty/tend/actions/runs/24219300860) (prior `review-reviewers` run at 23:59Z) observed a `tend-review` run on max-sixty/worktrunk#2041 submitting a fourth APPROVED review on a bot-authored commit pushed by `tend-notifications`, classified it as "Structural — recurs whenever the bot pushes to a PR it already reviewed," and filed #212. The judgment was wrong: commit authorship is not a review-logic problem. Run [24220122739](https://github.com/max-sixty/tend/actions/runs/24220122739) (`tend-review` on #212) then correctly executed the new logic the PR added, but the PR's premise was rejected by the maintainer minutes later in run [24221123712](https://github.com/max-sixty/tend/actions/runs/24221123712).

The underlying 5-stacked-approvals incident that originally motivated #154 ([PRQL/prql#5774](https://github.com/PRQL/prql/pull/5774)) was a *concurrency* issue — cancelled runs racing to POST approvals before SIGTERM arrived — not a review-logic issue. This is called out in the new "Non-issues" entry so it isn't confused for the same pattern in future.

## Gate assessment

| Gate | Result |
|---|---|
| **Evidence level** | Critical — two closed PRs with explicit maintainer rejection, plus an explicit "make that clear in our docs" request |
| **Occurrences** | 3 independent instances (PR #154 authoring run, PR #212 authoring run 24219300860, and each closure) |
| **Classification** | **Structural** — the skill has no guidance distinguishing expected re-approval from a loop; it will make the same judgment again without a fix |
| **Change type** | **Targeted fix** — 21 lines total across two files, no restructuring |
| **Passes Gate 1 (confidence)** | Yes — Critical bar is 1 occurrence; this has 2 |
| **Passes Gate 2 (magnitude)** | Yes — targeted fix at normal threshold |

## Test plan

- [ ] Next time a `tend-review` run re-approves after `tend-notifications` or `tend-ci-fix` pushes a fix, the subsequent `review-reviewers` run should not flag it as a behavioral problem.
- [ ] The `review` skill continues reviewing bot-pushed fixes normally (no behavior change — only documentation added).
