### PR TITLE
feat(generator): accept any GitHub step field on setup steps

### DIFF
--- a/docs/tend.example.toml
+++ b/docs/tend.example.toml
@@ -54,34 +54,86 @@ bot_name = "my-project-bot"
 # ## Setup steps
 #
 # Build tools, caches, and environment variables that run before Claude in every
-# workflow. Three forms:
+# workflow. A `[[setup]]` entry mirrors a GitHub Actions step: give it exactly
+# one of `uses` or `run`, plus any of these optional fields:
 #
-# - `uses` — a GitHub Action (local composite or marketplace); optional `with`
-#            table passes parameters to the action
-# - `run`  — a shell command
-# - `raw`  — verbatim YAML (for fall-back cases, e.g. injecting multiple steps
-#            or step-level `shell:`/`env:`)
+#     name, id, if, with, env, shell, working-directory,
+#     continue-on-error, timeout-minutes
 #
-# Prefer `uses` + `with` over `raw` when possible: `raw` steps cannot receive
-# the `if:` guard used by the notifications workflow, so they run even when
-# the pre-check has decided to skip the Claude invocation.
-
-# [[setup]]
-# uses = "astral-sh/setup-uv@v6"
+# The escape hatch is `raw` — verbatim YAML, useful for emitting multiple
+# steps from one config entry or for fields outside the list above.
 #
-# [[setup]]
-# uses = "actions/setup-node@v4"
-# with = { node-version-file = ".node-version" }
+# `tend-notifications` injects an `if:` guard on every structured step so
+# setup is skipped when the pre-check finds no work. `raw` steps can't receive
+# that guard — use the structured form whenever the step can express what you
+# need, and `raw` only when you actually need to emit multiple steps.
 #
-# [[setup]]
-# run = "echo CARGO_TERM_COLOR=always >> $GITHUB_ENV"
+# Each form below shows the TOML and the YAML it produces inside the `steps:`
+# block. The `if:` guard injected in `tend-notifications` is shown on the
+# first example; it's added the same way on every structured step.
 #
-# [[setup]]
-# raw = """
-# - uses: Swatinem/rust-cache@v2
-#   with:
-#     save-if: false
-# """
+# `uses`:
+#
+#     [[setup]]
+#     uses = "astral-sh/setup-uv@v6"
+#
+#     # renders as (in tend-notifications):
+#     #   - uses: astral-sh/setup-uv@v6
+#     #     if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'
+#     #
+#     # and in other workflows:
+#     #   - uses: astral-sh/setup-uv@v6
+#
+# `uses` with action inputs and step-level env:
+#
+#     [[setup]]
+#     uses = "actions/setup-node@v4"
+#     name = "Setup Node"
+#     with = { node-version-file = ".node-version" }
+#     env = { FORCE_COLOR = "1" }
+#
+#     # renders as:
+#     #   - uses: actions/setup-node@v4
+#     #     name: Setup Node
+#     #     with:
+#     #       node-version-file: .node-version
+#     #     env:
+#     #       FORCE_COLOR: '1'
+#
+# `run` with shell and working directory:
+#
+#     [[setup]]
+#     run = "cargo build --release"
+#     shell = "bash"
+#     working-directory = "./crates/core"
+#     env = { RUSTFLAGS = "-D warnings" }
+#
+#     # renders as:
+#     #   - run: cargo build --release
+#     #     shell: bash
+#     #     working-directory: ./crates/core
+#     #     env:
+#     #       RUSTFLAGS: -D warnings
+#
+# A user-supplied `if:` on a step is passed through unchanged — tend will
+# *not* also add the notifications guard, and you'll see a warning at
+# generation time reminding you that step runs purely on your condition.
+#
+# `raw` — verbatim YAML, re-indented into the `steps:` block:
+#
+#     [[setup]]
+#     raw = """
+#     - uses: Swatinem/rust-cache@v2
+#       with:
+#         save-if: false
+#     - run: cargo binstall cargo-nextest --no-confirm
+#     """
+#
+#     # renders as:
+#     #   - uses: Swatinem/rust-cache@v2
+#     #     with:
+#     #       save-if: false
+#     #   - run: cargo binstall cargo-nextest --no-confirm
 #
 # For complex setups, a local composite action
 # (`.github/actions/tend-setup/action.yaml`) referenced via `uses` is cleaner.

--- a/generator/src/tend/config.py
+++ b/generator/src/tend/config.py
@@ -31,19 +31,40 @@ KNOWN_SECRETS_KEYS = {"bot_token", "claude_token", "allowed"}
 _GITHUB_USERNAME = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$")
 
 
+ALLOWED_STEP_FIELDS = {
+    "uses",
+    "run",
+    "name",
+    "id",
+    "if",
+    "with",
+    "env",
+    "shell",
+    "working-directory",
+    "continue-on-error",
+    "timeout-minutes",
+}
+DICT_STEP_FIELDS = {"with", "env"}
+
+
 @dataclass
 class SetupStep:
-    """A single project setup step — `uses:`, `run:`, or `raw:` YAML.
+    """A single project setup step.
 
-    `uses` steps may carry a `with` table of parameters; this avoids forcing
-    parameterized actions (e.g. `actions/setup-node@v4`) into `raw`, which
-    cannot receive the `if:` guard used by the notifications workflow.
+    Two forms:
+
+    - **Structured** — `fields` is a dict mirroring GitHub's step schema
+      (exactly one of `uses` or `run`, plus any of `with`, `env`, `name`,
+      `id`, `shell`, `working-directory`, `continue-on-error`,
+      `timeout-minutes`, `if`). The renderer injects the notifications
+      pre-check `if:` guard when absent.
+    - **Raw** — `raw` is verbatim YAML spliced into the steps block.
+      Escape hatch for emitting multiple steps or YAML the structured form
+      can't express. Cannot receive the notifications guard.
     """
 
-    uses: str = ""
-    run: str = ""
+    fields: dict | None = None
     raw: str = ""
-    with_: dict | None = None
 
 
 @dataclass
@@ -122,21 +143,28 @@ class Config:
                 raise click.ClickException(
                     f"setup[{i}] must be a table with 'uses', 'run', or 'raw'"
                 )
-            keys = {"uses", "run", "raw"} & entry.keys()
-            if len(keys) != 1:
+            if "raw" in entry:
+                if set(entry.keys()) != {"raw"}:
+                    raise click.ClickException(
+                        f"setup[{i}]: `raw` cannot be combined with other step fields"
+                    )
+                setup.append(SetupStep(raw=entry["raw"]))
+                continue
+            unknown = set(entry.keys()) - ALLOWED_STEP_FIELDS
+            if unknown:
+                raise click.ClickException(
+                    f"setup[{i}]: unknown field(s): {', '.join(sorted(unknown))}. "
+                    f"Allowed: {', '.join(sorted(ALLOWED_STEP_FIELDS))}, or use `raw`."
+                )
+            step_keys = {"uses", "run"} & entry.keys()
+            if len(step_keys) != 1:
                 raise click.ClickException(
                     f"setup[{i}] must have exactly one of 'uses', 'run', or 'raw'"
                 )
-            key = keys.pop()
-            with_value = entry.get("with")
-            if with_value is not None:
-                if key != "uses":
-                    raise click.ClickException(
-                        f"setup[{i}]: `with` is only valid alongside `uses`"
-                    )
-                if not isinstance(with_value, dict):
-                    raise click.ClickException(f"setup[{i}]: `with` must be a table")
-            setup.append(SetupStep(**{key: entry[key], "with_": with_value}))
+            for k in DICT_STEP_FIELDS:
+                if k in entry and not isinstance(entry[k], dict):
+                    raise click.ClickException(f"setup[{i}]: `{k}` must be a table")
+            setup.append(SetupStep(fields=dict(entry)))
 
         workflows: dict[str, WorkflowConfig] = {}
         for name, wf_raw in raw.get("workflows", {}).items():

--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -41,31 +41,48 @@ def _reindent(text: str, indent: int) -> str:
     )
 
 
+_STEP_FIELD_ORDER = [
+    "uses",
+    "run",
+    "name",
+    "id",
+    "if",
+    "shell",
+    "working-directory",
+    "continue-on-error",
+    "timeout-minutes",
+    "with",
+    "env",
+]
+# Scalar fields where we want plain (unquoted) YAML emission, matching the
+# existing style of generated workflows and letting GitHub Actions expressions
+# pass through unescaped.
+_PLAIN_TOP_LEVEL = {
+    "uses",
+    "run",
+    "if",
+    "name",
+    "id",
+    "shell",
+    "working-directory",
+}
+
+
 def _setup_yaml(cfg: Config, indent: int = 6, condition: str = "") -> str:
     """Render setup steps as YAML, indented to `indent` spaces.
 
     Returns empty string when no steps, or newline-prefixed block when present,
     so templates can write `{setup}` without extra blank lines.
 
-    When *condition* is set, each step gets an ``if:`` guard. `uses` steps may
-    also carry a `with` table which is rendered as a nested block so actions
-    requiring parameters don't have to fall back to `raw` (which can't be
-    conditionally guarded).
+    When *condition* is set, structured steps without an explicit `if:`
+    receive one so they only run when the pre-check found work. Steps that
+    already specify `if:` are left alone (with a warning), and `raw` steps
+    are emitted verbatim (also with a warning) since tend can't splice into
+    user-supplied YAML reliably.
     """
-    pad = " " * indent
-    if_line = f"\n{pad}  if: {condition}" if condition else ""
     lines = []
     for step in cfg.setup:
-        if step.uses:
-            block = f"{pad}- uses: {step.uses}{if_line}"
-            if step.with_:
-                block += f"\n{pad}  with:"
-                for k, v in step.with_.items():
-                    block += f"\n{pad}    {k}: {_yaml_scalar(v)}"
-            lines.append(block)
-        elif step.run:
-            lines.append(f"{pad}- run: {step.run}{if_line}")
-        elif step.raw:
+        if step.raw:
             if condition:
                 click.echo(
                     "Warning: raw setup steps cannot be conditionally skipped; "
@@ -73,9 +90,49 @@ def _setup_yaml(cfg: Config, indent: int = 6, condition: str = "") -> str:
                     err=True,
                 )
             lines.append(_reindent(step.raw, indent))
+            continue
+        assert step.fields is not None
+        fields = dict(step.fields)
+        if condition:
+            if "if" in fields:
+                click.echo(
+                    "Warning: setup step has an explicit `if:`; the "
+                    "notifications pre-check guard will not be added. "
+                    "The step runs based on your condition alone.",
+                    err=True,
+                )
+            else:
+                fields["if"] = condition
+        lines.append(_render_step(_order_step_fields(fields), indent))
     if not lines:
         return ""
     return "\n" + "\n".join(lines) + "\n"
+
+
+def _order_step_fields(fields: dict) -> dict:
+    """Emit keys in a stable order: step kind first, then metadata, then tables."""
+    ordered = {k: fields[k] for k in _STEP_FIELD_ORDER if k in fields}
+    for k, v in fields.items():
+        if k not in ordered:
+            ordered[k] = v
+    return ordered
+
+
+def _render_step(fields: dict, indent: int) -> str:
+    """Render a step dict as a YAML list item at the given indent column."""
+    pad = " " * indent
+    lines = []
+    for i, (key, value) in enumerate(fields.items()):
+        prefix = f"{pad}- " if i == 0 else f"{pad}  "
+        if isinstance(value, dict):
+            lines.append(f"{prefix}{key}:")
+            for sk, sv in value.items():
+                lines.append(f"{pad}    {sk}: {_yaml_scalar(sv)}")
+        elif key in _PLAIN_TOP_LEVEL:
+            lines.append(f"{prefix}{key}: {value}")
+        else:
+            lines.append(f"{prefix}{key}: {_yaml_scalar(value)}")
+    return "\n".join(lines)
 
 
 def _yaml_scalar(value: object) -> str:

--- a/generator/tests/test_config_edge_cases.py
+++ b/generator/tests/test_config_edge_cases.py
@@ -419,8 +419,8 @@ def test_duplicate_setup_steps_accepted(tmp_path: Path) -> None:
     )
     cfg = Config.load(path)
     assert len(cfg.setup) == 2
-    assert cfg.setup[0].uses == "./.github/actions/setup"
-    assert cfg.setup[1].uses == "./.github/actions/setup"
+    assert cfg.setup[0].fields == {"uses": "./.github/actions/setup"}
+    assert cfg.setup[1].fields == {"uses": "./.github/actions/setup"}
     # Both duplicates appear in generated YAML
     workflows = generate_all(cfg)
     for wf in workflows:
@@ -573,9 +573,9 @@ def test_setup_steps_preserves_order(tmp_path: Path) -> None:
     )
     cfg = Config.load(path)
     assert len(cfg.setup) == 3
-    assert cfg.setup[0].uses == "./.github/actions/setup-node"
-    assert cfg.setup[1].run == "echo middle"
-    assert cfg.setup[2].uses == "./.github/actions/setup-cache"
+    assert cfg.setup[0].fields == {"uses": "./.github/actions/setup-node"}
+    assert cfg.setup[1].fields == {"run": "echo middle"}
+    assert cfg.setup[2].fields == {"uses": "./.github/actions/setup-cache"}
     # Verify order in generated YAML
     workflows = generate_all(cfg)
     for wf in workflows:

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -107,6 +107,92 @@ def test_setup_uses_with_parameters_gets_if_guard(tmp_path: Path) -> None:
     )
 
 
+def test_setup_step_passthrough_fields(tmp_path: Path) -> None:
+    """Any GitHub step field (env, name, shell, working-directory, etc.) flows
+    through on a structured step, so users don't need `raw` just to pass them.
+    """
+    extra = dedent("""\
+        [[setup]]
+        uses = "actions/setup-node@v4"
+        name = "Setup Node"
+        with = {node-version-file = ".node-version"}
+        env = {FORCE_COLOR = "1"}
+
+        [[setup]]
+        run = "cargo build --release"
+        shell = "bash"
+        working-directory = "./crates/core"
+        env = {RUSTFLAGS = "-D warnings"}
+    """)
+    cfg = Config.load(_minimal_config(tmp_path, extra))
+    workflows = {wf.filename: wf for wf in generate_all(cfg)}
+    review = workflows["tend-review.yaml"]
+    data = yaml.safe_load(review.content)
+
+    steps = data["jobs"]["review"]["steps"]
+    node = next(s for s in steps if s.get("uses") == "actions/setup-node@v4")
+    assert node["name"] == "Setup Node"
+    assert node["with"] == {"node-version-file": ".node-version"}
+    assert node["env"] == {"FORCE_COLOR": "1"}
+
+    build = next(s for s in steps if s.get("run") == "cargo build --release")
+    assert build["shell"] == "bash"
+    assert build["working-directory"] == "./crates/core"
+    assert build["env"] == {"RUSTFLAGS": "-D warnings"}
+
+
+def test_setup_step_user_if_preserved_in_notifications(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """User-supplied `if:` on a setup step is passed through; tend does not
+    add its own notifications guard on top. A warning is emitted so the user
+    knows they've opted out of the pre-check gating."""
+    extra = dedent("""\
+        setup = [
+          {run = "./flaky.sh", if = "runner.os == 'Linux'"},
+        ]
+    """)
+    cfg = Config.load(_minimal_config(tmp_path, extra))
+    workflows = {wf.filename: wf for wf in generate_all(cfg)}
+    captured = capsys.readouterr()
+    assert "explicit `if:`" in captured.err
+
+    notifications = workflows["tend-notifications.yaml"]
+    data = yaml.safe_load(notifications.content)
+    step = next(
+        s
+        for s in data["jobs"]["notifications"]["steps"]
+        if s.get("run") == "./flaky.sh"
+    )
+    assert step["if"] == "runner.os == 'Linux'"
+
+
+def test_setup_step_rejects_unknown_field(tmp_path: Path) -> None:
+    """Typos in step field names fail at config load, not at workflow parse."""
+    extra = dedent("""\
+        setup = [{uses = "actions/checkout@v4", continue-on-errors = true}]
+    """)
+    with pytest.raises(click.ClickException, match="unknown field.*continue-on-errors"):
+        Config.load(_minimal_config(tmp_path, extra))
+
+
+def test_setup_step_rejects_raw_mixed_with_fields(tmp_path: Path) -> None:
+    extra = dedent("""\
+        setup = [{raw = "- run: echo hi", name = "oops"}]
+    """)
+    with pytest.raises(click.ClickException, match="`raw` cannot be combined"):
+        Config.load(_minimal_config(tmp_path, extra))
+
+
+def test_setup_step_env_must_be_table(tmp_path: Path) -> None:
+    extra = dedent("""\
+        setup = [{run = "echo hi", env = "not a table"}]
+    """)
+    with pytest.raises(click.ClickException, match="`env` must be a table"):
+        Config.load(_minimal_config(tmp_path, extra))
+
+
 def test_empty_setup_no_blank_lines(tmp_path: Path) -> None:
     cfg = Config.load(_minimal_config(tmp_path))
     for wf in generate_all(cfg):


### PR DESCRIPTION
## Problem

Previously `[[setup]]` entries were constrained to `{uses, with}`, `{run}`, or `{raw}`. Needing `env`, `name`, `shell`, or `working-directory` forced a drop to `raw`, which can't receive the `if:` guard injected in `tend-notifications` — so those steps ran even when the pre-check decided to skip. This is the same bug class #282 fixed for `with`, just narrower in scope.

## Solution

Let a structured `[[setup]]` entry carry any field from GitHub's step schema: `uses`, `run`, `name`, `id`, `if`, `with`, `env`, `shell`, `working-directory`, `continue-on-error`, `timeout-minutes`. Unknown keys fail at config-load with a message listing what's allowed, so typos surface immediately instead of at workflow-parse time.

```toml
[[setup]]
uses = "actions/setup-node@v4"
name = "Setup Node"
with = { node-version-file = ".node-version" }
env = { FORCE_COLOR = "1" }

[[setup]]
run = "cargo build --release"
shell = "bash"
working-directory = "./crates/core"
env = { RUSTFLAGS = "-D warnings" }
```

`raw` stays as the escape hatch for emitting multiple steps from one entry. A user-supplied `if:` on a structured step is passed through unchanged in notifications — tend does not stack its guard on top, and emits a warning making that explicit.

## Testing

- New tests: passthrough for `env`/`name`/`shell`/`working-directory`; user-supplied `if:` preserved + warning; unknown fields rejected; `env` must be a table. The existing `with` test still passes.
- Full suite: 165 passed.
- `pre-commit run` clean.

## Not touching

Tend's own `.github/workflows/tend-*.yaml` — per `CLAUDE.md`, those track the latest published release and regenerate nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)