### PR TITLE
fix(mention): skip issue_comment events on tend-outage issues

### DIFF
--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -213,10 +213,17 @@ jobs:
   verify:
     # Filter out fork PRs for review events — secrets are unavailable there
     # (no _target variant exists). The notifications workflow polls for these.
+    # Skip comments on `tend-outage` issues: the action's Report-failure step
+    # auto-comments on those when Claude invocation fails, and without this
+    # guard those comments re-trigger tend-mention during a persistent outage
+    # (e.g. Anthropic 401), producing a self-sustaining ~1 run/minute loop
+    # until the outage clears. The prompt's self-loop guard can't help here
+    # because the model never executes — the action fails before Claude starts.
     if: |
       (github.event_name == 'issues' &&
         contains(github.event.issue.body, '@{bn}')) ||
-      (github.event_name == 'issue_comment') ||
+      (github.event_name == 'issue_comment' &&
+        !contains(github.event.issue.labels.*.name, 'tend-outage')) ||
       (github.event_name == 'pull_request_review_comment' &&
         github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'pull_request_review' &&

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
@@ -34,10 +34,17 @@ jobs:
   verify:
     # Filter out fork PRs for review events ? secrets are unavailable there
     # (no _target variant exists). The notifications workflow polls for these.
+    # Skip comments on `tend-outage` issues: the action's Report-failure step
+    # auto-comments on those when Claude invocation fails, and without this
+    # guard those comments re-trigger tend-mention during a persistent outage
+    # (e.g. Anthropic 401), producing a self-sustaining ~1 run/minute loop
+    # until the outage clears. The prompt's self-loop guard can't help here
+    # because the model never executes ? the action fails before Claude starts.
     if: |
       (github.event_name == 'issues' &&
         contains(github.event.issue.body, '@test-bot')) ||
-      (github.event_name == 'issue_comment') ||
+      (github.event_name == 'issue_comment' &&
+        !contains(github.event.issue.labels.*.name, 'tend-outage')) ||
       (github.event_name == 'pull_request_review_comment' &&
         github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'pull_request_review' &&

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
@@ -34,10 +34,17 @@ jobs:
   verify:
     # Filter out fork PRs for review events ? secrets are unavailable there
     # (no _target variant exists). The notifications workflow polls for these.
+    # Skip comments on `tend-outage` issues: the action's Report-failure step
+    # auto-comments on those when Claude invocation fails, and without this
+    # guard those comments re-trigger tend-mention during a persistent outage
+    # (e.g. Anthropic 401), producing a self-sustaining ~1 run/minute loop
+    # until the outage clears. The prompt's self-loop guard can't help here
+    # because the model never executes ? the action fails before Claude starts.
     if: |
       (github.event_name == 'issues' &&
         contains(github.event.issue.body, '@test-bot')) ||
-      (github.event_name == 'issue_comment') ||
+      (github.event_name == 'issue_comment' &&
+        !contains(github.event.issue.labels.*.name, 'tend-outage')) ||
       (github.event_name == 'pull_request_review_comment' &&
         github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'pull_request_review' &&


### PR DESCRIPTION
## Summary

The `tend-mention` workflow entered a self-sustaining feedback loop during a ~80-minute Anthropic API authentication outage (401 invalid bearer token) starting at 2026-04-14T03:03Z. **95 `tend-mention` runs fired in ~80 minutes**, all failing with the same 401 — see [run 24379786217](https://github.com/max-sixty/tend/actions/runs/24379786217) as a representative example.

### Root cause

1. The tend action's [`Report failure` step](https://github.com/max-sixty/tend/blob/5a27c18/action.yaml#L296-L358) auto-comments on an issue labeled `tend-outage` when Claude invocation fails.
2. The `tend-mention` `verify` job runs for every `issue_comment` event ([workflows.py:219](https://github.com/max-sixty/tend/blob/5a27c18/generator/src/tend/workflows.py#L219)).
3. Under a persistent outage, each failure-report comment re-triggers `tend-mention`, which also fails, which posts another comment → loop until the outage clears.

[#233](https://github.com/max-sixty/tend/pull/233) removed the `comment.user.login != {bn}` filter in favor of relying on the prompt's self-loop guard. That works for transient failures, but **when the API itself is unreachable, the model never executes** — the action fails before Claude starts, so the prompt-level guard is bypassed entirely.

Evidence that this is new/worsened:

| Outage issue | Created | Comments |
|---|---|---|
| [#162](https://github.com/max-sixty/tend/issues/162) | 2026-04-07 | 2 |
| [#171](https://github.com/max-sixty/tend/issues/171) | 2026-04-08 | 4 |
| [#184](https://github.com/max-sixty/tend/issues/184) | 2026-04-08 | 6 |
| [#267](https://github.com/max-sixty/tend/issues/267) | 2026-04-13 | **301** (after #233 merged 2026-04-10) |

### Fix

Add a workflow-level guard: skip `issue_comment` events on issues labeled `tend-outage`. The label is owned exclusively by the action's Report-failure step (see [action.yaml:300](https://github.com/max-sixty/tend/blob/5a27c18/action.yaml#L300)) and exists purely for operational tracking, so no legitimate bot responses belong there.

This is a workflow-level filter (not prompt-level), so it holds even when the model is unreachable. `actionlint` accepts the `!contains(github.event.issue.labels.*.name, 'tend-outage')` syntax.

### Gate assessment

- **Evidence**: Critical (clearly wrong outcome — 95 runaway runs, each invoking infrastructure) — 1 occurrence is sufficient.
- **Classification**: Structural — same conditions produce the same loop every time the underlying API is unreachable for more than one `tend-mention` cycle. No model decision involved.
- **Magnitude**: Targeted fix — one `if:` condition + generator regtest updates. Passes both gates.

## Test plan

- [x] `uv run pytest` passes (158 tests, 16 regtests auto-reset).
- [x] `actionlint` validates the regenerated `tend-mention.yaml`.
- [ ] Verify on next persistent outage that no cascade of `tend-mention` runs fires.
- [ ] Nightly regeneration picks up the change once the next release ships.
