### PR TITLE
fix(release): regenerate tend's own workflows after PyPI release

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -18,6 +18,8 @@ metadata:
 7. **Merge to main**: Create PR via `gh pr create`, wait for CI, merge with `gh pr merge --squash`
 8. **Tag and push**: `git tag X.Y.Z && git push origin X.Y.Z` (triggers PyPI release workflow in `.github/workflows/pypi-release.yaml`)
 9. **Wait for PyPI release**: Poll the release workflow until `uvx tend@X.Y.Z --help` succeeds
+10. **Regenerate tend's own workflows**: Run `uvx tend@latest init` and open a PR titled `chore: regenerate workflows with tend X.Y.Z`. Until this merges, tend's deployed workflows lag the just-released generator, so critical fixes (e.g. loop-prevention filters) remain unreachable on tend itself.
+
 ## Version scheme
 
 Tags are bare versions (`0.0.9`), not prefixed (`v0.0.9`).


### PR DESCRIPTION
## Problem

A fix that lands in the `tend` generator isn't deployed on tend itself until `.github/workflows/tend-*.yaml` is regenerated from the released version. That regeneration happens nightly, so between a release and the next nightly run there's a window where tend's own workflows lag the just-released generator.

For 0.0.12:

- 2026-04-14T13:56Z — PR #268 merged (adds `!contains(labels, 'tend-outage')` filter on `tend-mention.yaml`'s `issue_comment` branch).
- 17:16Z — Release 0.0.12 cut.
- 19:14–19:46Z — Anthropic outage; because tend's deployed `tend-mention.yaml` was still the pre-#268 version, the self-sustaining cascade the filter was meant to prevent fired again: 6 `tend-mention` failures + 1 `tend-notifications` failure posted 7 "Failed run at …" comments on outage tracking issue #267, each retriggering the next.
- 20:07Z — PR #273 regenerated the workflows; cascade stopped.

Full evidence in #274.

## Solution

Adds a step 10 to `.claude/skills/release/SKILL.md`: after the PyPI release is live, run `uvx tend@latest init` and open a regeneration PR (matching #273's format). This closes the post-release deployment gap on tend itself — consuming repos are unaffected since they already pick up the new release on their next nightly run.

Aligns with existing CLAUDE.md guidance: *"Updating earlier to the latest release (e.g., during a release commit) is fine."*

## Testing

- `uvx pre-commit run --all-files` — all hooks pass (skill text change only, no code).
- Change is two added lines in one markdown file.

---
Closes #274 — automated triage
