### PR TITLE
chore: release 0.0.12

### DIFF
--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tend"
-version = "0.0.11"
+version = "0.0.12"
 description = "Claude-powered CI for GitHub repos"
 license = "MIT"
 requires-python = ">=3.11"

--- a/generator/uv.lock
+++ b/generator/uv.lock
@@ -144,7 +144,7 @@ wheels = [
 
 [[package]]
 name = "tend"
-version = "0.0.11"
+version = "0.0.12"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Bumps generator version to 0.0.12 and syncs lockfile.

50 commits since 0.0.11. Highlights:
- feat: notifications cost cut + freshness gate (#251, #254)
- feat: token-report per-run table + cost estimate (#249, #250)
- feat: review-reviewers outcome-focused Haiku analysis (#255)
- feat: config `workflow_extra` / `jobs` pass-through (#227)
- skills: canonical `author_association` tiers (#261, #263)
- fix: action token aggregation (#266), plus numerous review/mention/ci-runner fixes

> _This was written by Claude Code on behalf of Maximilian_