### PR TITLE
skills: restore bang-escape warning (bug still fires in CI harness)

### DIFF
--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -290,7 +290,7 @@ Use `Agent` with `model: "haiku"` and a prompt like:
 > - Bot-closed issue was reopened
 > - Fix commit was reverted or CI still failing after bot pushed
 > - Human replied to bot with correction or complaint
-> - Bot comment contains corruption (literal `${`, broken heredoc markers)
+> - Bot comment contains corruption (literal `${`, unescaped bangs, broken heredoc markers)
 >
 > **Report format** — return a structured summary:
 > ```

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -351,6 +351,15 @@ expanded** — if you see a literal `${GITHUB_REPOSITORY}` in the rendered comme
 single-quoted heredoc (`<< 'EOF'`) which disables expansion. Rewrite using an unquoted `<<EOF`
 (so `${GITHUB_REPOSITORY}` interpolates) or compose the body with the Write tool.
 
+The Bash tool rewrites every exclamation mark to a literal backslash-bang before bash parses
+the command, so a greeting like "Thanks for the suggestion!" renders as "Thanks for the
+suggestion\!" in the posted comment. Quoting and heredoc form don't matter: `<< 'EOF'`,
+`<<EOF`, plain single-quoted, and double-quoted arguments all lose the character. Use the
+Write tool for any comment body containing an exclamation mark, then pass the file to
+`gh ... --body-file`. The same trap applies to `--jq` filters with `!=` — either avoid the
+`!=` operator (rephrase as `== "x" | not`), filter client-side after fetching, or load the
+jq script from a file written with the Write tool via `jq -f`.
+
 - **File-level link (no `#L` anchor)**: `blob/main/src/foo.rs` is fine
 - **Line reference**: `blob/<sha>/src/foo.rs#L42` — commit SHA required, never `blob/main/...#L42`
 - **Issues/PRs**: `#123` shorthand


### PR DESCRIPTION
PR #317 removed the `!`-escape heredoc warning from `running-in-ci` citing a local verification that Claude Code no longer rewrites `!` in heredocs. That verification doesn't hold in the GitHub Actions CI harness (Claude Code 2.1.114). The Bash tool still rewrites every `!` to `\!` in this run.

**Reproduction in this run** ([24641241367](https://github.com/max-sixty/tend/actions/runs/24641241367)):

```
$ cat << 'OUTER'
unquoted-1: Hello!
OUTER
unquoted-1: Hello\!

$ cat << 'INNER'
single-2: Hello!
INNER
single-2: Hello\!

$ echo 'plain-single: select(.x != "y")'
plain-single: select(.x \!= "y")

$ echo "plain-double: select(.x != \"y\")"
plain-double: select(.x \!= "y")
```

All four contexts — `<<EOF`, `<< 'EOF'`, plain single-quoted, and double-quoted — still rewrite the character. The bug isn't heredoc-specific; it's at the Bash-tool preprocessor layer.

**Why this matters:** the removed warning was the guard against bot comments shipping with literal `\!` corruption. With it gone, a future bot writing `"Thanks for the suggestion!"` via `gh ... --body` will publish `"Thanks for the suggestion\!"` — the exact user-visible failure mode the warning prevented. No corrupted comments have slipped through in the past ~4 hours since #317 merged, but that's luck, not correctness.

**Changes:**
- `running-in-ci`: restore the `!`-escape paragraph; expand it to cover plain single/double-quoted args (the case that bites `--jq 'select(.x != …)'` commands — already hit 3 times, recorded in the [evidence gist](https://gist.github.com/8f10d7c1abcb07c79bef00ee6d02d315)).
- `review-reviewers`: restore "unescaped bangs" to the corruption-signals list.

**Gate assessment:**
- Evidence level: **High / Critical**. Structural bug in the tool layer; reproduction is deterministic (4/4 contexts fail in this run).
- Occurrences: 1 structural reproduction + 3 cumulative `--jq` occurrences in the evidence gist.
- Change type: Targeted fix (restore removed paragraph, one-word addition in `review-reviewers`).
- Both gates pass.

**Caveat for the maintainer**: if the bug really is fixed in your local Claude Code but not in the CI-pinned version, the right long-term fix may be bumping whatever version the runner installs rather than keeping workaround guidance. Either way, removing the warning while the bug still fires in CI was premature.
