### PR TITLE
skills(nightly): audit bot PAT scopes via script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,3 +56,20 @@ and the next release, the local workflows lag the in-tree generator, and
 that is expected; the gap closes at the next release.
 
 Linting: `pre-commit run --all-files` (ruff, typos, actionlint, uv-lock).
+
+## Agent-driven vs deterministic steps
+
+Tend's workflows invoke Claude through `max-sixty/tend@v1`. When adding new
+capability, split work along this line:
+
+- **The agent drives diagnostics and remediation.** Once the action is
+  running, put logic into the relevant skill (or a script the skill calls —
+  see `plugins/tend-ci-runner/scripts/`). The agent handles edge cases,
+  interprets output, and writes clearer messages than shell.
+- **Actions gate whether the agent runs at all.** Agent invocations cost
+  tokens; gating them in YAML is cheap. Pre-check steps that early-exit
+  the job (e.g. `tend-notifications`'s "Check for unread notifications")
+  save an entire agent run when there's nothing to do.
+
+Don't build deterministic YAML steps for work that happens *inside* an
+agent run. Extend the skill instead.

--- a/plugins/tend-ci-runner/scripts/pat-scope-audit.sh
+++ b/plugins/tend-ci-runner/scripts/pat-scope-audit.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Reports bot PAT scope coverage against tend's required classic OAuth scopes.
+#
+# Classic PATs expose their granted scopes via the X-OAuth-Scopes response
+# header. Fine-grained PATs do not — no documented GitHub endpoint reveals
+# their permission set — so those are reported as STATUS=fine-grained and
+# the caller should skip.
+#
+# Output (stdout): key=value lines the caller parses.
+#   STATUS=ok | missing | fine-grained
+#   GRANTED=<csv of granted scopes>    (ok, missing)
+#   REQUIRED=<csv of required scopes>  (ok, missing)
+#   MISSING=<csv of missing scopes>    (missing)
+#
+# Required scopes are duplicated in prose at docs/tend.example.toml,
+# DESIGN.md, and plugins/install-tend/skills/install-tend/SKILL.md — keep
+# in sync when adding a scope. This script is the one executable reference.
+#
+# Exit code: 0 when the check ran to completion (STATUS carries the result);
+# non-zero only if gh or bash itself failed.
+#
+# Requires: gh (authenticated as the bot)
+
+set -euo pipefail
+
+REQUIRED="repo workflow notifications write:discussion gist"
+
+HEADERS=$(gh api -i user)
+SCOPES_LINE=$(printf '%s\n' "$HEADERS" | grep -i '^x-oauth-scopes:' | head -1 || true)
+
+if [ -z "$SCOPES_LINE" ]; then
+  echo "STATUS=fine-grained"
+  exit 0
+fi
+
+GRANTED=$(printf '%s' "$SCOPES_LINE" \
+  | sed 's/^[^:]*:[[:space:]]*//' \
+  | tr -d '\r' \
+  | tr ',' ' ' \
+  | xargs)
+
+# Exact match only. install-tend pre-fills the required scopes verbatim, so
+# parent-scope equivalence (e.g. admin:discussion satisfying write:discussion)
+# is not a common case and is not handled here.
+MISSING=""
+for req in $REQUIRED; do
+  found=0
+  for g in $GRANTED; do
+    [ "$g" = "$req" ] && found=1 && break
+  done
+  [ "$found" = "0" ] && MISSING="$MISSING $req"
+done
+MISSING=$(echo "$MISSING" | xargs || true)
+
+GRANTED_CSV=$(echo "$GRANTED" | tr ' ' ',')
+REQUIRED_CSV=$(echo "$REQUIRED" | tr ' ' ',')
+MISSING_CSV=$(echo "$MISSING" | tr ' ' ',')
+
+if [ -z "$MISSING" ]; then
+  echo "STATUS=ok"
+else
+  echo "STATUS=missing"
+fi
+echo "GRANTED=$GRANTED_CSV"
+echo "REQUIRED=$REQUIRED_CSV"
+echo "MISSING=$MISSING_CSV"

--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -10,7 +10,29 @@ metadata:
 Resolve conflicts on bot PRs, review recent commits, survey a slice of existing code/docs, and
 update tend workflows.
 
-## Step 1: Resolve conflicts on bot PRs
+## Step 1: Verify bot PAT scopes
+
+Run the scope audit script to check the bot PAT against tend's required classic
+OAuth scopes (`repo`, `workflow`, `notifications`, `write:discussion`, `gist`):
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/scripts/pat-scope-audit.sh
+```
+
+The script prints `key=value` lines. Act on `STATUS`:
+
+- `STATUS=ok`: all scopes present. Search for an open tracking issue whose
+  body contains the marker `<!-- tend-pat-scope-audit -->`; if found, close it
+  with a comment noting the scopes are now granted.
+- `STATUS=fine-grained`: no `X-OAuth-Scopes` header. Fine-grained PATs have
+  no documented self-introspection endpoint — skip.
+- `STATUS=missing`: open a tracking issue (or update an existing one matched
+  by the marker). The issue body must include the marker on its own line
+  for dedup, list the values from `MISSING=`, and link step 8 of the
+  `install-tend` skill for remediation:
+  https://github.com/max-sixty/tend/blob/main/plugins/install-tend/skills/install-tend/SKILL.md#8-bot-pat-and-secret
+
+## Step 2: Resolve conflicts on bot PRs
 
 ```bash
 BOT_LOGIN=$(gh api user --jq '.login')
@@ -32,7 +54,7 @@ Run subagents in parallel. Each must work in isolation (`git worktree add /tmp/p
 
 Skip if no PRs have conflicts.
 
-## Step 2: Review recent commits
+## Step 3: Review recent commits
 
 ```bash
 git log --since='24 hours ago' --oneline main
@@ -52,7 +74,7 @@ Read the project's CLAUDE.md before reviewing. Apply the review checklist below 
 focusing on changes rather than unchanged code. Also check whether CLAUDE.md itself needs updating
 to reflect the new code (e.g., new file paths, changed commands, removed patterns).
 
-## Step 3: Check existing issues
+## Step 4: Check existing issues
 
 ```bash
 gh issue list --state open --json number,title
@@ -72,7 +94,7 @@ issue). Close the issue with `gh issue close` when:
 
 Otherwise, leave it open for a maintainer to close.
 
-## Step 4: Rolling survey
+## Step 5: Rolling survey
 
 Run the survey script to get today's file list (rotating through the full repo over 28 days):
 
@@ -90,7 +112,7 @@ criteria it references. Apply the review checklist below to each file in full.
 
 ## Review checklist
 
-Used by both Step 2 (applied to recent diffs) and Step 4 (applied to full files).
+Used by both Step 3 (applied to recent diffs) and Step 5 (applied to full files).
 
 **General quality:**
 - Bugs, logic errors, unhandled edge cases
@@ -106,7 +128,7 @@ Used by both Step 2 (applied to recent diffs) and Step 4 (applied to full files)
 - Skills that have drifted from actual project behavior (instructions that no longer match how the
   code works)
 
-## Step 5: Update tend workflows
+## Step 6: Update tend workflows
 
 Regenerate the tend workflow files and open a PR if anything changed. The
 checkout's `.github/` directory may be mounted read-only under the sandbox
@@ -138,7 +160,7 @@ cd -
 git worktree remove "$TMPDIR/tend-update-workflows" --force
 ```
 
-## Step 6: Fix findings
+## Step 7: Fix findings
 
 Before acting on findings, check for duplicates and existing work:
 
@@ -178,7 +200,7 @@ changelog file and the branch to push to.
 6. Commit and push directly to the changelog branch — no PR needed, the branch is kept ready to
    merge for the next release.
 
-## Step 7: Summary
+## Step 8: Summary
 
 Report: commits reviewed, files surveyed, findings, actions taken, assessment (clean / minor
 issues / needs attention).


### PR DESCRIPTION
Catches the case where a required classic OAuth scope is added upstream (most recently `gist` in #291) but adopter repos still have older PATs that will silently fail the first time an affected skill runs.

**New:** `plugins/tend-ci-runner/scripts/pat-scope-audit.sh` parses the bot PAT's `X-OAuth-Scopes` response header, compares granted vs required, and prints `STATUS=ok|missing|fine-grained` plus CSV lists on stdout. No GitHub writes — detection only.

**Wired into nightly:** Step 1 of the `nightly` skill runs the script and acts on `STATUS` — closes a prior tracking issue when scopes are now complete, opens/updates one (deduped via marker `<!-- tend-pat-scope-audit -->`) when scopes are missing, skips fine-grained PATs with a log line. Remediation in the issue body points at step 8 of the `install-tend` skill.

**CLAUDE.md:** added a short section capturing the split we settled on while designing this — agent drives diagnostics/remediation inside the action; Actions gate whether the agent runs at all. The reason this landed as an agent-driven skill step rather than deterministic YAML.

Fine-grained PAT self-introspection is not supported by GitHub (no documented endpoint exposes a fine-grained token's permissions), so those are reported and skipped rather than probed. The three prose locations documenting required scopes (`docs/tend.example.toml`, `DESIGN.md`, `plugins/install-tend/skills/install-tend/SKILL.md`) remain the reader-facing source; this script is the one executable reference — a comment in the script names them so future scope additions are easy to keep in sync.