### PR TITLE
fix(running-in-ci): harden GitHub URL construction guidance

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -263,8 +263,11 @@ Always use markdown links for files, issues, PRs, and docs. Prefer permalinks (c
 over branch-based links for line references — line numbers shift and `blob/main/...#L42` links go
 stale.
 
-Derive the repository owner/name from `$GITHUB_REPOSITORY` (e.g., `owner/repo`) — never guess or
-hardcode the organization in URLs.
+**GitHub URLs — always embed `$GITHUB_REPOSITORY`.** Construct links as
+`https://github.com/${GITHUB_REPOSITORY}/...`; never hand-type the owner. The model reliably
+guesses wrong — past comments have shipped with `anthropics/worktrunk` and `worktrunk/worktrunk`
+on a repo actually owned by `max-sixty`. Before posting a comment, scan it for `github.com/` and
+confirm every owner matches `$GITHUB_REPOSITORY`.
 
 - **Files**: link to GitHub (`blob/main/...` for file-level, `blob/<sha>/...#L42` for lines)
 - **Issues/PRs**: `#123` shorthand


### PR DESCRIPTION
## Summary

Strengthen the running-in-ci skill's guidance on constructing GitHub URLs, after a second occurrence of the bot shipping a user-visible comment with the wrong repository owner in a `github.com` link.

## Evidence

Two recent tend-triage comments on `max-sixty/worktrunk` have shipped broken links because the model hardcoded a wrong owner:

1. **2026-04-02** — Run [23889208419](https://github.com/max-sixty/worktrunk/actions/runs/23889208419), triage on issue max-sixty/worktrunk#1888, session `d544ecc6-8bb7-4bfe-85a6-82bef8bec237.jsonl`. Comment linked `https://github.com/anthropics/worktrunk/blob/f6e89009/src/git/mod.rs#L222-L261` — the bot reached for the canonical "anthropics" org from training data. Recorded in [review-reviewers-tracking: 2026-04](https://github.com/max-sixty/tend/issues/133) under "Hardcoded organization in URL".
2. **2026-04-10** — Run [24254699778](https://github.com/max-sixty/worktrunk/actions/runs/24254699778), triage on issue max-sixty/worktrunk#2055, session `225e9f4d-8007-4b63-9a5a-f8f899e16891.jsonl`. [Comment](https://github.com/max-sixty/worktrunk/issues/2055#issuecomment-4225461187) linked `https://github.com/worktrunk/worktrunk/blob/main/src/commands/hook_commands.rs#L214-L226` — this time the bot inferred the owner from the repo name. Both links 404.

A third, related URL-grounding failure (inferred docs path `https://worktrunk.dev/claude-code/` on issue max-sixty/worktrunk#1903) is recorded in the same tracking issue — the overall pattern is "model composes URLs from context rather than verifying the source."

The running-in-ci skill has had a one-sentence "derive the owner from `$GITHUB_REPOSITORY` — never guess or hardcode the organization in URLs" directive since [#100](https://github.com/max-sixty/tend/pull/100) (2026-03-29). Both failures above happened *after* that guidance landed, so a passive sentence is not enough.

## Root cause

When composing a `github.com/…` URL in a comment, the model picks a plausible owner from context: training-data canonical org (`anthropics`) or the repo name itself (`worktrunk/worktrunk`). It does not consult `$GITHUB_REPOSITORY`.

## Fix

Replace the passive sentence with an imperative block:
- Bold heading so it survives skimming.
- Concrete construction template `https://github.com/${GITHUB_REPOSITORY}/...`.
- The two real wrong-answers as examples, so the model pattern-matches away from them.
- An explicit pre-post check step (grep for `github.com/`, verify owners).

## Gate assessment

- **Evidence level**: High — consistent pattern of user-visible comments with broken links, 2 occurrences of hardcoded-wrong-owner (specifically) + 1 related URL-grounding lapse. Failures are in public-facing bot output.
- **Classification**: Structural-ish stochastic — the lapse happens when the skill guidance is too weak to counter the model's default URL-composition habit. Strengthening the guidance is a predictable mitigation.
- **Change type**: Targeted fix — replaces one sentence with a slightly longer paragraph. Not a new section, not a structural reorg.
- **Passes both gates**: Yes — High/2–3 meets the threshold for targeted fixes.

## Test plan

- [ ] Running-in-ci skill still reads cleanly from the Comment Formatting section.
- [ ] Next triage run that emits a `github.com/…` URL uses `max-sixty/...` (observable in tracking issue #133).

