### PR TITLE
chore: regenerate tend-mention.yaml

### DIFF
--- a/.github/workflows/tend-mention.yaml
+++ b/.github/workflows/tend-mention.yaml
@@ -15,8 +15,20 @@ on:
   # Works for same-repo PRs only; secrets unavailable on fork PRs (no _target variant exists)
   pull_request_review:
     types: [submitted]
+  # `created` is intentionally absent. Modern GitHub fires *both*
+  # pull_request_review and pull_request_review_comment for every newly-created
+  # inline comment (the standalone POST /pulls/PR/comments endpoint, the
+  # /replies endpoint, the "Add single comment" UI button, and reviews
+  # submitted with inline comments — all empirically verified). Subscribing to
+  # `created` would produce a duplicate workflow run that collides on the
+  # tend-mention-handle-PR concurrency group, with the loser cancelled and
+  # posted as a CANCELLED check_run on the PR head SHA — which renders the
+  # PR's statusCheckRollup as FAILURE even though the bot did its job from the
+  # sibling run. Edits have no sibling event (review submissions don't fire on
+  # edits), so we still need to listen for `edited` to catch edit-to-summon
+  # ("@bot" added to an existing comment after the fact).
   pull_request_review_comment:
-    types: [created, edited]
+    types: [edited]
 
 jobs:
   verify:
@@ -25,8 +37,7 @@ jobs:
     if: |
       (github.event_name == 'issues' &&
         contains(github.event.issue.body, '@tend-agent')) ||
-      (github.event_name == 'issue_comment' &&
-        github.event.comment.user.login != 'tend-agent') ||
+      (github.event_name == 'issue_comment') ||
       (github.event_name == 'pull_request_review_comment' &&
         github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'pull_request_review' &&
@@ -49,6 +60,18 @@ jobs:
             exit 0
           fi
 
+          # pull_request_review payloads include review.body (checked above)
+          # but NOT the bodies of inline comments attached to the review.
+          # Fetch them so a first-contact @-mention inside an inline comment
+          # is detected on PRs where the bot has no prior engagement.
+          if [ "$EVENT_NAME" = "pull_request_review" ] && [ -n "$REVIEW_ID" ]; then
+            if gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$EVENT_PR_NUMBER/reviews/$REVIEW_ID/comments" \
+                 --jq '.[].body' | grep -qF '@tend-agent'; then
+              echo "should_run=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
           # Non-mention: check bot engagement
           if [ "$EVENT_NAME" = "issue_comment" ]; then
             ISSUE_NUMBER="$ISSUE_OR_PR_NUMBER"
@@ -60,7 +83,7 @@ jobs:
               if printf '%s\n' "$ISSUE_BODY" | grep -qF '@tend-agent'; then
                 echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
               fi
-              BOT_COMMENTS=$(gh api "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments" \
+              BOT_COMMENTS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments" \
                 --jq '[.[] | select(.user.login == "tend-agent")] | length')
               if [ "$BOT_COMMENTS" -gt "0" ]; then
                 echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
@@ -78,13 +101,13 @@ jobs:
             echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
           fi
 
-          BOT_REVIEWS=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
+          BOT_REVIEWS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
             --jq '[.[] | select(.user.login == "tend-agent")] | length')
           if [ "$BOT_REVIEWS" -gt "0" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
           fi
 
-          BOT_COMMENTS=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+          BOT_COMMENTS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
             --jq '[.[] | select(.user.login == "tend-agent")] | length')
           if [ "$BOT_COMMENTS" -gt "0" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
@@ -100,6 +123,7 @@ jobs:
           ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
           PR_URL: ${{ github.event.issue.pull_request.url }}
           EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          REVIEW_ID: ${{ github.event.review.id }}
 
       - name: React to mention
         if: |
@@ -180,18 +204,14 @@ jobs:
             ${{ github.event_name == 'issues'
               && format('An issue was updated with a mention of you ({0}). Read it and respond.', github.event.issue.html_url)
               || (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@tend-agent')
-                && format('You were mentioned in an inline review comment on PR #{0} ({1}, review comment ID {2}). Read the full PR context (description, diff, recent comments, CI status) and respond. If they are requesting changes, make the changes, commit, and push. Reply in the review thread using `gh api repos/{3}/pulls/{0}/comments/{2}/replies -f body="..."` — do not create a new top-level comment.', (github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number), github.event.comment.html_url, github.event.comment.id, github.repository))
+                && format('You were mentioned in an inline review comment on PR #{0} ({1}, comment ID {2}). Read the full context, then respond. If changes are requested, make them, commit, and push.', (github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number), github.event.comment.html_url, github.event.comment.id))
               || (github.event_name == 'pull_request_review_comment'
-                && format('A user left an inline review comment on a PR where you previously participated (PR #{0}, {1}, review comment ID {2}). Read the full context. Only respond if the comment is directed at you or requests changes. Reply in the review thread using `gh api repos/{3}/pulls/{0}/comments/{2}/replies -f body="..."`.', (github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number), github.event.comment.html_url, github.event.comment.id, github.repository))
+                && format('An inline review comment was posted on a PR where you previously participated (PR #{0}, {1}, comment ID {2}). Read the full context. Only respond if the comment is directed at you or requests changes.', (github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number), github.event.comment.html_url, github.event.comment.id))
               || (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@tend-agent')
-                && format('A review was submitted on PR #{0} that mentions you ({1}). Read the review and full PR context (description, diff, comments, CI status), then respond. If changes were requested, make them, commit, and push.', github.event.pull_request.number, github.event.review.html_url))
+                && format('A review was submitted on PR #{0} that mentions you ({1}, review ID {2}). Read the review and full context, then respond. If changes were requested, make them, commit, and push.', github.event.pull_request.number, github.event.review.html_url, github.event.review.id))
               || (github.event_name == 'pull_request_review'
-                && format('A review was submitted on a PR where you previously participated (PR #{0}, {1}). Read the review and full PR context. If the review requests changes or asks questions, respond appropriately. If the review approves or is between humans, exit silently.', github.event.pull_request.number, github.event.review.html_url))
+                && format('A review was submitted on a PR where you previously participated (PR #{0}, {1}, review ID {2}). Read the review and full context. If the review requests changes or asks questions, respond appropriately. If the review approves or is between humans, exit silently.', github.event.pull_request.number, github.event.review.html_url, github.event.review.id))
               || (contains(github.event.comment.body, '@tend-agent')
-                && format('You were mentioned in a comment ({0}). Read the full issue or PR (description, diff, recent comments, CI status) and respond. If they are requesting changes, make the changes, commit, and push.', github.event.comment.html_url))
-              || format('A user commented on an issue/PR where you previously participated ({0}). Read the full context. Only respond if the comment is directed at you, asks a question you can help with, or requests changes you can make. A comment that responds to concerns you raised in a review is directed at you — briefly acknowledge that the concerns are resolved (or explain why they are not). If the conversation is between other participants, exit silently. In multi-way conversations (other participants besides you and the commenter are active), apply a higher bar: only respond if you have something genuinely new to add — a code fix, reproduction, or specific technical detail no one else provided. Do not restate, agree with, or summarize what a maintainer said.', github.event.comment.html_url)
+                && format('You were mentioned in a comment ({0}). Read the full context and respond. If changes are requested, make them, commit, and push.', github.event.comment.html_url))
+              || format('A user commented on an issue/PR where you previously participated ({0}). Read the full context. Only respond if the comment is directed at you, asks a question you can help with, or requests changes you can make. If the conversation is between other participants, exit silently.', github.event.comment.html_url)
             }}
-
-            If you are responding to your own prior comment or review (not a human's reply to it), be cautious — only respond if there is a distinct role boundary (e.g., you are the reviewer on your own PR and need to address review feedback). If there is no such role distinction, exit silently to avoid self-conversation loops.
-
-            If you are going to propose a code fix for a bug, load /tend-ci-runner:triage first — it contains reproduction and testing gates that apply to all fix attempts, not just initial triage.


### PR DESCRIPTION
## Summary

Syncs `.github/workflows/tend-mention.yaml` with the in-repo generator. The file drifted across #225, #228, #233, and #235 — each updated `generator/src/tend/workflows.py` (and the regtest snapshots) but none regenerated the checked-in workflow YAML. Result: the generator and the file it supposedly produces no longer matched.

Pulled changes:
- `pull_request_review_comment` narrowed to `[edited]` only, with the rationale comment in the trigger block (#225)
- verify job now fetches inline review comments by `$REVIEW_ID` to detect first-contact `@bot` mentions inside inline review comments, with the `REVIEW_ID` env var wired from `github.event.review.id` (#225)
- `issue_comment` clause no longer filters by `comment.user.login \!= bot_name` (#233) — self-conversation is now handled at the content level by the `running-in-ci` skill's Self-conversation Guard
- `--paginate` added to the three `gh api` calls used for bot engagement detection (#228)
- mention prompt branches slimmed down; shared behavioral guidance (reply mechanics, multi-way rules, self-conversation guard, triage-loading gate) moved to `running-in-ci` (#235)

## Why not `uvx tend@latest init`?

The nightly skill's regen step is `uvx tend@latest init`, which pulls the most recent PyPI release (currently 0.0.11). For tend's own repo that produces the wrong result:

- PyPI 0.0.11 still has the hardcoded `timeout-minutes: 60` that #223 / #232 removed from the generator. Running `uvx tend@latest init` against `main` adds `timeout-minutes: 60` back to all 8 workflow files — a straight regression.
- PyPI 0.0.11 is also missing the mention generator changes above, so it wouldn't catch the drift either.

This PR was generated with `uv run --project generator tend init` against the worktree, which uses the source tree exactly as checked in. That produces a clean, one-file diff (tend-mention.yaml only) — every other workflow was already in sync with the local generator.

## Follow-up: self-regenerating nightly

The nightly dogfooding loop is structurally broken for tend's own repo: each release lag between a generator change landing on `main` and a PyPI bump re-introduces drift that `uvx tend@latest init` can't see (and can actively regress). A repo-local `running-tend` skill that overrides Step 5 to use `uv run --project generator tend init` would make tend's nightly self-consistent. Leaving that out of this PR so the fix stays scoped; happy to open a second PR if a maintainer wants it.

## Test plan

- [x] `uv run --project generator tend init` against the PR branch produces no further diff
- [x] `uvx tend@latest init` against the PR branch still wants to revert this (expected — the underlying PyPI-lag issue)
- [ ] CI (required checks)