### PR TITLE
skills(review-reviewers): document bot-self-trigger as non-issue

### DIFF
--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -58,6 +58,20 @@ flagging expected behaviors creates maintainer churn and costs trust.
   concurrency-group cancellation, that is a *concurrency* issue (the cancelled runs managed to
   POST before the SIGTERM arrived) — do not propose changes to review's approval rules.
 
+- **`tend-mention` firing on the bot's own comments and exiting silently.** When the bot comments
+  on an issue or PR where it has previously participated (including its own tracking issues such
+  as `review-reviewers-tracking` and `review-runs-tracking`), the `issue_comment` event fires
+  `tend-mention`; the prompt's self-conversation guard then detects the self-trigger and exits
+  silently after a few Claude turns. This looks wasteful (each exit costs ~$0.20–$0.50), but
+  [#203](https://github.com/max-sixty/tend/pull/203) ("fix: filter bot self-triggers in
+  tend-mention workflow") added sender-based filters for `pull_request_review` /
+  `pull_request_review_comment` events and was closed by the maintainer without merge — the same
+  authorship-keyed-guard pattern rejected in #154 and #212. Do not propose sender-based or
+  commenter-based filters to `tend-mention`. The outage-loop guard added in
+  [#268](https://github.com/max-sixty/tend/pull/268) (skipping `tend-outage`-labeled issues) is
+  the accepted shape for a label-based skip — propose new filters only when there's a distinct
+  loop risk that can't be expressed with a label.
+
 ## Target repo
 
 **Target repo:** $ARGUMENTS


### PR DESCRIPTION
## Summary

Add a second entry to the `review-reviewers` **Non-issues** list so future
hourly runs don't re-draft sender-based filters for `tend-mention`. The entry
covers the case where the bot's own `issue_comment` (e.g., posting on a user
issue where it previously replied, or its own tracking issue) fires
`tend-mention`, which then exits silently via the prompt's self-conversation
guard.

## Evidence

Three self-trigger runs on `max-sixty/tend` in the past ~2 hours (window
15:18Z–16:17Z on 2026-04-14), each spun up Claude and exited silently:

| Run | Trigger | Cost | Turns |
|---|---|---|---|
| [24407340908](https://github.com/max-sixty/tend/actions/runs/24407340908) | `tend-agent` comment on `review-reviewers-tracking` #133 | $0.47 | 12 |
| [24409523729](https://github.com/max-sixty/tend/actions/runs/24409523729) | `tend-agent` triage comment on issue #269 | $0.20 | 6 |
| [24410231240](https://github.com/max-sixty/tend/actions/runs/24410231240) | `tend-agent` comment on tracking issue #133 | $0.22 | 7 |

All three exit with reasoning like "self-trigger, no role boundary, exiting
silently" — the prompt-level guard works correctly, just at a few hundred
tokens of cost per occurrence.

## Why no workflow fix

[#203](https://github.com/max-sixty/tend/pull/203) ("fix: filter bot
self-triggers in tend-mention workflow") proposed exactly this sender filter
for `pull_request_review` / `pull_request_review_comment` events on
2026-04-09. @max-sixty closed it without merge or comment, matching the
pattern of earlier closures of authorship-keyed guards ([#154](https://github.com/max-sixty/tend/pull/154),
[#212](https://github.com/max-sixty/tend/pull/212)) already called out in the
non-issues list. Extending the same sender filter to `issue_comment` would
fit the same rejected shape, so this PR only updates the skill to prevent
future runs from re-drafting it.

## Gate assessment

- **Evidence level**: High — 3 occurrences this run, structural (every bot
  comment on a participated-in issue fires `tend-mention` verify→handle), and
  direct prior-art signal (#203 closed by maintainer).
- **Classification**: Structural (deterministic from workflow logic) — same
  condition always produces the wasted Claude invocation.
- **Change type**: Targeted simplification — adds one bullet to an existing
  warning list. No workflow or generator changes.
- **Passes both gates**: yes (structural 1+ occurrence sufficient for
  removal/simplification; change is one-paragraph docs).

## Test plan

- [ ] Rendered non-issues list reads sensibly and cites #203 / #268 accurately
