### PR TITLE
docs(readme): note on Claude subscription & OAuth tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,19 @@ For tend-specific guidance, add a skill overlay at
 `.claude/skills/running-tend/SKILL.md`. Common uses: recording which CI
 workflow names `tend-ci-fix` watches, PR title conventions, label policies.
 
+## Using your Claude subscription
+
+Tend wraps
+[`claude-code-action`](https://github.com/anthropics/claude-code-action),
+Anthropic's official GitHub Action for running Claude Code in CI. Your
+`CLAUDE_CODE_OAUTH_TOKEN` is used exactly as it would be in any
+claude-code-action workflow — tend adds the framework (workflows, skills,
+prompts) around it but never sees the token itself.
+
+Running Anthropic's own action against your own repo, with your own OAuth
+token and Max subscription, is a supported use of Claude Code. If you already
+have a Max subscription, tend is a safe way to put it to work on your project.
+
 ## Badge
 
 A badge signals the repo is maintained with tend:


### PR DESCRIPTION
## Summary

Drafts a brief README section addressing the TOS/OAuth question raised in #269. Frames tend as a supported path for using a Claude Max subscription (wraps Anthropic's own `claude-code-action`, token is used the same as in any claude-code-action workflow), rather than as a cautionary note.

Placed after "Project context" and before "Badge" — towards the bottom as requested, near the existing `CLAUDE_CODE_OAUTH_TOKEN` mention in the Configuration section.

Happy to rework the wording — this is a first pass.

## Test plan

- [ ] Maintainer reviews wording and placement
