### PR TITLE
fix(workflows): drop hardcoded 60-min job timeout

### DIFF
--- a/.github/workflows/tend-ci-fix.yaml
+++ b/.github/workflows/tend-ci-fix.yaml
@@ -17,7 +17,6 @@ jobs:
   fix-ci:
     if: github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/tend-mention.yaml
+++ b/.github/workflows/tend-mention.yaml
@@ -121,7 +121,6 @@ jobs:
       group: ${{ github.workflow }}-handle-${{ github.event.issue.number || github.event.pull_request.number }}
       cancel-in-progress: false
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/tend-nightly.yaml
+++ b/.github/workflows/tend-nightly.yaml
@@ -15,7 +15,6 @@ on:
 jobs:
   nightly:
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/tend-notifications.yaml
+++ b/.github/workflows/tend-notifications.yaml
@@ -15,7 +15,6 @@ on:
 jobs:
   notifications:
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/tend-review-runs.yaml
+++ b/.github/workflows/tend-review-runs.yaml
@@ -15,7 +15,6 @@ on:
 jobs:
   review-runs:
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/tend-review.yaml
+++ b/.github/workflows/tend-review.yaml
@@ -19,7 +19,6 @@ jobs:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/tend-triage.yaml
+++ b/.github/workflows/tend-triage.yaml
@@ -18,7 +18,6 @@ concurrency:
 jobs:
   triage:
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/tend-weekly.yaml
+++ b/.github/workflows/tend-weekly.yaml
@@ -15,7 +15,6 @@ on:
 jobs:
   weekly:
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -86,7 +86,6 @@ jobs:
     if: >-
       github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -145,7 +145,6 @@ jobs:
       group: ${{{{ github.workflow }}}}-${{{{ github.event.pull_request.number }}}}
       cancel-in-progress: true
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
     permissions:
 {perms}
     steps:
@@ -300,7 +299,6 @@ jobs:
       group: ${{{{ github.workflow }}}}-handle-${{{{ github.event.issue.number || github.event.pull_request.number }}}}
       cancel-in-progress: false
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
     permissions:
 {perms}
     steps:
@@ -404,7 +402,6 @@ concurrency:
 jobs:
   triage:
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
     permissions:
 {perms}
     steps:
@@ -467,7 +464,6 @@ jobs:
   fix-ci:
     if: github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
     permissions:
 {perms}
     steps:
@@ -525,7 +521,6 @@ on:
 jobs:
   {name}:
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
     permissions:
 {perms}
     steps:
@@ -583,7 +578,6 @@ on:
 jobs:
   notifications:
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
     permissions:
 {perms}
     steps:

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[ci-fix].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[ci-fix].out
@@ -17,7 +17,6 @@ jobs:
   fix-ci:
     if: github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
@@ -121,7 +121,6 @@ jobs:
       group: ${{ github.workflow }}-handle-${{ github.event.issue.number || github.event.pull_request.number }}
       cancel-in-progress: false
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[nightly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[nightly].out
@@ -15,7 +15,6 @@ on:
 jobs:
   nightly:
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
@@ -15,7 +15,6 @@ on:
 jobs:
   notifications:
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review-runs].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review-runs].out
@@ -15,7 +15,6 @@ on:
 jobs:
   review-runs:
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review].out
@@ -19,7 +19,6 @@ jobs:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[triage].out
@@ -18,7 +18,6 @@ concurrency:
 jobs:
   triage:
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[weekly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[weekly].out
@@ -15,7 +15,6 @@ on:
 jobs:
   weekly:
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[ci-fix].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[ci-fix].out
@@ -17,7 +17,6 @@ jobs:
   fix-ci:
     if: github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
@@ -121,7 +121,6 @@ jobs:
       group: ${{ github.workflow }}-handle-${{ github.event.issue.number || github.event.pull_request.number }}
       cancel-in-progress: false
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[nightly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[nightly].out
@@ -15,7 +15,6 @@ on:
 jobs:
   nightly:
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
@@ -15,7 +15,6 @@ on:
 jobs:
   notifications:
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review-runs].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review-runs].out
@@ -15,7 +15,6 @@ on:
 jobs:
   review-runs:
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review].out
@@ -19,7 +19,6 @@ jobs:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[triage].out
@@ -18,7 +18,6 @@ concurrency:
 jobs:
   triage:
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[weekly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[weekly].out
@@ -15,7 +15,6 @@ on:
 jobs:
   weekly:
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
A `tend-mention handle` run in max-sixty/worktrunk hit 58m51s against the 60-min cap doing real multi-step work — 4 commits across a shell-integration fix, docs, codecov coverage gaps, and a snapshot refresh, with ~24 min spent waiting on slow `codecov/patch`. A clean near-miss on legitimate work, not a hang.

The 60-minute constant had no principled basis. Rather than tuning the magic number to 120 (or 180, or 240), this drops the line entirely and falls back to GitHub's 360-min default. That removes a knob instead of adding one, which is the right direction given the repo's "no new options" rule.

Trade-off: worst-case runaway exposure goes from 1h to 6h per stuck job. The motivating incident was a near-miss on real work, not a runaway, so this seems acceptable — and a stuck job is bounded and observable either way.

Per-workflow override is a separate question to consider: there's currently no pass-through mechanism in `WorkflowConfig` for arbitrary job-level YAML keys. If we want one, that's its own design discussion.

Co-Authored-By: Claude <noreply@anthropic.com>

> _This was written by Claude Code on behalf of max-sixty_