### PR TITLE
running-in-ci: cover PR/issue titles in bang-escape guidance

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -360,6 +360,18 @@ Write tool for any comment body containing an exclamation mark, then pass the fi
 `!=` operator (rephrase as `== "x" | not`), filter client-side after fetching, or load the
 jq script from a file written with the Write tool via `jq -f`.
 
+`gh pr create` / `gh pr edit` / `gh issue create` / `gh issue edit` have no
+`--title-file` flag, so a title containing an exclamation mark (e.g. the
+conventional-commits breaking-change marker in a title like "feat(hooks)!:
+rename …") hits the same rewrite and ships a visibly corrupted title. Write the
+title with the Write tool and pass it via command substitution — `$(cat …)` is
+evaluated by bash after the preprocessor's string scan, so the exclamation mark
+stays literal:
+
+```bash
+gh pr create --title "$(cat /tmp/pr-title.txt)" --body-file /tmp/pr-body.md ...
+```
+
 - **File-level link (no `#L` anchor)**: `blob/main/src/foo.rs` is fine
 - **Line reference**: `blob/<sha>/src/foo.rs#L42` — commit SHA required, never `blob/main/...#L42`
 - **Issues/PRs**: `#123` shorthand


### PR DESCRIPTION
## Summary

Extend the bang-escape workaround in `running-in-ci` to cover PR and issue
titles. PR #318 restored the warning for comment bodies (via `--body-file`);
titles are still uncovered because `gh pr create` has no `--title-file` flag,
so a conventional-commits breaking-change marker in a title like
`feat(hooks)` followed by `!:` gets preprocessor-rewritten and ships with
a literal backslash before the bang.

## Evidence

First wild post-#318 occurrence: `worktrunk-bot` opened
[max-sixty/worktrunk#2359](https://github.com/max-sixty/worktrunk/pull/2359)
at 2026-04-21T18:40:19Z. Raw API confirms the title is stored with a
backslash before the bang:

```
$ gh api repos/max-sixty/worktrunk/pulls/2359 --jq '.title' | cat -A
feat(hooks)\!: rename pre-start/post-start to pre-create/post-create$
```

The corresponding commit message on the same branch is clean —
`git commit` uses `-F`/file internally, so the `!` survives there.
Only `gh pr create --title "feat(hooks)!: ..."` hit the preprocessor.

## Fix

Add one paragraph after the existing `--body-file` guidance documenting the
command-substitution workaround. `$(cat /tmp/pr-title.txt)` is evaluated by
bash after the preprocessor's string scan, so the bang in the file stays
literal. Same pattern covers `gh pr edit --title`, `gh issue create --title`,
and `gh issue edit --title`.

## Gate assessment

- **Evidence level**: Critical — public-facing PR title corruption, 1 occurrence (#2359).
- **Cumulative this month**: prior occurrence was in a comment body
  ([worktrunk#2309](https://github.com/max-sixty/worktrunk/issues/2309#issuecomment-4277108328))
  which PR #318 fixed; this is a different shape not yet covered.
- **Structural vs. stochastic**: structural. Any bot PR with `!` in its title
  reproduces deterministically until the skill documents the workaround.
- **Change type**: targeted fix (one paragraph, no structural changes).
- **Both gates pass**: Critical + structural + proportionate fix.

Evidence gist:
[review-reviewers evidence: max-sixty/worktrunk 2026-04](https://gist.github.com/44ab1483b29406255dd36141650c894d).

Triggering run: https://github.com/max-sixty/tend/actions/runs/24741474472
