### PR TITLE
fix(review): handle 422 case where no orphan review is persisted

### DIFF
--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -266,21 +266,30 @@ object keys, which GitHub rejects.
 
 #### Recovering from inline comment 422 errors
 
-GitHub returns `422 Unprocessable Entity` with "Line could not be resolved" when inline comment line numbers don't map to valid positions in the diff. This happens most often on large or complex diffs. **Do not retry by posting a second review** — the first `POST` to the reviews endpoint already created a review record (with the body but without the failed inline comments), so a second attempt creates a duplicate.
+GitHub returns `422 Unprocessable Entity` with "Line could not be resolved" when inline comment line numbers don't map to valid positions in the diff. Two failure modes produce the same error message but differ in whether a review record is persisted:
 
-Instead, when a 422 occurs on inline comments:
+- **(a) Large / complex diff**: the body is persisted first, then the inline comments are rejected — leaving an **orphan body-only review** on the PR. A blind retry creates a duplicate.
+- **(b) Line outside the diff entirely**: the entire POST is rejected up front — **no review is persisted**. Retrying without inline comments is correct; editing a non-existent review will fail.
 
-1. **Move the failed inline comments into the review body** as fenced code blocks with file paths.
-2. **Edit the existing review** rather than creating a new one:
-   ```bash
-   # Find the review that was just created (body posted, inline comments rejected)
-   REVIEW_ID=$(gh api "repos/$REPO/pulls/<number>/reviews" \
-     --jq "[.[] | select(.user.login == \"$BOT_LOGIN\" and .commit_id == \"$HEAD_SHA\")] | last | .id")
-   # Update its body to include the failed inline suggestions
-   gh api "repos/$REPO/pulls/<number>/reviews/$REVIEW_ID" \
-     -X PUT -F body=@/tmp/updated-review-body.md
-   ```
-3. If editing fails, **do not post another review** — the body-only review is sufficient.
+**Check which case you are in before deciding how to recover** — query for an orphan review on the current HEAD first, then branch on the result.
+
+```bash
+ORPHAN_ID=$(gh api "repos/$REPO/pulls/<number>/reviews" \
+  --jq "[.[] | select(.user.login == \"$BOT_LOGIN\" and .commit_id == \"$HEAD_SHA\")] | last | .id // empty")
+```
+
+Then, in either case, **move the failed inline comments into the review body** as fenced code blocks with file paths, and:
+
+- **If `ORPHAN_ID` is non-empty (case a)**: edit the existing review instead of creating a duplicate.
+  ```bash
+  gh api "repos/$REPO/pulls/<number>/reviews/$ORPHAN_ID" \
+    -X PUT -F body=@/tmp/updated-review-body.md
+  ```
+  If the edit itself fails, **do not post another review** — the body-only review is sufficient.
+
+- **If `ORPHAN_ID` is empty (case b)**: retry the `POST` with `comments` omitted (body-only), since no duplicate is possible.
+
+Prevention: before writing any inline comment, verify the target line falls inside one of the PR's diff hunks. For fixes outside the diff, use the "push a fix commit" path instead of an inline suggestion (see above).
 
 ### 6. Monitor CI
 


### PR DESCRIPTION
## Summary

- Split the review-skill's inline-comment 422 recovery into the two observed failure modes and branch on whether an orphan review record was actually persisted, rather than assuming one always is.
- Add a one-line prevention nudge to verify a target line falls inside a diff hunk before writing any inline comment.

## Evidence

Run [24291311025](https://github.com/max-sixty/tend/actions/runs/24291311025) (`tend-review` on PR #250) reviewed `token-report.sh`, found a stale `Requires:` header comment at line 20 — **outside** the PR's diff (which touched lines 32 and 131–137) — and wrote a review payload with an inline `suggestion` on line 20. The `POST /repos/.../pulls/250/reviews` call returned:

```
{"message":"Unprocessable Entity","errors":["Line could not be resolved"],"status":"422"}
```

A subsequent `gh api ... reviews` query filtered to `tend-agent` on HEAD returned `[]`: **no review was persisted**. The bot recovered by running `gh pr review 250 --approve --body-file …`, which created a fresh review — and that single review is the only one now on the PR (see `gh api repos/max-sixty/tend/pulls/250/reviews`).

This contradicts the existing guidance at [`plugins/tend-ci-runner/skills/review/SKILL.md:269`](https://github.com/max-sixty/tend/blob/b3b54f2/plugins/tend-ci-runner/skills/review/SKILL.md#L269), which asserts:

> **Do not retry by posting a second review** — the first `POST` to the reviews endpoint already created a review record (with the body but without the failed inline comments)

...and instructs a strict edit-only recovery. If the bot had followed that recipe verbatim this run, `REVIEW_ID` would have been empty, the `PUT` would have failed, step 3 ("do not post another review — the body-only review is sufficient") would have kicked in, and **PR #250 would have been left without any review**.

The original guidance (added in max-sixty/tend#123) is still correct for the case it was written for — large/complex diffs where the body _is_ persisted before the inline comments are rejected. Both failure modes surface the same `"Line could not be resolved"` error string, so the recovery path has to check persistence state directly instead of branching on the error text.

## Classification

- **Evidence level**: Medium — 1 observed run where the assumption was falsified, plus the pre-existing case from #123 showing the other mode exists. Independent.
- **Failure class**: Structural. The GitHub API's persistence semantics are deterministic per input shape; the same 422 path will repeat under the same conditions.
- **Change type**: Targeted fix (one section of an existing skill; 24 added, 15 removed lines). Gate 2 bar: normal.
- **Gates**: Passes Gate 1 (structural, 1 clear occurrence sufficient) and Gate 2 (targeted fix, proportionate).

## Why not also chase the proactive line-in-diff check

The skill already says "For fixes targeting lines outside the diff, offer to push a fix commit instead" at line 215. The bot in this run _knew_ the rule — it explicitly invoked it after the 422, in its assistant text ("Line 20 is outside the diff. Per the skill, for fixes outside the diff I should offer to push a fix commit instead"). Adding louder guidance for a rule the model already has is a stochastic remedy. One reinforcing sentence is included in the recovery section, but the primary fix is making the recovery path correct for the case where the bot still fires an out-of-diff inline anyway — because that's the case where the skill's text _materially misleads_.

> _This was written by Claude Code on behalf of @max-sixty_
