### PR TITLE
chore: add timeout-minutes to tend workflow jobs

### DIFF
--- a/.github/workflows/tend-ci-fix.yaml
+++ b/.github/workflows/tend-ci-fix.yaml
@@ -17,6 +17,7 @@ jobs:
   fix-ci:
     if: github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/tend-mention.yaml
+++ b/.github/workflows/tend-mention.yaml
@@ -145,6 +145,7 @@ jobs:
       group: ${{ github.workflow }}-handle-${{ github.event.issue.number || github.event.pull_request.number }}
       cancel-in-progress: false
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/tend-nightly.yaml
+++ b/.github/workflows/tend-nightly.yaml
@@ -15,6 +15,7 @@ on:
 jobs:
   nightly:
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/tend-notifications.yaml
+++ b/.github/workflows/tend-notifications.yaml
@@ -15,6 +15,7 @@ on:
 jobs:
   notifications:
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/tend-review-runs.yaml
+++ b/.github/workflows/tend-review-runs.yaml
@@ -15,6 +15,7 @@ on:
 jobs:
   review-runs:
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/tend-review.yaml
+++ b/.github/workflows/tend-review.yaml
@@ -19,6 +19,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/tend-triage.yaml
+++ b/.github/workflows/tend-triage.yaml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   triage:
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/tend-weekly.yaml
+++ b/.github/workflows/tend-weekly.yaml
@@ -15,6 +15,7 @@ on:
 jobs:
   weekly:
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary
- Adds `timeout-minutes: 60` to all `tend-*` workflow jobs
- The published generator already emits this, but the committed workflows were missing it
- Without an explicit timeout, runaway jobs fall back to GitHub's 6-hour default

## Test plan
- [ ] Verify `cd generator && uv run pytest` passes
- [ ] Confirm no other workflow content was modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)