### PR TITLE
docs(review-gates): reframe structural vs stochastic around decision points

### DIFF
--- a/plugins/tend-ci-runner/shared/review-gates.md
+++ b/plugins/tend-ci-runner/shared/review-gates.md
@@ -34,18 +34,22 @@ justification than a new paragraph. Prefer small, targeted fixes over broad rewr
 
 ### Structural vs. stochastic failures
 
-Before applying the gates, classify each failure:
+Before applying the gates, classify each failure by asking: **did the bot have a decision point?**
 
-- **Structural**: the failure has a deterministic cause that guidance can prevent — e.g., "the
-  checkout differs between `pull_request_target` and `issue_comment` events, so grepping always
-  finds stale content." These failures will recur every time the same conditions arise. One clear
-  occurrence is sufficient evidence for a targeted fix.
+- **Structural**: no decision point — the environment produces the failure regardless of how the
+  bot approached the task. E.g., "the checkout differs between `pull_request_target` and
+  `issue_comment` events, so grepping always finds stale content." The same conditions produce
+  the same failure every time, no matter which tool the bot reaches for. One clear occurrence is
+  sufficient evidence for a targeted fix.
 
-- **Stochastic**: the failure is a probabilistic model behavior — e.g., "the model was too
-  agreeable when challenged" or "the model forgot to check X." The same model might handle the
-  next identical situation correctly without any guidance change. These need significantly more
-  evidence (5+ occurrences) because adding guidance for a one-off stochastic lapse adds noise
-  that can degrade performance on other tasks.
+- **Stochastic**: the bot picked one option from several valid-looking alternatives, and a
+  different session might pick differently. This includes cases where the chosen tool is
+  deterministically lossy *once invoked* — the *choice* to invoke it is still a model behavior,
+  not a structural property of the environment. E.g., "the model was too agreeable when
+  challenged," "the model forgot to check X," or "the model reached for a lossy command when a
+  safe alternative existed." These need significantly more evidence (5+ occurrences) because
+  adding guidance for a one-off stochastic lapse adds noise that can degrade performance on other
+  tasks.
 
 The test: "If I replayed this exact scenario 10 times, would the failure occur every time
 (structural) or only sometimes (stochastic)?" When in doubt, classify as stochastic and wait for


### PR DESCRIPTION
## Summary

Reframes the Structural vs. stochastic definitions in [`review-gates.md`](https://github.com/max-sixty/tend/blob/main/plugins/tend-ci-runner/shared/review-gates.md) around a decision-point discriminator, to fix the exact misreading that produced the misclassification in #239.

## Why

In #239 I classified a `git checkout --ours <file>` data-loss finding as *structural* because the tool is deterministically lossy once invoked. The intended reading of "deterministic cause" was "the same conditions produce the same failure regardless of how the bot approached the task" — but "deterministic cause" is ambiguous enough that the tool-determinism reading is plausible on first pass. Max flagged this in [this comment](https://github.com/max-sixty/tend/pull/239#issuecomment-4229625945).

The minimal fix is to replace "deterministic cause" with explicit decision-point language:

- **Structural** = no decision point (environment is the failure, same outcome regardless of tool choice).
- **Stochastic** = bot picked one option from several valid alternatives, *including* cases where the chosen tool is lossy once invoked — the *choice* is still a model behavior, not a structural property.

I also added "the model reached for a lossy command when a safe alternative existed" to the stochastic examples, so the `--ours` case has a direct analogue in the guidance.

Scope: 30% of [the two suggestions](https://github.com/max-sixty/tend/pull/239#issuecomment-4229630649) in the #239 thread — just the definitional clarification, not the new "explicit replay-answer" checklist item (suggestion 2). Minimal targeted edit, no restructuring.

## Test plan

- [ ] CI green (lint)