### PR TITLE
fix(generator): support `with:` on `uses` setup steps

### DIFF
--- a/docs/tend.example.toml
+++ b/docs/tend.example.toml
@@ -56,12 +56,22 @@ bot_name = "my-project-bot"
 # Build tools, caches, and environment variables that run before Claude in every
 # workflow. Three forms:
 #
-# - `uses` — a GitHub Action (local composite or marketplace)
+# - `uses` — a GitHub Action (local composite or marketplace); optional `with`
+#            table passes parameters to the action
 # - `run`  — a shell command
-# - `raw`  — verbatim YAML (for actions needing `with:` parameters)
+# - `raw`  — verbatim YAML (for fall-back cases, e.g. injecting multiple steps
+#            or step-level `shell:`/`env:`)
+#
+# Prefer `uses` + `with` over `raw` when possible: `raw` steps cannot receive
+# the `if:` guard used by the notifications workflow, so they run even when
+# the pre-check has decided to skip the Claude invocation.
 
 # [[setup]]
 # uses = "astral-sh/setup-uv@v6"
+#
+# [[setup]]
+# uses = "actions/setup-node@v4"
+# with = { node-version-file = ".node-version" }
 #
 # [[setup]]
 # run = "echo CARGO_TERM_COLOR=always >> $GITHUB_ENV"

--- a/generator/src/tend/config.py
+++ b/generator/src/tend/config.py
@@ -33,11 +33,17 @@ _GITHUB_USERNAME = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$")
 
 @dataclass
 class SetupStep:
-    """A single project setup step — `uses:`, `run:`, or `raw:` YAML."""
+    """A single project setup step — `uses:`, `run:`, or `raw:` YAML.
+
+    `uses` steps may carry a `with` table of parameters; this avoids forcing
+    parameterized actions (e.g. `actions/setup-node@v4`) into `raw`, which
+    cannot receive the `if:` guard used by the notifications workflow.
+    """
 
     uses: str = ""
     run: str = ""
     raw: str = ""
+    with_: dict | None = None
 
 
 @dataclass
@@ -122,7 +128,15 @@ class Config:
                     f"setup[{i}] must have exactly one of 'uses', 'run', or 'raw'"
                 )
             key = keys.pop()
-            setup.append(SetupStep(**{key: entry[key]}))
+            with_value = entry.get("with")
+            if with_value is not None:
+                if key != "uses":
+                    raise click.ClickException(
+                        f"setup[{i}]: `with` is only valid alongside `uses`"
+                    )
+                if not isinstance(with_value, dict):
+                    raise click.ClickException(f"setup[{i}]: `with` must be a table")
+            setup.append(SetupStep(**{key: entry[key], "with_": with_value}))
 
         workflows: dict[str, WorkflowConfig] = {}
         for name, wf_raw in raw.get("workflows", {}).items():

--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -47,14 +47,22 @@ def _setup_yaml(cfg: Config, indent: int = 6, condition: str = "") -> str:
     Returns empty string when no steps, or newline-prefixed block when present,
     so templates can write `{setup}` without extra blank lines.
 
-    When *condition* is set, each step gets an ``if:`` guard.
+    When *condition* is set, each step gets an ``if:`` guard. `uses` steps may
+    also carry a `with` table which is rendered as a nested block so actions
+    requiring parameters don't have to fall back to `raw` (which can't be
+    conditionally guarded).
     """
     pad = " " * indent
     if_line = f"\n{pad}  if: {condition}" if condition else ""
     lines = []
     for step in cfg.setup:
         if step.uses:
-            lines.append(f"{pad}- uses: {step.uses}{if_line}")
+            block = f"{pad}- uses: {step.uses}{if_line}"
+            if step.with_:
+                block += f"\n{pad}  with:"
+                for k, v in step.with_.items():
+                    block += f"\n{pad}    {k}: {_yaml_scalar(v)}"
+            lines.append(block)
         elif step.run:
             lines.append(f"{pad}- run: {step.run}{if_line}")
         elif step.raw:
@@ -68,6 +76,18 @@ def _setup_yaml(cfg: Config, indent: int = 6, condition: str = "") -> str:
     if not lines:
         return ""
     return "\n" + "\n".join(lines) + "\n"
+
+
+def _yaml_scalar(value: object) -> str:
+    """Render a Python scalar as a YAML scalar using safe_dump semantics."""
+    # yaml.safe_dump emits a trailing newline and may add `...\n` document
+    # terminators; strip both. default_flow_style=True keeps scalars on one line.
+    dumped = yaml.safe_dump(
+        value, default_flow_style=True, allow_unicode=True, width=float("inf")
+    ).strip()
+    if dumped.endswith("\n..."):
+        dumped = dumped[: -len("\n...")]
+    return dumped
 
 
 def _permissions(issues: bool = True) -> str:

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -73,6 +73,40 @@ def test_setup_steps_rendered(tmp_path: Path) -> None:
         )
 
 
+def test_setup_uses_with_parameters_gets_if_guard(tmp_path: Path) -> None:
+    """A `uses` setup step with `with:` parameters must still receive the
+    `if:` guard in the notifications workflow.
+
+    Without `with` support on `uses`, steps like `actions/setup-node@v4` that
+    require parameters are forced into `raw`, which cannot receive the guard —
+    so they run even when the pre-check has skipped checkout, failing with
+    "The specified node version file does not exist" (issue #281).
+    """
+    extra = dedent("""\
+        setup = [
+          {uses = "actions/setup-node@v4", with = {node-version-file = ".node-version"}},
+        ]
+    """)
+    cfg = Config.load(_minimal_config(tmp_path, extra))
+    workflows = {wf.filename: wf for wf in generate_all(cfg)}
+    notifications = workflows["tend-notifications.yaml"]
+    data = yaml.safe_load(notifications.content)
+
+    steps = data["jobs"]["notifications"]["steps"]
+    setup_node = next(
+        (s for s in steps if s.get("uses") == "actions/setup-node@v4"), None
+    )
+    assert setup_node is not None, "setup-node step missing from notifications workflow"
+    assert setup_node.get("with") == {"node-version-file": ".node-version"}, (
+        "uses step must render `with:` parameters"
+    )
+    assert "if" in setup_node, (
+        "setup-node step must receive the `if:` guard so it is skipped when "
+        "checkout was skipped (otherwise .node-version is missing and the "
+        "step fails)"
+    )
+
+
 def test_empty_setup_no_blank_lines(tmp_path: Path) -> None:
     cfg = Config.load(_minimal_config(tmp_path))
     for wf in generate_all(cfg):


### PR DESCRIPTION
## Problem

The `tend-notifications` workflow fails when there are no notifications to process and the repo configures a parameterized setup action like `actions/setup-node@v4`.

`_setup_yaml()` only adds the `if:` guard to `uses` and `run` step types. A `raw` step gets rendered verbatim (by design — it's verbatim YAML), which means actions that need `with:` parameters — forced into `raw` because the old `uses` step type didn't support `with` — run even when the pre-check decided to skip. With checkout also skipped, `.node-version` doesn't exist and setup-node fails.

## Solution

Accept `with = {...}` alongside `uses` in `[[setup]]` and render it as a nested YAML block. This lets parameterized actions use the `uses` step type and receive the `if:` guard normally:

```toml
[[setup]]
uses = "actions/setup-node@v4"
with = { node-version-file = ".node-version" }
```

`with` on `run`/`raw` steps is rejected with a clear error.

`raw` is still supported for fall-back cases (injecting multiple steps, step-level `shell:`/`env:`), and the example config now nudges toward `uses` + `with` for anything it can express.

## Testing

- New test `test_setup_uses_with_parameters_gets_if_guard` reproduces the bug: before the fix it asserted `None == {'node-version-file': '.node-version'}` because the `with` key was silently dropped by the config parser. It now passes and also confirms the rendered step has the `if:` guard.
- Full test suite: 160 passed.
- `pre-commit run` clean on touched files.

## Not touching

Tend's own `.github/workflows/tend-*.yaml` — per `CLAUDE.md`, those track the latest published release and regenerate nightly. The gap between this generator change and the next release is expected.

---
Closes #281 — automated triage
