### PR TITLE
chore: regenerate workflows with tend 0.0.12

### DIFF
--- a/.github/workflows/tend-mention.yaml
+++ b/.github/workflows/tend-mention.yaml
@@ -34,10 +34,17 @@ jobs:
   verify:
     # Filter out fork PRs for review events — secrets are unavailable there
     # (no _target variant exists). The notifications workflow polls for these.
+    # Skip comments on `tend-outage` issues: the action's Report-failure step
+    # auto-comments on those when Claude invocation fails, and without this
+    # guard those comments re-trigger tend-mention during a persistent outage
+    # (e.g. Anthropic 401), producing a self-sustaining ~1 run/minute loop
+    # until the outage clears. The prompt's self-loop guard can't help here
+    # because the model never executes — the action fails before Claude starts.
     if: |
       (github.event_name == 'issues' &&
         contains(github.event.issue.body, '@tend-agent')) ||
-      (github.event_name == 'issue_comment') ||
+      (github.event_name == 'issue_comment' &&
+        !contains(github.event.issue.labels.*.name, 'tend-outage')) ||
       (github.event_name == 'pull_request_review_comment' &&
         github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'pull_request_review' &&

--- a/.github/workflows/tend-notifications.yaml
+++ b/.github/workflows/tend-notifications.yaml
@@ -32,7 +32,7 @@ jobs:
             exit 0
           fi
 
-          # Pre-mark notifications shadowed by recent dedicated-workflow runs.
+          # --- Layer B: drop notifications shadowed by recent dedicated runs ---
           # Event workflows mark their own notifications read via action.yaml's
           # post-step on success; this sweeps the case where Claude failed
           # (post-step is gated by `if: success()`) so the notification still
@@ -50,12 +50,40 @@ jobs:
             done
           fi
 
-          COUNT=$(gh api notifications --jq 'length')
+          # --- Layer C: drop notifications on bot-authored closed PRs ---
+          # The bot auto-subscribes to its own PRs. After merge/close, leftover
+          # subscription notifications are pure noise — no action needed.
+          NOTIFS=$(gh api notifications)
+          echo "$NOTIFS" | jq -r --arg repo "$GITHUB_REPOSITORY" '.[] | select(.repository.full_name == $repo and .subject.type == "PullRequest") | .id' | while read -r tid; do
+            [ -n "$tid" ] || continue
+            PR_NUM=$(echo "$NOTIFS" | jq -r --arg tid "$tid" '.[] | select(.id == $tid) | .subject.url | split("/") | last')
+            PR_INFO=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUM" --jq '"\(.user.login) \(.state)"' 2>/dev/null) || continue
+            PR_AUTHOR=${PR_INFO%% *}
+            PR_STATE=${PR_INFO##* }
+            if [ "$PR_AUTHOR" = "tend-agent" ] && [ "$PR_STATE" = "closed" ]; then
+              gh api "notifications/threads/$tid" -X PATCH || true
+            fi
+          done
+
+          # --- Layer D: count processable notifications ---
+          # Same-repo notifications younger than 10 minutes are deferred: a
+          # dedicated workflow (tend-review/mention/triage/ci-fix) is likely
+          # still starting up or mid-flight and hasn't posted its response yet.
+          # Processing them now risks duplicating work. Cross-repo notifications
+          # are exempt — no dedicated workflow handles them.
+          CUTOFF=$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
+          REMAINING=$(gh api notifications)
+          COUNT=$(echo "$REMAINING" | jq --arg repo "$GITHUB_REPOSITORY" --arg cutoff "$CUTOFF" '[.[] | select(.repository.full_name != $repo or .updated_at <= $cutoff)] | length')
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
           if [ "$COUNT" = "0" ]; then
-            echo "All notifications shadowed by dedicated workflows — skipping"
+            TOTAL=$(echo "$REMAINING" | jq 'length')
+            if [ "$TOTAL" = "0" ]; then
+              echo "All notifications handled by pre-checks — skipping"
+            else
+              echo "$TOTAL notification(s) remain but all are fresh same-repo (deferred) — skipping"
+            fi
           else
-            echo "$COUNT unread notification(s) remain — proceeding"
+            echo "$COUNT processable notification(s) — proceeding"
           fi
         env:
           GH_TOKEN: ${{ secrets.BOT_TOKEN }}


### PR DESCRIPTION
## Summary

Regenerates `tend-mention.yaml` and `tend-notifications.yaml` with tend 0.0.12 (released earlier today). The critical change is [#268](https://github.com/max-sixty/tend/pull/268)'s `tend-outage` skip guard for `tend-mention`, which tend's own deployed workflow has been missing since that fix landed.

## Evidence — outage loop reproduced today

[Run 24418078692](https://github.com/max-sixty/tend/actions/runs/24418078692) (review-reviewers, 2026-04-14T19:13:53Z) observed a fresh cascade on [#267](https://github.com/max-sixty/tend/issues/267):

| Time (UTC) | Run | Workflow | Result |
|---|---|---|---|
| 19:14:48Z | [24418118461](https://github.com/max-sixty/tend/actions/runs/24418118461) | tend-mention | failure → posted to #267 |
| 19:15:49Z | [24418164746](https://github.com/max-sixty/tend/actions/runs/24418164746) | tend-mention | failure → posted to #267 |
| 19:16:42Z | [24418203215](https://github.com/max-sixty/tend/actions/runs/24418203215) | tend-mention | failure → posted to #267 |
| 19:17:43Z | [24418247574](https://github.com/max-sixty/tend/actions/runs/24418247574) | tend-mention | success (Anthropic recovered) |

Each failure ran `action.yaml`'s `Report failure` step (`action.yaml:296-358`), which POSTed to the `tend-outage`-labeled #267. That `issue_comment` event re-triggered `tend-mention`, which failed the same way, producing the next run. The cascade stopped only when the Anthropic API came back online — the same pattern that produced 95 runs in ~80 minutes during the 2026-04-14T03:03Z outage documented in [#268](https://github.com/max-sixty/tend/pull/268).

## Root cause

[#268](https://github.com/max-sixty/tend/pull/268) merged the fix into `generator/src/tend/workflows.py` at 2026-04-14T13:56Z, and [#270](https://github.com/max-sixty/tend/pull/270) released 0.0.12. But tend's own `.github/workflows/tend-mention.yaml` was last regenerated at cb6e919 ([#236](https://github.com/max-sixty/tend/pull/236)), which predates #268. The deployed filter is still:

```yaml
(github.event_name == 'issue_comment') ||
```

which allows every comment on the `tend-outage` issue to re-trigger the workflow. This PR applies the 0.0.12 generator, which emits the guarded form:

```yaml
(github.event_name == 'issue_comment' &&
  !contains(github.event.issue.labels.*.name, 'tend-outage')) ||
```

## What's in this regen

- `tend-mention.yaml`: [#268](https://github.com/max-sixty/tend/pull/268) `tend-outage` skip guard.
- `tend-notifications.yaml`: [#254](https://github.com/max-sixty/tend/pull/254) freshness gate (Layer D) + bot-closed-PR drop (Layer C). Already released in 0.0.12; regenerating brings tend's own workflow in line.

CLAUDE.md authorizes regenerating to the latest release ("Updating earlier to the latest release (e.g., during a release commit) is fine"); 0.0.12 was released today in [#270](https://github.com/max-sixty/tend/pull/270).

## Gate assessment

- **Classification**: Structural — same conditions reproduce every time. An Anthropic outage lasting ≥ ~2 min triggers the cascade with probability 1 under the current deployed filter.
- **Evidence level**: Critical. 1 occurrence this run + 1 historical occurrence (95 runs on 2026-04-14T03:03Z, documented in [#268](https://github.com/max-sixty/tend/pull/268)). Per `review-gates.md`, a structural failure with a clear critical outcome passes Gate 1 at 1 occurrence.
- **Change type**: Mechanical regeneration. No generator or skill changes — only workflow YAML regenerated from already-merged, already-released source.
- **Gates**: Pass / Pass.

## Test plan

- [ ] CI green on this PR.
- [ ] On the next Anthropic outage lasting ≥ 2 minutes, `tend-mention` stays quiet on #267 instead of looping — the cascade can't re-enter because the `issue_comment` filter now excludes `tend-outage`-labeled issues.
