### PR TITLE
fix(mention): deduplicate review events causing FAILURE rollup

### DIFF
--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -194,8 +194,20 @@ on:
   # Works for same-repo PRs only; secrets unavailable on fork PRs (no _target variant exists)
   pull_request_review:
     types: [submitted]
+  # `created` is intentionally absent. Modern GitHub fires *both*
+  # pull_request_review and pull_request_review_comment for every newly-created
+  # inline comment (the standalone POST /pulls/PR/comments endpoint, the
+  # /replies endpoint, the "Add single comment" UI button, and reviews
+  # submitted with inline comments — all empirically verified). Subscribing to
+  # `created` would produce a duplicate workflow run that collides on the
+  # tend-mention-handle-PR concurrency group, with the loser cancelled and
+  # posted as a CANCELLED check_run on the PR head SHA — which renders the
+  # PR's statusCheckRollup as FAILURE even though the bot did its job from the
+  # sibling run. Edits have no sibling event (review submissions don't fire on
+  # edits), so we still need to listen for `edited` to catch edit-to-summon
+  # ("@bot" added to an existing comment after the fact).
   pull_request_review_comment:
-    types: [created, edited]
+    types: [edited]
 
 jobs:
   verify:
@@ -226,6 +238,18 @@ jobs:
           if [ -n "$COMMENT_BODY" ] && printf '%s\\n' "$COMMENT_BODY" | grep -qF '@{bn}'; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             exit 0
+          fi
+
+          # pull_request_review payloads include review.body (checked above)
+          # but NOT the bodies of inline comments attached to the review.
+          # Fetch them so a first-contact @-mention inside an inline comment
+          # is detected on PRs where the bot has no prior engagement.
+          if [ "$EVENT_NAME" = "pull_request_review" ] && [ -n "$REVIEW_ID" ]; then
+            if gh api "repos/$GITHUB_REPOSITORY/pulls/$EVENT_PR_NUMBER/reviews/$REVIEW_ID/comments" \\
+                 --jq '.[].body' | grep -qF '@{bn}'; then
+              echo "should_run=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           fi
 
           # Non-mention: check bot engagement
@@ -279,6 +303,7 @@ jobs:
           ISSUE_AUTHOR: ${{{{ github.event.issue.user.login }}}}
           PR_URL: ${{{{ github.event.issue.pull_request.url }}}}
           EVENT_PR_NUMBER: ${{{{ github.event.pull_request.number }}}}
+          REVIEW_ID: ${{{{ github.event.review.id }}}}
 
       - name: React to mention
         if: |

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
@@ -15,8 +15,20 @@ on:
   # Works for same-repo PRs only; secrets unavailable on fork PRs (no _target variant exists)
   pull_request_review:
     types: [submitted]
+  # `created` is intentionally absent. Modern GitHub fires *both*
+  # pull_request_review and pull_request_review_comment for every newly-created
+  # inline comment (the standalone POST /pulls/PR/comments endpoint, the
+  # /replies endpoint, the "Add single comment" UI button, and reviews
+  # submitted with inline comments ? all empirically verified). Subscribing to
+  # `created` would produce a duplicate workflow run that collides on the
+  # tend-mention-handle-PR concurrency group, with the loser cancelled and
+  # posted as a CANCELLED check_run on the PR head SHA ? which renders the
+  # PR's statusCheckRollup as FAILURE even though the bot did its job from the
+  # sibling run. Edits have no sibling event (review submissions don't fire on
+  # edits), so we still need to listen for `edited` to catch edit-to-summon
+  # ("@bot" added to an existing comment after the fact).
   pull_request_review_comment:
-    types: [created, edited]
+    types: [edited]
 
 jobs:
   verify:
@@ -47,6 +59,18 @@ jobs:
           if [ -n "$COMMENT_BODY" ] && printf '%s\n' "$COMMENT_BODY" | grep -qF '@test-bot'; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             exit 0
+          fi
+
+          # pull_request_review payloads include review.body (checked above)
+          # but NOT the bodies of inline comments attached to the review.
+          # Fetch them so a first-contact @-mention inside an inline comment
+          # is detected on PRs where the bot has no prior engagement.
+          if [ "$EVENT_NAME" = "pull_request_review" ] && [ -n "$REVIEW_ID" ]; then
+            if gh api "repos/$GITHUB_REPOSITORY/pulls/$EVENT_PR_NUMBER/reviews/$REVIEW_ID/comments" \
+                 --jq '.[].body' | grep -qF '@test-bot'; then
+              echo "should_run=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           fi
 
           # Non-mention: check bot engagement
@@ -100,6 +124,7 @@ jobs:
           ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
           PR_URL: ${{ github.event.issue.pull_request.url }}
           EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          REVIEW_ID: ${{ github.event.review.id }}
 
       - name: React to mention
         if: |

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
@@ -15,8 +15,20 @@ on:
   # Works for same-repo PRs only; secrets unavailable on fork PRs (no _target variant exists)
   pull_request_review:
     types: [submitted]
+  # `created` is intentionally absent. Modern GitHub fires *both*
+  # pull_request_review and pull_request_review_comment for every newly-created
+  # inline comment (the standalone POST /pulls/PR/comments endpoint, the
+  # /replies endpoint, the "Add single comment" UI button, and reviews
+  # submitted with inline comments ? all empirically verified). Subscribing to
+  # `created` would produce a duplicate workflow run that collides on the
+  # tend-mention-handle-PR concurrency group, with the loser cancelled and
+  # posted as a CANCELLED check_run on the PR head SHA ? which renders the
+  # PR's statusCheckRollup as FAILURE even though the bot did its job from the
+  # sibling run. Edits have no sibling event (review submissions don't fire on
+  # edits), so we still need to listen for `edited` to catch edit-to-summon
+  # ("@bot" added to an existing comment after the fact).
   pull_request_review_comment:
-    types: [created, edited]
+    types: [edited]
 
 jobs:
   verify:
@@ -47,6 +59,18 @@ jobs:
           if [ -n "$COMMENT_BODY" ] && printf '%s\n' "$COMMENT_BODY" | grep -qF '@test-bot'; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             exit 0
+          fi
+
+          # pull_request_review payloads include review.body (checked above)
+          # but NOT the bodies of inline comments attached to the review.
+          # Fetch them so a first-contact @-mention inside an inline comment
+          # is detected on PRs where the bot has no prior engagement.
+          if [ "$EVENT_NAME" = "pull_request_review" ] && [ -n "$REVIEW_ID" ]; then
+            if gh api "repos/$GITHUB_REPOSITORY/pulls/$EVENT_PR_NUMBER/reviews/$REVIEW_ID/comments" \
+                 --jq '.[].body' | grep -qF '@test-bot'; then
+              echo "should_run=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           fi
 
           # Non-mention: check bot engagement
@@ -100,6 +124,7 @@ jobs:
           ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
           PR_URL: ${{ github.event.issue.pull_request.url }}
           EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          REVIEW_ID: ${{ github.event.review.id }}
 
       - name: React to mention
         if: |

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -247,6 +247,82 @@ def test_mention_handles_pull_request_review(tmp_path: Path) -> None:
     assert "github.event.review.body" in prompt
 
 
+def test_mention_review_comment_listens_only_for_edits(tmp_path: Path) -> None:
+    """pull_request_review_comment must subscribe to `edited` only, not `created`.
+
+    Modern GitHub fires *both* pull_request_review and pull_request_review_comment
+    for every newly-created inline comment (verified across the standalone
+    POST /pulls/{n}/comments endpoint, the /replies endpoint, the "Add single
+    comment" UI button, and reviews submitted with inline comments). If we
+    subscribed to `created` here, the duplicate run would collide on the
+    tend-mention-handle-<PR#> concurrency group, the loser would be cancelled,
+    and the cancelled check_run on the PR head SHA would render the PR's
+    statusCheckRollup as FAILURE — even though the bot did its job from the
+    sibling run.
+
+    Edits have no sibling event (review submissions don't fire on edits), so
+    we still need to listen for `edited` to catch edit-to-summon ("@bot" added
+    to an existing comment after the fact)."""
+    cfg = Config.load(_minimal_config(tmp_path))
+    workflows = {wf.filename: wf for wf in generate_all(cfg)}
+    mention = workflows["tend-mention.yaml"]
+    data = yaml.safe_load(mention.content)
+    assert data[True]["pull_request_review_comment"] == {"types": ["edited"]}, (
+        "pull_request_review_comment must subscribe to ['edited'] only — see "
+        "the trigger comment in generate_mention for the dedup rationale"
+    )
+
+
+def test_mention_verify_detects_inline_mentions_on_review(tmp_path: Path) -> None:
+    """For pull_request_review events, verify must fetch the review's inline
+    comments and grep their bodies for the bot mention.
+
+    The pull_request_review event payload exposes review.body but NOT the
+    bodies of the inline comments attached to that review. So a first-contact
+    "@bot" mention written *inside* an inline review comment is invisible to
+    the COMMENT_BODY check (which only sees review.body for review events) and
+    to the engagement check (which only fires when the bot has prior
+    engagement on the PR). Without this fetch, such mentions would be silently
+    dropped on PRs where the bot has no prior engagement.
+
+    Today the gap is masked stochastically by the pull_request_review_comment
+    sibling event firing in parallel and exposing comment.body. Once we stop
+    subscribing to `created` for that event (see
+    test_mention_review_comment_listens_only_for_edits), the masking goes away
+    and verify must detect the mention via the API."""
+    cfg = Config.load(_minimal_config(tmp_path))
+    workflows = {wf.filename: wf for wf in generate_all(cfg)}
+    mention = workflows["tend-mention.yaml"]
+    data = yaml.safe_load(mention.content)
+    check_step = next(
+        s for s in data["jobs"]["verify"]["steps"] if s.get("id") == "check"
+    )
+
+    # The fetch must target the specific review's inline comments by review_id
+    assert "/reviews/$REVIEW_ID/comments" in check_step["run"], (
+        "verify must fetch inline comments for pull_request_review events via "
+        "the /pulls/{n}/reviews/{review_id}/comments endpoint"
+    )
+    # And grep their bodies for the bot mention (test-bot is the bot_name in
+    # _minimal_config). grep -qF means fixed-string, quiet — same shape as the
+    # other mention checks in this script.
+    assert "grep -qF '@test-bot'" in check_step["run"], (
+        "verify must grep the fetched inline comment bodies for the bot mention"
+    )
+
+    # The fetch must be gated on event_name == 'pull_request_review' so it
+    # doesn't fire for issue_comment / issues / pull_request_review_comment.
+    assert '[ "$EVENT_NAME" = "pull_request_review" ]' in check_step["run"], (
+        "the inline-mention fetch must only run for pull_request_review events"
+    )
+
+    # REVIEW_ID env var must be wired from the event payload
+    assert check_step["env"]["REVIEW_ID"] == "${{ github.event.review.id }}", (
+        "REVIEW_ID env var must be set from github.event.review.id so the "
+        "fetch can target the right review"
+    )
+
+
 def test_mention_verify_no_concurrency(tmp_path: Path) -> None:
     """verify job must not have concurrency — a non-mention comment can cancel
     an explicit @bot mention if both arrive on the same PR within seconds (#93)."""


### PR DESCRIPTION
GitHub fires both `pull_request_review` and `pull_request_review_comment` for every newly-created inline comment (verified across the standalone `POST /pulls/{n}/comments` endpoint, the `/replies` endpoint, the "Add single comment" UI button, and reviews submitted with inline comments). Both runs converge on the `tend-mention-handle-<PR#>` concurrency group with `cancel-in-progress: false`, so the loser is cancelled and posted as a `CANCELLED` check_run on the PR head SHA — rendering the PR's `statusCheckRollup` as `FAILURE`.

Narrow `pull_request_review_comment` from `[created, edited]` to `[edited]` only. Created inline comments are guaranteed to also fire `pull_request_review`, so dropping `created` eliminates the duplicate without losing coverage. Edits have no sibling event, so `edited` stays to handle edit-to-summon (`@bot` added to an existing comment after the fact).

Also fixes a latent bug: `pull_request_review` payloads include `review.body` but not the bodies of inline comments attached to the review. A first-contact `@bot` mention inside an inline review comment on a PR with no prior bot engagement was silently dropped by the verify job (the `COMMENT_BODY` check only sees `review.body`). Previously masked stochastically by the `pull_request_review_comment` sibling winning the concurrency race. The new verify-stage API fetch (`/reviews/{id}/comments`) detects these mentions directly.

> _This was written by Claude Code on behalf of @max-sixty_