### PR TITLE
fix(mention): remove bot-author filter from issue_comment

### DIFF
--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -215,8 +215,7 @@ jobs:
     if: |
       (github.event_name == 'issues' &&
         contains(github.event.issue.body, '@{bn}')) ||
-      (github.event_name == 'issue_comment' &&
-        github.event.comment.user.login != '{bn}') ||
+      (github.event_name == 'issue_comment') ||
       (github.event_name == 'pull_request_review_comment' &&
         github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'pull_request_review' &&

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
@@ -37,8 +37,7 @@ jobs:
     if: |
       (github.event_name == 'issues' &&
         contains(github.event.issue.body, '@test-bot')) ||
-      (github.event_name == 'issue_comment' &&
-        github.event.comment.user.login != 'test-bot') ||
+      (github.event_name == 'issue_comment') ||
       (github.event_name == 'pull_request_review_comment' &&
         github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'pull_request_review' &&

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
@@ -37,8 +37,7 @@ jobs:
     if: |
       (github.event_name == 'issues' &&
         contains(github.event.issue.body, '@test-bot')) ||
-      (github.event_name == 'issue_comment' &&
-        github.event.comment.user.login != 'test-bot') ||
+      (github.event_name == 'issue_comment') ||
       (github.event_name == 'pull_request_review_comment' &&
         github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'pull_request_review' &&

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -228,7 +228,6 @@ def test_mention_handles_pull_request_review(tmp_path: Path) -> None:
     verify_if = data["jobs"]["verify"]["if"]
     assert "pull_request_review" in verify_if
     assert "issue_comment" in verify_if
-    assert "comment.user.login" in verify_if
     assert "pull_request.head.repo.full_name" in verify_if
 
     # Handle job checks out PR branch for this event


### PR DESCRIPTION
The verify `if:` filtered out the bot's own issue_comments via `comment.user.login != '{bn}'`, but didn't filter bot-authored `pull_request_review` or `pull_request_review_comment` events. The bot submits reviews on every PR (via tend-review), so the asymmetry wasn't justified by frequency. Remove the filter and rely on the prompt's self-loop prevention for all event types uniformly.

> _This was written by Claude Code on behalf of @max-sixty_