### PR TITLE
review: explain CI monitor rationale, expand pending filter, dedupe

### DIFF
--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -294,46 +294,11 @@ Prevention: before writing any inline comment, verify the target line falls insi
 
 ### 6. Monitor CI
 
-After approving or staying silent, poll CI in **a single background loop** — do not launch
-individual sleep commands. Use the Bash tool with `run_in_background: true` and the loop below.
-**Exclude your own run (`/runs/$GITHUB_RUN_ID/`)** — your own job check will always show as
-pending while you're running. Filter on the run URL, not the check name: `gh pr checks` shows
-the job name (`review`), which does not match `$GITHUB_WORKFLOW` (`tend-review`). **NEVER use
-`--watch` flags** — they hang forever.
+After approving or staying silent, poll CI using the polling loop in
+`/tend-ci-runner:running-in-ci` under "CI Monitoring". Run it with the Bash tool's
+`run_in_background: true`.
 
-```bash
-# Run with Bash tool's run_in_background: true.
-# Poll statusCheckRollup (every check-run + status context on the commit).
-# `gh pr checks --required` only sees already-registered check-runs, so a
-# late-starting `if: always()` omnibus (e.g. `check-ok-to-merge`) could race
-# the loop and let it exit green while CI was still running (see
-# https://github.com/max-sixty/tend/issues/305). The 30s grace re-check
-# below covers the short gap between `needs:` jobs finishing and the omnibus
-# check-run registering.
-#
-# Don't use mergeStateStatus as an exit signal: it stays BLOCKED for the
-# entire run because our own check is pending, and the API can't distinguish
-# "self-blocking" from "required context not yet registered".
-pending() {
-  gh pr view <number> --json statusCheckRollup \
-    | jq --arg own "/runs/$GITHUB_RUN_ID/" '
-      [.statusCheckRollup[]
-       | select((.detailsUrl // .targetUrl // "") | test($own) | not)
-       | (.status // .state)
-       | select(. == "IN_PROGRESS" or . == "QUEUED" or . == "PENDING" or . == "WAITING")
-      ] | length'
-}
-for i in $(seq 1 15); do
-  sleep 60
-  [ "$(pending)" -gt 0 ] && continue
-  sleep 30
-  [ "$(pending)" -eq 0 ] || continue
-  gh pr checks <number>
-  exit 0
-done
-echo "CI still running after 15 minutes"
-exit 1
-```
+Then handle the outcome:
 
 - **All required checks passed** -> done.
 - **A check failed** and it's related to the PR -> post a follow-up COMMENT review with analysis

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -159,29 +159,43 @@ background task completes you will be notified — check the result and take any
 
 ```bash
 # Run with Bash tool's run_in_background: true.
-# Poll statusCheckRollup (every check-run + status context on the commit).
-# `gh pr checks --required` only sees already-registered check-runs, so a
-# late-starting `if: always()` omnibus (e.g. `check-ok-to-merge`) could race
-# the loop and let it exit green while CI was still running (see
-# https://github.com/max-sixty/tend/issues/305). The 30s grace re-check
-# below covers the short gap between `needs:` jobs finishing and the omnibus
-# check-run registering.
+#
+# Poll statusCheckRollup — every check-run + status context on the commit.
+# Exit when all non-own items are terminal.
+#
+# Why rollup, not `gh pr checks --required`:
+# `--required` only returns required contexts that are ALREADY registered on
+# the commit. An `if: always()` omnibus with a long `needs:` list (e.g.
+# PRQL's `check-ok-to-merge`) only registers once every dependency has
+# reached terminal. With `--required`, the loop would see only fast required
+# contexts (e.g. `pre-commit.ci - pr`), exit green, and miss the matrix
+# entirely. The rollup shows matrix jobs as IN_PROGRESS while they run, so
+# we correctly wait for them, then for the omnibus once it registers.
+# See https://github.com/max-sixty/tend/issues/305.
+#
+# The 30s grace re-check handles actual registration lag: when the matrix's
+# last `needs:` job finishes, the omnibus check-run registers within a
+# second or two. A poll in that narrow window might see PENDING=0; the
+# grace re-check catches the newly-IN_PROGRESS omnibus. The 23-min gap
+# described in #305 is NOT registration lag — that was the matrix running,
+# during which matrix jobs are visibly IN_PROGRESS in the rollup.
 #
 # Filter out the current run ($GITHUB_RUN_ID) — its own CheckRun is
 # IN_PROGRESS for the whole loop. Match on the run URL, not the check name:
 # `gh pr checks` shows the job name (e.g. "review"), which does not match
 # $GITHUB_WORKFLOW ("tend-review").
 #
-# Don't use mergeStateStatus as an exit signal: it stays BLOCKED for the
-# entire run because our own check is pending, and the API can't distinguish
-# "self-blocking" from "required context not yet registered".
+# Don't use mergeStateStatus as an exit signal. BLOCKED is a catch-all:
+# required checks pending, branch out of date (`type: update` rulesets),
+# required reviews missing, or our own check still running — all produce
+# BLOCKED, indistinguishable without admin scope on branch protection.
 pending() {
   gh pr view <number> --json statusCheckRollup \
     | jq --arg own "/runs/$GITHUB_RUN_ID/" '
       [.statusCheckRollup[]
        | select((.detailsUrl // .targetUrl // "") | test($own) | not)
        | (.status // .state)
-       | select(. == "IN_PROGRESS" or . == "QUEUED" or . == "PENDING" or . == "WAITING")
+       | select(. == "IN_PROGRESS" or . == "QUEUED" or . == "PENDING" or . == "WAITING" or . == "REQUESTED" or . == "EXPECTED")
       ] | length'
 }
 for i in $(seq 1 15); do


### PR DESCRIPTION
Follow-up to #311. Three refinements:

## 1. Expand the pending-state filter

Add `EXPECTED` (StatusContext) and `REQUESTED` (CheckRun) to the set of states treated as pending. Both represent "declared but not yet started" in GitHub's GraphQL enums — previously treated as terminal, which could cause premature exit when a status provider has posted `EXPECTED` for a check-run that hasn't actually run yet.

## 2. Rewrite the comment block to reflect what actually happens

The old comment said the 30s grace "covers the short gap between `needs:` jobs finishing and the omnibus check-run registering" and cited #305. That framing was misleading — the 23-min gap in #305 is the matrix itself running (during which matrix jobs are visibly `IN_PROGRESS` in the rollup), not registration lag. Registration lag is actually sub-second.

New comment explains:
- Why rollup beats `gh pr checks --required` (registration ordering in `if: always()` omnibus jobs)
- What the grace actually covers (sub-second registration window between last `needs:` finishing and the omnibus check-run appearing)
- Why the 23-min #305 gap isn't registration lag
- Why `mergeStateStatus` is unusable as an exit signal: `BLOCKED` conflates required-pending with stale branch (`type: update` rulesets), required reviews, and self-block — indistinguishable without admin scope. Verified empirically on PR #310's deadlock: that PR was `behind_by: 1`, which produced `BLOCKED` via the update rule, not via a self-block.

## 3. Consolidate the duplicated polling block

`review/SKILL.md` had the entire polling loop duplicated from `running-in-ci/SKILL.md`. The review skill already loads `running-in-ci` as a prerequisite in step 0. Replaced the duplicate with a reference. The duplication had drifted before (#305 followup flagged it).

## Test plan

- [ ] pre-commit passes on both files
- [ ] Downstream verification happens when consumers next regenerate nightly; the canonical signal is `tend-review` completing under 15 minutes on PRs with non-trivial CI

> _This was written by Claude Code on behalf of Maximilian_