### PR TITLE
fix(review-runs): use CLAUDE_PLUGIN_ROOT for token-report.sh path

### DIFF
--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -45,7 +45,7 @@ If no runs found, report "no runs to review" and exit.
 Run the token report script to get per-run token counts:
 
 ```bash
-"${CLAUDE_SKILL_DIR}/../scripts/token-report.sh" 12 > /tmp/token-report.json
+"${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" 12 > /tmp/token-report.json
 ```
 
 Include the totals and per-workflow breakdown in the summary (Step 6). Flag any


### PR DESCRIPTION
## Summary

`${CLAUDE_SKILL_DIR}/../scripts/token-report.sh` resolves to `plugins/tend-ci-runner/skills/scripts/token-report.sh` — a directory that doesn't exist. The script lives at `plugins/tend-ci-runner/scripts/token-report.sh` (one level above the skill directory). As a result, Step 2 of the review-runs skill fails every run with `No such file or directory`, and the token report is silently skipped.

Other skills in the same plugin already use `${CLAUDE_PLUGIN_ROOT}/scripts/...` — `nightly/SKILL.md:72` and `review-reviewers/SKILL.md:65`. Switched this call to match.

## Evidence

From this run:

```
$ "${CLAUDE_SKILL_DIR}/../scripts/token-report.sh" 12
/bin/bash: .../skills/review-runs/../scripts/token-report.sh: No such file or directory
$ "${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" 12
# writes /tmp/token-report.json correctly
```

## Gate assessment

- **Confidence**: Critical. Every invocation of the review-runs skill skips Step 2. Reproduced in-session.
- **Classification**: Structural. The path is wrong; it will fail every time.
- **Magnitude**: One-line path fix, matching the existing plugin convention.

## Test plan

- [x] `cd generator && uv run pytest` (147 passed)
- [x] Verified `${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh` is the correct path for this plugin
