### PR TITLE
ci: guard against bang-backtick preprocessor poison in plugin skills

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,39 @@ repos:
     rev: v1.7.10
     hooks:
       - id: actionlint
+  - repo: local
+    hooks:
+      # The Claude Code slash-command preprocessor treats a backticked token
+      # beginning with an exclamation mark as shell command substitution. Any
+      # plugin skill file loaded by /review (or another slash command) that
+      # contains this sequence crashes the session before any assistant turn
+      # runs. Regressed twice already: #217 introduced, #234 fixed, #226
+      # reintroduced, #243 fixed again. This guard rejects a third regression
+      # at commit time. The check uses chr(33)+chr(96) so the script itself
+      # is safe from the pattern it is searching for.
+      - id: no-preprocessor-poison-in-skills
+        name: forbid bang-backtick in plugin skill files
+        language: system
+        entry: python3
+        args:
+          - -c
+          - |
+            import pathlib, sys
+            poison = chr(33) + chr(96)
+            hits = [
+                (str(p), i, line)
+                for p in pathlib.Path("plugins").rglob("*.md")
+                for i, line in enumerate(p.read_text().splitlines(), start=1)
+                if poison in line
+            ]
+            for p, i, line in hits:
+                print(f"{p}:{i}: {line}")
+            if hits:
+                print(
+                    "\nERROR: bang-backtick sequence in plugin skill file. "
+                    "The Claude Code slash-command preprocessor treats this "
+                    "as command substitution and crashes the session. "
+                    "See max-sixty/tend#234, #243, #244."
+                )
+                sys.exit(1)
+        pass_filenames: false


### PR DESCRIPTION
## Summary

Add a pre-commit guard that rejects a regression pattern responsible for silently breaking 100% of `tend-review` runs twice this year.

## The regression history

The Claude Code slash-command preprocessor treats a backtick-enclosed token beginning with an exclamation mark as shell command substitution. When a plugin skill file loaded by `/review` (or another slash command) contains this sequence, the preprocessor attempts to execute the contents and crashes the session before any assistant turn — 5 JSONL lines, no Skill load, no tool calls, no review posted.

| Event | PR | Notes |
|---|---|---|
| First introduced | [#217](https://github.com/max-sixty/tend/pull/217) | `fix(ci-runner): replace if-not polling loop with ‖` — inline comment explained the bash escaping with the exact poisoned phrasing |
| First fix | [#234](https://github.com/max-sixty/tend/pull/234) | `fix(review): unbreak /review slash command poisoned by …` — rewrote the comment without the poison |
| Reintroduced | [#226](https://github.com/max-sixty/tend/pull/226) | `fix(ci-runner): filter CI polling by run URL, not workflow name` — legitimately restructured the polling comment for the `$GITHUB_WORKFLOW` → `$GITHUB_RUN_ID` change and accidentally put the pre-#234 phrasing back |
| Second fix | [#243](https://github.com/max-sixty/tend/pull/243) | `fix(review): remove re-introduced …-backtick poison from skill comments` |

PR [#244](https://github.com/max-sixty/tend/pull/244) (closed as a duplicate of #243) explicitly called out the missing guardrail in its description:

> A follow-up PR to add `grep -rn '!\`' plugins/` to the lint step (or `pre-commit` hook) would prevent a third reintroduction. Leaving that out of this PR to stay atomic.

The prior review-reviewers tracking comment on [#133](https://github.com/max-sixty/tend/issues/133) (run 24287235173) also flagged this as deferred structural-change work:

> A `grep -rn '!\`' plugins/` pre-commit guardrail would have caught both PR #226 and any future regression. Not acting on this as a third PR this run (skill limits us to 2), but worth adding to tracking evidence for a future structural-change PR.

This PR is that follow-up.

## Evidence from this hour's runs

Three consecutive `tend-review` runs on max-sixty/tend produced the same 5-line failure trace while #243/#245 were in flight:

| Run | Target PR | Lines | Review posted |
|---|---|---|---|
| [24287435413](https://github.com/max-sixty/tend/actions/runs/24287435413) | [#243](https://github.com/max-sixty/tend/pull/243) | 5 | no |
| [24287475431](https://github.com/max-sixty/tend/actions/runs/24287475431) | [#244](https://github.com/max-sixty/tend/pull/244) | 5 | no |
| [24287533590](https://github.com/max-sixty/tend/actions/runs/24287533590) | [#245](https://github.com/max-sixty/tend/pull/245) | 5 | no |

Each session's last line (from the downloaded `claude-session-logs*` artifacts) was identical:

```
<local-command-stderr>Error: Shell command failed for pattern "!` — the Bash tool escapes `": [stderr]
/bin/bash: line 1: —: command not found</local-command-stderr>
```

All three PRs merged without successful bot review because the reviewer was silently broken until each fix merged — a chicken-and-egg problem where the bot cannot self-review its own fix for a broken reviewer.

## The guard

```python
poison = chr(33) + chr(96)  # bang + backtick, built at runtime
hits = [... if poison in line ...]
```

The check constructs its search string from `chr()` calls so the hook source itself is safe from the pattern it is searching for — a literal `!` adjacent to a backtick in this file would otherwise poison any future skill that loaded `.pre-commit-config.yaml` (none does today, but defensive).

Runs as a `local` hook under the existing `pre-commit/action@v3.0.1` invocation in the `lint` job of `ci.yaml`. No new external dependencies; `python3` is already available everywhere pre-commit runs.

## Gate assessment

- **Evidence level**: Critical. Clearly wrong outcome (100% of `tend-review` runs silently broken), with two historical regressions plus three session failures this hour.
- **Classification**: Structural. The failure is deterministic — every invocation with the pattern present in a loaded skill file produces the identical 5-line trace. The guard is a mechanical grep rule, also structural.
- **Occurrences (current + historical)**: 3 this hour + 3 in the prior review-reviewers window (noted in [#133](https://github.com/max-sixty/tend/issues/133) run 24287235173 comment) + prior #217→#234 and #226→#243 regression mechanism. Well above the critical threshold (1 sufficient).
- **Change type**: Targeted fix. Adds one `local` hook entry (~36 lines in `.pre-commit-config.yaml`); no new files, no restructuring.
- **Gate 1 (confidence)**: passes. Critical evidence with multiple documented instances.
- **Gate 2 (magnitude)**: passes. Small, scoped addition to an existing config.

## Verification

- `pre-commit run --all-files no-preprocessor-poison-in-skills` → passes on current `main` (no matches in plugin files today).
- Positive control — temporarily wrote a fake `plugins/tend-ci-runner/skills/test-poison.md` containing the pattern → hook failed with the expected line-keyed error output and exit 1.
- `generator/` pytest suite still passes (`158 passed`).
- YAML validates; the existing `check-yaml` pre-commit hook runs clean on the updated file.

## Test plan

- [ ] `pre-commit/action@v3.0.1` lint job on this PR executes the new hook and passes (no current matches)
- [ ] `ci` test job still passes
- [ ] After merge, a future PR accidentally introducing the pattern is rejected at `pre-commit` time with the line-keyed error and the footer pointing at #234/#243/#244
