### PR TITLE
feat(notifications): freshness gate + bot-closed-PR drop

### DIFF
--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -616,7 +616,7 @@ jobs:
             exit 0
           fi
 
-          # Pre-mark notifications shadowed by recent dedicated-workflow runs.
+          # --- Layer B: drop notifications shadowed by recent dedicated runs ---
           # Event workflows mark their own notifications read via action.yaml's
           # post-step on success; this sweeps the case where Claude failed
           # (post-step is gated by `if: success()`) so the notification still
@@ -634,12 +634,40 @@ jobs:
             done
           fi
 
-          COUNT=$(gh api notifications --jq 'length')
+          # --- Layer C: drop notifications on bot-authored closed PRs ---
+          # The bot auto-subscribes to its own PRs. After merge/close, leftover
+          # subscription notifications are pure noise — no action needed.
+          NOTIFS=$(gh api notifications)
+          echo "$NOTIFS" | jq -r --arg repo "$GITHUB_REPOSITORY" '.[] | select(.repository.full_name == $repo and .subject.type == "PullRequest") | .id' | while read -r tid; do
+            [ -n "$tid" ] || continue
+            PR_NUM=$(echo "$NOTIFS" | jq -r --arg tid "$tid" '.[] | select(.id == $tid) | .subject.url | split("/") | last')
+            PR_INFO=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUM" --jq '"\\(.user.login) \\(.state)"' 2>/dev/null) || continue
+            PR_AUTHOR=${{PR_INFO%% *}}
+            PR_STATE=${{PR_INFO##* }}
+            if [ "$PR_AUTHOR" = "{bn}" ] && [ "$PR_STATE" = "closed" ]; then
+              gh api "notifications/threads/$tid" -X PATCH || true
+            fi
+          done
+
+          # --- Layer D: count processable notifications ---
+          # Same-repo notifications younger than 10 minutes are deferred: a
+          # dedicated workflow (tend-review/mention/triage/ci-fix) is likely
+          # still starting up or mid-flight and hasn't posted its response yet.
+          # Processing them now risks duplicating work. Cross-repo notifications
+          # are exempt — no dedicated workflow handles them.
+          CUTOFF=$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
+          REMAINING=$(gh api notifications)
+          COUNT=$(echo "$REMAINING" | jq --arg repo "$GITHUB_REPOSITORY" --arg cutoff "$CUTOFF" '[.[] | select(.repository.full_name != $repo or .updated_at <= $cutoff)] | length')
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
           if [ "$COUNT" = "0" ]; then
-            echo "All notifications shadowed by dedicated workflows — skipping"
+            TOTAL=$(echo "$REMAINING" | jq 'length')
+            if [ "$TOTAL" = "0" ]; then
+              echo "All notifications handled by pre-checks — skipping"
+            else
+              echo "$TOTAL notification(s) remain but all are fresh same-repo (deferred) — skipping"
+            fi
           else
-            echo "$COUNT unread notification(s) remain — proceeding"
+            echo "$COUNT processable notification(s) — proceeding"
           fi
         env:
           GH_TOKEN: {bt}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
@@ -32,7 +32,7 @@ jobs:
             exit 0
           fi
 
-          # Pre-mark notifications shadowed by recent dedicated-workflow runs.
+          # --- Layer B: drop notifications shadowed by recent dedicated runs ---
           # Event workflows mark their own notifications read via action.yaml's
           # post-step on success; this sweeps the case where Claude failed
           # (post-step is gated by `if: success()`) so the notification still
@@ -50,12 +50,40 @@ jobs:
             done
           fi
 
-          COUNT=$(gh api notifications --jq 'length')
+          # --- Layer C: drop notifications on bot-authored closed PRs ---
+          # The bot auto-subscribes to its own PRs. After merge/close, leftover
+          # subscription notifications are pure noise ? no action needed.
+          NOTIFS=$(gh api notifications)
+          echo "$NOTIFS" | jq -r --arg repo "$GITHUB_REPOSITORY" '.[] | select(.repository.full_name == $repo and .subject.type == "PullRequest") | .id' | while read -r tid; do
+            [ -n "$tid" ] || continue
+            PR_NUM=$(echo "$NOTIFS" | jq -r --arg tid "$tid" '.[] | select(.id == $tid) | .subject.url | split("/") | last')
+            PR_INFO=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUM" --jq '"\(.user.login) \(.state)"' 2>/dev/null) || continue
+            PR_AUTHOR=${PR_INFO%% *}
+            PR_STATE=${PR_INFO##* }
+            if [ "$PR_AUTHOR" = "test-bot" ] && [ "$PR_STATE" = "closed" ]; then
+              gh api "notifications/threads/$tid" -X PATCH || true
+            fi
+          done
+
+          # --- Layer D: count processable notifications ---
+          # Same-repo notifications younger than 10 minutes are deferred: a
+          # dedicated workflow (tend-review/mention/triage/ci-fix) is likely
+          # still starting up or mid-flight and hasn't posted its response yet.
+          # Processing them now risks duplicating work. Cross-repo notifications
+          # are exempt ? no dedicated workflow handles them.
+          CUTOFF=$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
+          REMAINING=$(gh api notifications)
+          COUNT=$(echo "$REMAINING" | jq --arg repo "$GITHUB_REPOSITORY" --arg cutoff "$CUTOFF" '[.[] | select(.repository.full_name != $repo or .updated_at <= $cutoff)] | length')
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
           if [ "$COUNT" = "0" ]; then
-            echo "All notifications shadowed by dedicated workflows ? skipping"
+            TOTAL=$(echo "$REMAINING" | jq 'length')
+            if [ "$TOTAL" = "0" ]; then
+              echo "All notifications handled by pre-checks ? skipping"
+            else
+              echo "$TOTAL notification(s) remain but all are fresh same-repo (deferred) ? skipping"
+            fi
           else
-            echo "$COUNT unread notification(s) remain ? proceeding"
+            echo "$COUNT processable notification(s) ? proceeding"
           fi
         env:
           GH_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
@@ -32,7 +32,7 @@ jobs:
             exit 0
           fi
 
-          # Pre-mark notifications shadowed by recent dedicated-workflow runs.
+          # --- Layer B: drop notifications shadowed by recent dedicated runs ---
           # Event workflows mark their own notifications read via action.yaml's
           # post-step on success; this sweeps the case where Claude failed
           # (post-step is gated by `if: success()`) so the notification still
@@ -50,12 +50,40 @@ jobs:
             done
           fi
 
-          COUNT=$(gh api notifications --jq 'length')
+          # --- Layer C: drop notifications on bot-authored closed PRs ---
+          # The bot auto-subscribes to its own PRs. After merge/close, leftover
+          # subscription notifications are pure noise ? no action needed.
+          NOTIFS=$(gh api notifications)
+          echo "$NOTIFS" | jq -r --arg repo "$GITHUB_REPOSITORY" '.[] | select(.repository.full_name == $repo and .subject.type == "PullRequest") | .id' | while read -r tid; do
+            [ -n "$tid" ] || continue
+            PR_NUM=$(echo "$NOTIFS" | jq -r --arg tid "$tid" '.[] | select(.id == $tid) | .subject.url | split("/") | last')
+            PR_INFO=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUM" --jq '"\(.user.login) \(.state)"' 2>/dev/null) || continue
+            PR_AUTHOR=${PR_INFO%% *}
+            PR_STATE=${PR_INFO##* }
+            if [ "$PR_AUTHOR" = "test-bot" ] && [ "$PR_STATE" = "closed" ]; then
+              gh api "notifications/threads/$tid" -X PATCH || true
+            fi
+          done
+
+          # --- Layer D: count processable notifications ---
+          # Same-repo notifications younger than 10 minutes are deferred: a
+          # dedicated workflow (tend-review/mention/triage/ci-fix) is likely
+          # still starting up or mid-flight and hasn't posted its response yet.
+          # Processing them now risks duplicating work. Cross-repo notifications
+          # are exempt ? no dedicated workflow handles them.
+          CUTOFF=$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
+          REMAINING=$(gh api notifications)
+          COUNT=$(echo "$REMAINING" | jq --arg repo "$GITHUB_REPOSITORY" --arg cutoff "$CUTOFF" '[.[] | select(.repository.full_name != $repo or .updated_at <= $cutoff)] | length')
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
           if [ "$COUNT" = "0" ]; then
-            echo "All notifications shadowed by dedicated workflows ? skipping"
+            TOTAL=$(echo "$REMAINING" | jq 'length')
+            if [ "$TOTAL" = "0" ]; then
+              echo "All notifications handled by pre-checks ? skipping"
+            else
+              echo "$TOTAL notification(s) remain but all are fresh same-repo (deferred) ? skipping"
+            fi
           else
-            echo "$COUNT unread notification(s) remain ? proceeding"
+            echo "$COUNT processable notification(s) ? proceeding"
           fi
         env:
           GH_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/plugins/tend-ci-runner/skills/notifications/SKILL.md
+++ b/plugins/tend-ci-runner/skills/notifications/SKILL.md
@@ -72,15 +72,18 @@ Before acting on ANY notification:
 
 For each unread notification (oldest first):
 
-### 4a. Dedup check
+### 4a. Freshness gate and dedup check
 
-Most unread same-repo notifications are leftovers from events the dedicated workflows
-(`tend-review`, `tend-mention`, `tend-triage`, `tend-ci-fix`) already handled. The action's
-post-step marks them read on success, and the workflow's pre-check sweeps any that slipped
-through. Anything still unread by the time you reach this step needs one targeted check:
+**Freshness gate (same-repo only):** Same-repo notifications younger than 10 minutes are likely
+being handled by a concurrent dedicated workflow (`tend-review`, `tend-mention`, etc.) that hasn't
+posted its response yet. **Skip** these — do not process, do not mark read. The next scheduled run
+will pick them up once the grace period has elapsed and the dedicated workflow has either succeeded
+or failed.
 
-For same-repo notifications on a PR or Issue, ask: has the bot posted a comment or review newer
-than the notification's `updated_at`?
+Cross-repo notifications are exempt from the freshness gate — no dedicated workflow handles them.
+
+**Dedup check:** For same-repo notifications older than 10 minutes, check whether the bot already
+responded:
 
 ```bash
 BOT_LOGIN=$(gh api user --jq '.login')
@@ -115,7 +118,7 @@ The notifications skill is the **sole handler** for these categories — respond
 
 - **Cross-repo mentions** — the bot was `@`-mentioned in another repository. Read the context and respond helpfully, but do not push code or create PRs in other repos (per step 3 scope rules).
 
-- **Stale unanswered items** — notifications where the `updated_at` timestamp is more than 30 minutes old and no bot response exists. This catches items where a dedicated workflow was expected to run but failed or was skipped. Process these as if they were new:
+- **Stale unanswered items** — same-repo notifications older than 10 minutes where no bot response exists. This catches items where a dedicated workflow was expected to run but failed or was skipped. Process these as if they were new:
   - For issues: attempt triage following `/tend-ci-runner:triage`.
   - For PRs with review requested: load `/tend-ci-runner:review`.
   - For mentions/comments: read context and respond helpfully.


### PR DESCRIPTION
Empirical data (4.5-day sample across worktrunk + tend) showed two waste patterns in `tend-notifications`:

**Races (2/6 substantive runs):** tend-notifications grabbed fresh notifications while tend-mention/tend-review were concurrently handling the same event. One case produced duplicate PRs for the same issue; another posted a duplicate reply 20s before tend-mention finished.

**Bot-closed-PR noise (6/13 "substantive" runs):** The bot auto-subscribes to its own PRs. After merge, subscription notifications lingered and Claude spent 100-300s per run cross-checking before marking them read.

Two new pre-check layers in `generate_notifications`:

- **Layer C**: PATCH-reads notifications on bot-authored closed PRs — permanent drop, these are pure dedup noise.
- **Layer D**: Counts only "processable" notifications — cross-repo (no race possible) OR same-repo with `updated_at` older than 10 minutes (dedicated workflows have had time to complete). Fresh same-repo notifications are left unread for the next scheduled run.

SKILL.md step 4a gains a matching freshness gate so Claude also skips fresh same-repo notifications if invoked via `workflow_dispatch`. Stale-item threshold tightened from 30min to 10min to match.

> _This was written by Claude Code on behalf of @max-sixty_