### PR TITLE
fix(running-in-ci): warn against heredoc comment bodies with \\! or env vars

### DIFF
--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -293,9 +293,10 @@ the job name (`review`), which does not match `$GITHUB_WORKFLOW` (`tend-review`)
 
 ```bash
 # Run with Bash tool's run_in_background: true.
-# Use `||` rather than `if !` — the Bash tool escapes `!` as `\!`, which
-# prevents bash from recognizing the pipeline-negation reserved word and
-# leaves the loop stuck until the 10-minute timeout.
+# Use `||` rather than if-based negation. The Bash tool escapes the
+# exclamation mark to a literal backslash-exclamation, which prevents bash
+# from recognizing the pipeline-negation reserved word and leaves the loop
+# stuck until the 10-minute timeout.
 for i in $(seq 1 10); do
   sleep 60
   gh pr checks <number> --required 2>&1 \

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -295,7 +295,17 @@ valid but starts pointing at different code than the comment describes. Get the 
 `https://github.com/${GITHUB_REPOSITORY}/...`; never hand-type the owner. The model reliably
 guesses wrong — past comments have shipped with `anthropics/worktrunk` and `worktrunk/worktrunk`
 on a repo actually owned by `max-sixty`. Before posting a comment, scan it for `github.com/` and
-confirm every owner matches `$GITHUB_REPOSITORY`.
+confirm every owner matches `$GITHUB_REPOSITORY`. **Also check that the variable actually
+expanded** — if you see a literal `${GITHUB_REPOSITORY}` in the rendered comment, you used a
+single-quoted heredoc (`<< 'EOF'`) which disables expansion. Rewrite using an unquoted `<<EOF`
+(so `${GITHUB_REPOSITORY}` interpolates) or compose the body with the Write tool.
+
+Bash heredocs are also a trap for comment bodies containing exclamation marks — the Bash tool
+rewrites every exclamation mark to a literal backslash-bang before bash parses the heredoc, so
+a greeting like "Thanks for the suggestion!" renders as "Thanks for the suggestion\!" in the
+posted comment. The quoting mode doesn't matter: both `<< 'EOF'` and `<<EOF` lose the
+character. Use the Write tool for any comment body containing an exclamation mark, then pass
+the file to `gh ... --body-file`.
 
 - **File-level link (no `#L` anchor)**: `blob/main/src/foo.rs` is fine
 - **Line reference**: `blob/<sha>/src/foo.rs#L42` — commit SHA required, never `blob/main/...#L42`

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -144,9 +144,10 @@ background task completes you will be notified — check the result and take any
 # show as "pending" since it IS the running job. Watching yourself deadlocks.
 # Match on the run URL, not the check name: `gh pr checks` shows the job name
 # (e.g. "review"), which does not match $GITHUB_WORKFLOW ("tend-review").
-# Use `||` rather than `if !` — the Bash tool escapes `!` as `\!`, which
-# prevents bash from recognizing the pipeline-negation reserved word and
-# leaves the loop stuck until the 10-minute timeout.
+# Use `||` rather than if-based negation. The Bash tool escapes the
+# exclamation mark to a literal backslash-exclamation, which prevents bash
+# from recognizing the pipeline-negation reserved word and leaves the loop
+# stuck until the 10-minute timeout.
 for i in $(seq 1 10); do
   sleep 60
   gh pr checks <number> --required 2>&1 | grep -v "/runs/$GITHUB_RUN_ID/" | grep -q 'pending\|queued\|in_progress' || {


### PR DESCRIPTION
## Summary

Adds a two-sentence warning to the GitHub URLs paragraph in `running-in-ci/SKILL.md` after a `tend-triage` run posted a public comment with both `${GITHUB_REPOSITORY}` and `\\!` rendering failures, both originating in a single `cat > /tmp/comment.md << 'EOF'` heredoc. The guidance promotes a below-threshold tracking finding into a targeted fix after a second occurrence.

This PR is a superset of [#243](https://github.com/max-sixty/tend/pull/243) (cherry-picked as the first commit) so that `/review` on this PR can run at all — the top of the v1 tag currently has the same `` `if \!` `` slash-command preprocessor poison that #243 removes, and without that fix `/review` on worktrunk has been failing silently since PR #226 merged. If #243 lands first, the merge of this PR is a no-op on those lines.

## Evidence

### Occurrence 2 (this run) — live broken comment on worktrunk#2076

- **Run**: [24286871206](https://github.com/max-sixty/worktrunk/actions/runs/24286871206) (`tend-triage`, 2026-04-11 16:40Z, 20 min)
- **Session**: `8df12230-4c54-4e80-8ed1-20c13b5faddb.jsonl`
- **Issue**: [max-sixty/worktrunk#2076](https://github.com/max-sixty/worktrunk/issues/2076) — "Update worktrunk skill with Opencode CLI usage examples"
- **Posted comment**: [comment id 4229779789](https://github.com/max-sixty/worktrunk/issues/2076#issuecomment-4229779789) (still live)

The bot's comment contains three markdown links that all rendered as broken URLs with the literal env var string:

- `https://github.com/${GITHUB_REPOSITORY}/blob/8742c3a648f17e5874d93b6e5c59a620af64acd0/skills/worktrunk/reference/config.md#L136-L141`
- `https://github.com/${GITHUB_REPOSITORY}/blob/.../reference/llm-commits.md#L27-L38`
- `https://github.com/${GITHUB_REPOSITORY}/blob/.../reference/tips-patterns.md#L168`

Plus a visible `\\!` in the greeting: *"Thanks for the suggestion\\!"*.

Root cause from the session log — the bot ran:

```bash
cat > /tmp/comment-2076.md << 'EOF'
Thanks for the suggestion\! Some OpenCode examples already exist in the worktrunk skill:

- [`reference/config.md`](https://github.com/${GITHUB_REPOSITORY}/blob/.../reference/config.md#L136-L141) ...
...
EOF
gh issue comment 2076 --body-file /tmp/comment-2076.md
```

Two things broke simultaneously in that one heredoc:

1. **Single-quoted heredoc disables variable expansion.** `<< 'EOF'` prevents bash from interpolating `$GITHUB_REPOSITORY`, so the literal 26-character string `${GITHUB_REPOSITORY}` ends up in `/tmp/comment-2076.md` and then in the posted comment. An unquoted `<<EOF` would have expanded the variable.
2. **The Bash tool rewrites `\!` to `\\!` before bash parses the heredoc.** Quoting mode doesn't help here — the escape happens at the tool-input layer, above bash. Every greeting, exclamation, or literal `\!` in the body ends up rendered as `\\!`.

The bot never verified the posted output after `gh issue comment`, declared the task complete, and moved on.

### Occurrence 1 (prior run, already recorded below-threshold)

- **Run**: [24281303125 analysis](https://github.com/max-sixty/tend/issues/133) in the review-reviewers tracking issue, finding A from 2026-04-11 11:55Z
- **Source run**: [24281048388](https://github.com/max-sixty/worktrunk/actions/runs/24281048388) (`tend-review` on worktrunk PR #2074, `ext-subcommand-completions`, 11:00Z)
- **Session**: `0024f69d-67b4-4886-bc5d-a4c190dbc025.jsonl`
- **Detail**: The inline review suggestion body contained `if \!is_builtin && which::which(&binary).is_ok() {`. The heredoc that wrote it to `$TMPDIR/comment-body.md` used `<< 'COMMENTEOF'` — single-quoted — and the `\!` still got rewritten to `\\!`. The bot noticed the escaped `\\!` during a post-write verify step and **recovered** by rewriting the body via `python3 -c "open(...).write(...)"`, then PATCHing the existing inline comment. Outcome was correct but cost ~6 extra Bash calls and a few thousand tokens.

The tracking issue explicitly recorded the follow-up condition:

> **Action**: None this run. If this surface produces a second occurrence, promote to a one-paragraph addition in `plugins/tend-ci-runner/skills/review/SKILL.md` (or `running-in-ci/SKILL.md` under the existing `\!`-escape paragraph).

This PR is that promotion.

## Fix

Two sentences added to the existing GitHub URLs paragraph in `running-in-ci/SKILL.md`:

1. The scan-before-posting step now explicitly calls out `${GITHUB_REPOSITORY}` — if the literal string appears in the rendered comment, the bot used a single-quoted heredoc that disabled expansion, and should rewrite using unquoted `<<EOF` or the Write tool.
2. A follow-up sentence warns that bash heredocs are also a trap for comment bodies containing exclamation marks — quoting mode doesn't matter, and the Write tool is the reliable escape.

The new prose is deliberately worded to contain zero `` \!` `` sequences, so it can't trip the slash-command preprocessor. Verified with `grep -rn '\!\`' plugins/` after rebasing on #243 — zero matches.

## Why this goes under the existing URLs paragraph instead of being a new section

Both failures occurred in the same heredoc, and both share the same mitigation (verify before posting; prefer the Write tool). The running-in-ci skill already has a "scan before posting" instruction in the URLs paragraph — extending that instruction by one sentence is narrower than introducing a new section. This keeps the skill context budget small while closing the specific observed failure.

## Gate assessment

- **Evidence level**: High — structural, 2 occurrences in the heredoc-write surface, second occurrence produced a live public broken artifact with three visibly broken URLs and a mis-rendered greeting.
- **Classification**: Structural — the Bash tool's `\!`-escape is deterministic at the tool-input layer; single-quoted heredocs not expanding variables is standard bash. The bot has no decision point that would produce different behavior while still following the existing `${GITHUB_REPOSITORY}` guidance literally.
- **Change type**: Targeted fix (two-sentence addition to an existing paragraph, no new section).
- **Both gates**: pass.

## Test plan

- [ ] `grep -rn '\!\`' plugins/` returns zero matches after this PR merges.
- [ ] A subsequent bot comment that includes a `github.com/${GITHUB_REPOSITORY}/...` link has the env var expanded in the rendered output.
- [ ] A subsequent bot comment containing an exclamation mark renders it as `\!` (not `\\!`).
- [ ] Maintainer follow-up: worktrunk#2076 [comment id 4229779789](https://github.com/max-sixty/worktrunk/issues/2076#issuecomment-4229779789) has live broken links and would benefit from a manual edit or repost.
