### PR TITLE
fix(review): re-unbreak /review slash command poisoned by PR #226 regression

### DIFF
--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -293,9 +293,10 @@ the job name (`review`), which does not match `$GITHUB_WORKFLOW` (`tend-review`)
 
 ```bash
 # Run with Bash tool's run_in_background: true.
-# Use `||` rather than `if !` — the Bash tool escapes `!` as `\!`, which
-# prevents bash from recognizing the pipeline-negation reserved word and
-# leaves the loop stuck until the 10-minute timeout.
+# Use `||` rather than `if`-based negation. The Bash tool escapes the
+# exclamation mark to a literal backslash-exclamation, which prevents bash
+# from recognizing the pipeline-negation reserved word and leaves the loop
+# stuck until the 10-minute timeout.
 for i in $(seq 1 10); do
   sleep 60
   gh pr checks <number> --required 2>&1 \

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -144,9 +144,10 @@ background task completes you will be notified — check the result and take any
 # show as "pending" since it IS the running job. Watching yourself deadlocks.
 # Match on the run URL, not the check name: `gh pr checks` shows the job name
 # (e.g. "review"), which does not match $GITHUB_WORKFLOW ("tend-review").
-# Use `||` rather than `if !` — the Bash tool escapes `!` as `\!`, which
-# prevents bash from recognizing the pipeline-negation reserved word and
-# leaves the loop stuck until the 10-minute timeout.
+# Use `||` rather than `if`-based negation. The Bash tool escapes the
+# exclamation mark to a literal backslash-exclamation, which prevents bash
+# from recognizing the pipeline-negation reserved word and leaves the loop
+# stuck until the 10-minute timeout.
 for i in $(seq 1 10); do
   sleep 60
   gh pr checks <number> --required 2>&1 | grep -v "/runs/$GITHUB_RUN_ID/" | grep -q 'pending\|queued\|in_progress' || {


### PR DESCRIPTION
## Summary

[PR #226](https://github.com/max-sixty/tend/pull/226) (`fix(ci-runner): filter CI polling by run URL, not workflow name`, merged 2026-04-11T15:01:22Z) reintroduced the exact poisoned-text regression that [PR #234](https://github.com/max-sixty/tend/pull/234) fixed. Its diff on `plugins/tend-ci-runner/skills/review/SKILL.md` and `plugins/tend-ci-runner/skills/running-in-ci/SKILL.md` reverted the CI-polling comment from PR #234's wording back to the pre-#234 wording containing `` `if \!` `` adjacent to backticks — which the slash-command preprocessor scans and exec's as bash regardless of markdown code fences, consuming through the next backtick and trying to run the em-dash-led fragment as a command.

Since PR #226 merged, **every `/review` invocation has failed identically**. All three `tend-review` runs in this hour produced the same 5-line trace:

```
{"type":"queue-operation","operation":"enqueue"}
{"type":"queue-operation","operation":"dequeue"}
{"type":"user","content":"<local-command-caveat>..."}
{"type":"user","content":"<command-name>/review</command-name> <command-args>N</command-args>"}
{"type":"user","content":"<local-command-stderr>Error: Shell command failed for pattern \"\!` — the Bash tool escapes `\":\n/bin/bash: line 1: —: command not found</local-command-stderr>"}
```

No assistant turn, no Skill loads, no tool calls, no review. The model was never given instructions to follow — the exact same failure signature PR #234 documented.

## Evidence (this hour)

| Run | PR | Branch | Session size | Review posted |
|---|---|---|---|---|
| [24286232974](https://github.com/max-sixty/tend/actions/runs/24286232974) | [#240](https://github.com/max-sixty/tend/pull/240) | `hourly/review-24286117723-permalink-sha` | 5 lines | ❌ |
| [24286792302](https://github.com/max-sixty/tend/actions/runs/24286792302) | [#241](https://github.com/max-sixty/tend/pull/241) | `fix/review-gates-decision-point` | 5 lines | ❌ |
| [24287054138](https://github.com/max-sixty/tend/actions/runs/24287054138) | [#242](https://github.com/max-sixty/tend/pull/242) | `fix/review-gates-trim-decision-point` | 5 lines | ❌ |

Confirmation via `gh pr view <N> --json reviews`: all three PRs return `[]`. PRs #240 and #241 were merged by max-sixty without bot review because the bot was silently broken.

No earlier broken `tend-review` run exists between PR #226's merge at 15:01Z and the current window — #240 was the first PR to land after the regression.

## Gate assessment

- **Evidence level**: Critical — wrong outcome, reviews 100% non-functional since 2026-04-11T15:01:22Z
- **Classification**: Structural — deterministic preprocessor failure; every invocation produces the identical 5-line trace regardless of which PR is being reviewed
- **Occurrences this run**: 3 (one per `tend-review` run in the past hour)
- **Historical evidence**: N/A for the regression itself (reintroduced today by PR #226), but the underlying preprocessor bug is well-characterized — PR #217 first introduced it, PR #234 first fixed it, PR #226 reintroduced it, this PR fixes it again
- **Change type**: Targeted fix (rephrase two lines in two files)
- **Both gates**: pass

## Fix

Rephrase the CI-polling comment in both files to avoid any `\!` adjacent to a backtick. Guidance content is unchanged. Matches the exact wording PR #234 merged — this is a straight restoration of that fix.

Before:

```bash
# Use `||` rather than `if \!` — the Bash tool escapes `\!` as `\\!`, which
# prevents bash from recognizing the pipeline-negation reserved word and
# leaves the loop stuck until the 10-minute timeout.
```

After:

```bash
# Use `||` rather than `if`-based negation. The Bash tool escapes the
# exclamation mark to a literal backslash-exclamation, which prevents bash
# from recognizing the pipeline-negation reserved word and leaves the loop
# stuck until the 10-minute timeout.
```

`grep -rn '\!`' plugins/` after the fix returns zero matches.

## Why this happened twice

PR #234 fixed the poison text but didn't add a regression guard. When PR #226 later restructured the surrounding comment (legitimately, for the `$GITHUB_WORKFLOW` → `$GITHUB_RUN_ID` filter change), the author rewrote the whole block and put the poisoned phrasing back in. A follow-up PR to add `grep -rn '\!`' plugins/` to the lint step (or `pre-commit` hook) would prevent a third reintroduction. Leaving that out of this PR to stay atomic.

## Test plan

- [ ] Lint, test, and review checks pass on this PR
- [ ] Bot's self-review session on this PR executes with an assistant session longer than 5 lines (proving the preprocessor poison is gone)
- [ ] `grep -rn '\!`' plugins/` returns no matches after merge
- [ ] First post-merge `tend-review` run on an unrelated PR posts an actual review
