### PR TITLE
skills(review-runs): write summary to step summary

### DIFF
--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -160,7 +160,8 @@ If no problems found (or none passed the gates), report "all clear" with: runs a
 reviewed, brief quality assessment, and any below-threshold findings recorded in the tracking
 issue.
 
-Write the summary to the GitHub Actions step summary so it appears on the run page:
+Save the summary to `/tmp/summary.md`, then write it to the GitHub Actions step summary so it
+appears on the run page:
 
 ```bash
 cat /tmp/summary.md >> "$GITHUB_STEP_SUMMARY"

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -73,7 +73,7 @@ Run the token report script to get per-run token counts:
 "${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" 24 > /tmp/token-report.json
 ```
 
-Include the totals and per-workflow breakdown in the summary (Step 6). Flag any
+Include the totals and per-workflow breakdown in the summary (Step 7). Flag any
 runs with unusually high token usage for closer inspection in Step 3.
 
 ## Step 3: Download and analyze session logs
@@ -159,3 +159,9 @@ tracking issue.
 If no problems found (or none passed the gates), report "all clear" with: runs analyzed, sessions
 reviewed, brief quality assessment, and any below-threshold findings recorded in the tracking
 issue.
+
+Write the summary to the GitHub Actions step summary so it appears on the run page:
+
+```bash
+cat /tmp/summary.md >> "$GITHUB_STEP_SUMMARY"
+```


### PR DESCRIPTION
The review-runs analysis was only visible in raw job logs — you had to expand the step output and scroll through to see the summary. Write it to `$GITHUB_STEP_SUMMARY` so it renders as markdown on the run page, alongside the per-run token usage table that's already there.

Also fixes Step 2's cross-reference from "Step 6" to "Step 7" (the summary is Step 7).

> _This was written by Claude Code on behalf of @max-sixty_