### PR TITLE
chore: release 0.0.16

### DIFF
--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tend"
-version = "0.0.15"
+version = "0.0.16"
 description = "Claude-powered CI for GitHub repos"
 license = "MIT"
 requires-python = ">=3.11"

--- a/generator/uv.lock
+++ b/generator/uv.lock
@@ -144,7 +144,7 @@ wheels = [
 
 [[package]]
 name = "tend"
-version = "0.0.15"
+version = "0.0.16"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Bumps generator to 0.0.16.

## Changes since 0.0.15

- #294 — nightly: audit bot PAT scopes via script
- #292 — review-reviewers: fetch current-month gist once per run
- #291 — review-reviewers: pilot gist-backed evidence storage
- #290 — nightly: close bot-opened tracking issues when resolved
- #289 — skills: drop `GITHUB_STEP_SUMMARY` writes that fail under Claude sandbox
- #288 — docs(release): commit on the current branch, don't create a new one
- #279 — notifications: dedup bot-authored PRs cross-referencing the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)