### PR TITLE
fix(skills): recheck open PRs immediately before gh pr create

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -97,6 +97,23 @@ git branch -r --list 'origin/fix/*'
 
 If an existing PR addresses the same problem, work on that PR instead.
 
+### Dedup recheck immediately before `gh pr create`
+
+A separate mention on a different issue/PR can trigger a concurrent run asking for the same fix.
+Those runs are not serialized — each has its own concurrency group — so both may read an empty
+`gh pr list` at session start and then each open their own PR minutes later, producing
+near-duplicates. Re-run the check **as the last step before `gh pr create`**:
+
+```bash
+BOT_LOGIN=$(gh api user --jq '.login')
+gh pr list --state open --author "$BOT_LOGIN" --json number,title,headRefName,createdAt
+```
+
+Compare by title keywords **and** the files the new PR would modify — two concurrent fixes for
+the same bug typically pick different branch names, so a branch-name match is not sufficient.
+If a sibling bot PR overlaps in scope, **do not create**: post a comment on the triggering
+thread linking the existing PR and exit.
+
 ## Pushing to PR Branches
 
 Always use `git push` without specifying a remote — `gh pr checkout` configures tracking to the


### PR DESCRIPTION
## Summary

Add a dedup recheck step in `running-in-ci` for PR creation, analogous to the existing dedup check for inline review comment replies. Re-run `gh pr list` immediately before `gh pr create` so a concurrent sibling run doesn't slip a duplicate PR past the initial session-start check.

## Evidence

Observed on `PRQL/prql` in runs [24464554439](https://github.com/PRQL/prql/actions/runs/24464554439) and [24464634498](https://github.com/PRQL/prql/actions/runs/24464634498).

Timeline:

- 15:57:00 — `max-sixty` commented "do the follow-up please" on issue [PRQL/prql#5802](https://github.com/PRQL/prql/issues/5802) (Zig 0.16 follow-up)
- 15:57:03 — `tend-mention` run A started on issue #5802
- 15:58:45 — `vanillajonathan` commented on PR [PRQL/prql#5801](https://github.com/PRQL/prql/pull/5801) asking the bot to create a Zig 0.16 PR
- 15:58:48 — `tend-mention` run B started on PR #5801 (different concurrency group — runs in parallel with A)
- ~16:02  — each run calls `gh pr list` once, early in its session; no Zig fix PR exists yet
- 16:08:17 — run B calls `gh pr create` → [PRQL/prql#5803](https://github.com/PRQL/prql/pull/5803)
- 16:09:05 — run A calls `gh pr create` → [PRQL/prql#5804](https://github.com/PRQL/prql/pull/5804), 48s after #5803 appeared; no recheck

Both PRs modify the same two files (`.github/workflows/test-prqlc-c.yaml` to drop the `version: 0.15.2` pin, and `prqlc/bindings/prqlc-c/examples/minimal-zig/build.zig` to move calls onto `root_module`) with the same intent — near-duplicates differing only in refactoring style. Maintainers must now triage and close one.

## Root cause

`tend-mention`'s [`handle` job concurrency group](https://github.com/max-sixty/tend/blob/main/generator/src/tend/workflows.py) is keyed by `issue.number || pull_request.number`, so mentions on different threads (issue #5802 vs PR #5801) run concurrently. The current `PR Creation` guidance says to check `gh pr list` before creating, but in practice runs do this once at session start. Minutes pass between the check and `gh pr create`, during which a sibling run can open a scope-overlapping PR — invisible to the stale check.

## Gate assessment

- **Confidence**: High — concrete wrong outcome (two open PRs for the same fix) with a traced decision chain for both runs.
- **Structural vs stochastic**: **Structural**. The same conditions (two mentions on different threads asking for the same fix within a few minutes) will reliably reproduce this; the current guidance prescribes a one-shot check that the race outflanks.
- **Occurrences**: 1 this run, 0 historical in [#133](https://github.com/max-sixty/tend/issues/133). Passes Gate 1 under the "one clear occurrence sufficient for structural failures" rule.
- **Magnitude**: Targeted fix — adds a 17-line recheck section analogous to the existing `Dedup check for inline review comment replies` pattern merged in [#141](https://github.com/max-sixty/tend/pull/141). Passes Gate 2.

## Test plan

- [ ] Skill lint (`pre-commit run --all-files`)
- [ ] Verify the proposed `gh pr list --state open --author $BOT_LOGIN --json number,title,headRefName,createdAt` returns what a bot can actually use to decide (it does: standard gh flags)
- [ ] Spot-check: the next time two concurrent mentions hit different threads asking for the same fix, only one PR should be created
