### PR TITLE
fix(review-reviewers): drop hardcoded 60-min timeout

### DIFF
--- a/.github/workflows/review-reviewers.yaml
+++ b/.github/workflows/review-reviewers.yaml
@@ -22,7 +22,6 @@ jobs:
           - max-sixty/tend
           - PRQL/prql
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Same rationale as #223 — fall back to GitHub's 360-min default rather than maintaining an arbitrary constant. This is the hand-maintained `review-reviewers.yaml` (not generated by tend), which tend-agent flagged in the #223 review.

Co-Authored-By: Claude <noreply@anthropic.com>

> _This was written by Claude Code on behalf of max-sixty_