### PR TITLE
fix(token-report): set CLICOLOR_FORCE=0 to defeat forced colors

### DIFF
--- a/plugins/tend-ci-runner/scripts/token-report.sh
+++ b/plugins/tend-ci-runner/scripts/token-report.sh
@@ -43,11 +43,20 @@ if [ ${#WORKFLOWS[@]} -eq 0 ]; then
   exit 0
 fi
 
+# Strips ANSI color escape sequences. In some CI environments (observed on
+# PRQL/prql, gh 2.89.0) `gh run list --json` emits ANSI color codes even with
+# NO_COLOR=1/CLICOLOR=0/GH_FORCE_TTY="" set, breaking downstream jq parsing.
+# We strip defensively so the script is robust regardless of what the
+# environment does. The sed expression is a no-op when no codes are present.
+strip_ansi() {
+  sed -E $'s/\x1b\\[[0-9;]*[A-Za-z]//g'
+}
+
 # Collect all completed runs across workflows
 ALL_RUNS="[]"
 for wf in "${WORKFLOWS[@]}"; do
   runs=$(gh run list "${repo_args[@]}" --workflow "$wf" --created ">=$SINCE" --status completed \
-    --json databaseId,conclusion,createdAt,name --limit 100 2>/dev/null || echo "[]")
+    --json databaseId,conclusion,createdAt,name --limit 100 2>/dev/null | strip_ansi || echo "[]")
   ALL_RUNS=$(echo "$ALL_RUNS" "$runs" | jq -s 'add | unique_by(.databaseId)')
 done
 

--- a/plugins/tend-ci-runner/scripts/token-report.sh
+++ b/plugins/tend-ci-runner/scripts/token-report.sh
@@ -20,7 +20,13 @@
 # Requires: gh, jq, GNU coreutils (date -d)
 
 set -euo pipefail
+# Disable gh's colored JSON output. NO_COLOR=1 alone is insufficient when the
+# environment sets CLICOLOR_FORCE=1 (e.g. PRQL/prql's tend-setup action sets
+# it in $GITHUB_ENV to force cargo/clippy colors), because gh treats
+# CLICOLOR_FORCE as higher priority than NO_COLOR — resulting in ANSI codes
+# in --json output that break downstream jq parsing.
 export NO_COLOR=1
+export CLICOLOR_FORCE=0
 
 HOURS=${1:-168}
 SINCE=$(date -u -d "$HOURS hours ago" +%Y-%m-%dT%H:%M:%SZ)
@@ -43,20 +49,11 @@ if [ ${#WORKFLOWS[@]} -eq 0 ]; then
   exit 0
 fi
 
-# Strips ANSI color escape sequences. In some CI environments (observed on
-# PRQL/prql, gh 2.89.0) `gh run list --json` emits ANSI color codes even with
-# NO_COLOR=1/CLICOLOR=0/GH_FORCE_TTY="" set, breaking downstream jq parsing.
-# We strip defensively so the script is robust regardless of what the
-# environment does. The sed expression is a no-op when no codes are present.
-strip_ansi() {
-  sed -E $'s/\x1b\\[[0-9;]*[A-Za-z]//g'
-}
-
 # Collect all completed runs across workflows
 ALL_RUNS="[]"
 for wf in "${WORKFLOWS[@]}"; do
   runs=$(gh run list "${repo_args[@]}" --workflow "$wf" --created ">=$SINCE" --status completed \
-    --json databaseId,conclusion,createdAt,name --limit 100 2>/dev/null | strip_ansi || echo "[]")
+    --json databaseId,conclusion,createdAt,name --limit 100 2>/dev/null || echo "[]")
   ALL_RUNS=$(echo "$ALL_RUNS" "$runs" | jq -s 'add | unique_by(.databaseId)')
 done
 


### PR DESCRIPTION
## Summary

`token-report.sh` was exporting `NO_COLOR=1` but `gh run list --json` still emitted ANSI color codes into its JSON in PRQL/prql's CI, breaking the downstream `jq` pipeline with:

```
jq: parse error: Invalid numeric literal at line 1, column 5
```

…making the token report silently empty.

## Root cause (updated)

PRQL/prql's [`.github/actions/tend-setup/action.yaml`](https://github.com/PRQL/prql/blob/main/.github/actions/tend-setup/action.yaml) sets `CLICOLOR_FORCE=1` in `$GITHUB_ENV` to force cargo/clippy color output. gh's iostreams logic treats `CLICOLOR_FORCE` as higher priority than `NO_COLOR`, so `NO_COLOR=1` alone cannot suppress colors when something upstream sets `CLICOLOR_FORCE=1`.

Verified against gh 2.89.0 in tend's own env:

| env | output |
|---|---|
| `CLICOLOR_FORCE=1 gh run list --json ...` | `\e[1;37m[\e[m\e[1;37m]\e[m` |
| `CLICOLOR_FORCE=1 NO_COLOR=1 gh run list --json ...` | `\e[1;37m[\e[m...` (still colored) |
| `CLICOLOR_FORCE=1 CLICOLOR=0 gh run list --json ...` | `\e[1;37m[\e[m...` (still colored) |
| `CLICOLOR_FORCE=0 gh run list --json ...` | `[{...}]` (clean) |

## Fix

Add `export CLICOLOR_FORCE=0` next to the existing `export NO_COLOR=1` at the top of `token-report.sh`. This overrides an inherited `CLICOLOR_FORCE=1` from the ambient env and lets gh fall back to its normal non-TTY behavior (no colors).

## Verification

- **Baseline repro:** `CLICOLOR_FORCE=1 NO_COLOR=1 gh run list --json databaseId --limit 2` → emits `\e[1;37m[\e[m...`, confirmed against tend's CI gh 2.89.0.
- **Fix repro:** `CLICOLOR_FORCE=1 NO_COLOR=1 bash -c 'export CLICOLOR_FORCE=0; gh run list --json databaseId --limit 2'` → emits `[{"databaseId":...}]` cleanly.
- **End-to-end:** Ran `CLICOLOR_FORCE=1 ./plugins/tend-ci-runner/scripts/token-report.sh 2` → script parses successfully, downloads artifacts, outputs valid JSON.
- **Tests:** `cd generator && uv run pytest` → 147/147 passed.
- **Syntax:** `bash -n` passes.

## Scope

Only `token-report.sh`, since that's the script the bug demonstrably broke. `list-recent-runs.sh` has the same `gh run list --json` pattern but is only invoked from the review-reviewers skill which runs on tend itself (where no upstream sets `CLICOLOR_FORCE=1`), so I'm leaving it alone rather than making speculative changes.
