### PR TITLE
fix(action): restore token aggregation broken by result-event filter

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -240,40 +240,39 @@ runs:
       if: always()
       id: tokens
       shell: bash
+      env:
+        EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
+        MODEL: ${{ inputs.model }}
       run: |
         LOGS_DIR="/home/runner/.claude/projects"
         mkdir -p "$LOGS_DIR"
 
-        mapfile -t FILES < <(find "$LOGS_DIR" -name "*.jsonl" -type f 2>/dev/null)
-
-        MODEL="${{ inputs.model }}"
-        if [ ${#FILES[@]} -eq 0 ]; then
-          USAGE='{"input_tokens":0,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"turns":0,"model":"'"$MODEL"'","cost_usd":0}'
+        # claude-code-action writes the full SDK message stream to
+        # $RUNNER_TEMP/claude-execution-output.json and exposes the path as
+        # its `execution_file` output. The array ends with a
+        # `type: "result"` entry that carries total_cost_usd, num_turns,
+        # and the per-session usage totals across all models — so cost
+        # stays accurate regardless of which model the session used.
+        if [ -n "$EXECUTION_FILE" ] && [ -f "$EXECUTION_FILE" ]; then
+          USAGE=$(jq -c --arg model "$MODEL" '
+            (map(select(.type == "result")) | last) as $r |
+            if $r == null then
+              {input_tokens:0, output_tokens:0, cache_creation_input_tokens:0,
+               cache_read_input_tokens:0, turns:0, model:$model, cost_usd:0}
+            else
+              {
+                input_tokens: ($r.usage.input_tokens // 0),
+                output_tokens: ($r.usage.output_tokens // 0),
+                cache_creation_input_tokens: ($r.usage.cache_creation_input_tokens // 0),
+                cache_read_input_tokens: ($r.usage.cache_read_input_tokens // 0),
+                turns: ($r.num_turns // 0),
+                model: $model,
+                cost_usd: (($r.total_cost_usd // 0) * 100 | round / 100)
+              }
+            end
+          ' "$EXECUTION_FILE")
         else
-          # Aggregate usage across assistant turns. claude-code-action's
-          # session JSONL does not emit a `type: "result"` summary entry, so
-          # cost is computed from per-turn usage × published rates rather
-          # than read from `total_cost_usd`. Rates are Claude Opus 4 list
-          # prices ($/MTok): input 15, output 75, cache write 18.75
-          # (5m default), cache read 1.50.
-          USAGE=$(cat "${FILES[@]}" | jq -sc --arg model "$MODEL" '
-            [.[] | select(.type == "assistant") | .message.usage | select(.)] |
-            {
-              input_tokens: (map(.input_tokens // 0) | add // 0),
-              output_tokens: (map(.output_tokens // 0) | add // 0),
-              cache_creation_input_tokens: (map(.cache_creation_input_tokens // 0) | add // 0),
-              cache_read_input_tokens: (map(.cache_read_input_tokens // 0) | add // 0),
-              turns: length,
-              model: $model
-            } | . + {
-              cost_usd: (
-                (.input_tokens * 15
-                 + .output_tokens * 75
-                 + .cache_creation_input_tokens * 18.75
-                 + .cache_read_input_tokens * 1.5) / 1000000
-                | . * 100 | round / 100
-              )
-            }')
+          USAGE='{"input_tokens":0,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"turns":0,"model":"'"$MODEL"'","cost_usd":0}'
         fi
 
         echo "$USAGE" > "$LOGS_DIR/token-usage.json"

--- a/action.yaml
+++ b/action.yaml
@@ -250,16 +250,29 @@ runs:
         if [ ${#FILES[@]} -eq 0 ]; then
           USAGE='{"input_tokens":0,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"turns":0,"model":"'"$MODEL"'","cost_usd":0}'
         else
+          # Aggregate usage across assistant turns. claude-code-action's
+          # session JSONL does not emit a `type: "result"` summary entry, so
+          # cost is computed from per-turn usage × published rates rather
+          # than read from `total_cost_usd`. Rates are Claude Opus 4 list
+          # prices ($/MTok): input 15, output 75, cache write 18.75
+          # (5m default), cache read 1.50.
           USAGE=$(cat "${FILES[@]}" | jq -sc --arg model "$MODEL" '
-            [.[] | select(.type == "result")] |
+            [.[] | select(.type == "assistant") | .message.usage | select(.)] |
             {
-              input_tokens: (map(.usage.input_tokens // 0) | add // 0),
-              output_tokens: (map(.usage.output_tokens // 0) | add // 0),
-              cache_creation_input_tokens: (map(.usage.cache_creation_input_tokens // 0) | add // 0),
-              cache_read_input_tokens: (map(.usage.cache_read_input_tokens // 0) | add // 0),
-              turns: (map(.num_turns // 0) | add // 0),
-              model: $model,
-              cost_usd: (map(.total_cost_usd // 0) | add // 0 | . * 100 | round / 100)
+              input_tokens: (map(.input_tokens // 0) | add // 0),
+              output_tokens: (map(.output_tokens // 0) | add // 0),
+              cache_creation_input_tokens: (map(.cache_creation_input_tokens // 0) | add // 0),
+              cache_read_input_tokens: (map(.cache_read_input_tokens // 0) | add // 0),
+              turns: length,
+              model: $model
+            } | . + {
+              cost_usd: (
+                (.input_tokens * 15
+                 + .output_tokens * 75
+                 + .cache_creation_input_tokens * 18.75
+                 + .cache_read_input_tokens * 1.5) / 1000000
+                | . * 100 | round / 100
+              )
             }')
         fi
 


### PR DESCRIPTION
## Problem

Every `token-usage.json` since #249 reports zero tokens. Confirmed across all 61 tend CI runs in the past 24 h on this repo (12 `tend-review`, 19 `tend-mention`, 22 `review-reviewers`, 6 `tend-notifications`, 1 `tend-nightly`, 1 `tend-weekly`).

Sample artifact (run [24330280717](https://github.com/max-sixty/tend/actions/runs/24330280717), `tend-review`):

```json
{"input_tokens":0,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"turns":0,"model":"opus","cost_usd":0}
```

## Root cause

#249 added a `select(.type == "result")` filter that targets the SDK's per-session result event — which carries `total_cost_usd`, `num_turns`, and a session-level `usage` object. That event is real, but it isn't written to the per-turn session JSONL under `/home/runner/.claude/projects/`; `claude-code-action` writes it (along with the rest of the SDK message stream) to `$RUNNER_TEMP/claude-execution-output.json` and exposes that path as the `execution_file` action output. Reading from `/home/runner/.claude/projects/` therefore matched zero entries and every numeric field fell back to 0.

This was masked yesterday because the 24 h analysis window straddled the #249 merge time (2026-04-11 20:28 UTC) — most artifacts in that window pre-dated the regression. Today's window is fully post-#249, so every run reports zeros.

## Fix

Read `${{ steps.claude.outputs.execution_file }}` and pull `total_cost_usd`, `num_turns`, and `usage.*` directly from the `result` entry. Cost is now whatever the SDK reports (no hard-coded model rate table), so Sonnet/Haiku adopters and 1-hour cache usage are accounted for correctly.

Verified with a synthetic execution-file array containing a real `result` entry from run 24330280717: produces `34 input / 4954 output / 1035105 cache_read / 39191 cache_creation, 24 turns, $0.89` — matches the `total_cost_usd` printed in that run's job log (0.886... rounded to 2dp).
