### PR TITLE
chore: release 0.0.14

### DIFF
--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tend"
-version = "0.0.13"
+version = "0.0.14"
 description = "Claude-powered CI for GitHub repos"
 license = "MIT"
 requires-python = ">=3.11"

--- a/generator/uv.lock
+++ b/generator/uv.lock
@@ -144,7 +144,7 @@ wheels = [
 
 [[package]]
 name = "tend"
-version = "0.0.13"
+version = "0.0.14"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Bumps generator version to 0.0.14 and syncs lockfile.
- 1 commit since 0.0.13: accept any GitHub step field on setup steps (#284).

🤖 Generated with [Claude Code](https://claude.com/claude-code)