### PR TITLE
chore: release 0.0.11

### DIFF
--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tend"
-version = "0.0.10"
+version = "0.0.11"
 description = "Claude-powered CI for GitHub repos"
 license = "MIT"
 requires-python = ">=3.11"

--- a/generator/uv.lock
+++ b/generator/uv.lock
@@ -144,7 +144,7 @@ wheels = [
 
 [[package]]
 name = "tend"
-version = "0.0.10"
+version = "0.0.11"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Bumps generator version to 0.0.11 and syncs lockfile.

4 commits since 0.0.10:
- docs(review-reviewers): mark bot re-approval as a non-issue (#213)
- chore: regenerate workflows with tend 0.0.10 (#210)
- fix: update example config nightly/weekly descriptions (#211)
- Clean up install-tend skill (#209)

> _This was written by Claude Code on behalf of Maximilian_