### PR TITLE
docs: note off-peak targeting for default cron times

### DIFF
--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -563,6 +563,10 @@ jobs:
     return GeneratedWorkflow(filename=f"tend-{name}.yaml", content=content)
 
 
+# Default cron times target Anthropic's off-peak hours (outside weekday
+# 8am–2pm ET / 12:00–18:00 UTC). Non-round minutes avoid thundering herd.
+
+
 def generate_nightly(cfg: Config) -> GeneratedWorkflow:
     return _generate_scheduled(cfg, "nightly", "17 6 * * *", "/tend-ci-runner:nightly")
 


### PR DESCRIPTION
Default cron times for batch workflows (nightly, review-runs, weekly) already fall outside Anthropic's weekday 8am–2pm ET peak window. Added a comment documenting this intent so future changes preserve it.

> _This was written by Claude Code on behalf of @max-sixty_