### PR TITLE
skills(triage): skip maintainer-deferral when filer is a maintainer

### DIFF
--- a/plugins/tend-ci-runner/skills/triage/SKILL.md
+++ b/plugins/tend-ci-runner/skills/triage/SKILL.md
@@ -177,6 +177,15 @@ Always comment via `gh issue comment`. Keep it brief, polite, and specific. A
 maintainer will always review — never claim the issue is fully resolved by
 automation alone.
 
+**Drop the "a maintainer will review" closer when `author_association` is
+`OWNER`, `MEMBER`, or `COLLABORATOR`** — deferring to a maintainer reads as
+absurd when the reporter is one. Keep it otherwise, where it signals the
+action isn't authoritative.
+
+```bash
+gh issue view $ARGUMENTS --json author,authorAssociation --jq '.authorAssociation'
+```
+
 **Stay within what you verified.** State facts you found in the codebase — don't characterize
 something as "known" unless you find prior issues or documentation about it. Don't speculate
 beyond the code you read.
@@ -235,3 +244,14 @@ Choose the appropriate template:
 ### Duplicate
 
 > Thanks for reporting this! This appears to be related to #EXISTING_ISSUE [and/or PR #EXISTING_PR]. I'll leave it to a maintainer to confirm and link them.
+
+### Maintainer-filed request (feature example)
+
+When the filer's `author_association` is `OWNER`, `MEMBER`, or `COLLABORATOR`,
+drop the deferral closer and the "I'll leave it for a maintainer to evaluate
+and prioritize" framing — the filer already has that authority. The opener can
+stay or go; lead with substance either way.
+
+> Searched the codebase — no existing implementation of [feature]. The closest related functionality is [X], which does [Y].
+>
+> [If a PR was opened: opened #PR_NUMBER with an implementation.]


### PR DESCRIPTION
The bot was routinely appending "A maintainer will review it shortly" on issues filed by the owner/members themselves — telling the maintainer that a maintainer will review reads as absurd.

The closer is still informative for non-maintainer reporters (signals the bot's action isn't authoritative), so this is a conditional rather than a blanket removal. Keyed on `author_association`: drop the closer for `OWNER`/`MEMBER`/`COLLABORATOR`, keep it for everyone else.

Also adds one new template section (`### Maintainer-filed request`) showing what a substantive response looks like without the deferral framing.

All existing non-maintainer templates are unchanged.