### PR TITLE
fix(action): race condition in outage error extraction

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -299,13 +299,18 @@ runs:
 
         TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-        # Fetch error annotations from the current (in-progress) job
+        # Fetch error annotations from the current job.
+        # Sleep briefly — GitHub indexes ##[error] annotations asynchronously
+        # and they may not be available via the API immediately after the step
+        # fails. Also match both in_progress (normal) and failure (if GitHub
+        # already transitioned the status) to handle matrix timing.
+        sleep 5
         ERRORS=""
         JOB_ID=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs" \
-          --jq '[.jobs[] | select(.status == "in_progress")] | first | .id' 2>/dev/null || true)
+          --jq '[.jobs[] | select(.status == "in_progress" or .conclusion == "failure")] | first | .id' 2>/dev/null || true)
         if [ -n "$JOB_ID" ] && [ "$JOB_ID" != "null" ]; then
           ERRORS=$(gh api "repos/${GITHUB_REPOSITORY}/check-runs/${JOB_ID}/annotations" \
-            --jq '[.[] | select(.annotation_level == "failure") | .message] | join("\n")' 2>/dev/null || true)
+            --jq '[.[] | select(.annotation_level == "failure") | .message | select(test("^Process completed") | not)] | join("\n")' 2>/dev/null || true)
         fi
 
         ERROR_BLOCK=""


### PR DESCRIPTION
## Summary

- Fix race condition where the Report failure step queries the annotations API before GitHub has indexed the `##[error]` output from the failed step
- Broaden job-status filter to match both `in_progress` and `failure` states, handling matrix workflow timing where the job status may have transitioned
- Filter out the generic "Process completed with exit code 1" annotation which adds no diagnostic value

Diagnosed in #184 — the error extraction code was present but never surfaced errors because annotations weren't available yet at query time.

## Test plan

- [ ] Wait for the next `review-reviewers` failure (or trigger one) and verify the issue comment includes `<details><summary>Error details</summary>` with the actual error message
- [ ] Verify successful runs are unaffected (the `Report failure` step only runs on failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
