### PR TITLE
fix(running-in-ci): make commit-SHA permalink rule unmissable

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -285,9 +285,10 @@ gist without expanding. Don't collapse content that *is* the answer (e.g., a req
 </details>
 ```
 
-Always use markdown links for files, issues, PRs, and docs. Prefer permalinks (commit SHA URLs)
-over branch-based links for line references — line numbers shift and `blob/main/...#L42` links go
-stale.
+Always use markdown links for files, issues, PRs, and docs. **Any link containing `#L` must
+use a commit SHA, never `blob/main/...#L42`** — line numbers shift silently, so the link stays
+valid but starts pointing at different code than the comment describes. Get the SHA with
+`git rev-parse HEAD` before composing the link.
 
 **GitHub URLs — always embed `$GITHUB_REPOSITORY`.** Construct links as
 `https://github.com/${GITHUB_REPOSITORY}/...`; never hand-type the owner. The model reliably
@@ -295,7 +296,8 @@ guesses wrong — past comments have shipped with `anthropics/worktrunk` and `wo
 on a repo actually owned by `max-sixty`. Before posting a comment, scan it for `github.com/` and
 confirm every owner matches `$GITHUB_REPOSITORY`.
 
-- **Files**: link to GitHub (`blob/main/...` for file-level, `blob/<sha>/...#L42` for lines)
+- **File-level link (no `#L` anchor)**: `blob/main/src/foo.rs` is fine
+- **Line reference**: `blob/<sha>/src/foo.rs#L42` — commit SHA required, never `blob/main/...#L42`
 - **Issues/PRs**: `#123` shorthand
 - **External**: `[text](url)` format
 


### PR DESCRIPTION
## Summary

Strengthen the running-in-ci skill's guidance on permalinks for line references, after four fresh occurrences of `blob/main/...#L42` line links in a single hour on `max-sixty/worktrunk` issue [#2075](https://github.com/max-sixty/worktrunk/issues/2075), on top of one prior occurrence on issue [#2072](https://github.com/max-sixty/worktrunk/issues/2072). The current wording ("Prefer permalinks...") is a soft preference buried in a bullet that co-lists the `blob/main/...` file-level form and the `blob/<sha>/...#L42` line-reference form inside parentheses. Under cognitive load, the model anchors on the first form and pastes `#L42` onto `blob/main/...` — producing a link that stays valid but silently starts pointing at different code once the surrounding file changes.

## Evidence

Past hour on `max-sixty/worktrunk` — 4 occurrences across 2 sessions, all on issue [#2075](https://github.com/max-sixty/worktrunk/issues/2075) ("Allow wt step aliases to change the parent shell's directory"):

1. **Run [24285060091](https://github.com/max-sixty/worktrunk/actions/runs/24285060091)** — `tend-triage` on the newly-opened #2075. Session `242fb543-d70d-47e7-a0cd-5e3ce6ced53d.jsonl`. The [posted comment](https://github.com/max-sixty/worktrunk/issues/2075#issuecomment-4229633818) linked to `blob/main/src/config/user/sections.rs#L528`.

2. **Run [24285659522](https://github.com/max-sixty/worktrunk/actions/runs/24285659522)** — `tend-mention` on #2075 (response to max-sixty's question about the implicit option). Session `fa2b09a6-9e74-4997-9fb2-967990c765d1.jsonl`. The comment linked three files via `blob/main/...#L`:
   - `blob/main/src/commands/for_each.rs#L214`
   - `blob/main/src/commands/alias.rs#L282-L296`
   - `blob/main/src/output/global.rs#L227`

Historical evidence from tracking issue [#133](https://github.com/max-sixty/tend/issues/133) — 1 prior occurrence:

- **Run [24280812931](https://github.com/max-sixty/worktrunk/actions/runs/24280812931)** — `tend-triage` on `max-sixty/worktrunk#2072`. Session `c897d54c-17c7-44c1-a6dc-426c8813ce4b.jsonl`. Comment linked `blob/main/src/help.rs#L157-L162` to the very line that PR [#2073](https://github.com/max-sixty/worktrunk/pull/2073) then rewrote (`eprint\!` → `print\!`).

**Cumulative: 5 occurrences across 3 sessions and 2 issues.**

## Gate assessment

| Gate | Result | Notes |
|---|---|---|
| **Confidence (Gate 1)** | PASS | High — consistent pattern across multiple sessions (5 occurrences, 3 sessions, 2 issues). Well above the 2–3 threshold for "consistent pattern." |
| **Magnitude (Gate 2)** | PASS | Targeted fix — rephrasing one prose sentence and splitting one bullet. Not a new section or structural change. Normal thresholds apply. |
| **Classification** | Structural-adjacent | The rule exists but the current framing lets the model conflate `blob/main/...` (for file-level) with `blob/main/...#L42` (for lines). A sharper imperative removes that ambiguity. The replay test: if you replayed the same "paste a line ref into a comment" scenario 10 times, the current guidance would hit the same ambiguity every time — it's not a random model lapse. |

## The change

**Prose sentence** — from "Prefer permalinks (commit SHA URLs) over branch-based links for line references" (soft) to "**Any link containing `#L` must use a commit SHA, never `blob/main/...#L42`**" (hard rule, with `git rev-parse HEAD` named as the SHA source so the bot has an obvious next step rather than rationalizing `main` as "I don't have a SHA handy").

**Bullet list** — from the single co-listed `Files` bullet to two separate bullets, so the `#L42` case can't be skimmed past:

- **File-level link (no `#L` anchor)**: `blob/main/src/foo.rs` is fine
- **Line reference**: `blob/<sha>/src/foo.rs#L42` — commit SHA required, never `blob/main/...#L42`

## Test plan

- [ ] Diff reviews cleanly as a pure guidance rewrite (no behavior changes in generator or workflows).
- [ ] Future `tend-triage` and `tend-mention` runs that reference specific lines use `blob/<sha>/...#L` form.
- [ ] Watch tracking issue [#133](https://github.com/max-sixty/tend/issues/133) for a decrease in new-occurrence count of this pattern.
