### PR TITLE
chore: regenerate workflows with tend 0.0.16

### DIFF
--- a/.github/workflows/tend-review.yaml
+++ b/.github/workflows/tend-review.yaml
@@ -26,9 +26,26 @@ jobs:
       actions: read
       issues: write
     steps:
+      # GitHub only materializes refs/pull/N/merge for mergeable PRs — on
+      # conflicting PRs it 404s and every downstream step cascades as skipped.
+      # Probe first and fall back to /head so review always runs; on fallback
+      # the review sees the PR branch in isolation rather than the post-merge
+      # tree.
+      - name: Resolve PR checkout ref
+        id: pr_ref
+        env:
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          if gh api "repos/${{ github.repository }}/git/ref/pull/$PR/merge" --silent 2>/dev/null; then
+            echo "ref=refs/pull/$PR/merge" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=refs/pull/$PR/head" >> "$GITHUB_OUTPUT"
+            echo "::notice::refs/pull/$PR/merge unavailable (likely merge conflict); falling back to /head"
+          fi
       - uses: actions/checkout@v6
         with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          ref: ${{ steps.pr_ref.outputs.ref }}
           fetch-depth: 0
           fetch-tags: true
           token: ${{ secrets.BOT_TOKEN }}


### PR DESCRIPTION
Picks up the tend-review PR-merge-ref fallback from 0.0.16 so tend-on-tend benefits from recent skill fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)