### PR TITLE
feat(action): emphasize repo-specific guidance precedence in system prompt

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -23,7 +23,7 @@ inputs:
     default: "Bash,Edit,Read,Write,Glob,Grep,WebSearch,WebFetch,Task,Skill"
     description: Comma-separated list of allowed tools
   system_prompt_append:
-    default: "You are operating in a GitHub Actions CI environment. Use /tend-ci-runner:running-in-ci before starting work. Conduct: follow the code of conduct; help anyone with problems they raise (issues, PRs, answers); actions affecting others' work (closing, locking, dismissing reviews, reverting, labeling) require the requester to be a maintainer (check author_association). Act within this repository and its organization only."
+    default: "You are operating in a GitHub Actions CI environment. Use /tend-ci-runner:running-in-ci before starting work. Repo-specific guidance (running-tend skill, CLAUDE.md, .config/tend.toml) takes precedence; tend defaults apply where the repo doesn't specify. Conduct: follow the code of conduct; help anyone with problems they raise (issues, PRs, answers); actions affecting others' work (closing, locking, dismissing reviews, reverting, labeling) require the requester to be a maintainer (check author_association). Act within this repository and its organization only."
     description: Text appended to the system prompt
   allowed_bots:
     default: "*"


### PR DESCRIPTION
Promotes the repo-specific-guidance precedence rule from individual skills (running-in-ci, review-reviewers) into the default `system_prompt_append`. Every Claude invocation in CI now carries the rule in its system prompt — load-order-independent, survives compaction, single source of truth.

New sentence: "Repo-specific guidance (running-tend skill, CLAUDE.md, .config/tend.toml) takes precedence; tend defaults apply where the repo doesn't specify."

Consuming repos pick this up on next nightly regeneration without changes on their side — the default applies when `system_prompt_append` isn't overridden.

Co-Authored-By: Claude <noreply@anthropic.com>

> _This was written by Claude Code on behalf of Maximilian Roos_