### PR TITLE
skills: load running-in-ci in review-runs, weekly, review-reviewers

### DIFF
--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -12,6 +12,12 @@ Analyze Claude-powered CI behavior on the target repo over the past hour. Focus 
 what the bot produced publicly and whether it was accepted — rather than internal session mechanics.
 Create PRs or issues on tend when outcomes reveal behavioral problems.
 
+## First steps
+
+Load `/tend-ci-runner:running-in-ci` first — it contains CI security rules, PR/comment
+formatting (line wrapping, heredoc hazards), and polling conventions. This skill opens PRs
+and issue comments on tend, so those rules apply.
+
 ## Cost discipline: Haiku subagents for exploration
 
 Session log parsing and outcome checking are token-heavy. Delegate all broad exploration to **Haiku

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -15,6 +15,10 @@ This skill runs **in the adopter repo**, not in tend. Improvements target `.clau
 
 ## First steps
 
+Load `/tend-ci-runner:running-in-ci` first — it contains CI security rules, PR/comment
+formatting (line wrapping, heredoc hazards), and polling conventions. This skill opens PRs
+and issue comments, so those rules apply.
+
 ```bash
 ls .claude/skills/
 ```

--- a/plugins/tend-ci-runner/skills/weekly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/weekly/SKILL.md
@@ -7,6 +7,12 @@ metadata:
 
 # Weekly Maintenance
 
+## Step 0: Load environment skills
+
+Load `/tend-ci-runner:running-in-ci` first — it contains CI security rules, review/comment
+formatting, and polling conventions. This skill posts approvals and comments on PRs, so those
+rules apply.
+
 ## Step 1: Find dependency PRs
 
 ```bash


### PR DESCRIPTION
Fixes #295.

## Summary

Three skills — `review-runs`, `weekly`, and `review-reviewers` — author PRs or issue comments but did not tell the bot to load `/tend-ci-runner:running-in-ci`. That's where the "Line wrapping", heredoc-exclamation, and `body-file` hygiene rules live, so they never reached those sessions. Adding a single "Load running-in-ci first" paragraph to each, matching the pattern used in `ci-fix`, `triage`, `review`, `notifications`, and `nightly`.

## Evidence this is the right fix

Session log inspection on the numbagg run that produced [numbagg/numbagg#585](https://github.com/numbagg/numbagg/pull/585) confirms `running-in-ci` was listed in available skills but never loaded via the Skill tool — only `tend-ci-runner:review-runs` was loaded. Details in [#295 comment](https://github.com/max-sixty/tend/issues/295#issuecomment-4271033967).

## On adding it to the system prompt

The `system_prompt_append` in [`action.yaml` L26](https://github.com/max-sixty/tend/blob/d438d6ad5b23b03a317f7057e5ffad2f1b058a20/action.yaml#L26) already says "Use `/tend-ci-runner:running-in-ci` before starting work." — so the instruction is already in the system prompt for every invocation. Despite that, it didn't fire during the review-runs session that produced numbagg#585, which suggests that when the bot enters a slash-command skill, the per-skill SKILL.md becomes the operative instruction stream and the system-prompt line gets deprioritized. The in-skill reinforcement in this PR is what the other five skills already do and is the lower-cost fix.

If you want to also strengthen the system-prompt wording (e.g., "Load `/tend-ci-runner:running-in-ci` via the Skill tool as your first action, before any Bash/Edit/Write commands") I can follow up — but I'd try this PR first and see whether the next review-runs/weekly runs comply. If they still skip it, that's evidence the system prompt needs strengthening.

## Test plan

- [ ] Next `tend-review-runs` scheduled run (daily 07:47 UTC) loads `running-in-ci` before composing any PR body
- [ ] Any resulting PR body is written as single-line paragraphs, not hard-wrapped
- [ ] `tend-weekly` and hourly `review-reviewers` runs likewise load `running-in-ci`
