### PR TITLE
skills(review-gates): tell the bot to use $GITHUB_RUN_ID, not guess

### DIFF
--- a/plugins/tend-ci-runner/shared/review-gates.md
+++ b/plugins/tend-ci-runner/shared/review-gates.md
@@ -142,16 +142,28 @@ Never replace the body — prior entries contain per-run evidence needed for gat
 
 If `EXISTING_COMMENT` is empty, create a new comment.
 
-Format each finding under a `## Run <run-id>` heading:
+Format each finding under a `## Run <run-id>` heading. **Always derive the run ID, timestamp, and
+repo from the CI environment — never hand-type them.** Past sessions have filled the `<run-id>`
+placeholder with fabricated round numbers (e.g. `24294000000`) when the skill didn't explicitly
+point at `$GITHUB_RUN_ID`, producing dead link-anchors in the tracking log.
+
+```bash
+RUN_ID="$GITHUB_RUN_ID"
+TIMESTAMP=$(date -u -Iseconds | sed 's/+00:00/Z/')
+REPO="$GITHUB_REPOSITORY"
+```
+
+When composing the findings file, either interpolate the values with an unquoted heredoc (so
+`$RUN_ID` expands) or read them first and write the literal values into the file:
 
 ```
-## Run <run-id> — <ISO timestamp>
+## Run <RUN_ID> — <TIMESTAMP>
 
 ### <short description>
 - **Evidence level**: Medium
 - **Occurrences this run**: 1
-- **Run ID**: <run-id>
-- **Workflow**: https://github.com/{owner}/{repo}/actions/runs/<run-id>
+- **Run ID**: <RUN_ID>
+- **Workflow**: https://github.com/<REPO>/actions/runs/<RUN_ID>
 - **Session**: <session file>
 - **Detail**: <brief description of what was observed>
 ```


### PR DESCRIPTION
## Summary

- Two sibling `review-reviewers` matrix sessions in run [24293521847](https://github.com/max-sixty/tend/actions/runs/24293521847) both hallucinated the same run ID (`24294000000`) and timestamp (`2026-04-11T23:00Z`) when composing tracking-comment headings. Neither session consulted `$GITHUB_RUN_ID` — both independently filled the skill template's `<run-id>` placeholder with the same round-number guess.
- Two independent sessions producing the *same* wrong value from the same template is the signature of a structural gap, not a stochastic lapse: the skill never explicitly points at `$GITHUB_RUN_ID`, so every session hits the same decision point and can guess.
- This change adds an explicit `RUN_ID="$GITHUB_RUN_ID"` / `TIMESTAMP=$(date -u -Iseconds)` / `REPO="$GITHUB_REPOSITORY"` recipe immediately above the heading template in `shared/review-gates.md`, plus a one-sentence warning citing the `24294000000` incident so the rationale survives. The file is symlinked into both `review-reviewers` and `review-runs`, so the fix propagates to both skills.

## Evidence

- **Session log (PRQL matrix job)**: artifact `claude-session-logs-afae2a71`, file `ea775fa3-6423-4492-a33e-f581a8f5e639.jsonl`. Write tool call at `/tmp/claude/findings.md` contains the literal string `## Run 24294000000 — 2026-04-11T23:00Z (review-reviewers on PRQL/prql)`. Grep of the session for `GITHUB_RUN_ID` returns zero hits.
- **Session log (worktrunk matrix job)**: artifact `claude-session-logs-6d4c34fe`, file `4fe6a076-99c9-49cd-b533-1d6759b232e7.jsonl`. Write tool call at `/tmp/claude/new-finding.md` contains the literal string `## Run 24294000000 — 2026-04-11T23:00Z (review-reviewers on max-sixty/worktrunk)`. Also zero `GITHUB_RUN_ID` hits.
- **Tracking-comment proof**: [issue #133, comment 4230256357](https://github.com/max-sixty/tend/issues/133#issuecomment-4230256357) lines 86 and 103 both show the hallucinated heading.
- **Run ID does not exist**: `gh run view 24294000000 -R max-sixty/tend` and `gh run view 24294000000 -R PRQL/prql` both return HTTP 404. Actual run ID is `24293521847`.
- **Prior run behaved correctly**: the previous review-reviewers run (`24292497557`) wrote both of its matrix-entry headings with the correct run ID. The hallucination is new — not a long-standing pattern — but reproducing in 2/2 sibling sessions the first time it happens is strong structural evidence and justifies a proactive fix.

## Gate assessment

- **Confidence (Gate 1)**: **High / structural**. N=2 independent sessions in the same run, same fabricated value — same skill template → same guess. Structural failures need only 1 occurrence for a targeted fix per `review-gates.md`; N=2 comfortably exceeds.
- **Magnitude (Gate 2)**: **Targeted fix**. Adds ~12 lines of explicit derivation instruction immediately above the existing template, no structural rewrite. Normal threshold.
- **Both gates: PASS**.

## Why this isn't already covered by existing guidance

`running-in-ci`'s "Grounded analysis" section already forbids hallucinated identifiers in public comments, and "User-facing comments require source evidence" tells the bot to verify specific claims before posting. Both rules apply in principle — but they can't anchor to a concrete derivation step for a field the skill template displays as an unfilled `<run-id>` placeholder. Two sessions independently made the same confident guess, which tells us the general rule isn't enough: the specific template needs to name the source variable. This PR anchors the rule to the exact field.

## Test plan

- [x] `pre-commit run --files plugins/tend-ci-runner/shared/review-gates.md` — passes (trim whitespace, eof, typos, bang-backtick guard all clean).
- [x] `cd generator && uv run pytest` — 158 tests pass, no regressions.
- [x] Diff is a minimal targeted addition: 16 insertions, 4 deletions, one file, no symlink churn.
- [ ] Next `review-reviewers` / `review-runs` run exercises the updated guidance (observable in the tracking-issue comment — the next run's heading should use the actual `$GITHUB_RUN_ID`).

Recorded in [#133 (comment)](https://github.com/max-sixty/tend/issues/133#issuecomment-4230256357) under this run's findings section.
