### PR TITLE
review: add test additions to concrete-fix enumeration (#303)

### DIFF
--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -214,13 +214,7 @@ inline suggestion on the exact line — never as a code block in the review body
 let the author apply with one click; code blocks force them to find the line and copy-paste
 manually.
 
-For fixes targeting lines outside the diff, offer to push a fix commit. Use concrete wording —
-**"I can push this as a follow-up commit — let me know."** Hedging like `if helpful` or `if you'd
-like` reads as optional rather than a real offer.
-
-**Apply offers consistently across a single review.** If one concrete finding gets an offer to
-push, every concrete finding in the same review should get one too — or be posted as an inline
-suggestion if it's inside the diff. Don't leave some findings with offers and others bare.
+For fixes targeting lines outside the diff, offer to push a fix commit instead.
 
 Post inline suggestions via the review API:
 

--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -209,10 +209,9 @@ changes"). Use `gh pr review` for reviews, not `gh pr comment`. Note: `--comment
 non-empty body — if there's nothing to say, use the approve-with-empty-body pattern.
 
 **Inline suggestions are mandatory for concrete fixes.** Whenever there's a concrete fix (typos,
-doc updates, naming, missing imports, minor refactors, one-line test additions), post it as an
-inline suggestion on the exact line — never as a code block in the review body. Inline suggestions
-let the author apply with one click; code blocks force them to find the line and copy-paste
-manually.
+doc updates, naming, missing imports, minor refactors, test additions), post it as an inline
+suggestion on the exact line — never as a code block in the review body. Inline suggestions let
+the author apply with one click; code blocks force them to find the line and copy-paste manually.
 
 For fixes targeting lines outside the diff, offer to push a fix commit instead.
 

--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -209,11 +209,18 @@ changes"). Use `gh pr review` for reviews, not `gh pr comment`. Note: `--comment
 non-empty body — if there's nothing to say, use the approve-with-empty-body pattern.
 
 **Inline suggestions are mandatory for concrete fixes.** Whenever there's a concrete fix (typos,
-doc updates, naming, missing imports, minor refactors), post it as an inline suggestion on the
-exact line — never as a code block in the review body. Inline suggestions let the author apply
-with one click; code blocks force them to find the line and copy-paste manually.
+doc updates, naming, missing imports, minor refactors, one-line test additions), post it as an
+inline suggestion on the exact line — never as a code block in the review body. Inline suggestions
+let the author apply with one click; code blocks force them to find the line and copy-paste
+manually.
 
-For fixes targeting lines outside the diff, offer to push a fix commit instead.
+For fixes targeting lines outside the diff, offer to push a fix commit. Use concrete wording —
+**"I can push this as a follow-up commit — let me know."** Hedging like `if helpful` or `if you'd
+like` reads as optional rather than a real offer.
+
+**Apply offers consistently across a single review.** If one concrete finding gets an offer to
+push, every concrete finding in the same review should get one too — or be posted as an inline
+suggestion if it's inside the diff. Don't leave some findings with offers and others bare.
 
 Post inline suggestions via the review API:
 


### PR DESCRIPTION
Fixes #303.

## Evidence

On worktrunk [PR #2285](https://github.com/max-sixty/worktrunk/pull/2285), the bot's review identified two concrete follow-ups:

- A help-text / docs mismatch (outside the diff): *"Consider updating that sentence … Happy to push that follow-up if helpful."* — the author picked this up on a force-push.
- A missing underscore case in `test_vars_invalid_key` (inside the diff): *"A one-line extension to also assert the underscore path would lock in the new behaviour."* — no inline suggestion, never got added.

The test-addition is the failure that mattered. It was inside the diff, so it should have been an inline `suggestion` block with one-click apply. The skill's enumeration at `plugins/tend-ci-runner/skills/review/SKILL.md` lines 211–214 lists "typos, doc updates, naming, missing imports, minor refactors" and reads as exhaustive — test additions don't obviously fit, so the rule didn't fire.

## Change

Add "one-line test additions" to the concrete-fix enumeration so a one-line test extension clearly triggers the mandatory-inline-suggestion rule.

(Earlier drafts of this PR also tightened the "offer to push" wording and added a cross-finding consistency rule; both were dropped after review — the hedged offer on #2285 was actually accepted, so wording wasn't the failure mode, and in-diff findings belong as inline suggestions rather than offers, so the consistency framing doesn't apply.)

## Evidence trail

- Issue: [#303](https://github.com/max-sixty/tend/issues/303)
- Source comment: https://github.com/max-sixty/worktrunk/pull/2285#issuecomment-4273924848
- Review that triggered the feedback: https://github.com/max-sixty/worktrunk/pull/2285#pullrequestreview-PRR_kwDOQEkLn872bMO0
- Triggering review-reviewers run: https://github.com/max-sixty/tend/actions/runs/24607354709
