### PR TITLE
fix(ci-runner): replace if-not polling loop with || to avoid bash escaping

### DIFF
--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -290,14 +290,17 @@ individual sleep commands. Use the Bash tool with `run_in_background: true` and 
 you're running. **NEVER use `--watch` flags** — they hang forever.
 
 ```bash
-# Run with Bash tool's run_in_background: true
+# Run with Bash tool's run_in_background: true.
+# Use `||` rather than `if !` — the Bash tool escapes `!` as `\!`, which
+# prevents bash from recognizing the pipeline-negation reserved word and leaves
+# the loop stuck until the 10-minute timeout.
 for i in $(seq 1 10); do
   sleep 60
-  if ! gh pr checks <number> --required 2>&1 \
-       | grep -v "tend-review" | grep -q 'pending\|queued\|in_progress'; then
+  gh pr checks <number> --required 2>&1 \
+       | grep -v "tend-review" | grep -q 'pending\|queued\|in_progress' || {
     gh pr checks <number> --required
     exit 0
-  fi
+  }
 done
 echo "CI still running after 10 minutes"
 exit 1

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -139,12 +139,15 @@ background task completes you will be notified — check the result and take any
 # Run with Bash tool's run_in_background: true
 # Filter out the current workflow ($GITHUB_WORKFLOW) — it will always show as
 # "pending" since it IS the running job. Watching yourself deadlocks.
+# Use `||` rather than `if !` — the Bash tool escapes `!` as `\!`, which
+# prevents bash from recognizing the pipeline-negation reserved word and leaves
+# the loop stuck until the 10-minute timeout.
 for i in $(seq 1 10); do
   sleep 60
-  if ! gh pr checks <number> --required 2>&1 | grep -v "$GITHUB_WORKFLOW" | grep -q 'pending\|queued\|in_progress'; then
+  gh pr checks <number> --required 2>&1 | grep -v "$GITHUB_WORKFLOW" | grep -q 'pending\|queued\|in_progress' || {
     gh pr checks <number> --required
     exit 0
-  fi
+  }
 done
 echo "CI still running after 10 minutes"
 exit 1


### PR DESCRIPTION
## Summary

The CI polling loop in `running-in-ci` and `review` skills uses `if ! cmd`, but the Claude Code Bash tool escapes `!` as `\!` before handing commands to bash. Bash then parses the escaped token as a literal command (`!: command not found`), so the early-exit branch of `if ! pipeline` is unreachable. Every poll runs all 10 iterations and prints a false "CI still running after 10 minutes".

Switched both loops to `cmd || { ...; }`, which doesn't rely on `!`.

## Evidence

Reproduced in the bash tool this run:

```
$ echo 'if ! false; then echo then; else echo else; fi' > /tmp/t.sh
$ cat /tmp/t.sh
if \! false; then echo then; else echo else; fi
$ bash /tmp/t.sh
/tmp/t.sh: line 1: !: command not found
else
```

And similarly `printf '%s\n' '!test'` writes `\!test` — the escape happens even inside single quotes, so there is no source-level workaround.

Observed in a real polling run — tend-mention PR #212, run [24220018870](https://github.com/max-sixty/tend/actions/runs/24220018870). The background task output was:

```
CI still running after 10 minutes
no required checks reported on the 'hourly/review-24219300860' branch
```

With a working `!`, the first iteration's pipeline exits 1 (grep -q no match), the `!` flips it to 0, and the loop exits immediately. Instead, the loop ran to completion — consistent with `if ! pipeline` always evaluating to the else branch (because `!` is treated as an unknown command, exit 127, which is non-zero, which `if` sees as false).

The bot on that run attributed the timeout to "no required checks" but that explanation doesn't hold — any polling of any PR in this harness suffers the same fate.

## Fix

Replace

```bash
if ! gh pr checks <n> --required 2>&1 | grep -v ... | grep -q 'pending\|...'; then
  gh pr checks <n> --required
  exit 0
fi
```

with

```bash
gh pr checks <n> --required 2>&1 | grep -v ... | grep -q 'pending\|...' || {
  gh pr checks <n> --required
  exit 0
}
```

`||` is a distinct operator (not `!`), so the escape doesn't apply. Verified locally that the rewritten loop exits on iteration 1 when the pipeline returns non-zero.

## Gate assessment

- **Confidence**: Critical. Every polling run hits this; reproduced in-session and observed in a real run. One occurrence is sufficient per the gates.
- **Classification**: Structural. The same conditions will recur on every polling invocation.
- **Magnitude**: Targeted fix — 6 lines changed across 2 skill files, no behavior change on the happy path.

## Test plan

- [x] `cd generator && uv run pytest` (147 passed)
- [ ] Next tend-review run on this branch polls CI and exits cleanly within one iteration instead of timing out at 10 minutes
