### PR TITLE
fix(action): ensure uvx is available for Claude sessions

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -119,6 +119,25 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.github_token }}
 
+    # Ensure uv/uvx is on PATH for Claude sessions. The nightly skill runs
+    # `uvx tend@latest init` to regenerate workflow files, and mention/review
+    # skills may invoke tend as well. Adopters can override the workflow
+    # `setup` step with their own composite action (e.g. one that installs
+    # project toolchains) — if that custom setup doesn't install uv, the
+    # Claude session won't have it. Install here as a no-op when already
+    # present so tend's own skills always have a working uvx regardless of
+    # how adopters customize their setup steps.
+    - name: Ensure uv is available
+      shell: bash
+      run: |
+        if command -v uvx >/dev/null 2>&1; then
+          echo "uvx already available at $(command -v uvx)"
+          exit 0
+        fi
+        echo "uvx not found; installing uv"
+        curl -LsSf https://astral.sh/uv/install.sh | sh -s -- --quiet
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
     # claude-code-action restores these from the base branch on all PRs
     # (RCE vectors — hooks, env vars, MCP servers):
     #   .claude/  .mcp.json  .claude.json  .gitmodules  .ripgreprc


### PR DESCRIPTION
## Summary

Add a `Ensure uv is available` step to tend's composite action so `uvx` is always on PATH for Claude sessions, even when adopters override the workflow-level setup with a custom composite action that doesn't install uv.

## Problem

The nightly skill's Step 5 runs `uvx tend@latest init` to regenerate tend workflow files. The default generated `setup` step installs `astral-sh/setup-uv@v6`, but adopters can replace it — e.g. PRQL/prql uses `./.github/actions/tend-setup` (Rust toolchain + cargo caching) and has no uv install. That leaves the Claude session without uvx on PATH, so the nightly sweep burns turns fumbling through ad-hoc install approaches before it can do the actual work.

## Evidence (PRQL/prql tend-nightly runs)

Two observed occurrences, both with the same root cause (adopter overrides `setup` with Rust-only tooling):

| Run | Date | Recovery path |
|---|---|---|
| [24176715649](https://github.com/PRQL/prql/actions/runs/24176715649) | 2026-04-09 | Fell back to `pip install tend` + `tend init` after discovering uvx unavailable. |
| [24276866429](https://github.com/PRQL/prql/actions/runs/24276866429) | 2026-04-11 | Tried `pip install uv`, then `pip install --user --target=$TMPDIR/pip-uv uv`, then `pip install --target=$TMPDIR/pip-uv uv`, then exported `PATH=$TMPDIR/pip-uv/bin:$PATH` to find uvx. Eventually succeeded, but multiple turns spent on environment discovery before reaching the actual workflow regeneration. |

Both runs completed successfully and each nightly recovered — but the failure is structural, not stochastic: PRQL/prql's `.config/tend.toml` has `[[setup]] uses = "./.github/actions/tend-setup"`, and that composite action sets up Rust tooling (cargo-insta, cargo-nextest, rust-cache) but has no uv install. Every nightly run on PRQL/prql will hit this path until something pre-installs uv.

## Root cause

tend's composite action (`action.yaml`) trusts that whatever the adopter put in the workflow's setup step has already installed uv. It's a reasonable assumption for the default generated workflow (which uses `astral-sh/setup-uv@v6`), but adopters who customize setup have no obligation to include uv, and tend's own skills don't declare the dependency anywhere tend itself can enforce.

## Fix

Add a `Ensure uv is available` step to the composite action in `action.yaml`, after the bot-ID resolution step and before `Run Claude Code`. It:

1. Checks `command -v uvx` and exits cleanly if uv is already on PATH (the normal case — adopters using `astral-sh/setup-uv@v6` pay nothing).
2. Otherwise runs the standard Astral shell installer and adds `$HOME/.local/bin` to `$GITHUB_PATH` so subsequent steps (including the Claude Code action's bash commands) inherit the updated PATH.

The no-op-if-present guard means existing adopters who already install uv see no change in their runs.

## Gate assessment

- **Confidence**: High. 2 observed structural occurrences on PRQL/prql in the past 48 hours. Root cause verified via `.config/tend.toml` (`[[setup]] uses = "./.github/actions/tend-setup"`) and the contents of `./.github/actions/tend-setup/action.yaml` (no `astral-sh/setup-uv` anywhere).
- **Classification**: Structural. The failure is deterministic: any adopter whose custom setup doesn't install uv will hit this on every nightly until the custom setup is updated or tend pre-installs uv itself.
- **Change type**: Targeted fix — add a single missing setup step (one conditional install block, 10 lines of bash).
- **Passes both gates**: Gate 1 (High confidence, 2+ occurrences of a structural issue — meets the 2–3 threshold). Gate 2 (Targeted fix at normal evidence threshold).

## Analysis run

Review-reviewers run: 24277386897
Tracking issue: #133 (below-threshold observations recorded separately)

## Test plan

- [ ] Verify the step is a no-op on tend's own workflows (uv is already set up via `astral-sh/setup-uv@v6`).
- [ ] Confirm `$HOME/.local/bin` is on `$GITHUB_PATH` in downstream Claude bash calls when uv was installed by this step.
- [ ] Tomorrow's PRQL/prql nightly should no longer spend turns installing uv.