### PR TITLE
feat: notifications cost cut + token-report fixes

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: running-tend
+description: Tend-specific guidance for tend CI workflows. Adds non-standard workflow inclusion for usage analysis and repo conventions on top of the generic tend-* skills.
+metadata:
+  internal: true
+---
+
+# Tend CI
+
+Repo-specific guidance for tend workflows running on tend itself. The generic
+skills (`tend-running-in-ci`, `tend-review`, `tend-triage`, etc.) provide the
+workflow framework; this skill adds tend conventions.
+
+## Non-standard workflows
+
+Tend has Claude-powered workflows beyond the generated `tend-*` set:
+
+| Workflow | File | Schedule | Purpose |
+|----------|------|----------|---------|
+| `review-reviewers` | `review-reviewers.yaml` | `47 * * * *` | Hourly analysis of adopter repo sessions |
+
+These use the `tend@v1` action and produce `claude-session-logs*` artifacts,
+but their names don't match the `tend-*` prefix that scripts filter on by
+default.
+
+### Usage analysis
+
+Pass extra prefixes when running token reports or listing runs so these
+workflows are included:
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" 24 "review-"
+TARGET_REPO=max-sixty/tend "${CLAUDE_PLUGIN_ROOT}/scripts/list-recent-runs.sh" "tend-" "review-"
+```
+
+## Labels
+
+- `claude-behavior` — findings from `review-reviewers`
+- `review-runs` — findings from `review-runs`
+
+## Session Log Paths
+
+Artifact paths: `-home-runner-work-tend-tend/<session-id>.jsonl`
+
+`review-reviewers` runs produce 3 session logs per run (one per matrix repo:
+`max-sixty/worktrunk`, `max-sixty/tend`, `PRQL/prql`).

--- a/.github/workflows/tend-notifications.yaml
+++ b/.github/workflows/tend-notifications.yaml
@@ -26,11 +26,33 @@ jobs:
         id: check
         run: |
           COUNT=$(gh api notifications --jq 'length')
+          if [ "$COUNT" = "0" ]; then
+            echo "count=0" >> "$GITHUB_OUTPUT"
+            echo "No unread notifications — skipping"
+            exit 0
+          fi
+
+          # Pre-mark notifications shadowed by recent dedicated-workflow runs.
+          # Event workflows mark their own notifications read in action.yaml's
+          # post-step; this is defense in depth for races and for runs whose
+          # action.yaml predates that post-step.
+          SINCE=$(date -u -d '30 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
+          RECENT_PRS=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs?created=>=$SINCE&per_page=50" --jq '[.workflow_runs[] | select(.name | test("tend-review|tend-mention|tend-triage|tend-ci-fix")) | .pull_requests[]?.number] | unique | .[]' 2>/dev/null || echo "")
+
+          for pr in $RECENT_PRS; do
+            URL_PR="https://api.github.com/repos/$GITHUB_REPOSITORY/pulls/$pr"
+            URL_ISSUE="https://api.github.com/repos/$GITHUB_REPOSITORY/issues/$pr"
+            gh api notifications | jq -r --arg url_pr "$URL_PR" --arg url_issue "$URL_ISSUE" '.[] | select(.subject.url == $url_pr or .subject.url == $url_issue) | .id' 2>/dev/null | while read -r tid; do
+              [ -n "$tid" ] && gh api "notifications/threads/$tid" -X PATCH 2>/dev/null || true
+            done
+          done
+
+          COUNT=$(gh api notifications --jq 'length')
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
           if [ "$COUNT" = "0" ]; then
-            echo "No unread notifications — skipping"
+            echo "All notifications shadowed by dedicated workflows — skipping"
           else
-            echo "$COUNT unread notification(s) — proceeding"
+            echo "$COUNT unread notification(s) remain — proceeding"
           fi
         env:
           GH_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/.github/workflows/tend-notifications.yaml
+++ b/.github/workflows/tend-notifications.yaml
@@ -33,19 +33,22 @@ jobs:
           fi
 
           # Pre-mark notifications shadowed by recent dedicated-workflow runs.
-          # Event workflows mark their own notifications read in action.yaml's
-          # post-step; this is defense in depth for races and for runs whose
-          # action.yaml predates that post-step.
+          # Event workflows mark their own notifications read via action.yaml's
+          # post-step on success; this sweeps the case where Claude failed
+          # (post-step is gated by `if: success()`) so the notification still
+          # gets cleared without burning Claude turns to rediscover it.
           SINCE=$(date -u -d '30 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
-          RECENT_PRS=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs?created=>=$SINCE&per_page=50" --jq '[.workflow_runs[] | select(.name | test("tend-review|tend-mention|tend-triage|tend-ci-fix")) | .pull_requests[]?.number] | unique | .[]' 2>/dev/null || echo "")
+          RECENT_PRS=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs?created=>=$SINCE&per_page=50" --jq '[.workflow_runs[] | select(.name | test("^(tend-review|tend-mention|tend-triage|tend-ci-fix)$")) | .pull_requests[]?.number] | unique | .[]' || true)
 
-          for pr in $RECENT_PRS; do
-            URL_PR="https://api.github.com/repos/$GITHUB_REPOSITORY/pulls/$pr"
-            URL_ISSUE="https://api.github.com/repos/$GITHUB_REPOSITORY/issues/$pr"
-            gh api notifications | jq -r --arg url_pr "$URL_PR" --arg url_issue "$URL_ISSUE" '.[] | select(.subject.url == $url_pr or .subject.url == $url_issue) | .id' 2>/dev/null | while read -r tid; do
-              [ -n "$tid" ] && gh api "notifications/threads/$tid" -X PATCH 2>/dev/null || true
+          if [ -n "$RECENT_PRS" ]; then
+            NOTIFS=$(gh api notifications)
+            for pr in $RECENT_PRS; do
+              echo "$NOTIFS" | jq -r --arg repo "$GITHUB_REPOSITORY" --arg pr "$pr" '.[] | select(.subject.url == "https://api.github.com/repos/" + $repo + "/pulls/" + $pr or .subject.url == "https://api.github.com/repos/" + $repo + "/issues/" + $pr) | .id' | while read -r tid; do
+                [ -n "$tid" ] || continue
+                gh api "notifications/threads/$tid" -X PATCH || true
+              done
             done
-          done
+          fi
 
           COUNT=$(gh api notifications --jq 'length')
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"

--- a/action.yaml
+++ b/action.yaml
@@ -187,6 +187,51 @@ runs:
           --allowedTools ${{ inputs.allowed_tools }}
           --append-system-prompt "${{ inputs.system_prompt_append }}"
 
+    - name: Mark event notification read
+      if: success()
+      shell: bash
+      run: |
+        # Mark the GitHub notification thread for the triggering event as read
+        # so the scheduled tend-notifications poll doesn't burn tokens
+        # rediscovering it. The thread is only marked when its updated_at
+        # predates this run's start — newer activity stays unread for the next
+        # workflow run to handle.
+        case "$GITHUB_EVENT_NAME" in
+          pull_request_target|pull_request_review|pull_request_review_comment)
+            NUM=$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")
+            SUBJECT_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${NUM}"
+            ;;
+          issue_comment)
+            # issue_comment fires for both issues AND PR conversation comments,
+            # but PR notifications always use /pulls/N in subject.url. Detect
+            # via the issue's pull_request field.
+            NUM=$(jq -r '.issue.number' "$GITHUB_EVENT_PATH")
+            if [ "$(jq -r '.issue.pull_request.url // empty' "$GITHUB_EVENT_PATH")" != "" ]; then
+              SUBJECT_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${NUM}"
+            else
+              SUBJECT_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${NUM}"
+            fi
+            ;;
+          issues)
+            NUM=$(jq -r '.issue.number' "$GITHUB_EVENT_PATH")
+            SUBJECT_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${NUM}"
+            ;;
+          *)
+            exit 0
+            ;;
+        esac
+
+        gh api notifications \
+          | jq -r --arg url "$SUBJECT_URL" --arg started "$RUN_STARTED_AT" \
+              '.[] | select(.subject.url == $url and .updated_at <= $started) | .id' \
+          | while read -r tid; do
+              [ -n "$tid" ] || continue
+              gh api "notifications/threads/$tid" -X PATCH || true
+            done
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        RUN_STARTED_AT: ${{ github.event.workflow_run.created_at || github.run_started_at }}
+
     - name: Token usage
       if: always()
       id: tokens

--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -610,11 +610,36 @@ jobs:
         id: check
         run: |
           COUNT=$(gh api notifications --jq 'length')
+          if [ "$COUNT" = "0" ]; then
+            echo "count=0" >> "$GITHUB_OUTPUT"
+            echo "No unread notifications — skipping"
+            exit 0
+          fi
+
+          # Pre-mark notifications shadowed by recent dedicated-workflow runs.
+          # Event workflows mark their own notifications read via action.yaml's
+          # post-step on success; this sweeps the case where Claude failed
+          # (post-step is gated by `if: success()`) so the notification still
+          # gets cleared without burning Claude turns to rediscover it.
+          SINCE=$(date -u -d '30 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
+          RECENT_PRS=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs?created=>=$SINCE&per_page=50" --jq '[.workflow_runs[] | select(.name | test("^(tend-review|tend-mention|tend-triage|tend-ci-fix)$")) | .pull_requests[]?.number] | unique | .[]' || true)
+
+          if [ -n "$RECENT_PRS" ]; then
+            NOTIFS=$(gh api notifications)
+            for pr in $RECENT_PRS; do
+              echo "$NOTIFS" | jq -r --arg repo "$GITHUB_REPOSITORY" --arg pr "$pr" '.[] | select(.subject.url == "https://api.github.com/repos/" + $repo + "/pulls/" + $pr or .subject.url == "https://api.github.com/repos/" + $repo + "/issues/" + $pr) | .id' | while read -r tid; do
+                [ -n "$tid" ] || continue
+                gh api "notifications/threads/$tid" -X PATCH || true
+              done
+            done
+          fi
+
+          COUNT=$(gh api notifications --jq 'length')
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
           if [ "$COUNT" = "0" ]; then
-            echo "No unread notifications — skipping"
+            echo "All notifications shadowed by dedicated workflows — skipping"
           else
-            echo "$COUNT unread notification(s) — proceeding"
+            echo "$COUNT unread notification(s) remain — proceeding"
           fi
         env:
           GH_TOKEN: {bt}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
@@ -26,11 +26,36 @@ jobs:
         id: check
         run: |
           COUNT=$(gh api notifications --jq 'length')
+          if [ "$COUNT" = "0" ]; then
+            echo "count=0" >> "$GITHUB_OUTPUT"
+            echo "No unread notifications ? skipping"
+            exit 0
+          fi
+
+          # Pre-mark notifications shadowed by recent dedicated-workflow runs.
+          # Event workflows mark their own notifications read via action.yaml's
+          # post-step on success; this sweeps the case where Claude failed
+          # (post-step is gated by `if: success()`) so the notification still
+          # gets cleared without burning Claude turns to rediscover it.
+          SINCE=$(date -u -d '30 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
+          RECENT_PRS=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs?created=>=$SINCE&per_page=50" --jq '[.workflow_runs[] | select(.name | test("^(tend-review|tend-mention|tend-triage|tend-ci-fix)$")) | .pull_requests[]?.number] | unique | .[]' || true)
+
+          if [ -n "$RECENT_PRS" ]; then
+            NOTIFS=$(gh api notifications)
+            for pr in $RECENT_PRS; do
+              echo "$NOTIFS" | jq -r --arg repo "$GITHUB_REPOSITORY" --arg pr "$pr" '.[] | select(.subject.url == "https://api.github.com/repos/" + $repo + "/pulls/" + $pr or .subject.url == "https://api.github.com/repos/" + $repo + "/issues/" + $pr) | .id' | while read -r tid; do
+                [ -n "$tid" ] || continue
+                gh api "notifications/threads/$tid" -X PATCH || true
+              done
+            done
+          fi
+
+          COUNT=$(gh api notifications --jq 'length')
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
           if [ "$COUNT" = "0" ]; then
-            echo "No unread notifications ? skipping"
+            echo "All notifications shadowed by dedicated workflows ? skipping"
           else
-            echo "$COUNT unread notification(s) ? proceeding"
+            echo "$COUNT unread notification(s) remain ? proceeding"
           fi
         env:
           GH_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
@@ -26,11 +26,36 @@ jobs:
         id: check
         run: |
           COUNT=$(gh api notifications --jq 'length')
+          if [ "$COUNT" = "0" ]; then
+            echo "count=0" >> "$GITHUB_OUTPUT"
+            echo "No unread notifications ? skipping"
+            exit 0
+          fi
+
+          # Pre-mark notifications shadowed by recent dedicated-workflow runs.
+          # Event workflows mark their own notifications read via action.yaml's
+          # post-step on success; this sweeps the case where Claude failed
+          # (post-step is gated by `if: success()`) so the notification still
+          # gets cleared without burning Claude turns to rediscover it.
+          SINCE=$(date -u -d '30 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
+          RECENT_PRS=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs?created=>=$SINCE&per_page=50" --jq '[.workflow_runs[] | select(.name | test("^(tend-review|tend-mention|tend-triage|tend-ci-fix)$")) | .pull_requests[]?.number] | unique | .[]' || true)
+
+          if [ -n "$RECENT_PRS" ]; then
+            NOTIFS=$(gh api notifications)
+            for pr in $RECENT_PRS; do
+              echo "$NOTIFS" | jq -r --arg repo "$GITHUB_REPOSITORY" --arg pr "$pr" '.[] | select(.subject.url == "https://api.github.com/repos/" + $repo + "/pulls/" + $pr or .subject.url == "https://api.github.com/repos/" + $repo + "/issues/" + $pr) | .id' | while read -r tid; do
+                [ -n "$tid" ] || continue
+                gh api "notifications/threads/$tid" -X PATCH || true
+              done
+            done
+          fi
+
+          COUNT=$(gh api notifications --jq 'length')
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
           if [ "$COUNT" = "0" ]; then
-            echo "No unread notifications ? skipping"
+            echo "All notifications shadowed by dedicated workflows ? skipping"
           else
-            echo "$COUNT unread notification(s) ? proceeding"
+            echo "$COUNT unread notification(s) remain ? proceeding"
           fi
         env:
           GH_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -216,7 +216,9 @@ The bot needs a classic PAT with `repo`, `workflow`, `notifications`, and
 notifications. `write:discussion` allows commenting on GitHub Discussions.
 Fine-grained PATs also work (`contents:write`, `pull-requests:write`,
 `issues:write`, `actions:write`, `workflows:write`, `discussions:write`,
-`notifications:read`) — create one manually and skip to step 9.
+`notifications:write`) — create one manually and skip to step 9.
+`notifications:write` is required so the action can mark threads read after
+handling an event (the classic `notifications` scope already includes write).
 Use Chrome for classic PATs:
 
 1. Verify the browser is logged in as `<bot-name>` (click avatar, check

--- a/plugins/tend-ci-runner/scripts/token-report.sh
+++ b/plugins/tend-ci-runner/scripts/token-report.sh
@@ -8,8 +8,9 @@
 # Reads the token-usage.json file from each run's session log artifact
 # (produced by the "Token usage" step in action.yaml).
 #
-# Usage: ./token-report.sh [HOURS]
+# Usage: ./token-report.sh [HOURS] [PREFIX ...]
 #   HOURS: lookback period in hours (default: 168 = 7 days)
+#   PREFIX: additional workflow name prefixes to include (default: tend-)
 #
 # Output (stdout): JSON — { runs: [...], totals: {...} }
 # Output (stderr): human-readable summary table
@@ -29,6 +30,9 @@ export NO_COLOR=1
 export CLICOLOR_FORCE=0
 
 HOURS=${1:-168}
+shift 2>/dev/null || true
+EXTRA_PREFIXES=("$@")
+
 SINCE=$(date -u -d "$HOURS hours ago" +%Y-%m-%dT%H:%M:%SZ)
 
 repo_args=()
@@ -39,10 +43,15 @@ fi
 WORKDIR=$(mktemp -d)
 trap 'rm -rf "$WORKDIR"' EXIT
 
-# Discover tend workflows
-mapfile -t WORKFLOWS < <(
-  gh workflow list "${repo_args[@]}" --json name --jq '.[].name | select(startswith("tend-"))'
-)
+# Discover tend workflows (tend-* by default, plus any extra prefixes)
+PREFIXES=("tend-" "${EXTRA_PREFIXES[@]}")
+WORKFLOWS=()
+for prefix in "${PREFIXES[@]}"; do
+  mapfile -t matches < <(
+    gh workflow list "${repo_args[@]}" --json name --jq ".[].name | select(startswith(\"$prefix\"))"
+  )
+  WORKFLOWS+=("${matches[@]}")
+done
 
 if [ ${#WORKFLOWS[@]} -eq 0 ]; then
   echo '{"runs":[],"totals":{"input_tokens":0,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"turns":0}}'
@@ -78,12 +87,21 @@ for row in "${ROWS[@]}"; do
     continue
   fi
 
-  USAGE_FILE=$(find "$RUNDIR" -name "token-usage.json" -type f | head -1)
-  if [ -z "$USAGE_FILE" ]; then
+  mapfile -t USAGE_FILES < <(find "$RUNDIR" -name "token-usage.json" -type f)
+  if [ ${#USAGE_FILES[@]} -eq 0 ]; then
     continue
   fi
 
-  jq -c --argjson usage "$(cat "$USAGE_FILE")" \
+  # Aggregate across matrix jobs (each job produces its own token-usage.json)
+  USAGE=$(cat "${USAGE_FILES[@]}" | jq -s '{
+    input_tokens: (map(.input_tokens) | add),
+    output_tokens: (map(.output_tokens) | add),
+    cache_creation_input_tokens: (map(.cache_creation_input_tokens) | add),
+    cache_read_input_tokens: (map(.cache_read_input_tokens) | add),
+    turns: (map(.turns) | add)
+  }')
+
+  jq -c --argjson usage "$USAGE" \
     '. + $usage + {run_id: .databaseId, workflow: .name, created_at: .createdAt} | del(.databaseId, .name, .createdAt)' \
     <<< "$row" >> "$ENTRIES"
 

--- a/plugins/tend-ci-runner/skills/notifications/SKILL.md
+++ b/plugins/tend-ci-runner/skills/notifications/SKILL.md
@@ -72,46 +72,42 @@ Before acting on ANY notification:
 
 For each unread notification (oldest first):
 
-### 4a. Determine if already handled
+### 4a. Dedup check
 
-Check whether the bot has already responded since the notification was generated. `BOT_LOGIN`
-and `NOTIF_UPDATED_AT` are not pre-populated by the workflow — set them explicitly before the jq
-call (`NOTIF_UPDATED_AT` is the `updated_at` field from the notification fetched in step 1):
+Most unread same-repo notifications are leftovers from events the dedicated workflows
+(`tend-review`, `tend-mention`, `tend-triage`, `tend-ci-fix`) already handled. The action's
+post-step marks them read on success, and the workflow's pre-check sweeps any that slipped
+through. Anything still unread by the time you reach this step needs one targeted check:
+
+For same-repo notifications on a PR or Issue, ask: has the bot posted a comment or review newer
+than the notification's `updated_at`?
 
 ```bash
 BOT_LOGIN=$(gh api user --jq '.login')
 NOTIF_UPDATED_AT=<updated_at from the notification>
 
-# For issues
-gh api repos/{owner}/{repo}/issues/{number}/comments \
+# Conversation comments (covers issues and PR conversation, not PR reviews)
+gh api "repos/{owner}/{repo}/issues/{number}/comments" \
   --jq "[.[] | select(.user.login == \"$BOT_LOGIN\" and .created_at > \"$NOTIF_UPDATED_AT\")] | length"
+```
 
-# For PRs — also check reviews
-gh api repos/{owner}/{repo}/pulls/{number}/reviews \
+For PR notifications, also check reviews (a separate endpoint):
+
+```bash
+gh api "repos/{owner}/{repo}/pulls/{number}/reviews" \
   --jq "[.[] | select(.user.login == \"$BOT_LOGIN\" and .submitted_at > \"$NOTIF_UPDATED_AT\")] | length"
 ```
 
-If the bot already responded after the notification timestamp, mark the notification as read and
-move on:
+If either returns `> 0`, mark read and move on:
 
 ```bash
 gh api notifications/threads/{thread_id} -X PATCH
 ```
 
-### 4b. Skip notifications handled by dedicated workflows
+Cross-repo notifications skip dedup (no good signal for "already handled" across repos) — go
+straight to step 4b. Stop the check here: no author-association lookups, no workflow-run queries.
 
-Other workflows (`tend-triage`, `tend-review`, event-triggered runs) already handle most same-repo activity. To avoid duplicate work, **mark as read and skip** these notification types when they come from `$GITHUB_REPOSITORY`:
-
-- **`review_requested`** — handled by the `tend-review` workflow.
-- **`assign`** on issues — handled by `tend-triage`.
-- **`mention`** or **`subscribed`/`comment`** on issues/PRs that already have a recent bot response or a workflow run triggered by the same event — the dedicated workflow got there first. Check with:
-  ```bash
-  # Did a workflow already run for this issue/PR recently?
-  gh api "repos/{owner}/{repo}/actions/runs?event=issues&created=>=$(date -u -d '30 minutes ago' +%Y-%m-%dT%H:%M:%SZ)&per_page=5" \
-    --jq '[.workflow_runs[] | select(.name | test("triage|review"))] | length'
-  ```
-
-### 4c. Respond to notifications only this skill covers
+### 4b. Respond to notifications only this skill covers
 
 The notifications skill is the **sole handler** for these categories — respond to them:
 
@@ -126,7 +122,7 @@ The notifications skill is the **sole handler** for these categories — respond
 
 - **`subscribed`/`comment`** on threads the bot participates in (same-repo), where the comment is directed at the bot and no dedicated workflow handled it — respond if the comment asks a question, requests changes, or replies to a concern the bot raised. If the conversation is between humans, do not respond.
 
-### 4d. Mark as read
+### 4c. Mark as read
 
 After processing (whether or not a response was posted):
 

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -73,6 +73,9 @@ Run the token report script to get per-run token counts:
 "${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" 24 > /tmp/token-report.json
 ```
 
+Pass additional workflow prefixes to include non-`tend-*` workflows that use the tend
+action (e.g., `review-reviewers`). Check the repo's `running-tend` skill for the list.
+
 Include the totals and per-workflow breakdown in the summary (Step 7). Flag any
 runs with unusually high token usage for closer inspection in Step 3.
 


### PR DESCRIPTION
This branch bundles two cost-related changes that built on each other.

## 1. token-report.sh fixes

- Accepts additional workflow name prefixes as positional args after the hours parameter, matching the pattern `list-recent-runs.sh` already uses
- Aggregates all `token-usage.json` files per run instead of picking the first one — fixes undercounting for matrix workflows like `review-reviewers` (3 jobs per run)
- Adds `.claude/skills/running-tend/SKILL.md` documenting tend's non-standard workflows and how to include them in usage analysis

Before this change, `review-reviewers` was invisible to the token report despite being 75% of all token usage on tend.

## 2. Notifications cost cut (3-layer fix)

`tend-notifications` was burning ~$50/day on worktrunk because most "unread" notifications were leftovers from events that dedicated workflows already handled. Each notification cost $2-6 in Claude turns to investigate and skip.

- **Layer A (action.yaml)** — Post-step marks the event's notification thread as read on success. Scoped by `updated_at <= run_started_at` so newer activity stays unread. Handles `issue_comment`'s PR-vs-issue distinction via `.issue.pull_request.url`.

- **Layer B (workflows.py pre-check)** — `tend-notifications` workflow's existing pre-check now also sweeps notifications shadowed by recent dedicated workflow runs in bash before invoking Claude. Catches the case where Claude failed mid-run (Layer A's post-step is gated by `if: success()`).

- **Layer C (notifications skill)** — Step 4a collapsed to a single comment+review check. Removed the workflow-runs investigation that Layer B now handles in bash.

Bonus: fine-grained PAT scope updated from `notifications:read` to `notifications:write` (the post-step needs PATCH access).

Combined, this should drop `tend-notifications` cost from ~$56/day across both repos to under ~$10/day.

> _This was written by Claude Code on behalf of @max-sixty_