### PR TITLE
docs: explain workflow overrides and test skip-review-label example

### DIFF
--- a/docs/tend.example.toml
+++ b/docs/tend.example.toml
@@ -142,3 +142,51 @@ bot_name = "my-project-bot"
 #
 # Daily (default 07:47 UTC). Reviews recent CI runs for behavioral problems
 # and proposes skill/config improvements.
+
+# ## Workflow overrides
+#
+# The generator owns every `tend-*.yaml` file — editing them directly loses
+# changes on the next `uvx tend@latest init`. To customize the generated YAML,
+# set overrides in `.config/tend.toml`; they survive regeneration.
+#
+# Two scopes are supported:
+#
+# - `workflow_extra` — adds or replaces top-level keys (e.g. `env`, `defaults`)
+# - `jobs.<name>`    — adds or replaces keys inside a specific job
+#
+# Overrides use RFC 7396 (JSON Merge Patch): mappings deep-merge, scalars and
+# lists replace. Unknown job names print a warning but don't fail. Step-level
+# overrides aren't supported — use the `[[setup]]` mechanism above to inject
+# steps.
+#
+# ### Example: skip review on labeled PRs
+#
+# The `review` job's default `if:` only skips draft PRs. To also skip PRs
+# carrying a `tend:dismissed` label (useful once a PR has been reviewed and
+# the author doesn't want re-reviews on every push), replace the `if:` —
+# scalars replace under JSON Merge Patch, so duplicate the draft check:
+#
+# [workflows.review.jobs.review]
+# if = "github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'tend:dismissed')"
+#
+# ### Example: extend permissions without losing defaults
+#
+# Mappings deep-merge, so adding one permission preserves the rest:
+#
+# [workflows.review.jobs.review.permissions]
+# packages = "read"
+#
+# ### Example: longer timeout on a specific job
+#
+# [workflows.review.jobs.review]
+# timeout-minutes = 240
+#
+# ### Example: target a specific job in a multi-job workflow
+#
+# [workflows.mention.jobs.handle]
+# timeout-minutes = 180
+#
+# ### Example: top-level env vars
+#
+# [workflows.review.workflow_extra.env]
+# MY_VAR = "hello"

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -530,6 +530,31 @@ def test_no_extras_output_unchanged(tmp_path: Path) -> None:
             )
 
 
+def test_job_extras_replace_if_for_skip_review_label(tmp_path: Path) -> None:
+    """Override `if:` on the review job to skip PRs with a dismissal label.
+
+    Documented in docs/tend.example.toml and the install-tend skill as the
+    canonical way to opt out of re-reviews after the initial pass, replacing
+    post-regeneration patching scripts.
+    """
+    skip_if = (
+        "github.event.pull_request.draft == false && "
+        "!contains(github.event.pull_request.labels.*.name, 'tend:dismissed')"
+    )
+    extra = dedent(f"""\
+        [workflows.review.jobs.review]
+        if = "{skip_if}"
+    """)
+    cfg = Config.load(_minimal_config(tmp_path, extra))
+    workflows = {wf.filename: wf for wf in generate_all(cfg)}
+    data = yaml.safe_load(workflows["tend-review.yaml"].content)
+    assert data["jobs"]["review"]["if"] == skip_if
+    # Other review-job keys are preserved (deep merge of the job mapping).
+    assert data["jobs"]["review"]["runs-on"] == "ubuntu-24.04"
+    assert "permissions" in data["jobs"]["review"]
+    assert "steps" in data["jobs"]["review"]
+
+
 def test_unknown_job_warns(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     extra = dedent("""\
         [workflows.review.jobs.nonexistent]

--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -73,6 +73,25 @@ user create one first.
 
 Ask the user about other overrides (setup steps, workflow overrides).
 
+### Customizing generated workflow YAML
+
+The generator owns every `tend-*.yaml` file — direct edits are lost on the next
+`uvx tend@latest init`. Instead, set `workflow_extra` (top-level) or
+`jobs.<name>` (job-level) overrides in `.config/tend.toml`. Overrides follow
+RFC 7396 (JSON Merge Patch): mappings deep-merge, scalars and lists replace.
+
+Common example — skip review on PRs labeled `tend:dismissed` (so authors can
+opt out of re-reviews after the initial pass). Because scalars replace under
+Merge Patch, the override must duplicate the default draft check:
+
+```toml
+[workflows.review.jobs.review]
+if = "github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'tend:dismissed')"
+```
+
+See `docs/tend.example.toml` in the tend repo for more override examples
+(extending permissions, timeouts, top-level env vars).
+
 ## 2. Generate workflows
 
 ```bash


### PR DESCRIPTION
## Summary

Makes the `workflow_extra` / `jobs.<name>` override mechanism discoverable for adopters, so skipping reviews on labeled PRs (and similar customizations) doesn't require post-regeneration patch scripts.

- Adds a "Workflow overrides" section to `docs/tend.example.toml` with the skip-review-label example and notes on JSON Merge Patch semantics.
- Updates the install-tend skill to briefly cover the override mechanism and link to the config reference.
- Adds a regression test pinning the exact `if:` override used to skip labeled PRs.

Addresses #276.

## Test plan

- [x] `cd generator && uv run pytest` — all 159 tests pass, including the new `test_job_extras_replace_if_for_skip_review_label`
- [x] `pre-commit run` on changed files
