### PR TITLE
docs: update CLAUDE.md runtime deps after pyyaml move

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,8 @@ from `.config/tend.toml`. Edit the generator or config, not the workflow files
 directly.
 
 The generator is a Python package under `generator/` — uses hatchling, requires
-Python 3.11+, only runtime dependency is click. Dev dependencies: pytest, pyyaml.
+Python 3.11+. Runtime dependencies: click, pyyaml. Dev dependencies: pytest,
+pytest-regtest.
 
 Consuming repos regenerate their `tend-*.yaml` workflows nightly (tend itself
 included — it dogfoods its own workflows). Changes to the generator do not


### PR DESCRIPTION
## Summary

CLAUDE.md's structure section still says the generator's "only runtime dependency is click. Dev dependencies: pytest, pyyaml." That was true before #227 promoted pyyaml to a runtime dependency (`_apply_extras` in [`generator/src/tend/workflows.py`](https://github.com/max-sixty/tend/blob/main/generator/src/tend/workflows.py) calls `yaml.safe_load` / `yaml.dump` on every `generate_all()` invocation, so it's on the main code path).

Updates the blurb to reflect what `generator/pyproject.toml` actually declares:

- Runtime: `click`, `pyyaml`
- Dev: `pytest`, `pytest-regtest`

## Test plan

- [ ] CI passes