### PR TITLE
docs(review-gates): trim decision-point reframe, drop --ours examples

### DIFF
--- a/plugins/tend-ci-runner/shared/review-gates.md
+++ b/plugins/tend-ci-runner/shared/review-gates.md
@@ -36,20 +36,16 @@ justification than a new paragraph. Prefer small, targeted fixes over broad rewr
 
 Before applying the gates, classify each failure by asking: **did the bot have a decision point?**
 
-- **Structural**: no decision point — the environment produces the failure regardless of how the
-  bot approached the task. E.g., "the checkout differs between `pull_request_target` and
-  `issue_comment` events, so grepping always finds stale content." The same conditions produce
-  the same failure every time, no matter which tool the bot reaches for. One clear occurrence is
-  sufficient evidence for a targeted fix.
+- **Structural**: no decision point — the same conditions produce the same failure every time,
+  regardless of how the bot approached the task. E.g., "the checkout differs between
+  `pull_request_target` and `issue_comment` events, so grepping always finds stale content." One
+  clear occurrence is sufficient evidence for a targeted fix.
 
-- **Stochastic**: the bot picked one option from several valid-looking alternatives, and a
-  different session might pick differently. This includes cases where the chosen tool is
-  deterministically lossy *once invoked* — the *choice* to invoke it is still a model behavior,
-  not a structural property of the environment. E.g., "the model was too agreeable when
-  challenged," "the model forgot to check X," or "the model reached for a lossy command when a
-  safe alternative existed." These need significantly more evidence (5+ occurrences) because
-  adding guidance for a one-off stochastic lapse adds noise that can degrade performance on other
-  tasks.
+- **Stochastic**: the failure is a probabilistic model behavior — e.g., "the model was too
+  agreeable when challenged" or "the model forgot to check X." The same model might handle the
+  next identical situation correctly without any guidance change. These need significantly more
+  evidence (5+ occurrences) because adding guidance for a one-off stochastic lapse adds noise
+  that can degrade performance on other tasks.
 
 The test: "If I replayed this exact scenario 10 times, would the failure occur every time
 (structural) or only sometimes (stochastic)?" When in doubt, classify as stochastic and wait for


### PR DESCRIPTION
## Summary

Trims #241 per max-sixty/tend#239 (comment) — "do 30% of the changes suggested re deterministic vs stochastic above / remove all object-level changes."

The critical fix is keeping the "did the bot have a decision point?" question header and the trimmed structural definition (`no decision point — the same conditions produce the same failure every time, regardless of how the bot approached the task`). That alone resolves the "deterministic cause" misreading that caused the misclassification in #239.

Everything else in #241 was supplementary and is reverted to the pre-#241 wording:

- The redundant "The same conditions produce the same failure every time, no matter which tool the bot reaches for" sentence in the structural paragraph (merged into the definition itself).
- The entire rewording of the stochastic paragraph, which is the carrier for the two object-level references max called out:
  - `This includes cases where the chosen tool is deterministically lossy *once invoked* — the *choice* to invoke it is still a model behavior, not a structural property of the environment.`
  - `"the model reached for a lossy command when a safe alternative existed"` as a stochastic example.

Both are direct references to the `git checkout --ours` incident in #239, not framework-level guidance — so they belong in an incident write-up, not in `review-gates.md`.

Net: 10 additions, 14 deletions vs. current main; roughly a third of #241's footprint.

## Test plan

- [ ] CI green (lint)
