### PR TITLE
skills: remove workarounds for fixed `!` escaping bug

### DIFF
--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -290,7 +290,7 @@ Use `Agent` with `model: "haiku"` and a prompt like:
 > - Bot-closed issue was reopened
 > - Fix commit was reverted or CI still failing after bot pushed
 > - Human replied to bot with correction or complaint
-> - Bot comment contains corruption (literal `${`, unescaped bangs, broken heredoc markers)
+> - Bot comment contains corruption (literal `${`, broken heredoc markers)
 >
 > **Report format** — return a structured summary:
 > ```

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -351,13 +351,6 @@ expanded** — if you see a literal `${GITHUB_REPOSITORY}` in the rendered comme
 single-quoted heredoc (`<< 'EOF'`) which disables expansion. Rewrite using an unquoted `<<EOF`
 (so `${GITHUB_REPOSITORY}` interpolates) or compose the body with the Write tool.
 
-Bash heredocs are also a trap for comment bodies containing exclamation marks — the Bash tool
-rewrites every exclamation mark to a literal backslash-bang before bash parses the heredoc, so
-a greeting like "Thanks for the suggestion!" renders as "Thanks for the suggestion\!" in the
-posted comment. The quoting mode doesn't matter: both `<< 'EOF'` and `<<EOF` lose the
-character. Use the Write tool for any comment body containing an exclamation mark, then pass
-the file to `gh ... --body-file`.
-
 - **File-level link (no `#L` anchor)**: `blob/main/src/foo.rs` is fine
 - **Line reference**: `blob/<sha>/src/foo.rs#L42` — commit SHA required, never `blob/main/...#L42`
 - **Issues/PRs**: `#123` shorthand


### PR DESCRIPTION
The Bash tool no longer rewrites exclamation marks to backslash-bang in heredocs. Verified locally — both `<<EOF` and `<< 'EOF'` now pass `!` through unchanged.

Changes:
- `running-in-ci`: drop the paragraph telling agents to use the Write tool + `--body-file` for comment bodies containing `!`. Heredocs with `gh ... --body` work fine again.
- `review-reviewers`: drop "unescaped bangs" from the bot-comment corruption signals — no longer a thing to watch for.

Kept intentionally:
- The `${GITHUB_REPOSITORY}` heredoc-quoting warning (bash semantics around single-quoted heredocs, not a Claude Code bug).
- The `.pre-commit-config.yaml` bang-backtick guard — that's a separate slash-command preprocessor issue (#234/#243/#244), not the heredoc bug.

> _This was written by Claude Code on behalf of @max-sixty_