### PR TITLE
skills(review): disambiguate self-authored PRs from owner-authored PRs

### DIFF
--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -181,11 +181,6 @@ attempt `gh pr review --approve` — GitHub rejects self-approvals. Submit as CO
 concerns, or stay silent and skip to step 6. Always post CI failure analysis as a COMMENT, even on
 self-authored PRs.
 
-PRs authored by the repo owner, a maintainer, or any other human are **not** self-authored.
-GitHub only blocks self-approval when reviewer and author are the same account, so approve those
-PRs normally when there are no concerns — do not fall back to "skip review, owner can't
-self-approve." That reasoning only applies when `PR_AUTHOR` exactly equals `BOT_LOGIN`.
-
 **Not confident enough to approve** (unfamiliar module, subtle logic): Add a `+1` reaction
 instead — no review needed unless there are specific observations.
 

--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -174,11 +174,17 @@ when deciding whether to approve — the value of this review is as an uncorrela
 this bypass or duplicate an existing API?" "What does this change *not* handle?" If the design
 involves a judgment call, flag it for human review as a COMMENT.
 
-**Self-authored PRs** (`PR_AUTHOR == BOT_LOGIN`): Still perform the full review (steps 2-3) —
+**Self-authored PRs** (`PR_AUTHOR == BOT_LOGIN` — compare the literal bot login string, not
+"authored by someone senior" or "by the repo owner"): Still perform the full review (steps 2-3) —
 self-review catches real issues (lint failures, edge cases) and is intentionally valuable. Do NOT
 attempt `gh pr review --approve` — GitHub rejects self-approvals. Submit as COMMENT when there are
 concerns, or stay silent and skip to step 6. Always post CI failure analysis as a COMMENT, even on
 self-authored PRs.
+
+PRs authored by the repo owner, a maintainer, or any other human are **not** self-authored.
+GitHub only blocks self-approval when reviewer and author are the same account, so approve those
+PRs normally when there are no concerns — do not fall back to "skip review, owner can't
+self-approve." That reasoning only applies when `PR_AUTHOR` exactly equals `BOT_LOGIN`.
 
 **Not confident enough to approve** (unfamiliar module, subtle logic): Add a `+1` reaction
 instead — no review needed unless there are specific observations.


### PR DESCRIPTION
## Summary

Two `tend-review` runs on `max-sixty/worktrunk` this hour completed with conclusion `success` but posted zero reviews on trivial `max-sixty`-authored PRs. Session logs show identical hallucinated reasoning: the bot concluded "PR is self-authored by the owner (max-sixty), I'll not submit a review (GitHub rejects self-approval)." The bot's login is `worktrunk-bot` — a distinct account from `max-sixty` — and other runs in the same hour correctly approved `max-sixty`-authored PRs (#2140, #2141, #2143, #2146, #2147, #2148). The conflation of "repo owner" with "self" is the bug.

## Evidence

| Run | PR | Author | Bot output |
|---|---|---|---|
| [24320901871](https://github.com/max-sixty/worktrunk/actions/runs/24320901871) | [#2149](https://github.com/max-sixty/worktrunk/pull/2149) (docs-only, 8 lines) | `max-sixty` | no review, ran ~10 min then exited |
| [24320033081](https://github.com/max-sixty/worktrunk/actions/runs/24320033081) | [#2142](https://github.com/max-sixty/worktrunk/pull/2142) (7-line TODO comment) | `max-sixty` | no review, ran ~10 min then exited |

Both sessions substantively reviewed the code, found no concerns, and then rationalized skipping with the incorrect "self-approval" reasoning. Excerpt from run 24320901871:

> Since the PR is self-authored by the owner, I'll not submit a review (GitHub rejects self-approval) and instead skip to CI monitoring per the workflow.

Both PRs merged without any automated review. No user-visible harm (max-sixty merged them), but the bot spent ~20 minutes of compute producing nothing.

## Gate assessment

- **Evidence level**: High — 2 occurrences this hour with identical reasoning chain across two different PRs. No matching precedent in the `review-reviewers-tracking: 2026-04` tracking issue (prior "self-authored" entries there describe genuinely bot-authored PRs being handled correctly).
- **Failure class**: Stochastic, but with a consistent trigger — trivial PRs where the bot finds nothing substantive to comment on seem to push the model toward fabricating an escape hatch.
- **Proposed change type**: Targeted clarification (7 new lines, no restructuring).
- **Gate 1**: High evidence, 2 occurrences ≥ 2–3 minimum → passes.
- **Gate 2**: Targeted fix to an existing paragraph → normal bar, passes.

## Fix

The existing guidance at `plugins/tend-ci-runner/skills/review/SKILL.md:177` already defines self-authored as `PR_AUTHOR == BOT_LOGIN`, but the model still pattern-matched "self" onto "repo owner." Add an explicit negative: human authors (including the owner and maintainers) are **not** self-authored; approve normally.

## Test plan

- [ ] Verify skill still renders correctly (pre-commit passes).
- [ ] Monitor `tend-review` runs on `max-sixty/worktrunk` over the next few days — trivial human-authored PRs should either get an APPROVE or a `+1` reaction, not a silent 10-minute no-op.