### PR TITLE
fix(review-runs): edit .claude/skills/ in a writable worktree

### DIFF
--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -99,6 +99,28 @@ Improvements target **repo-local** files:
 
 **Prefer PRs over issues.** A PR with a clear description is immediately actionable.
 
+The checkout's `.claude/` directory is bind-mounted read-only under the sandbox
+(protecting bots from modifying their own skills in place), so edits to
+`.claude/skills/` files fail with `OSError: [Errno 30] Read-only file system`.
+Do the edit, commit, and push from a git worktree under `$TMPDIR`, which is
+writable:
+
+```bash
+git worktree add "$TMPDIR/review-runs-fix" -b daily/review-runs-$GITHUB_RUN_ID HEAD
+cd "$TMPDIR/review-runs-fix"
+# edit .claude/skills/... here
+git add .claude/skills/...
+git commit -m "skills(running-tend): ..."
+git push -u origin daily/review-runs-$GITHUB_RUN_ID
+gh pr create --title "..." --body-file /tmp/pr-body.md --head daily/review-runs-$GITHUB_RUN_ID
+cd -
+git worktree remove "$TMPDIR/review-runs-fix" --force
+```
+
+`.config/tend.toml` and `CLAUDE.md` are not under the read-only mount, but if
+you're already in the worktree for a `.claude/skills/` edit, do those edits
+there too so the branch stays self-contained.
+
 - **PR** (default): Branch `daily/review-runs-$GITHUB_RUN_ID`, fix, commit, push, create with
   label `review-runs`. Put full analysis in PR description (run IDs, log excerpts, root cause,
   gate assessment).


### PR DESCRIPTION
## Summary

The review-runs skill's Step 6 tells the bot to edit `.claude/skills/` files and open a PR, but the checkout's `.claude/` directory is bind-mounted read-only under the Claude Code 2.1.97+ sandbox — the same RCE-vector protection that PR #216 handled for `.github/` in the nightly skill. In-place edits fail with `OSError: [Errno 30] Read-only file system`, and the bot has to diagnose the mount and set up a worktree mid-run.

Add the worktree pattern to Step 6 so the bot opens the fix PR from a writable worktree under `$TMPDIR` from the start.

## Evidence

Run [24233412050](https://github.com/max-sixty/worktrunk/actions/runs/24233412050) (tend-review-runs on max-sixty/worktrunk, 2026-04-10 07:47Z, session `8adb40c1-4b13-4d11-97dc-bcbbe461b468.jsonl`) decided to add transient-failure guidance to `.claude/skills/running-tend/SKILL.md` (creating PR [max-sixty/worktrunk#2050](https://github.com/max-sixty/worktrunk/pull/2050)). The bot:

1. Ran `git checkout -b daily/review-runs-24233412050` on the workspace checkout.
2. Called `Edit` on `.claude/skills/running-tend/SKILL.md` → permission error from the harness.
3. Fell back to `python3` write on the same path → `OSError: [Errno 30] Read-only file system: '.claude/skills/running-tend/SKILL.md'`.
4. Ran `mount | grep claude` to diagnose.
5. Tried `git worktree add /tmp/claude-1001/wt-review daily/review-runs-24233412050` — failed because the branch was already checked out in the workspace.
6. Had to `git worktree remove --force`, `git checkout main`, then recreate the worktree.
7. Finally edited inside the worktree, committed, pushed, and opened the PR.

Confirmed in this review-reviewers session's sandbox:

```
$ mount | grep -E "\.claude|\.github"
/dev/root on /home/runner/work/tend/tend/.claude type ext4 (ro,...)
/dev/root on /home/runner/work/tend/tend/.github type ext4 (ro,...)
```

Same root cause as PR #216: claude-code-action restores `.claude/`, `.mcp.json`, `.claude.json`, `.gitmodules`, and `.ripgreprc` from the base branch as RCE-vector protection, and Claude Code 2.1.97+ bind-mounts them read-only.

## Gate assessment

- **Confidence**: High. Structural — the mount is deterministic and would produce the same failure on every review-runs session that tries to edit `.claude/skills/` in place. One observed occurrence this run plus an independent confirmation via `mount` in this review-reviewers session. Same class of failure as PR #216 (`.github/` in nightly), which has already been accepted upstream as a structural fix.
- **Classification**: Structural sandbox mount.
- **Magnitude**: Targeted fix — adds one worktree snippet to Step 6 of an existing skill file, mirrors the pattern PR #216 introduced for nightly Step 5.

Passes both gates. Paired with the simplification that most review-runs fix PRs already want a branch anyway, the worktree pattern adds no overhead.

## Test plan

- [x] Diff reviewed — docs-only change to `plugins/tend-ci-runner/skills/review-runs/SKILL.md`.
- [x] Verified `plugins/tend-ci-runner/skills/review-runs/SKILL.md` is not under the read-only `.claude/` mount (writable in this session).
- [ ] Next review-runs invocation on an adopter repo edits `.claude/skills/` via the new worktree pattern on the first try.
