### PR TITLE
install-tend: capture bot auth stance in profile bio

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -173,11 +173,13 @@ doesn't maintain an allowlist. Unknown job names produce a warning.
 
 Each adopter creates a GitHub bot account and a classic PAT (`public_repo`
 for public repos, `repo` for private) plus `workflow`, `notifications`,
-`write:discussion`, and `gist` scopes. The PAT and a Claude OAuth token are
-stored as repo secrets. The `gist` scope supports bot-owned secret gists
-used by internal skills as a per-month structured evidence store (currently
-`review-reviewers`), avoiding the 65 KB comment-body limit and the
-append-to-issue-comment complexity.
+`write:discussion`, `gist`, and `user` scopes. The PAT and a Claude OAuth
+token are stored as repo secrets. The `gist` scope supports bot-owned
+secret gists used by internal skills as a per-month structured evidence
+store (currently `review-reviewers`), avoiding the 65 KB comment-body
+limit and the append-to-issue-comment complexity. The `user` scope lets
+`install-tend` set the bot's profile bio (`PATCH /user`) so the account's
+authorization stance is discoverable on the bot's user page.
 
 Classic PATs are all-or-nothing — `public_repo` grants full write to every
 public repo the user can access. Fine-grained PATs allow per-category

--- a/docs/tend.example.toml
+++ b/docs/tend.example.toml
@@ -33,14 +33,16 @@ bot_name = "my-project-bot"
 # | `CLAUDE_CODE_OAUTH_TOKEN` | Claude Code OAuth token (PKCE flow, not an API key)         |
 #
 # Classic PAT scopes: `repo`, `workflow`, `notifications`, `write:discussion`,
-# `gist`. `workflow` is required to push commits that modify
+# `gist`, `user`. `workflow` is required to push commits that modify
 # `.github/workflows/` files. `gist` lets internal skills store structured
-# evidence in secret gists owned by the bot.
+# evidence in secret gists owned by the bot. `user` lets `install-tend` set
+# the bot's profile bio so contributors can see the authorization stance.
 #
 # Fine-grained PAT permissions: `contents:write`, `pull-requests:write`,
 # `issues:write`, `actions:write`, `workflows:write`, `discussions:write`,
-# `notifications:write`, `gists:write`. `notifications:write` is required so
-# the action can mark threads read after handling an event.
+# `notifications:write`, `gists:write`, plus the account-level `Profile:
+# read and write` permission (for the bio). `notifications:write` is
+# required so the action can mark threads read after handling an event.
 #
 # Override names if the repo uses different secret names:
 #

--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -293,17 +293,12 @@ bot to do, then reflect that stance in the bot's profile bio (≤160 chars)
 so it's discoverable on the bot's user page. This is advisory — the bot
 doesn't gate behavior on it.
 
-Ask the creator which stance applies. Typical answers:
+Ask the creator which stance applies. Each option is a drop-in bio suffix;
+the middle one is the recommended default.
 
-- **Open to anyone** — anyone may @-mention the bot
-- **Contributors only** — only prior contributors to the repo
-- **Maintainers only** — only repo maintainers
-
-Draft a short bio from the stance. Examples:
-
-- `Claude-powered CI bot for <owner>/<repo>. @-mention me — open to anyone.`
-- `Claude-powered CI bot for <owner>/<repo>. Contributors welcome to @-mention.`
-- `Claude-powered CI bot for <owner>/<repo>. Maintainers only, please.`
+- `tend agent for <owner>/<repo>. Feel free to ask me questions about <repo>.`
+- `tend agent for <owner>/<repo>. I triage issues and help maintain <repo>.` (recommended)
+- `tend agent for <owner>/<repo>. I respond to maintainers of <repo>.`
 
 Check the current bio as the bot — skip if already set to the chosen value:
 

--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -230,15 +230,17 @@ echo "$TOKEN" | gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo "$REPO"
 ## 8. Bot PAT and secret
 
 The bot needs a classic PAT with `repo`, `workflow`, `notifications`,
-`write:discussion`, and `gist` scopes. `workflow` is required to push commits
-that modify `.github/workflows/` files. `notifications` lets the bot read/dismiss
-its own notifications. `write:discussion` allows commenting on GitHub
-Discussions. `gist` allows skills like `review-reviewers` to store structured
-evidence in secret gists owned by the bot.
+`write:discussion`, `gist`, and `user` scopes. `workflow` is required to push
+commits that modify `.github/workflows/` files. `notifications` lets the bot
+read/dismiss its own notifications. `write:discussion` allows commenting on
+GitHub Discussions. `gist` allows skills like `review-reviewers` to store
+structured evidence in secret gists owned by the bot. `user` lets step 10
+set the bot's profile bio via `PATCH /user`.
 
 Fine-grained PATs also work (`contents:write`, `pull-requests:write`,
 `issues:write`, `actions:write`, `workflows:write`, `discussions:write`,
-`notifications:write`, `gists:write`) — create one manually and skip to step 9.
+`notifications:write`, `gists:write`, plus the account-level `Profile: read
+and write` permission for the bio) — create one manually and skip to step 9.
 `notifications:write` is required so the action can mark threads read after
 handling an event (the classic `notifications` scope already includes write).
 Use Chrome for classic PATs:
@@ -246,7 +248,7 @@ Use Chrome for classic PATs:
 1. Verify the browser is logged in as `<bot-name>` (click avatar, check
    username). If not, tell the user to log in as the bot first.
 2. Navigate to
-   `https://github.com/settings/tokens/new?scopes=repo,workflow,notifications,write:discussion,gist&description=tend-ci`
+   `https://github.com/settings/tokens/new?scopes=repo,workflow,notifications,write:discussion,gist,user&description=tend-ci`
 3. The URL pre-fills the note and scopes. Set expiration to
    "No expiration" via the dropdown.
 4. Click "Generate token" (scroll to bottom of page).
@@ -258,7 +260,7 @@ Use Chrome for classic PATs:
 echo "<pat-value>" | gh secret set BOT_TOKEN --repo "$REPO"
 ```
 
-Keep the PAT value — step 9 uses it to accept invitations as the bot.
+Keep the PAT value — steps 9 and 10 use it to act as the bot.
 
 Verify both secrets exist:
 
@@ -284,7 +286,38 @@ fi
 gh api "repos/$REPO/collaborators" --jq '.[].login'
 ```
 
-## 10. Commit and push
+## 10. Bot profile bio
+
+Capture what the creator is comfortable with contributors/users asking the
+bot to do, then reflect that stance in the bot's profile bio (≤160 chars)
+so it's discoverable on the bot's user page. This is advisory — the bot
+doesn't gate behavior on it.
+
+Ask the creator which stance applies. Typical answers:
+
+- **Open to anyone** — anyone may @-mention the bot
+- **Contributors only** — only prior contributors to the repo
+- **Maintainers only** — only repo maintainers
+
+Draft a short bio from the stance. Examples:
+
+- `Claude-powered CI bot for <owner>/<repo>. @-mention me — open to anyone.`
+- `Claude-powered CI bot for <owner>/<repo>. Contributors welcome to @-mention.`
+- `Claude-powered CI bot for <owner>/<repo>. Maintainers only, please.`
+
+Check the current bio as the bot — skip if already set to the chosen value:
+
+```bash
+GH_TOKEN=<bot-pat> gh api user --jq '.bio'
+```
+
+Otherwise write it (requires `user` scope on the PAT from step 8):
+
+```bash
+GH_TOKEN=<bot-pat> gh api user -X PATCH -f bio="<drafted bio>"
+```
+
+## 11. Commit and push
 
 Stage all changes:
 
@@ -305,6 +338,7 @@ After completing all steps, present this checklist:
 - [ ] Badge: offered to add to README (optional)
 - [ ] Bot account: `<bot-name>` exists on GitHub
 - [ ] Claude token: `CLAUDE_CODE_OAUTH_TOKEN` secret set
-- [ ] Bot PAT: `BOT_TOKEN` secret set (classic `repo`+`workflow`+`notifications`+`write:discussion`+`gist` or fine-grained)
+- [ ] Bot PAT: `BOT_TOKEN` secret set (classic `repo`+`workflow`+`notifications`+`write:discussion`+`gist`+`user` or fine-grained)
 - [ ] Bot access: repo collaborator with write access, invitation accepted
+- [ ] Bot bio: profile bio reflects the authorization stance
 - [ ] Committed (push requires explicit permission)

--- a/plugins/tend-ci-runner/scripts/pat-scope-audit.sh
+++ b/plugins/tend-ci-runner/scripts/pat-scope-audit.sh
@@ -13,8 +13,9 @@
 #   MISSING=<csv of missing scopes>    (missing)
 #
 # Required scopes are duplicated in prose at docs/tend.example.toml,
-# DESIGN.md, and plugins/install-tend/skills/install-tend/SKILL.md — keep
-# in sync when adding a scope. This script is the one executable reference.
+# DESIGN.md, plugins/install-tend/skills/install-tend/SKILL.md, and
+# plugins/tend-ci-runner/skills/nightly/SKILL.md — keep in sync when adding
+# a scope. This script is the one executable reference.
 #
 # Exit code: 0 when the check ran to completion (STATUS carries the result);
 # non-zero only if gh or bash itself failed.

--- a/plugins/tend-ci-runner/scripts/pat-scope-audit.sh
+++ b/plugins/tend-ci-runner/scripts/pat-scope-audit.sh
@@ -23,7 +23,7 @@
 
 set -euo pipefail
 
-REQUIRED="repo workflow notifications write:discussion gist"
+REQUIRED="repo workflow notifications write:discussion gist user"
 
 HEADERS=$(gh api -i user)
 SCOPES_LINE=$(printf '%s\n' "$HEADERS" | grep -i '^x-oauth-scopes:' | head -1 || true)

--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -13,7 +13,8 @@ update tend workflows.
 ## Step 1: Verify bot PAT scopes
 
 Run the scope audit script to check the bot PAT against tend's required classic
-OAuth scopes (`repo`, `workflow`, `notifications`, `write:discussion`, `gist`):
+OAuth scopes (`repo`, `workflow`, `notifications`, `write:discussion`, `gist`,
+`user`):
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/pat-scope-audit.sh


### PR DESCRIPTION
## Summary
- Adds a new step to `install-tend` that asks the creator what contributors/users may ask the bot to do, drafts a ≤160-char bio, and writes it via `PATCH /user` using the bot PAT from step 8.
- Extends the default classic PAT scopes with `user` (pre-fill URL, checklist, audit script) and documents the fine-grained `Profile: read and write` equivalent. `pat-scope-audit.sh` now flags bots missing `user` on the nightly run.
- Keeps the behavior advisory — the bio is discoverable on the bot's user page; bot runtime behavior doesn't gate on it.

Closes #296.

## Test plan
- [ ] Dry-run `install-tend` on a sandbox repo: verify step 10 prompts for stance, drafts bio, and `gh api user --jq '.bio'` returns the new value.
- [ ] Generate a new classic PAT via the pre-filled URL and confirm `user` is pre-checked alongside the existing scopes.
- [ ] Run `plugins/tend-ci-runner/scripts/pat-scope-audit.sh` against a bot PAT that lacks `user`; expect `STATUS=missing`.
- [ ] `uvx pre-commit run --files <modified>` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)