### PR TITLE
fix(skills): drop GITHUB_STEP_SUMMARY writes that fail under Claude sandbox

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -236,6 +236,15 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.github_token }}
 
+    - name: Append skill step summary
+      if: always()
+      shell: bash
+      run: |
+        if [ -f /tmp/claude/step-summary.md ]; then
+          cat /tmp/claude/step-summary.md >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+        fi
+
     - name: Token usage
       if: always()
       id: tokens

--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -244,7 +244,7 @@ independently. Exit after pushing and creating the PR.
 
 ## Step 6: Summary
 
-Report results to both the log and `$GITHUB_STEP_SUMMARY`:
+Report results in the conversation log.
 
 If no problems found (or none passed the gates), report "all clear" with: runs analyzed, outcomes
 checked, brief quality assessment, and any below-threshold findings recorded in the tracking issue.

--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -244,7 +244,16 @@ independently. Exit after pushing and creating the PR.
 
 ## Step 6: Summary
 
-Report results in the conversation log.
+Report results in the conversation log and save a markdown summary to `/tmp/claude/step-summary.md`
+(a post-Claude step copies this into the GitHub Actions step summary):
+
+```bash
+mkdir -p /tmp/claude
+cat > /tmp/claude/step-summary.md << 'EOF'
+## Review-reviewers summary
+...
+EOF
+```
 
 If no problems found (or none passed the gates), report "all clear" with: runs analyzed, outcomes
 checked, brief quality assessment, and any below-threshold findings recorded in the tracking issue.

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -161,4 +161,15 @@ tracking issue.
 
 If no problems found (or none passed the gates), report "all clear" with: runs analyzed, sessions
 reviewed, brief quality assessment, and any below-threshold findings recorded in the tracking
-issue. Report the summary in the conversation log.
+issue.
+
+Save the summary to `/tmp/claude/step-summary.md` (a post-Claude step copies this into the GitHub
+Actions step summary):
+
+```bash
+mkdir -p /tmp/claude
+cat > /tmp/claude/step-summary.md << 'EOF'
+## Review-runs summary
+...
+EOF
+```

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -161,11 +161,4 @@ tracking issue.
 
 If no problems found (or none passed the gates), report "all clear" with: runs analyzed, sessions
 reviewed, brief quality assessment, and any below-threshold findings recorded in the tracking
-issue.
-
-Save the summary to `/tmp/summary.md`, then write it to the GitHub Actions step summary so it
-appears on the run page:
-
-```bash
-cat /tmp/summary.md >> "$GITHUB_STEP_SUMMARY"
-```
+issue. Report the summary in the conversation log.


### PR DESCRIPTION
## Summary

- Every `review-reviewers` and `review-runs` run emits `Read-only file system` errors when the skill tries to append to `$GITHUB_STEP_SUMMARY`.
- The Claude sandbox (`allowOnly` writes) doesn't include `/home/runner/work/_temp/_runner_file_commands/`, which is where the `$GITHUB_STEP_SUMMARY` file lives, so the redirect always fails.
- The post-Claude "Token Usage" step in `action.yaml:281-294` already writes to `$GITHUB_STEP_SUMMARY` from an unsandboxed bash step, so the Actions UI still gets the token-usage table. Only the skill-driven writes are removed.

## Evidence

| Run | Workflow | Outcome |
|---|---|---|
| [24484585485](https://github.com/max-sixty/tend/actions/runs/24484585485) | `tend-notifications` (23:59Z) | No-op — verify step found empty inbox; Claude action skipped. Correct. |
| [24483721390](https://github.com/max-sixty/tend/actions/runs/24483721390) | `tend-notifications` (23:30Z) | No-op — empty inbox. Correct. |
| [24483187063](https://github.com/max-sixty/tend/actions/runs/24483187063) | `tend-notifications` (23:13Z) | No-op — empty inbox. Correct. |
| [24482866759](https://github.com/max-sixty/tend/actions/runs/24482866759) | `review-reviewers` (23:03Z, 3-repo matrix) | All 3 matrix jobs reached "all clear", no PRs/issues opened. **All 3 sessions failed to write `$GITHUB_STEP_SUMMARY`** with `Read-only file system` errors, then moved on. |

Session-log transcripts (decoded Bash tool_results) from run 24482866759:

```
cb64c945 (target max-sixty/worktrunk):
  /bin/bash: line 45: /home/runner/work/_temp/_runner_file_commands/step_summary_...: Read-only file system
2fe1fc6b (target max-sixty/tend):
  cp: cannot create regular file '/home/runner/work/_temp/_runner_file_commands/step_summary_...': Read-only file system
db9d6136 (target PRQL/prql):
  /bin/bash: line 16: /home/runner/work/_temp/_runner_file_commands/step_summary_...: Read-only file system
```

The same pattern is visible in the preceding review-reviewers run [24478401012](https://github.com/max-sixty/tend/actions/runs/24478401012) (all 3 matrix jobs), so this is not a one-off.

## Gate assessment

- **Evidence level**: High — 6 sessions across 2 runs all fail identically on the same path. Likely present in every review-reviewers / review-runs session since the sandbox tightening (cf. tend#216 for the analogous `.github/` read-only regression under Claude Code 2.1.97+).
- **Structural vs stochastic**: **Structural.** The sandbox's `allowOnly` list doesn't include the runner's `_runner_file_commands` directory, so the write will fail every time. Replaying 10× yields 10× the same error.
- **Change type**: Removal / simplification — drops one line from `review-reviewers/SKILL.md` and a 5-line block from `review-runs/SKILL.md`. Gate 2 bar for removals is low (1 occurrence is enough) and this run alone supplies 6.
- **Both gates pass.**

## Trade-off

Removing the instruction means maintainers lose the skill-written summary in the Actions UI and have to read the conversation log / session artifact for the narrative. The token-usage table remains. If the UI summary matters, a follow-up can plumb a summary file through `action.yaml`'s post-Claude step (where writes aren't sandboxed) instead of trying to write from inside the sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)