### PR TITLE
fix(review-reviewers): resolve target repo's bot from .config/tend.toml

### DIFF
--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -74,10 +74,21 @@ Use `TRACKING_LABEL="review-reviewers-tracking"` for this skill's tracking issue
 
 ## Step 1: Setup
 
-Resolve the bot's identity and load repo-specific guidance upfront — both are needed throughout:
+Resolve the **target repo's** bot login and load repo-specific guidance upfront — both are
+needed throughout. `gh api user` returns the *analysis* bot (e.g., `tend-agent` when
+review-reviewers runs on tend), which is typically **not** the target repo's bot
+(e.g., `worktrunk-bot`) — filtering reviews/comments by the wrong login produces false
+"no bot output" negatives. Read `bot_name` from the target repo's `.config/tend.toml`:
 
 ```bash
-BOT_LOGIN=$(gh api user --jq '.login')
+BOT_LOGIN=$(gh api "repos/$ARGUMENTS/contents/.config/tend.toml" --jq '.content' 2>/dev/null \
+  | base64 -d 2>/dev/null \
+  | grep -E '^bot_name\s*=' | head -1 | sed -E 's/.*=\s*"?([^"]+)"?.*/\1/')
+if [ -z "$BOT_LOGIN" ]; then
+  echo "ERROR: could not resolve bot_name from $ARGUMENTS/.config/tend.toml" >&2
+  exit 1
+fi
+echo "BOT_LOGIN=$BOT_LOGIN (target: $ARGUMENTS)"
 ```
 
 Read the target repo's repo-specific guidance to understand what the bot was told to do:


### PR DESCRIPTION
## Summary

The review-reviewers skill's Step 1 resolved `BOT_LOGIN` with `gh api user --jq '.login'`, which returns the currently authenticated analysis bot — e.g., `tend-agent` when review-reviewers runs on tend. That login is **not** the target repo's bot when analyzing cross-repo (e.g., `worktrunk-bot` on max-sixty/worktrunk, `prql-bot` on PRQL/prql). The wrong login was then passed into the Haiku outcome-survey subagent's prompt as ``The bot's login is `$BOT_LOGIN`.``, and the subagent filtered reviews/comments by that wrong login → false "no bot output" negatives on runs where real bot reviews were posted.

Fix: read `bot_name` from the target repo's `.config/tend.toml` — the authoritative source every tend adopter already declares.

## Evidence

**Run**: [24295690958](https://github.com/max-sixty/tend/actions/runs/24295690958) (review-reviewers on max-sixty/worktrunk)

The Haiku subagent I spawned was told ``The bot's login is `tend-agent`.`` and reported:

> - **24295397943** — `tend-review` on PR #2108 — No bot review posted despite run completing successfully
> - **24295084845** — `tend-review` on PR #2104 — No bot review posted despite run completing successfully
> - **24294851520** — `tend-review` on PR #2107 — No bot review posted despite run completing successfully

Verified directly with the actual bot login:

```
$ gh api repos/max-sixty/worktrunk/pulls/2107/reviews --jq '.[] | {user: .user.login, state, submitted_at}'
{"state":"APPROVED","submitted_at":"2026-04-12T00:25:46Z","user":"worktrunk-bot"}

$ gh api repos/max-sixty/worktrunk/pulls/2104/reviews --jq '.[] | {user: .user.login, state, submitted_at}'
{"state":"COMMENTED","submitted_at":"2026-04-12T00:09:43Z","user":"worktrunk-bot"}
{"state":"APPROVED","submitted_at":"2026-04-12T00:17:08Z","user":"worktrunk-bot"}
{"state":"APPROVED","submitted_at":"2026-04-12T00:20:28Z","user":"worktrunk-bot"}
```

So PR #2107 *was* reviewed+approved+merged, and PR #2104 had three prior bot reviews — the analysis bot filtered them out because it was looking for `tend-agent`, not `worktrunk-bot`. The false negatives would have triggered session-log drilldowns and potentially spurious findings if the main Opus agent hadn't manually double-checked.

The prior [max-sixty/worktrunk PR #2108](https://github.com/max-sixty/worktrunk/pull/2108) (bot-authored docs PR) also "looked" unreviewed — but that one was a correct silent exit on a self-authored PR, and only visible as such after verifying the bot login manually.

## Fix

Before:
```bash
BOT_LOGIN=$(gh api user --jq '.login')
```

After:
```bash
BOT_LOGIN=$(gh api "repos/$ARGUMENTS/contents/.config/tend.toml" --jq '.content' 2>/dev/null \
  | base64 -d 2>/dev/null \
  | grep -E '^bot_name\s*=' | head -1 | sed -E 's/.*=\s*"?([^"]+)"?.*/\1/')
if [ -z "$BOT_LOGIN" ]; then
  echo "ERROR: could not resolve bot_name from \$ARGUMENTS/.config/tend.toml" >&2
  exit 1
fi
```

Verified against all three live tend adopters:

| Target | Resolved BOT_LOGIN |
|---|---|
| max-sixty/worktrunk | worktrunk-bot |
| max-sixty/tend | tend-agent |
| PRQL/prql | prql-bot |

## Gate assessment

- **Evidence level**: Critical. The bug silently produces wrong analysis input for every cross-repo run. **1 occurrence is sufficient.**
- **Classification**: **Structural** — same inputs always produce the wrong `BOT_LOGIN` for cross-repo analysis. Deterministic, not model-dependent.
- **Change type**: Targeted fix (small bash-block replacement, same step, no new step).
- **Gate 1 (confidence)**: PASS — critical structural bug, 1 confirmed occurrence.
- **Gate 2 (magnitude)**: PASS — targeted fix is proportionate to the bug.

## Not fixed here (out of scope)

`plugins/tend-ci-runner/skills/review-runs/SKILL.md:101` references `$BOT_LOGIN` without defining it (that skill runs in-repo, so `gh api user` would at least be consistent, but the var is never set). Separate problem; leaving alone.

## Test plan

- [x] Pre-commit passes on edited file
- [x] Dry-run of the new bash block correctly resolves `worktrunk-bot` from `max-sixty/worktrunk/.config/tend.toml`
- [x] Dry-run resolves `tend-agent` from `max-sixty/tend/.config/tend.toml`
- [x] Dry-run resolves `prql-bot` from `PRQL/prql/.config/tend.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)