### PR TITLE
skills(notifications): dedup bot-authored PRs cross-referencing the issue

### DIFF
--- a/plugins/tend-ci-runner/skills/notifications/SKILL.md
+++ b/plugins/tend-ci-runner/skills/notifications/SKILL.md
@@ -99,7 +99,21 @@ gh api "repos/{owner}/{repo}/pulls/{number}/reviews" \
   --jq "[.[] | select(.user.login == \"$BOT_LOGIN\" and .submitted_at > \"$NOTIF_UPDATED_AT\")] | length"
 ```
 
-If either returns `> 0`, mark read and move on:
+For issue notifications, also check the timeline for bot-authored PRs that cross-reference the
+issue. `tend-mention` typically handles an `@`-mention-asking-for-a-PR by opening a PR with
+`Refs #N` in its body — *without* commenting on the issue. The comments check above misses that
+path, so without this timeline check the same notification races to a duplicate PR from this
+skill (observed in run 24438413763 which opened PR #278 duplicating PR #277):
+
+```bash
+gh api "repos/{owner}/{repo}/issues/{number}/timeline" \
+  --jq "[.[] | select(.event == \"cross-referenced\"
+    and .source.issue.pull_request
+    and .source.issue.user.login == \"$BOT_LOGIN\"
+    and .created_at > \"$NOTIF_UPDATED_AT\")] | length"
+```
+
+If any of the three returns `> 0`, mark read and move on:
 
 ```bash
 gh api notifications/threads/{thread_id} -X PATCH


### PR DESCRIPTION
## Summary

The notifications skill's dedup check only looks at issue comments and PR reviews. When `tend-mention` handles an `@`-mention by opening a PR with `Refs #N` in the body (and no issue comment), the next `tend-notifications` run misses that signal and opens a duplicate PR.

## Evidence

Observed today in issue [max-sixty/tend#276](https://github.com/max-sixty/tend/issues/276):

| Time (UTC) | Event |
|---|---|
| 04:54:15 | `@max-sixty` commented on #276 with `@tend-agent` mention asking for a PR |
| 04:54:19 | [`tend-mention` run 24437112906](https://github.com/max-sixty/tend/actions/runs/24437112906) fires |
| 04:58:58 | tend-mention opens [PR #277](https://github.com/max-sixty/tend/pull/277) with `Refs #276` in body — **no issue comment** |
| 05:40:46 | [`tend-notifications` run 24438413763](https://github.com/max-sixty/tend/actions/runs/24438413763) starts — past the 10-min freshness gate |
| 05:40:xx | Dedup check: `gh api repos/.../issues/276/comments --jq '[.[] \| select(bot login and created_at > 04:54:37)] \| length'` returns `0` |
| 05:46:11 | Opens duplicate [PR #278](https://github.com/max-sixty/tend/pull/278) on the same branch name `docs/workflow-override-example` |
| 05:59:16 | Closes #278 as duplicate after discovering #277 merged at 05:43:22 |

Direct cost: ~$4 of wasted API tokens on the second run, a confused issue timeline, and a correction comment the maintainer had to read.

Classification: **structural** — the failure is deterministic. For any `@tend-agent` mention that tend-mention handles by opening a PR with `Refs #N` (no issue comment), the notifications skill will always miss the dedup and produce a duplicate.

## Fix

Add a third dedup check for issue notifications: search the issue timeline for `cross-referenced` events from bot-authored PRs created after `NOTIF_UPDATED_AT`. GitHub emits these events when a PR body references the issue (via `Refs #N`, `#N`, etc.), so this reliably catches the tend-mention→PR path.

Verified against the real timeline for issue #276:

```
$ gh api "repos/max-sixty/tend/issues/276/timeline" --jq '[.[] | select(.event == "cross-referenced") | {pr: .source.issue.number, author: .source.issue.user.login, created_at}]'
[{"pr":277,"author":"tend-agent","created_at":"2026-04-15T04:58:59Z"}, ...]
```

A dedup run at 05:40 with `NOTIF_UPDATED_AT=2026-04-15T04:54:37Z` would have returned `length > 0` and correctly skipped.

## Gate assessment

- **Gate 1 (confidence)**: 1 occurrence today, classified **structural** — one occurrence is sufficient per review-gates.md.
- **Gate 2 (magnitude)**: Targeted fix (one extra dedup query) — normal evidence bar, met.

## Test plan

- [ ] Next `tend-notifications` run that processes an issue already handled by `tend-mention` (via `Refs #N` PR) should skip and mark read instead of opening a duplicate PR.
- [ ] Existing dedup on bot comments and PR reviews still works — the new check is additive.
