### PR TITLE
docs(claude.md): document local-workflow update policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,4 +48,11 @@ Consuming repos regenerate their `tend-*.yaml` workflows nightly (tend itself
 included — it dogfoods its own workflows). Changes to the generator do not
 require manual regeneration in downstream repos.
 
+Tend's own `tend-*.yaml` workflows track the latest published release. They
+update each night via `uvx tend@latest init`. Updating earlier to the latest
+release (e.g., during a release commit) is fine. Do not update them beyond
+the latest release using the in-tree generator — between a generator commit
+and the next release, the local workflows lag the in-tree generator, and
+that is expected; the gap closes at the next release.
+
 Linting: `pre-commit run --all-files` (ruff, typos, actionlint, uv-lock).

--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -103,11 +103,22 @@ Used by both Step 2 (applied to recent diffs) and Step 4 (applied to full files)
 Regenerate the tend workflow files and open a PR if anything changed. The
 checkout's `.github/` directory may be mounted read-only under the sandbox
 (protecting bots from modifying their own workflows in place), so do the
-regeneration in a git worktree under `$TMPDIR`, which is writable:
+regeneration in a git worktree under `$TMPDIR`, which is writable.
+
+If the repo contains the tend generator in-tree (`generator/pyproject.toml`
+exists — i.e. the tend repo itself), run against the in-tree generator so
+nightly regeneration reflects `main`'s generator state. Otherwise, use the
+published release. Running `uvx tend@latest init` on tend itself would pull
+from PyPI, which lags `main` — that produces PRs that revert unreleased
+generator commits back to the last published version.
 
 ```bash
 git worktree add "$TMPDIR/tend-update-workflows" -b tend/update-workflows HEAD
-(cd "$TMPDIR/tend-update-workflows" && uvx tend@latest init)
+if [ -f "$TMPDIR/tend-update-workflows/generator/pyproject.toml" ]; then
+  (cd "$TMPDIR/tend-update-workflows" && uv run --project generator tend init)
+else
+  (cd "$TMPDIR/tend-update-workflows" && uvx tend@latest init)
+fi
 git -C "$TMPDIR/tend-update-workflows" status --porcelain .github/workflows
 ```
 

--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -105,20 +105,19 @@ checkout's `.github/` directory may be mounted read-only under the sandbox
 (protecting bots from modifying their own workflows in place), so do the
 regeneration in a git worktree under `$TMPDIR`, which is writable.
 
-If the repo contains the tend generator in-tree (`generator/pyproject.toml`
-exists — i.e. the tend repo itself), run against the in-tree generator so
-nightly regeneration reflects `main`'s generator state. Otherwise, use the
-published release. Running `uvx tend@latest init` on tend itself would pull
-from PyPI, which lags `main` — that produces PRs that revert unreleased
-generator commits back to the last published version.
+**Skip this step on tend itself.** If the repo contains the tend generator
+in-tree (`generator/pyproject.toml` exists), workflow regeneration is part of
+the release flow, not nightly. Running `uvx tend@latest init` against tend
+between releases produces PRs that revert unreleased generator commits back to
+the last published version.
 
 ```bash
-git worktree add "$TMPDIR/tend-update-workflows" -b tend/update-workflows HEAD
-if [ -f "$TMPDIR/tend-update-workflows/generator/pyproject.toml" ]; then
-  (cd "$TMPDIR/tend-update-workflows" && uv run --project generator tend init)
-else
-  (cd "$TMPDIR/tend-update-workflows" && uvx tend@latest init)
+if [ -f generator/pyproject.toml ]; then
+  echo "Skipping workflow regen on tend (handled at release time)"
+  exit 0
 fi
+git worktree add "$TMPDIR/tend-update-workflows" -b tend/update-workflows HEAD
+(cd "$TMPDIR/tend-update-workflows" && uvx tend@latest init)
 git -C "$TMPDIR/tend-update-workflows" status --porcelain .github/workflows
 ```
 

--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -103,19 +103,9 @@ Used by both Step 2 (applied to recent diffs) and Step 4 (applied to full files)
 Regenerate the tend workflow files and open a PR if anything changed. The
 checkout's `.github/` directory may be mounted read-only under the sandbox
 (protecting bots from modifying their own workflows in place), so do the
-regeneration in a git worktree under `$TMPDIR`, which is writable.
-
-**Skip this step on tend itself.** If the repo contains the tend generator
-in-tree (`generator/pyproject.toml` exists), workflow regeneration is part of
-the release flow, not nightly. Running `uvx tend@latest init` against tend
-between releases produces PRs that revert unreleased generator commits back to
-the last published version.
+regeneration in a git worktree under `$TMPDIR`, which is writable:
 
 ```bash
-if [ -f generator/pyproject.toml ]; then
-  echo "Skipping workflow regen on tend (handled at release time)"
-  exit 0
-fi
 git worktree add "$TMPDIR/tend-update-workflows" -b tend/update-workflows HEAD
 (cd "$TMPDIR/tend-update-workflows" && uvx tend@latest init)
 git -C "$TMPDIR/tend-update-workflows" status --porcelain .github/workflows


### PR DESCRIPTION
## Summary

Per maintainer guidance ([comment](https://github.com/max-sixty/tend/pull/265#issuecomment-4234764327)): document the local-workflow update policy in CLAUDE.md rather than adding skip logic to the nightly skill. Tend's `tend-*.yaml` workflows track the latest published release; nightly regen via `uvx tend@latest init` is the source of truth, updating earlier to the latest release is fine, and the in-tree generator should not push workflows beyond the latest release. The lag between a generator commit and the next release is expected and closes at the next release.

The earlier nightly-skill skip is reverted; only CLAUDE.md changes remain.

## Test plan

- [ ] Future nightly runs on tend continue to regen against `uvx tend@latest`; reviewers reading CLAUDE.md understand the resulting "revert" PRs are expected during the post-commit/pre-release window
