### PR TITLE
refactor(generator): remove `raw` setup step

### DIFF
--- a/docs/tend.example.toml
+++ b/docs/tend.example.toml
@@ -60,17 +60,19 @@ bot_name = "my-project-bot"
 #     name, id, if, with, env, shell, working-directory,
 #     continue-on-error, timeout-minutes
 #
-# The escape hatch is `raw` — verbatim YAML, useful for emitting multiple
-# steps from one config entry or for fields outside the list above.
+# For multi-step setup, add multiple `[[setup]]` entries — they render in
+# declared order. For anything more elaborate (conditional shells, shared
+# env across many steps, anchored caches), move the YAML into a local
+# composite action (`.github/actions/tend-setup/action.yaml`) and reference
+# it from one `[[setup]]` entry with `uses`.
 #
-# `tend-notifications` injects an `if:` guard on every structured step so
-# setup is skipped when the pre-check finds no work. `raw` steps can't receive
-# that guard — use the structured form whenever the step can express what you
-# need, and `raw` only when you actually need to emit multiple steps.
+# `tend-notifications` injects an `if:` guard on every step so setup is
+# skipped when the pre-check finds no work. A user-supplied `if:` is passed
+# through unchanged (with a generation-time warning) — your condition wins.
 #
 # Each form below shows the TOML and the YAML it produces inside the `steps:`
 # block. The `if:` guard injected in `tend-notifications` is shown on the
-# first example; it's added the same way on every structured step.
+# first example; it's added the same way on every step.
 #
 # `uses`:
 #
@@ -114,29 +116,6 @@ bot_name = "my-project-bot"
 #     #     working-directory: ./crates/core
 #     #     env:
 #     #       RUSTFLAGS: -D warnings
-#
-# A user-supplied `if:` on a step is passed through unchanged — tend will
-# *not* also add the notifications guard, and you'll see a warning at
-# generation time reminding you that step runs purely on your condition.
-#
-# `raw` — verbatim YAML, re-indented into the `steps:` block:
-#
-#     [[setup]]
-#     raw = """
-#     - uses: Swatinem/rust-cache@v2
-#       with:
-#         save-if: false
-#     - run: cargo binstall cargo-nextest --no-confirm
-#     """
-#
-#     # renders as:
-#     #   - uses: Swatinem/rust-cache@v2
-#     #     with:
-#     #       save-if: false
-#     #   - run: cargo binstall cargo-nextest --no-confirm
-#
-# For complex setups, a local composite action
-# (`.github/actions/tend-setup/action.yaml`) referenced via `uses` is cleaner.
 
 # ## Workflows
 #

--- a/generator/src/tend/config.py
+++ b/generator/src/tend/config.py
@@ -49,22 +49,16 @@ DICT_STEP_FIELDS = {"with", "env"}
 
 @dataclass
 class SetupStep:
-    """A single project setup step.
+    """A single project setup step, mirroring GitHub's step schema.
 
-    Two forms:
-
-    - **Structured** — `fields` is a dict mirroring GitHub's step schema
-      (exactly one of `uses` or `run`, plus any of `with`, `env`, `name`,
-      `id`, `shell`, `working-directory`, `continue-on-error`,
-      `timeout-minutes`, `if`). The renderer injects the notifications
-      pre-check `if:` guard when absent.
-    - **Raw** — `raw` is verbatim YAML spliced into the steps block.
-      Escape hatch for emitting multiple steps or YAML the structured form
-      can't express. Cannot receive the notifications guard.
+    Exactly one of `uses` or `run`, plus any of `with`, `env`, `name`,
+    `id`, `shell`, `working-directory`, `continue-on-error`,
+    `timeout-minutes`, `if`. The renderer injects the notifications
+    pre-check `if:` guard when absent. For multi-step setup, add multiple
+    `[[setup]]` entries — or reference a local composite action with `uses`.
     """
 
-    fields: dict | None = None
-    raw: str = ""
+    fields: dict
 
 
 @dataclass
@@ -141,25 +135,24 @@ class Config:
         for i, entry in enumerate(raw.get("setup", [])):
             if not isinstance(entry, dict):
                 raise click.ClickException(
-                    f"setup[{i}] must be a table with 'uses', 'run', or 'raw'"
+                    f"setup[{i}] must be a table with `uses` or `run`"
                 )
             if "raw" in entry:
-                if set(entry.keys()) != {"raw"}:
-                    raise click.ClickException(
-                        f"setup[{i}]: `raw` cannot be combined with other step fields"
-                    )
-                setup.append(SetupStep(raw=entry["raw"]))
-                continue
+                raise click.ClickException(
+                    f"setup[{i}]: `raw` was removed. Split into multiple "
+                    "[[setup]] entries, or move the YAML into a local "
+                    "composite action and reference it with `uses`."
+                )
             unknown = set(entry.keys()) - ALLOWED_STEP_FIELDS
             if unknown:
                 raise click.ClickException(
                     f"setup[{i}]: unknown field(s): {', '.join(sorted(unknown))}. "
-                    f"Allowed: {', '.join(sorted(ALLOWED_STEP_FIELDS))}, or use `raw`."
+                    f"Allowed: {', '.join(sorted(ALLOWED_STEP_FIELDS))}."
                 )
             step_keys = {"uses", "run"} & entry.keys()
             if len(step_keys) != 1:
                 raise click.ClickException(
-                    f"setup[{i}] must have exactly one of 'uses', 'run', or 'raw'"
+                    f"setup[{i}] must have exactly one of `uses` or `run`"
                 )
             for k in DICT_STEP_FIELDS:
                 if k in entry and not isinstance(entry[k], dict):

--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import textwrap
 from collections.abc import Callable
 from dataclasses import dataclass
 
@@ -28,17 +27,6 @@ def _bot_token(cfg: Config) -> str:
 
 def _claude_token(cfg: Config) -> str:
     return f"${{{{ secrets.{cfg.claude_token_secret} }}}}"
-
-
-def _reindent(text: str, indent: int) -> str:
-    """Dedent raw YAML and re-indent to `indent` spaces."""
-    stripped = textwrap.dedent(text).strip("\n")
-    if not stripped:
-        return ""
-    pad = " " * indent
-    return "\n".join(
-        pad + line if line.strip() else line for line in stripped.splitlines()
-    )
 
 
 _STEP_FIELD_ORDER = [
@@ -74,24 +62,12 @@ def _setup_yaml(cfg: Config, indent: int = 6, condition: str = "") -> str:
     Returns empty string when no steps, or newline-prefixed block when present,
     so templates can write `{setup}` without extra blank lines.
 
-    When *condition* is set, structured steps without an explicit `if:`
-    receive one so they only run when the pre-check found work. Steps that
-    already specify `if:` are left alone (with a warning), and `raw` steps
-    are emitted verbatim (also with a warning) since tend can't splice into
-    user-supplied YAML reliably.
+    When *condition* is set, steps without an explicit `if:` receive one so
+    they only run when the pre-check found work. Steps that already specify
+    `if:` are left alone (with a warning) — their condition wins.
     """
     lines = []
     for step in cfg.setup:
-        if step.raw:
-            if condition:
-                click.echo(
-                    "Warning: raw setup steps cannot be conditionally skipped; "
-                    "notifications pre-check will not gate this step",
-                    err=True,
-                )
-            lines.append(_reindent(step.raw, indent))
-            continue
-        assert step.fields is not None
         fields = dict(step.fields)
         if condition:
             if "if" in fields:

--- a/generator/tests/test_config_edge_cases.py
+++ b/generator/tests/test_config_edge_cases.py
@@ -599,7 +599,7 @@ def test_setup_steps_empty_list(tmp_path: Path) -> None:
 
 
 def test_setup_steps_entry_missing_key(tmp_path: Path) -> None:
-    """setup entry without uses, run, or raw is rejected."""
+    """setup entry without uses or run is rejected."""
     path = _write_config(
         tmp_path,
         dedent("""\

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -177,14 +177,6 @@ def test_setup_step_rejects_unknown_field(tmp_path: Path) -> None:
         Config.load(_minimal_config(tmp_path, extra))
 
 
-def test_setup_step_rejects_raw_mixed_with_fields(tmp_path: Path) -> None:
-    extra = dedent("""\
-        setup = [{raw = "- run: echo hi", name = "oops"}]
-    """)
-    with pytest.raises(click.ClickException, match="`raw` cannot be combined"):
-        Config.load(_minimal_config(tmp_path, extra))
-
-
 def test_setup_step_env_must_be_table(tmp_path: Path) -> None:
     extra = dedent("""\
         setup = [{run = "echo hi", env = "not a table"}]
@@ -282,52 +274,20 @@ def test_setup_after_checkout_in_review(tmp_path: Path) -> None:
     assert setup_idx > checkout_idx, "Setup must come after checkout"
 
 
-def test_setup_raw_yaml_injected(tmp_path: Path) -> None:
+def test_setup_raw_rejected_with_migration_hint(tmp_path: Path) -> None:
+    """`raw` was removed in favor of structured steps — the error message
+    must point users at the two supported paths so they can migrate."""
     extra = dedent('''\
         setup = [
           {raw = """
         - uses: Swatinem/rust-cache@v2
           with:
             save-if: false
-        - run: cargo binstall cargo-insta --no-confirm
-          shell: bash
         """},
         ]
     ''')
-    cfg = Config.load(_minimal_config(tmp_path, extra))
-    for wf in generate_all(cfg):
-        data = yaml.safe_load(wf.content)
-        assert isinstance(data, dict), f"{wf.filename} did not parse as valid YAML"
-        assert "Swatinem/rust-cache@v2" in wf.content, (
-            f"{wf.filename} missing raw uses step"
-        )
-        assert "save-if: false" in wf.content, f"{wf.filename} missing with parameter"
-        assert "cargo binstall" in wf.content, f"{wf.filename} missing raw run step"
-
-
-def test_setup_raw_interleaved_with_steps(tmp_path: Path) -> None:
-    extra = dedent('''\
-        setup = [
-          {uses = "./.github/actions/my-setup"},
-          {raw = """
-        - uses: Swatinem/rust-cache@v2
-          with:
-            save-if: false
-        """},
-          {run = "echo FOO=bar >> $GITHUB_ENV"},
-        ]
-    ''')
-    cfg = Config.load(_minimal_config(tmp_path, extra))
-    for wf in generate_all(cfg):
-        assert "./.github/actions/my-setup" in wf.content
-        assert "Swatinem/rust-cache@v2" in wf.content
-        assert "save-if: false" in wf.content
-        assert "echo FOO=bar" in wf.content
-        # Order preserved: uses, raw, run
-        uses_idx = wf.content.index("./.github/actions/my-setup")
-        raw_idx = wf.content.index("Swatinem/rust-cache@v2")
-        run_idx = wf.content.index("echo FOO=bar")
-        assert uses_idx < raw_idx < run_idx, f"{wf.filename}: wrong order"
+    with pytest.raises(click.ClickException, match="composite action"):
+        Config.load(_minimal_config(tmp_path, extra))
 
 
 def test_mention_handles_pull_request_review(tmp_path: Path) -> None:


### PR DESCRIPTION
## Why

`raw` was a pre-`with`-support escape hatch for passing parameters to actions. After #284 structured steps accept every field in GitHub's step schema (`uses`, `run`, `name`, `id`, `if`, `with`, `env`, `shell`, `working-directory`, `continue-on-error`, `timeout-minutes`), so the only thing `raw` still uniquely offered was emitting multiple steps from one config entry — redundant with writing multiple `[[setup]]` entries.

Two paths in the schema that do almost the same thing but with subtly different semantics (the `raw` path can't receive the notifications `if:` guard) is exactly the kind of low-cardinality violation the project's CLAUDE.md warns against. Collapsing to one canonical form removes the warning codepath, the `_reindent` helper, and a tradeoff paragraph in the docs.

## Migration

Anything previously in `raw` becomes either:

1. **Multiple `[[setup]]` entries** — one per step. They render in declared order.
2. **A local composite action** (`.github/actions/tend-setup/action.yaml`) referenced with `uses`. This is the better answer whenever setup has real logic (conditional shells, shared env, anchored caches) — full YAML, version-controlled, reusable.

`raw` in an existing config now fails at load-time with a message pointing to both paths, matching tend's "no backward compat, fail clear" stance.

## Testing

- Replaced the two `test_setup_raw_*` tests with one that confirms the migration hint is surfaced.
- Full suite: 163 passed.
- `pre-commit run` clean.

## Not touching

Tend's own `.github/workflows/tend-*.yaml` — per `CLAUDE.md`, those track the latest published release and regenerate nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)