### PR TITLE
docs: document workflow override mechanism with skip-review-label example

### DIFF
--- a/docs/tend.example.toml
+++ b/docs/tend.example.toml
@@ -142,3 +142,39 @@ bot_name = "my-project-bot"
 #
 # Daily (default 07:47 UTC). Reviews recent CI runs for behavioral problems
 # and proposes skill/config improvements.
+
+# ## Workflow overrides (patching)
+#
+# Generated `tend-*.yaml` files are regenerated from this config on every
+# `tend init`. Don't patch them directly — edits will be clobbered. Use the
+# built-in override mechanism instead. Two override points per workflow:
+#
+# - `workflow_extra` — top-level workflow keys (e.g. `env:`)
+# - `jobs.<job-name>` — keys inside a named job (e.g. `if:`, `timeout-minutes`,
+#   `runs-on`, `permissions`)
+#
+# Overrides use RFC 7396 JSON Merge Patch semantics: mappings deep-merge,
+# scalars and lists replace, and `= nil` deletes a key. See DESIGN.md §
+# "Extending generated workflows" for the full spec.
+#
+# ### Example: skip review on labeled PRs
+#
+# The review job's default `if:` is `github.event.pull_request.draft == false`.
+# Replace the scalar to also skip PRs carrying a dismiss label (useful for
+# silencing re-reviews on already-reviewed PRs). Because `if:` is a scalar,
+# the override replaces the base — include the existing draft check too.
+#
+# [workflows.review.jobs.review]
+# if = "github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'tend:dismissed')"
+#
+# ### Example: add a permission without losing the defaults
+#
+# Permissions is a mapping, so keys deep-merge — existing permissions stay.
+#
+# [workflows.review.jobs.review.permissions]
+# packages = "read"
+#
+# ### Example: top-level env var on one workflow
+#
+# [workflows.review.workflow_extra.env]
+# MY_VAR = "hello"

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -463,6 +463,27 @@ def test_job_extras_deep_merge_permissions(tmp_path: Path) -> None:
     assert perms["packages"] == "read"
 
 
+def test_skip_review_on_label_override(tmp_path: Path) -> None:
+    """The `if:` override example documented in install-tend SKILL.md and
+    tend.example.toml: replace the review job's `if:` to skip labeled PRs."""
+    extra = dedent("""\
+        [workflows.review.jobs.review]
+        if = "github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'tend:dismissed')"
+    """)
+    cfg = Config.load(_minimal_config(tmp_path, extra))
+    workflows = {wf.filename: wf for wf in generate_all(cfg)}
+    data = yaml.safe_load(workflows["tend-review.yaml"].content)
+    condition = data["jobs"]["review"]["if"]
+    # Existing draft check preserved (scalar replace semantics require the
+    # override to include it explicitly)
+    assert "github.event.pull_request.draft == false" in condition
+    # Label check added
+    assert "tend:dismissed" in condition
+    assert "contains(github.event.pull_request.labels.*.name" in condition
+    # Surrounding job keys untouched
+    assert data["jobs"]["review"]["runs-on"] == "ubuntu-24.04"
+
+
 def test_workflow_extras_add_env(tmp_path: Path) -> None:
     extra = dedent("""\
         [workflows.review.workflow_extra.env]

--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -73,6 +73,45 @@ user create one first.
 
 Ask the user about other overrides (setup steps, workflow overrides).
 
+### Workflow patching
+
+Generated `tend-*.yaml` files carry a "do not edit directly" header — edits
+are clobbered on the next regeneration. To change something the generator
+doesn't expose as a first-class config option, use the built-in override
+mechanism instead of patching the generated YAML.
+
+Two override points live under `[workflows.<name>]`:
+
+- `workflow_extra` — top-level keys on the workflow (e.g. `env:`)
+- `jobs.<job-name>` — keys inside a specific job (e.g. `if:`, `timeout-minutes`,
+  `runs-on`, `permissions`)
+
+Both use [RFC 7396 JSON Merge Patch](https://datatracker.ietf.org/doc/html/rfc7396)
+semantics: mappings deep-merge (new keys added, existing keys overwritten),
+scalars and lists replace wholesale, and `= nil` deletes a key. Overrides
+survive regeneration — they live in `.config/tend.toml`, not in the workflow
+file.
+
+**Example — skip review when a `tend:dismissed` label is present:**
+
+The generated `tend-review.yaml` has `if: github.event.pull_request.draft == false`
+on its `review` job. To also skip PRs carrying a dismiss label (so fixup pushes
+on an already-reviewed PR don't re-trigger), replace the `if:` scalar:
+
+```toml
+[workflows.review.jobs.review]
+if = "github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'tend:dismissed')"
+```
+
+Because `if:` is a scalar, the override replaces the base value — include the
+existing draft check alongside the new label check. The PR author adds the
+label when feedback has been absorbed and removes it if they want another
+pass.
+
+See [DESIGN.md § Extending generated workflows](https://github.com/max-sixty/tend/blob/main/DESIGN.md#extending-generated-workflows)
+for the full mechanism and more examples (adding permissions, per-workflow
+env vars, job timeouts).
+
 ## 2. Generate workflows
 
 ```bash


### PR DESCRIPTION
## Summary

- Documents the `workflow_extra` / `jobs.<name>` override mechanism in both the install-tend skill (where setup-stage users look for guidance) and `docs/tend.example.toml` (where `README.md` already points for advanced options).
- Uses the skip-review-on-label pattern from #276 as the worked example, since it's the concrete need that prompted this gap report.
- Adds `test_skip_review_on_label_override` to pin the exact override documented in both places (scalar replace of the review job's `if:`), so the example can't silently break.

The mechanism already exists in the generator and is spec'd in `DESIGN.md § Extending generated workflows` — #276 notes that it's just not surfaced where adopters see it during setup. A dedicated `skip_review_label` config option could still be added on top of this; intentionally leaving that call to a maintainer since the generic mechanism already covers the need without maintaining a second knob.

Closes max-sixty/tend#276 once merged (or leave open if a dedicated option is preferred).

## Test plan

- [x] `cd generator && uv run pytest` — 159 passed
- [x] `pre-commit` on changed files — ruff/typos/format/trailing-ws clean
- [ ] Render check: confirm the new section in `tend.example.toml` reads well alongside the existing `### review-runs` block
