### PR TITLE
fix(review-reviewers): replace broken gh -R api example

### DIFF
--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -72,10 +72,11 @@ If empty, report "no runs to review" and exit.
 
 ## Step 2: Load repo-specific guidance and download session logs
 
-First, read the target repo's repo-specific guidance to understand what the bot was told to do:
+First, read the target repo's repo-specific guidance to understand what the bot was told to do.
+`gh api` does not accept `-R` — embed the repo in the endpoint path instead:
 
 ```bash
-gh -R $ARGUMENTS api repos/{owner}/{repo}/contents/.claude/skills/running-tend/SKILL.md \
+gh api "repos/$ARGUMENTS/contents/.claude/skills/running-tend/SKILL.md" \
   --jq '.content' | base64 -d
 ```
 
@@ -84,7 +85,9 @@ If the file doesn't exist, try common alternatives (`.claude/skills/running-tend
 session — without it, you'll misjudge authorized behavior as a violation.
 
 Then load `/install-tend:debug-ci-session` for download commands and JSONL parsing queries. Use
-`-R $ARGUMENTS` for all `gh` commands targeting the adopter repo.
+`-R $ARGUMENTS` for `gh run`, `gh pr`, and `gh issue` commands targeting the adopter repo. For
+`gh api` calls, substitute the repo into the endpoint path (as shown above) since the `-R` flag is
+not supported there.
 
 Skip runs without artifacts. Trace decision chains: what did Claude decide, what evidence did it
 use, what was the outcome?


### PR DESCRIPTION
## Summary

The `review-reviewers` Step 2 example calls `gh -R $ARGUMENTS api …`, but `gh api` does not accept a `-R/--repo` flag. Every run of this skill hits the error:

```
unknown shorthand flag: 'R' in -R
Usage:  gh api <endpoint> [flags]
```

The bot then has to improvise a retry, and the broader rule *"Use `-R $ARGUMENTS` for all `gh` commands targeting the adopter repo"* is itself incorrect for `gh api`. This PR fixes the example to embed the repo in the endpoint path (which is how `gh api` actually targets another repo) and narrows the usage rule to the commands that accept `-R`.

## Evidence

- **Run 24228180513** (`review-reviewers`, scheduled 2026-04-10 05:34Z, max-sixty/tend target session [`0bd962f0`](https://github.com/max-sixty/tend/actions/runs/24228180513)):
  ```
  gh -R max-sixty/tend api repos/max-sixty/tend/contents/.claude/skills/running-tend/SKILL.md --jq '.content' 2>/dev/null | base64 -d
  ```
  Returned `unknown shorthand flag: 'R' in -R`. The bot retried without `-R` and proceeded, but the initial call is dead code every time.
- **Current run** (this PR's session, also max-sixty/tend target): same command, same `unknown shorthand flag: 'R' in -R` error.
- `gh api --help` confirms no `-R` / `--repo` flag — only `GH_REPO` env var or `{owner}/{repo}` placeholders are supported for cross-repo calls.

## Gate assessment

- **Classification**: Structural failure (deterministic — the command does not parse).
- **Change type**: Targeted fix (one code block + one sentence).
- **Occurrences**: 2 (prior `review-reviewers` run + current run). Structural failures need 1 occurrence; this has 2.
- **Verdict**: Passes both gates.

## What else was in the past-hour window

| Run | Workflow | Outcome |
|---|---|---|
| [24229457226](https://github.com/max-sixty/tend/actions/runs/24229457226) | `tend-notifications` (06:18Z) | `No unread notifications — skipping`. No Claude session. |
| [24228354661](https://github.com/max-sixty/tend/actions/runs/24228354661) | `tend-notifications` (05:40Z) | `No unread notifications — skipping`. No Claude session. |
| [24228180513](https://github.com/max-sixty/tend/actions/runs/24228180513) | `review-reviewers` (05:34Z) | 3 target sessions (max-sixty/tend, PRQL/prql, max-sixty/worktrunk). Previous run reported "all clear"; grounded analysis correct. Hit the `gh -R api` error as noted above. |

No other findings to gate. Nothing appended to [#133](https://github.com/max-sixty/tend/issues/133).

## Test plan

- [ ] `gh api "repos/max-sixty/tend/contents/.claude/skills/running-tend/SKILL.md" --jq '.content'` returns a 404 (file doesn't exist on that repo) rather than a flag-parse error — confirming the fixed form parses.
- [ ] Next `review-reviewers` run's Step 2 command succeeds on first try.
