### PR TITLE
weekly: also run repo-specific weekly tasks from running-tend

### DIFF
--- a/plugins/tend-ci-runner/skills/weekly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/weekly/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: weekly
-description: Weekly maintenance — reviews dependency PRs.
+description: Weekly maintenance — reviews dependency PRs and runs any repo-specific weekly tasks defined in running-tend.
 metadata:
   internal: true
 ---
@@ -11,7 +11,8 @@ metadata:
 
 Load `/tend-ci-runner:running-in-ci` first — it contains CI security rules, review/comment
 formatting, and polling conventions. This skill posts approvals and comments on PRs, so those
-rules apply.
+rules apply. `running-in-ci` will also load the repo's `running-tend` overlay if one exists;
+keep the loaded content in mind for Step 3.
 
 ## Step 1: Find dependency PRs
 
@@ -20,7 +21,8 @@ gh pr list --state open --json number,title,author,labels \
   --jq '.[] | select(.author.login == "dependabot[bot]" or .author.login == "renovate[bot]" or (.labels | any(.name == "dependencies")))'
 ```
 
-If no dependency PRs are open, report "No dependency PRs to process" and skip to the summary.
+If no dependency PRs are open, note "0 dependency PRs to process" and continue to Step 3 —
+do not exit; repo-specific weekly tasks may still be due.
 
 ## Step 2: For each dependency PR
 
@@ -34,6 +36,16 @@ If no dependency PRs are open, report "No dependency PRs to process" and skip to
 4. If CI is failing, comment with the failure summary and skip
 5. If a major version bump, comment noting it needs manual review and skip
 
-## Step 3: Summary
+## Step 3: Repo-specific weekly tasks
 
-Report: dependency PRs processed/approved/skipped (with reasons).
+Scan the loaded `running-tend` skill for sections describing weekly maintenance — typical
+headings include "Weekly Maintenance", "Weekly:", or task names like "MSRV bump", "toolchain
+update", "cache audit", "README refresh". For each such task, perform it as the repo describes
+and follow the repo's PR title conventions when opening a PR.
+
+If `running-tend` defines no weekly tasks (or none are due this week), say so in the summary.
+
+## Step 4: Summary
+
+Report: dependency PRs processed/approved/skipped (with reasons), and repo-specific weekly
+tasks completed (or "no repo-specific weekly tasks defined" / "no weekly tasks due").


### PR DESCRIPTION
## Problem

The bundled `tend-ci-runner:weekly` skill exits early when no dependency PRs are open, never consulting the repo's `running-tend` overlay for additional weekly maintenance tasks. This is a structural gap: any adopter that documents weekly tasks in their overlay (MSRV bumps, toolchain updates, cache audits, etc.) silently misses them.

Worktrunk run [`24625947135`](https://github.com/max-sixty/worktrunk/actions/runs/24625947135) (tend-weekly, 97s) demonstrates the gap. The agent loaded `running-in-ci` and `running-tend` (worktrunk's overlay defines two "Weekly Maintenance" sections — MSRV/toolchain bump and statusline cache-check), then ran `gh pr list`, found no dependency PRs, and exited per the bundled skill's "skip to the summary" instruction. Today is the first weekly run since Rust 1.95.0 became stable (2026-04-16), so per worktrunk's "latest stable − 1" rule, `Cargo.toml` and `tests/helpers/wt-perf/Cargo.toml` should have been bumped from `rust-version = "1.93"` → `"1.94"`. They weren't, because the agent never reached the repo-specific tasks.

Session log evidence (22 lines, 6 turns): only 3 tool calls — `Skill: tend-ci-runner:running-in-ci`, `Skill: running-tend`, then the single `gh pr list` for dependency PRs.

## Fix

Modify [`plugins/tend-ci-runner/skills/weekly/SKILL.md`](plugins/tend-ci-runner/skills/weekly/SKILL.md):

1. Remove the early-exit on "no dependency PRs" — always proceed to the new Step 3.
2. Add **Step 3: Repo-specific weekly tasks** — scan `running-tend` for weekly-maintenance sections and perform them.
3. Update **Step 4: Summary** to also report repo-specific task outcomes.
4. Update the skill's `description` frontmatter so dispatch hints at the broader scope.

The fix targets the bundled skill (which is what the agent loads) rather than worktrunk's overlay (which already correctly documents the tasks).

## Gate assessment

- **Evidence level**: High — structural failure with a clear missed action (MSRV bump that should have happened today).
- **Classification**: Structural. The bundled skill literally instructs "skip to the summary" — replaying this scenario 10× would skip the repo-specific tasks every time.
- **Occurrences**: 1 this run; this is the first weekly run since 1.95.0 released, so prior weekly runs had no MSRV work to do (target = current).
- **Change type**: Targeted fix (small edit to one skill file).
- **Magnitude gate**: Targeted-fix bar (Gate 1 thresholds) — structural failures justify action at 1 occurrence per [`review-gates.md`](https://github.com/max-sixty/tend/blob/main/plugins/tend-ci-runner/skills/review-reviewers/review-gates.md).

Both gates pass.

## Evidence

Full evidence log (current month): https://gist.github.com/44ab1483b29406255dd36141650c894d
