### PR TITLE
fix(skills): let nightly close bot-opened tracking issues when resolved

### DIFF
--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -65,7 +65,7 @@ issue). Close the issue with `gh issue close` when:
 
 - The bot opened the issue itself to report a transient condition (e.g., a "Nightly tests failed"
   report from a prior run) and the condition has clearly resolved — the fix PR is merged and the
-  relevant CI on `main` is passing. Skip this case if the issue body contains "do not close
+  relevant CI on `main` is passing. Skip this case if the issue body contains "Do not close
   manually"; those are recurring tracking issues (e.g., monthly review-runs trackers) with their
   own lifecycle.
 - The repo's guidance (e.g., `running-tend` skill) explicitly authorizes closing issues.

--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -61,8 +61,16 @@ gh pr list --state open --json number,title,headRefName
 
 For each open issue, check whether recent commits or the current codebase state already resolve
 it. If resolved, comment with the evidence (commits, CI runs, or code state that resolves the
-issue). Only close the issue with `gh issue close` if the repo's guidance (e.g., `running-tend`
-skill) explicitly authorizes closing issues. Otherwise, leave it open for a maintainer to close.
+issue). Close the issue with `gh issue close` when:
+
+- The bot opened the issue itself to report a transient condition (e.g., a "Nightly tests failed"
+  report from a prior run) and the condition has clearly resolved — the fix PR is merged and the
+  relevant CI on `main` is passing. Skip this case if the issue body contains "do not close
+  manually"; those are recurring tracking issues (e.g., monthly review-runs trackers) with their
+  own lifecycle.
+- The repo's guidance (e.g., `running-tend` skill) explicitly authorizes closing issues.
+
+Otherwise, leave it open for a maintainer to close.
 
 ## Step 4: Rolling survey
 


### PR DESCRIPTION
## Summary

The nightly Step 3 rule defaults to leaving resolved issues open for a maintainer unless the repo's `running-tend` skill explicitly authorizes closing. That default causes the bot to leave *its own* tracking issues open indefinitely after the tracked condition resolves.

Adds a narrow carve-out: the bot may `gh issue close` an issue it opened itself to report a transient condition (e.g. a "Nightly tests failed" report), once the fix PR is merged and the relevant CI on `main` is passing. Issues whose body contains "do not close manually" (monthly review-runs / review-reviewers trackers) are explicitly excluded.

## Evidence

- **Run**: [PRQL/prql run 24499795330](https://github.com/PRQL/prql/actions/runs/24499795330) (tend-review-runs, 2026-04-16T08:19Z)
- **Incident thread**: [PRQL/prql#5802](https://github.com/PRQL/prql/issues/5802) — bot opened "Nightly tests failed", opened fixes [#5801](https://github.com/PRQL/prql/pull/5801) and [#5803](https://github.com/PRQL/prql/pull/5803), both merged, main CI went green, bot commented "Leaving open for a maintainer to close"
- **Maintainer pushback**: max-sixty: *"@prql-bot you should close these when things pass"* and then *"presumably we need to add this to the tend skill?"*
- **Bot's own diagnosis** (posted as a diff in issue #5802): proposed to authorize closures in PRQL's local `running-tend` skill; the tend-level default was the actual structural gap

## Gate assessment

- **Evidence level**: Critical — direct maintainer correction on a bot behavior
- **Classification**: Structural — the nightly skill's Step 3 explicitly instructed "leave it open for a maintainer to close" in every case not covered by `running-tend`; same conditions → same outcome every run
- **Change type**: Targeted fix — one carve-out paragraph added, existing default preserved for user-reported issues
- **Occurrences**: 1 direct this window; prior tracking on #133 documented one *inverse* case (closing a tracking issue with "do not close manually"), which this carve-out explicitly guards against by excluding that marker

Both gates pass. The carve-out is intentionally narrow so the #155 / #158 policy (no unauthorized closures on user-reported issues) stays intact.

## Test plan

- [ ] Nightly run on a repo without `running-tend` close-authorization where the bot has an open self-opened "X failed" issue with the fix merged → bot closes the issue with a short comment citing the fix
- [ ] Same flow but issue body says "do not close manually" (e.g. review-runs tracker) → bot still leaves it open
- [ ] User-reported issue (non-bot author) resolved by recent commits on a repo without close authorization → bot comments with evidence, does **not** close (unchanged behavior)