### PR TITLE
fix(action): repair notification marking — resolve run_started_at, catch API errors

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -221,13 +221,8 @@ runs:
             ;;
         esac
 
-        # github.run_started_at is not a real context property — the env
-        # expression only has a value for workflow_run events.  Fall back
-        # to the REST API, then to "now" if the API call fails.
-        if [ -z "$RUN_STARTED_AT" ]; then
-          RUN_STARTED_AT=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
-            --jq '.run_started_at' 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)
-        fi
+        RUN_STARTED_AT=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+          --jq '.run_started_at')
 
         # Wrap in a subshell — a transient API error (non-JSON response)
         # must not fail the composite action.
@@ -240,7 +235,6 @@ runs:
             done) || echo "::warning::Failed to mark notification as read (non-fatal)"
       env:
         GH_TOKEN: ${{ inputs.github_token }}
-        RUN_STARTED_AT: ${{ github.event.workflow_run.created_at }}
 
     - name: Token usage
       if: always()

--- a/action.yaml
+++ b/action.yaml
@@ -221,16 +221,26 @@ runs:
             ;;
         esac
 
-        gh api notifications \
+        # github.run_started_at is not a real context property — the env
+        # expression only has a value for workflow_run events.  Fall back
+        # to the REST API, then to "now" if the API call fails.
+        if [ -z "$RUN_STARTED_AT" ]; then
+          RUN_STARTED_AT=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --jq '.run_started_at' 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)
+        fi
+
+        # Wrap in a subshell — a transient API error (non-JSON response)
+        # must not fail the composite action.
+        (gh api notifications \
           | jq -r --arg url "$SUBJECT_URL" --arg started "$RUN_STARTED_AT" \
               '.[] | select(.subject.url == $url and .updated_at <= $started) | .id' \
           | while read -r tid; do
               [ -n "$tid" ] || continue
               gh api "notifications/threads/$tid" -X PATCH || true
-            done
+            done) || echo "::warning::Failed to mark notification as read (non-fatal)"
       env:
         GH_TOKEN: ${{ inputs.github_token }}
-        RUN_STARTED_AT: ${{ github.event.workflow_run.created_at || github.run_started_at }}
+        RUN_STARTED_AT: ${{ github.event.workflow_run.created_at }}
 
     - name: Token usage
       if: always()


### PR DESCRIPTION
## Summary

- Fix `run_started_at` resolution — `github.run_started_at` is not a real context property, so the env was always empty for non-`workflow_run` events. Now fetched from the REST API (`repos/{owner}/{repo}/actions/runs/{id}`), which works for all event types.
- Wrap the `gh api notifications | jq` pipeline in a subshell with a warning fallback, so a transient API error (non-JSON response) emits a warning instead of failing the composite action.

## Evidence

Observed on PRQL/prql runs [24301240279](https://github.com/PRQL/prql/actions/runs/24301240279) (`tend-review`) and [24301252595](https://github.com/PRQL/prql/actions/runs/24301252595) (`tend-triage`) on 2026-04-12. Both failed with:

```
jq: parse error: Invalid numeric literal at line 1, column 2
##[error]Process completed with exit code 5.
```

Verified that `RUN_STARTED_AT` is empty in successful runs too (e.g., tend-notifications run [24301882032](https://github.com/PRQL/prql/actions/runs/24301882032)), confirming `github.run_started_at` is universally absent.

**Gate assessment**: High confidence (verified directly via docs and live runs), structural (same conditions always produce the same result), targeted fix.

## Test plan

- [x] `cd generator && uv run pytest` — 158 passed
- [ ] Verify on next PRQL/prql `pull_request_target` or `issues` event that `RUN_STARTED_AT` is populated and the step doesn't crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)