### PR TITLE
feat: add cost estimate to token usage output

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -45,7 +45,8 @@ outputs:
   token_usage:
     description: >-
       JSON object with token usage: input_tokens, output_tokens,
-      cache_creation_input_tokens, cache_read_input_tokens, turns
+      cache_creation_input_tokens, cache_read_input_tokens, turns,
+      model, cost_usd
     value: ${{ steps.tokens.outputs.usage }}
 
 runs:
@@ -196,17 +197,20 @@ runs:
 
         mapfile -t FILES < <(find "$LOGS_DIR" -name "*.jsonl" -type f 2>/dev/null)
 
+        MODEL="${{ inputs.model }}"
         if [ ${#FILES[@]} -eq 0 ]; then
-          USAGE='{"input_tokens":0,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"turns":0}'
+          USAGE='{"input_tokens":0,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"turns":0,"model":"'"$MODEL"'","cost_usd":0}'
         else
-          USAGE=$(cat "${FILES[@]}" | jq -s '
-            [.[] | select(.type == "assistant") | .message.usage | select(.)] |
+          USAGE=$(cat "${FILES[@]}" | jq -sc --arg model "$MODEL" '
+            [.[] | select(.type == "result")] |
             {
-              input_tokens: (map(.input_tokens // 0) | add // 0),
-              output_tokens: (map(.output_tokens // 0) | add // 0),
-              cache_creation_input_tokens: (map(.cache_creation_input_tokens // 0) | add // 0),
-              cache_read_input_tokens: (map(.cache_read_input_tokens // 0) | add // 0),
-              turns: length
+              input_tokens: (map(.usage.input_tokens // 0) | add // 0),
+              output_tokens: (map(.usage.output_tokens // 0) | add // 0),
+              cache_creation_input_tokens: (map(.usage.cache_creation_input_tokens // 0) | add // 0),
+              cache_read_input_tokens: (map(.usage.cache_read_input_tokens // 0) | add // 0),
+              turns: (map(.num_turns // 0) | add // 0),
+              model: $model,
+              cost_usd: (map(.total_cost_usd // 0) | add // 0 | . * 100 | round / 100)
             }')
         fi
 
@@ -214,14 +218,18 @@ runs:
         echo "usage=$(jq -c . <<< "$USAGE")" >> "$GITHUB_OUTPUT"
 
         jq -r '
+          def usd: tostring | if test("\\.") then split(".") | "\(.[0]).\((.[1] + "00")[:2])" else . + ".00" end | "$" + .;
           "## Token Usage",
-          "| Metric | Tokens |",
-          "|--------|--------|",
+          "| Metric | Value |",
+          "|--------|-------|",
           "| Input | \(.input_tokens) |",
           "| Output | \(.output_tokens) |",
           "| Cache creation | \(.cache_creation_input_tokens) |",
           "| Cache read | \(.cache_read_input_tokens) |",
-          "| Turns | \(.turns) |"
+          "| Cost | \(.cost_usd | usd) |",
+          "| Turns | \(.turns) |",
+          "",
+          "*Cost at API list prices — a large multiple of the effective rate on Claude Code subscriptions.*"
         ' <<< "$USAGE" >> "$GITHUB_STEP_SUMMARY"
 
     - name: Report failure

--- a/plugins/tend-ci-runner/scripts/token-report.sh
+++ b/plugins/tend-ci-runner/scripts/token-report.sh
@@ -45,7 +45,7 @@ mapfile -t WORKFLOWS < <(
 )
 
 if [ ${#WORKFLOWS[@]} -eq 0 ]; then
-  echo '{"runs":[],"totals":{"input_tokens":0,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"turns":0}}'
+  echo '{"runs":[],"totals":{"input_tokens":0,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"turns":0,"cost_usd":0}}'
   exit 0
 fi
 
@@ -59,7 +59,7 @@ done
 
 RUN_COUNT=$(echo "$ALL_RUNS" | jq 'length')
 if [ "$RUN_COUNT" -eq 0 ]; then
-  echo '{"runs":[],"totals":{"input_tokens":0,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"turns":0}}'
+  echo '{"runs":[],"totals":{"input_tokens":0,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"turns":0,"cost_usd":0}}'
   exit 0
 fi
 
@@ -83,9 +83,10 @@ for row in "${ROWS[@]}"; do
     continue
   fi
 
-  jq -c --argjson usage "$(cat "$USAGE_FILE")" \
-    '. + $usage + {run_id: .databaseId, workflow: .name, created_at: .createdAt} | del(.databaseId, .name, .createdAt)' \
-    <<< "$row" >> "$ENTRIES"
+  jq -c --argjson usage "$(cat "$USAGE_FILE")" '
+    . + $usage + {run_id: .databaseId, workflow: .name, created_at: .createdAt} |
+    .cost_usd //= 0 |
+    del(.databaseId, .name, .createdAt)' <<< "$row" >> "$ENTRIES"
 
   rm -rf "$RUNDIR"
 done
@@ -98,7 +99,8 @@ jq -s '{
     output_tokens: (map(.output_tokens) | add // 0),
     cache_creation_input_tokens: (map(.cache_creation_input_tokens) | add // 0),
     cache_read_input_tokens: (map(.cache_read_input_tokens) | add // 0),
-    turns: (map(.turns) | add // 0)
+    turns: (map(.turns) | add // 0),
+    cost_usd: (map(.cost_usd) | add // 0 | . * 100 | round / 100)
   }
 }' "$ENTRIES" | tee "$WORKDIR/report.json"
 
@@ -109,17 +111,22 @@ jq -r '
     elif . >= 1000 then "\(. / 100 | floor | . / 10)K"
     else "\(.)" end;
 
+  def usd: tostring | if test("\\.") then split(".") | "\(.[0]).\((.[1] + "00")[:2])" else . + ".00" end | "$" + .;
+
   "\n\(.runs | length) runs since '"$SINCE"'",
-  "Totals: \(.totals.input_tokens | fmt) in, \(.totals.output_tokens | fmt) out, \(.totals.cache_creation_input_tokens | fmt) cache-create, \(.totals.cache_read_input_tokens | fmt) cache-read",
+  "Totals: \(.totals.input_tokens | fmt) in, \(.totals.output_tokens | fmt) out, \(.totals.cache_creation_input_tokens | fmt) cache-create, \(.totals.cache_read_input_tokens | fmt) cache-read, \(.totals.cost_usd | usd) cost",
   "",
-  (["WORKFLOW", "RUNS", "INPUT", "OUTPUT", "CACHE-CREATE", "CACHE-READ"] | @tsv),
+  (["WORKFLOW", "RUNS", "INPUT", "OUTPUT", "CACHE-CREATE", "CACHE-READ", "COST"] | @tsv),
   (.runs | group_by(.workflow) | map({
     w: .[0].workflow,
     n: length,
     i: (map(.input_tokens) | add),
     o: (map(.output_tokens) | add),
     cc: (map(.cache_creation_input_tokens) | add),
-    cr: (map(.cache_read_input_tokens) | add)
+    cr: (map(.cache_read_input_tokens) | add),
+    cost: (map(.cost_usd) | add | . * 100 | round / 100)
   }) | sort_by(.cr) | reverse | .[] |
-    [.w, (.n | tostring), (.i | fmt), (.o | fmt), (.cc | fmt), (.cr | fmt)] | @tsv)
+    [.w, (.n | tostring), (.i | fmt), (.o | fmt), (.cc | fmt), (.cr | fmt), (.cost | usd)] | @tsv),
+  "",
+  "Cost at API list prices — a large multiple of the effective rate on Claude Code subscriptions."
 ' "$WORKDIR/report.json" | column -t >&2


### PR DESCRIPTION
Read `total_cost_usd` from Claude Code's session JSONL `type: "result"` entry and surface it in `token-usage.json`, the step summary table, and `token-report.sh`. This also switches token extraction to use the result entry's aggregated usage instead of summing individual assistant messages — single jq pass, single source of truth.

`token-report.sh` reads `cost_usd` from each run's artifact (falls back to 0 for old runs without the field). Costs are rounded to 2 decimal places and formatted as `$X.XX`.

Footnote notes that cost reflects API list prices, which are a large multiple of the effective rate on Claude Code subscriptions.

> _This was written by Claude Code on behalf of @max-sixty_