### PR TITLE
fix(running-in-ci): warn against checkout --ours <file> after merge conflict

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -130,6 +130,16 @@ When asked to merge the default branch into a PR branch:
    If this fails, the branch history is disconnected. Re-checkout the PR with full history
    (`fetch-depth: 0`) before retrying.
 
+4. **Resolve content conflicts in place — never `git checkout --ours/--theirs <file>`.** Those
+   commands replace the *entire* file with one side's blob, silently dropping any non-conflicting
+   changes from the other side that git already auto-merged into the file. The result looks clean
+   (no conflict markers, `git status` shows the file resolved) but you've quietly reverted unrelated
+   improvements from `main` — and the loss is invisible until someone diffs against `main` later.
+   To keep "ours" *only* for the conflicted hunk while preserving auto-merged content, edit the
+   conflict markers in place. If you genuinely want a per-hunk "favor ours" policy across the whole
+   merge, pass `-X ours` at merge time (`git merge -X ours origin/main`) — it resolves conflicting
+   hunks in favor of HEAD without discarding auto-merged content.
+
 ## CI Monitoring
 
 After pushing, wait for CI before reporting completion.


### PR DESCRIPTION
## Summary

`git checkout --ours/--theirs <file>` replaces the *entire* file with one side's blob, silently dropping any non-conflicting changes that git already auto-merged from the other side. The result looks resolved (no conflict markers, `git status` clean) but quietly reverts unrelated content. Add a fourth bullet to the "Merging Upstream into PR Branches" section in `running-in-ci/SKILL.md` warning against this and pointing at the two correct alternatives (in-place edit of conflict markers, or `git merge -X ours` at merge time which is per-hunk).

## Evidence

Run [24276411750](https://github.com/max-sixty/tend/actions/runs/24276411750) (`tend-mention`, `issue_comment` on max-sixty/tend#226 at 06:13:24Z). The bot was asked by `@max-sixty` to resolve conflicts. Trace:

1. `git merge origin/main` → conflict in `plugins/tend-ci-runner/skills/review/SKILL.md` and `plugins/tend-ci-runner/skills/running-in-ci/SKILL.md` (both inside the CI polling-loop comment block).
2. `git checkout --ours plugins/tend-ci-runner/skills/{review,running-in-ci}/SKILL.md` → "resolved".
3. `git commit` → merge commit `36515a8` pushed to `hourly/review-24261599977`.

The bot's confirmation comment said it had "kept this branch's version since the URL-filter fix is the point of this PR" — matching the *intended* policy for the conflict region. But the `--ours` checkout overwrote the *whole* file, silently dropping four chunks that `main` had added since the PR was opened (none of them in conflict with PR 226's polling-block change):

1. The "load `/tend-ci-runner:triage` before proposing a code fix" instruction (from #235).
2. The "Review events with inline comments" reply pattern in the Replying to Comments section.
3. The "responds to concerns you raised" acknowledge-resolution paragraph in Multi-way Conversations.
4. The entire `## Self-conversation Guard` section.

Verified directly:

```bash
$ git show 2f92a88:plugins/tend-ci-runner/skills/running-in-ci/SKILL.md | grep -c "Self-conversation Guard"
1
$ git show 36515a8:plugins/tend-ci-runner/skills/running-in-ci/SKILL.md | grep -c "Self-conversation Guard"
0
```

`2f92a88` is the second parent of merge commit `36515a8`. The chunks are present on the `main` side but not in the merge result — confirming the loss is post-merge, not pre-existing in the PR branch.

The follow-up [`tend-review` run 24276481328](https://github.com/max-sixty/tend/actions/runs/24276481328) caught this (correctly, with the right diagnosis and a clear restoration commit `e2523da`). It got cancelled by concurrency before posting its review, but the restoration commit had already pushed. So in this specific case the data loss was caught and undone — but the underlying footgun remains, and it produces silent regressions whenever a future review run doesn't happen to look closely enough.

## Gate assessment

- **Confidence**: Critical — verified silent content loss from a single command. Single occurrence is sufficient at the Critical level per the gates.
- **Type**: Structural — `git checkout --ours <file>` deterministically discards auto-merged "theirs" content whenever the file has changes outside the conflict region. Will recur every time the bot reaches for that command.
- **Magnitude**: Targeted fix — one new bullet in an existing section, no restructuring.
- **Both gates**: pass.

## Test plan

- [ ] CI green (lint + test)