### PR TITLE
fix(review): remove re-introduced \\!-backtick poison from skill comments

### DIFF
--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -293,9 +293,10 @@ the job name (`review`), which does not match `$GITHUB_WORKFLOW` (`tend-review`)
 
 ```bash
 # Run with Bash tool's run_in_background: true.
-# Use `||` rather than `if !` — the Bash tool escapes `!` as `\!`, which
-# prevents bash from recognizing the pipeline-negation reserved word and
-# leaves the loop stuck until the 10-minute timeout.
+# Use `||` rather than if-based negation. The Bash tool escapes the
+# exclamation mark to a literal backslash-exclamation, which prevents bash
+# from recognizing the pipeline-negation reserved word and leaves the loop
+# stuck until the 10-minute timeout.
 for i in $(seq 1 10); do
   sleep 60
   gh pr checks <number> --required 2>&1 \

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -144,9 +144,10 @@ background task completes you will be notified — check the result and take any
 # show as "pending" since it IS the running job. Watching yourself deadlocks.
 # Match on the run URL, not the check name: `gh pr checks` shows the job name
 # (e.g. "review"), which does not match $GITHUB_WORKFLOW ("tend-review").
-# Use `||` rather than `if !` — the Bash tool escapes `!` as `\!`, which
-# prevents bash from recognizing the pipeline-negation reserved word and
-# leaves the loop stuck until the 10-minute timeout.
+# Use `||` rather than if-based negation. The Bash tool escapes the
+# exclamation mark to a literal backslash-exclamation, which prevents bash
+# from recognizing the pipeline-negation reserved word and leaves the loop
+# stuck until the 10-minute timeout.
 for i in $(seq 1 10); do
   sleep 60
   gh pr checks <number> --required 2>&1 | grep -v "/runs/$GITHUB_RUN_ID/" | grep -q 'pending\|queued\|in_progress' || {


### PR DESCRIPTION
## Summary

PR #226 (76debaf) re-introduced the exact `` \\!` `` poison pattern that PR #234 fixed on 2026-04-10. Every `tend-review` run on `max-sixty/worktrunk` since that PR landed has failed silently at the slash-command preprocessor stage — the `/review` invocation produces a 5-line session artifact with a `Shell command failed` stderr and no assistant turn. No review is posted on the target PR.

## Root cause

PR #226 ("filter CI polling by run URL, not workflow name") rewrote the CI-polling code block in two files to include the explanatory comment:

```
# Use `||` rather than `if \!` — the Bash tool escapes `\!` as `\\!`, which
```

Claude Code's slash-command preprocessor treats `` \\!` `` as a prefix meaning "execute the next backticked string as a shell command" — and does so **regardless of markdown code fences**. When the preprocessor hits the sequence `` \!` — the Bash tool escapes ` `` it runs `` — the Bash tool escapes `` as a shell command. The em-dash is not a valid command, so bash reports:

```
Error: Shell command failed for pattern "\!` — the Bash tool escapes `":
/bin/bash: line 1: —: command not found
```

When the preprocessor fails, the prompt body is not delivered and Claude never gets the review instructions. This is identical to the failure mode documented in #234 — PR #226 simply rewrote the comment in a way that restored the poison.

## Evidence

Two `tend-review` runs on max-sixty/worktrunk PR `fix/issue-2075` (worktrunk#2077) in the past hour, both failed identically:

| Run | Time | Branch | Session size | Review posted |
|---|---|---|---|---|
| [24287041911](https://github.com/max-sixty/worktrunk/actions/runs/24287041911) | 16:49Z | `fix/issue-2075` | 5 lines | no |
| [24287289871](https://github.com/max-sixty/worktrunk/actions/runs/24287289871) | 17:03Z | `fix/issue-2075` | 5 lines | no |

Both session artifacts end with the same `<local-command-stderr>` from the preprocessor. The last successful review run on worktrunk was [24281048388](https://github.com/max-sixty/worktrunk/actions/runs/24281048388) at 11:00Z (PR #2074), which ran before #226 landed; the failure window begins after the v1 tag picked up the #226 commit.

Reference session for run 24287041911: `c3229e75-698b-48af-905e-ecf240b1dcba.jsonl` (5 lines total: 2 queue-operation, 1 local-command-caveat, 1 command-args `2077`, 1 local-command-stderr with the preprocessor error).

## Fix

Rephrase both comments to drop the backticks around `` `if \!` `` and `` `\!` ``, matching the approach #234 used. The guidance content is preserved; only the poison characters are removed. No behavior change for humans reading the skill — the model still gets the same instruction.

After the fix, `grep -rn '\!\`' plugins/` returns zero matches. The `if \!` shell patterns that remain in `plugins/install-tend/skills/install-tend/scripts/oauth-token.sh` and `plugins/tend-ci-runner/scripts/token-report.sh` are in `.sh` files which the slash-command preprocessor does not load, so they are not affected.

## Gate assessment

- **Evidence level**: Critical — clearly wrong outcome (100% of reviews on the affected PR are empty); regresses a ship-fix that was previously validated.
- **Classification**: Structural — the slash-command preprocessor's backtick scan is deterministic; every `` \\!` `` sequence in a loaded file will produce the same failure regardless of which model or session runs it.
- **Occurrences this run**: 2 (same PR, back-to-back).
- **Historical evidence**: #234 previously fixed the same surface; #217 and #226 have each reintroduced the pattern. This is the third "regression of the backtick-bang poison" in two days.
- **Change type**: Targeted fix (3 lines per file × 2 files).
- **Both gates**: pass.

## Why this keeps regressing and a guardrail suggestion

The underlying problem is that the skill file's own text *documents* the `\!`-escape gotcha, and the most natural way to write that documentation is to put the offending string in backticks for clarity. Each time someone rewrites this paragraph (PR #217, PR #226) the poison reappears by accident.

A CI pre-commit check — e.g., `grep -rn '\!\`' plugins/ && exit 1` — would catch this mechanically. I considered adding it as part of this PR but held off: a guardrail belongs in a separate PR so the hotfix can merge fast.

## Test plan

- [ ] A `tend-review` run on this PR completes with an assistant session longer than 5 lines and posts an actual review (self-approval is blocked by GitHub, but the bot must at least read the diff and comment).
- [ ] `grep -rn '\!\`' plugins/` returns no matches.
- [ ] `tend-mention` and `tend-notifications` skill loads of `running-in-ci` no longer show `Shell command failed for pattern` in tool_results.
