### PR TITLE
chore: release 0.0.13

### DIFF
--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tend"
-version = "0.0.12"
+version = "0.0.13"
 description = "Claude-powered CI for GitHub repos"
 license = "MIT"
 requires-python = ">=3.11"

--- a/generator/uv.lock
+++ b/generator/uv.lock
@@ -144,7 +144,7 @@ wheels = [
 
 [[package]]
 name = "tend"
-version = "0.0.12"
+version = "0.0.13"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Bumps generator version to 0.0.13 and syncs lockfile.

6 commits since 0.0.12:
- fix(generator): support `with:` on `uses` setup steps (#282)
- fix(release): regenerate tend's own workflows after PyPI release (#275)
- docs: explain workflow overrides and test skip-review-label example (#277)
- docs(readme): note on Claude subscription & OAuth tokens (#272)
- skills(review-reviewers): document bot-self-trigger as non-issue (#271)
- chore: regenerate workflows with tend 0.0.12 (#273)

> _This was written by Claude Code on behalf of Maximilian_