### PR TITLE
skills(review-reviewers): pilot gist-backed evidence storage

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -172,9 +172,12 @@ doesn't maintain an allowlist. Unknown job names produce a warning.
 ## Auth
 
 Each adopter creates a GitHub bot account and a classic PAT (`public_repo`
-for public repos, `repo` for private) plus `workflow`, `notifications`, and
-`write:discussion` scopes. The PAT and a Claude OAuth token are stored as repo
-secrets.
+for public repos, `repo` for private) plus `workflow`, `notifications`,
+`write:discussion`, and `gist` scopes. The PAT and a Claude OAuth token are
+stored as repo secrets. The `gist` scope supports bot-owned secret gists
+used by internal skills as a per-month structured evidence store (currently
+`review-reviewers`), avoiding the 65 KB comment-body limit and the
+append-to-issue-comment complexity.
 
 Classic PATs are all-or-nothing — `public_repo` grants full write to every
 public repo the user can access. Fine-grained PATs allow per-category

--- a/docs/tend.example.toml
+++ b/docs/tend.example.toml
@@ -32,12 +32,15 @@ bot_name = "my-project-bot"
 # | `BOT_TOKEN`               | Bot account PAT (see scopes below)                          |
 # | `CLAUDE_CODE_OAUTH_TOKEN` | Claude Code OAuth token (PKCE flow, not an API key)         |
 #
-# Classic PAT scopes: `repo`, `workflow`, `notifications`, `write:discussion`.
-# `workflow` is required to push commits that modify `.github/workflows/` files.
+# Classic PAT scopes: `repo`, `workflow`, `notifications`, `write:discussion`,
+# `gist`. `workflow` is required to push commits that modify
+# `.github/workflows/` files. `gist` lets internal skills store structured
+# evidence in secret gists owned by the bot.
 #
 # Fine-grained PAT permissions: `contents:write`, `pull-requests:write`,
 # `issues:write`, `actions:write`, `workflows:write`, `discussions:write`,
-# `notifications:read`.
+# `notifications:write`, `gists:write`. `notifications:write` is required so
+# the action can mark threads read after handling an event.
 #
 # Override names if the repo uses different secret names:
 #

--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -229,13 +229,16 @@ echo "$TOKEN" | gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo "$REPO"
 
 ## 8. Bot PAT and secret
 
-The bot needs a classic PAT with `repo`, `workflow`, `notifications`, and
-`write:discussion` scopes. `workflow` is required to push commits that modify
-`.github/workflows/` files. `notifications` lets the bot read/dismiss its own
-notifications. `write:discussion` allows commenting on GitHub Discussions.
+The bot needs a classic PAT with `repo`, `workflow`, `notifications`,
+`write:discussion`, and `gist` scopes. `workflow` is required to push commits
+that modify `.github/workflows/` files. `notifications` lets the bot read/dismiss
+its own notifications. `write:discussion` allows commenting on GitHub
+Discussions. `gist` allows skills like `review-reviewers` to store structured
+evidence in secret gists owned by the bot.
+
 Fine-grained PATs also work (`contents:write`, `pull-requests:write`,
 `issues:write`, `actions:write`, `workflows:write`, `discussions:write`,
-`notifications:write`) — create one manually and skip to step 9.
+`notifications:write`, `gists:write`) — create one manually and skip to step 9.
 `notifications:write` is required so the action can mark threads read after
 handling an event (the classic `notifications` scope already includes write).
 Use Chrome for classic PATs:
@@ -243,7 +246,7 @@ Use Chrome for classic PATs:
 1. Verify the browser is logged in as `<bot-name>` (click avatar, check
    username). If not, tell the user to log in as the bot first.
 2. Navigate to
-   `https://github.com/settings/tokens/new?scopes=repo,workflow,notifications,write:discussion&description=tend-ci`
+   `https://github.com/settings/tokens/new?scopes=repo,workflow,notifications,write:discussion,gist&description=tend-ci`
 3. The URL pre-fills the note and scopes. Set expiration to
    "No expiration" via the dropdown.
 4. Click "Generate token" (scroll to bottom of page).
@@ -302,6 +305,6 @@ After completing all steps, present this checklist:
 - [ ] Badge: offered to add to README (optional)
 - [ ] Bot account: `<bot-name>` exists on GitHub
 - [ ] Claude token: `CLAUDE_CODE_OAUTH_TOKEN` secret set
-- [ ] Bot PAT: `BOT_TOKEN` secret set (classic `repo`+`workflow`+`notifications`+`write:discussion` or fine-grained)
+- [ ] Bot PAT: `BOT_TOKEN` secret set (classic `repo`+`workflow`+`notifications`+`write:discussion`+`gist` or fine-grained)
 - [ ] Bot access: repo collaborator with write access, invitation accepted
 - [ ] Committed (push requires explicit permission)

--- a/plugins/tend-ci-runner/shared/review-gates.md
+++ b/plugins/tend-ci-runner/shared/review-gates.md
@@ -14,11 +14,12 @@ Before creating a PR, every finding must pass two gates.
 | **Medium** | Plausible problem seen once, could be noise | 5+ |
 | **Low** | Nitpick or stylistic preference | Do not act |
 
-Occurrences include both the current analysis **and** historical evidence from the tracking issue
-(see [Evidence accumulation](#evidence-accumulation)).
+Occurrences include both the current analysis **and** historical evidence recorded by prior runs.
+Each skill defines where that evidence lives — see the calling skill's "Evidence accumulation"
+section.
 
 If a finding doesn't meet the threshold, **skip it** — don't create a PR, don't create an issue,
-don't comment. Record it in the tracking issue so it can accumulate evidence over future runs.
+don't comment. Record it in the evidence store so it can accumulate over future runs.
 
 ### Gate 2: Magnitude — is the fix proportionate?
 
@@ -61,91 +62,13 @@ For each finding, state:
 
 Only proceed to act on findings that pass both gates.
 
-## Evidence accumulation
+## Finding format
 
-Each run only sees a window of CI sessions, but patterns may emerge over days or weeks. Use a
-**monthly tracking issue** to accumulate evidence across runs.
-
-The tracking issue label should match the calling skill — e.g., `review-reviewers-tracking` or
-`review-runs-tracking`.
-
-### Finding or creating the tracking issue
-
-```bash
-MONTH=$(date +%Y-%m)
-TRACKING_LABEL="<skill-name>-tracking"  # set by the calling skill
-gh issue list --state open --label "$TRACKING_LABEL" \
-  --json number,title --jq ".[] | select(.title | contains(\"$MONTH\"))"
-```
-
-If none exists for the current month, create one:
-
-```bash
-cat > /tmp/tracking-body.md << 'EOF'
-Monthly tracking issue for below-threshold findings. Each run appends findings as a comment. Future runs read these to build cumulative evidence.
-
-**Do not close manually** — a new issue is created each month.
-EOF
-gh issue create \
-  --title "$TRACKING_LABEL: $MONTH" \
-  --label "$TRACKING_LABEL" \
-  -F /tmp/tracking-body.md
-```
-
-### Reading historical evidence
-
-Before applying the gates, read the current tracking issue's comments to find prior observations
-that overlap with current findings:
-
-```bash
-TRACKING_NUMBER=<number from above>
-gh issue view "$TRACKING_NUMBER" --json comments \
-  --jq '.comments[] | {author: .author.login, body: .body}'
-```
-
-Also check last month's tracking issue (if it exists) for recent carry-over.
-
-When a historical entry looks like it might match a current finding, **download and investigate the
-linked workflow's session logs** — don't rely on the summary text alone, which lacks sufficient
-context to judge relatedness. Trace the original decision chain in the session JSONL to confirm the
-historical case is genuinely the same pattern, not just superficially similar.
-
-### Recording below-threshold findings
-
-After analysis, find **the bot's existing comment** on the tracking issue and **append** new
-findings to it. If no bot comment exists yet, create one. This avoids notification spam from
-frequent runs.
-
-```bash
-REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
-BOT_LOGIN=$(gh api user --jq '.login')
-EXISTING_COMMENT=$(gh api "repos/$REPO/issues/$TRACKING_NUMBER/comments" \
-  --jq "[.[] | select(.user.login == \"$BOT_LOGIN\")] | last | .id // empty")
-```
-
-If `EXISTING_COMMENT` is non-empty, check its size before appending. GitHub rejects comment bodies
-over 65536 characters — start a new comment when the existing one is too large.
-
-```bash
-gh api "repos/$REPO/issues/comments/$EXISTING_COMMENT" --jq '.body' > /tmp/existing.md
-EXISTING_SIZE=$(wc -c < /tmp/existing.md)
-if [ "$EXISTING_SIZE" -lt 50000 ]; then
-  cat /tmp/existing.md /tmp/findings.md > /tmp/combined.md
-  gh api "repos/$REPO/issues/comments/$EXISTING_COMMENT" -X PATCH -F body=@/tmp/combined.md
-else
-  # Comment approaching limit — start a new one
-  gh api "repos/$REPO/issues/$TRACKING_NUMBER/comments" -F body=@/tmp/findings.md
-fi
-```
-
-Never replace the body — prior entries contain per-run evidence needed for gate evaluation.
-
-If `EXISTING_COMMENT` is empty, create a new comment.
-
-Format each finding under a `## Run <run-id>` heading. **Always derive the run ID, timestamp, and
-repo from the CI environment — never hand-type them.** Past sessions have filled the `<run-id>`
-placeholder with fabricated round numbers (e.g. `24294000000`) when the skill didn't explicitly
-point at `$GITHUB_RUN_ID`, producing dead link-anchors in the tracking log.
+Each run appends findings to the skill's evidence store under a `## Run <run-id>` heading.
+**Always derive the run ID, timestamp, and repo from the CI environment — never hand-type them.**
+Past sessions have filled the `<run-id>` placeholder with fabricated round numbers (e.g.
+`24294000000`) when the skill didn't explicitly point at `$GITHUB_RUN_ID`, producing dead
+link-anchors in the evidence log.
 
 ```bash
 RUN_ID="$GITHUB_RUN_ID"
@@ -170,3 +93,8 @@ When composing the findings file, either interpolate the values with an unquoted
 
 Each run gets its own heading so future runs can count prior occurrences and trace incidents to
 session logs.
+
+When a historical entry looks like it might match a current finding, **download and investigate the
+linked workflow's session logs** — don't rely on the summary text alone, which lacks sufficient
+context to judge relatedness. Trace the original decision chain in the session JSONL to confirm the
+historical case is genuinely the same pattern, not just superficially similar.

--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -84,7 +84,130 @@ without `-R` default to tend.
 
 @review-gates.md
 
-Use `TRACKING_LABEL="review-reviewers-tracking"` for this skill's tracking issues.
+## Evidence accumulation
+
+Each run only sees a window of CI sessions, but patterns emerge over days or weeks. Evidence
+for this skill lives in **secret gists owned by the bot** — one per `(target repo, month)`
+pair. A monthly tracking issue on tend labeled `review-reviewers-tracking` lists the gists
+via bot comments, so maintainers can discover them.
+
+Secret gists are URL-unlisted but readable by anyone with the URL; they are at least as
+private as the current public tracking issues, and give a single structured file that
+accumulates per-target findings without hitting the 65 KB comment limit.
+
+### Setup
+
+```bash
+MONTH=$(date +%Y-%m)
+TRACKING_LABEL="review-reviewers-tracking"
+TARGET="$ARGUMENTS"
+GIST_DESC="review-reviewers evidence: $TARGET $MONTH"
+```
+
+### Finding or creating the tracking issue
+
+The tracking issue lives on tend (the current repo). It indexes gists via one comment per
+new gist — no per-run comments, no body edits.
+
+The matrix runs three targets concurrently on the same cron tick, so the first run of a new
+month races: all three targets can find no tracking issue and each create one. Sorting and
+picking the lowest-numbered match keeps later runs deterministic — maintainers can close any
+duplicates. `gh issue create` prints the new issue's URL; parse the number from its basename.
+
+```bash
+TRACKING_NUMBER=$(gh issue list --state open --label "$TRACKING_LABEL" \
+  --json number,title --jq ".[] | select(.title | contains(\"$MONTH\")) | .number" \
+  | sort -n | head -1)
+
+if [ -z "$TRACKING_NUMBER" ]; then
+  cat > /tmp/tracking-body.md << 'EOF'
+Monthly tracking issue for `review-reviewers`. Per-target evidence lives in secret gists owned by the bot. A comment below is posted when each target's gist is first created.
+
+**Do not close manually** — a new issue is created each month.
+EOF
+  TRACKING_URL=$(gh issue create \
+    --title "$TRACKING_LABEL: $MONTH" \
+    --label "$TRACKING_LABEL" \
+    -F /tmp/tracking-body.md)
+  if [ -z "$TRACKING_URL" ]; then
+    echo "ERROR: gh issue create failed" >&2
+    exit 1
+  fi
+  TRACKING_NUMBER=$(basename "$TRACKING_URL")
+fi
+```
+
+### Finding or creating the evidence gist
+
+Search the bot's own gists by description. Descriptions are our stable key — GitHub does not
+let us pick gist IDs.
+
+```bash
+GIST_ID=$(gh api /gists --paginate \
+  --jq ".[] | select(.description == \"$GIST_DESC\") | .id" | head -1)
+
+if [ -z "$GIST_ID" ]; then
+  cat > /tmp/gist-seed.md << EOF
+# review-reviewers evidence — $TARGET — $MONTH
+
+Secret gist. Append-only log of below-threshold findings used for gate evaluation.
+EOF
+  GIST_URL=$(gh gist create --desc "$GIST_DESC" /tmp/gist-seed.md)
+  if [ -z "$GIST_URL" ]; then
+    echo "ERROR: gh gist create failed — BOT_TOKEN likely lacks 'gist' scope (see install-tend)" >&2
+    exit 1
+  fi
+  GIST_ID=$(basename "$GIST_URL")
+  # First time this month for this target — announce the gist on the tracking issue
+  gh issue comment "$TRACKING_NUMBER" \
+    --body "Evidence gist for \`$TARGET\`: $GIST_URL"
+else
+  GIST_URL="https://gist.github.com/$GIST_ID"
+fi
+```
+
+The BOT_TOKEN needs `gist` scope (see install-tend). Without it, `gh gist create` fails with
+`403 Forbidden` and the skill exits before posting a broken tracking-issue comment.
+
+### Reading historical evidence
+
+Before applying the gates, read the current month's gist for this target. Pass `--raw` so
+`gh` emits the file content verbatim instead of a TTY-rendered form:
+
+```bash
+gh gist view "$GIST_ID" -f findings.md --raw > /tmp/historical-findings.md
+```
+
+Also check last month's gist for recent carry-over. Compute last month by subtracting a day
+from the first of the current month — `date -d 'last month'` on the 31st can return the
+current month on GNU date, silently skipping the prior month's evidence:
+
+```bash
+FIRST=$(date -u +%Y-%m-01)
+LAST_MONTH=$(date -u -d "$FIRST -1 day" +%Y-%m 2>/dev/null || date -u -v-1d -jf %Y-%m-%d "$FIRST" +%Y-%m)
+LAST_DESC="review-reviewers evidence: $TARGET $LAST_MONTH"
+LAST_GIST_ID=$(gh api /gists --paginate \
+  --jq ".[] | select(.description == \"$LAST_DESC\") | .id" | head -1)
+[ -n "$LAST_GIST_ID" ] && gh gist view "$LAST_GIST_ID" -f findings.md --raw > /tmp/last-month-findings.md
+```
+
+### Recording below-threshold findings
+
+After applying the gates, write each run's new findings (format in `@review-gates.md`) to
+`/tmp/findings.md`, then append them to the gist's `findings.md`. Read current content with
+`--raw`, concatenate, and PATCH via the API (`--rawfile` preserves trailing newlines that
+command substitution would strip):
+
+```bash
+gh gist view "$GIST_ID" -f findings.md --raw > /tmp/current.md
+cat /tmp/current.md /tmp/findings.md > /tmp/combined.md
+jq -n --rawfile content /tmp/combined.md \
+  '{files: {"findings.md": {content: $content}}}' \
+  | gh api "/gists/$GIST_ID" -X PATCH --input -
+```
+
+Never replace wholesale — prior entries contain per-run evidence needed for gate evaluation.
+See `@review-gates.md` for the per-finding format.
 
 ## Step 1: Setup
 
@@ -237,14 +360,19 @@ progress updates, fix-PR status, or re-statements of evidence already in the iss
   outcome evidence, root cause analysis.
 
 Group multiple findings by broad theme. **Limit to at most 2 PRs per run** — if you have more
-findings, pick the highest-confidence ones and note the rest in the tracking issue.
+findings, pick the highest-confidence ones and record the rest in the evidence gist.
+
+PR/issue bodies should link to the evidence gist (`$GIST_URL`) so reviewers can see the
+accumulated history behind the finding.
 
 **Do not poll CI** after creating a PR. The `tend-review` and `tend-ci-fix` workflows handle PRs
 independently. Exit after pushing and creating the PR.
 
 ## Step 6: Summary
 
-Report results to both the log and `$GITHUB_STEP_SUMMARY`:
+Report results to both the log and `$GITHUB_STEP_SUMMARY`. Include `$GIST_URL` at the top so
+maintainers viewing the run page can click through to the full evidence log.
 
 If no problems found (or none passed the gates), report "all clear" with: runs analyzed, outcomes
-checked, brief quality assessment, and any below-threshold findings recorded in the tracking issue.
+checked, brief quality assessment, and a link to the evidence gist for any below-threshold findings
+recorded this run.

--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -147,12 +147,15 @@ GIST_ID=$(gh api /gists --paginate \
   --jq ".[] | select(.description == \"$GIST_DESC\") | .id" | head -1)
 
 if [ -z "$GIST_ID" ]; then
-  cat > /tmp/gist-seed.md << EOF
+  # The gist file takes its name from the local file's basename; later reads
+  # and PATCHes target `findings.md`, so the seed must live at that basename.
+  mkdir -p /tmp/gist-seed
+  cat > /tmp/gist-seed/findings.md << EOF
 # review-reviewers evidence — $TARGET — $MONTH
 
 Secret gist. Append-only log of below-threshold findings used for gate evaluation.
 EOF
-  GIST_URL=$(gh gist create --desc "$GIST_DESC" /tmp/gist-seed.md)
+  GIST_URL=$(gh gist create --desc "$GIST_DESC" /tmp/gist-seed/findings.md)
   if [ -z "$GIST_URL" ]; then
     echo "ERROR: gh gist create failed — BOT_TOKEN likely lacks 'gist' scope (see install-tend)" >&2
     exit 1

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -23,7 +23,87 @@ Load any repo-specific skill overlay before proceeding.
 
 @review-gates.md
 
-Use `TRACKING_LABEL="review-runs-tracking"` for this skill's tracking issues.
+## Evidence accumulation
+
+Each run only sees a window of CI sessions, but patterns emerge over days or weeks. Accumulate
+evidence in a **monthly tracking issue** labeled `review-runs-tracking`.
+
+<!-- TODO: migrate this to gist-backed storage once the review-reviewers pilot validates it -->
+
+### Finding or creating the tracking issue
+
+`gh issue create` prints the new issue's URL; parse the number from its basename. Sort and
+pick the lowest-numbered match so later runs stay deterministic if the month ever has
+duplicate tracking issues.
+
+```bash
+MONTH=$(date +%Y-%m)
+TRACKING_LABEL="review-runs-tracking"
+TRACKING_NUMBER=$(gh issue list --state open --label "$TRACKING_LABEL" \
+  --json number,title --jq ".[] | select(.title | contains(\"$MONTH\")) | .number" \
+  | sort -n | head -1)
+
+if [ -z "$TRACKING_NUMBER" ]; then
+  cat > /tmp/tracking-body.md << 'EOF'
+Monthly tracking issue for below-threshold findings. Each run appends findings as a comment. Future runs read these to build cumulative evidence.
+
+**Do not close manually** — a new issue is created each month.
+EOF
+  TRACKING_URL=$(gh issue create \
+    --title "$TRACKING_LABEL: $MONTH" \
+    --label "$TRACKING_LABEL" \
+    -F /tmp/tracking-body.md)
+  if [ -z "$TRACKING_URL" ]; then
+    echo "ERROR: gh issue create failed" >&2
+    exit 1
+  fi
+  TRACKING_NUMBER=$(basename "$TRACKING_URL")
+fi
+```
+
+### Reading historical evidence
+
+Before applying the gates, read the current tracking issue's comments to find prior observations
+that overlap with current findings:
+
+```bash
+gh issue view "$TRACKING_NUMBER" --json comments \
+  --jq '.comments[] | {author: .author.login, body: .body}'
+```
+
+Also check last month's tracking issue (if it exists) for recent carry-over.
+
+### Recording below-threshold findings
+
+After analysis, find **the bot's existing comment** on the tracking issue and **append** new
+findings to it. If no bot comment exists yet, create one. This avoids notification spam from
+frequent runs.
+
+```bash
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+BOT_LOGIN=$(gh api user --jq '.login')
+EXISTING_COMMENT=$(gh api "repos/$REPO/issues/$TRACKING_NUMBER/comments" \
+  --jq "[.[] | select(.user.login == \"$BOT_LOGIN\")] | last | .id // empty")
+```
+
+If `EXISTING_COMMENT` is non-empty, check its size before appending. GitHub rejects comment bodies
+over 65536 characters — start a new comment when the existing one is too large.
+
+```bash
+gh api "repos/$REPO/issues/comments/$EXISTING_COMMENT" --jq '.body' > /tmp/existing.md
+EXISTING_SIZE=$(wc -c < /tmp/existing.md)
+if [ "$EXISTING_SIZE" -lt 50000 ]; then
+  cat /tmp/existing.md /tmp/findings.md > /tmp/combined.md
+  gh api "repos/$REPO/issues/comments/$EXISTING_COMMENT" -X PATCH -F body=@/tmp/combined.md
+else
+  # Comment approaching limit — start a new one
+  gh api "repos/$REPO/issues/$TRACKING_NUMBER/comments" -F body=@/tmp/findings.md
+fi
+```
+
+Never replace the body — prior entries contain per-run evidence needed for gate evaluation.
+
+If `EXISTING_COMMENT` is empty, create a new comment. See the finding format in `@review-gates.md`.
 
 ## Step 1: Find recent runs
 


### PR DESCRIPTION
Pilots per-month, per-target secret gists as the evidence store for `review-reviewers`. The tracking issue becomes a directory — one bot comment per new gist — so maintainers still get a notification when new monthly evidence appears, without the old per-run comment churn.

`review-runs` keeps the issue-comment mechanism (inlined from the shared file it used to import) with a TODO to migrate once the pilot validates. `shared/review-gates.md` now holds just the gates + finding format, not the storage mechanism.

## Why gists

- Single growing file instead of fighting the 65 KB comment-body limit
- Gist revision history gives a per-run diff for free
- Per-target separation (`worktrunk`, `tend`, `prql`) — the matrix already fans out, now the evidence does too

## PAT scope change

Classic PATs need `gist` scope; fine-grained PATs need `gists:write`. Existing adopters' bots will need their PAT regenerated before the pilot expands beyond tend, but this PR only activates gist storage in `review-reviewers` (tend-internal), so downstream repos are unaffected today.

## Notes

- First run of a new month in the 3-target matrix can briefly create duplicate tracking issues (all three concurrent entries see no existing one); later runs pick the lowest-numbered match deterministically and maintainers close duplicates.
- BSD/GNU date fallback for "last month" handles end-of-month quirks.
- Went through two review passes with the code-reviewer agent — caught invalid `gh issue create --json` flag, missing `--raw` on `gh gist view`, `$(cat)` newline-stripping, undefined per-run findings filename, and `date -d 'last month'` EOM quirk.

> _This was written by Claude Code on behalf of max-sixty_