### PR TITLE
running-in-ci: anti-example for hard-wrapped PR/issue bodies

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -326,6 +326,32 @@ comments — a line break in the source becomes a `<br>` in the output. Write ea
 single long line and let the browser reflow. Hard wraps at 72–80 chars create awkward mid-sentence
 breaks on GitHub. (This applies to GitHub-rendered content only, not to skill files or code.)
 
+This applies to every delivery path — heredoc, `--body "…"`, and `--body-file`. The Write tool
+does not reflow paragraphs, so authoring to a file is not a fix on its own: the wrapping you
+type is the wrapping that ships.
+
+<example>
+<bad reason="Paragraph hard-wrapped at ~72 chars; GitHub renders each newline as `<br>`, producing mid-sentence breaks">
+
+```
+Extend the bang-escape workaround in `running-in-ci` to cover PR and issue
+titles. PR #318 restored the warning for comment bodies (via `--body-file`);
+titles are still uncovered because `gh pr create` has no `--title-file` flag.
+```
+
+</bad>
+<good reason="Paragraph is one long line; GitHub reflows it to the reader's window width">
+
+```
+Extend the bang-escape workaround in `running-in-ci` to cover PR and issue titles. PR #318 restored the warning for comment bodies (via `--body-file`); titles are still uncovered because `gh pr create` has no `--title-file` flag.
+```
+
+</good>
+</example>
+
+Code blocks, bullet lists, and tables keep their newlines as-is — only prose paragraphs need to
+be unwrapped.
+
 Keep comments concise. Put supporting detail inside `<details>` tags — the reader should get the
 gist without expanding. Don't collapse content that *is* the answer (e.g., a requested analysis).
 


### PR DESCRIPTION
## Problem

The `running-in-ci` skill already says "write each paragraph as a single long line and let the browser reflow," but PR #319 still shipped with a body hard-wrapped at ~72 chars. GitHub renders each source newline as `<br>`, so the description reads with mid-sentence breaks instead of reflowing to the reader's window.

Filed as #320 per @max-sixty's request.

## Solution

Add an explicit do/don't `<example>` block to the existing line-wrapping paragraph, using the observed failure case from #319 as the anti-example. Also clarify two points the prior wording left implicit:

- The rule applies to every delivery path — heredoc, `--body "…"`, and `--body-file` — because the source newlines pass through unchanged.
- The Write tool does not reflow paragraphs, so authoring the body to a file is not a fix on its own.

Code blocks, lists, and tables are called out as still keeping their newlines; only prose paragraphs need to be unwrapped.

## Alternatives considered

The issue suggested two other angles:

- **Lint the composed body before `gh pr create`** — more robust, but significantly more machinery, and the false-positive shape (prose that happens to line up near 80 chars) is awkward to spec.
- **Unify on Write tool + `--body-file` as the canonical path** — doesn't actually solve it: the model can (and did) write a wrapped paragraph to the file.

Strengthening the wording is the smallest change with direct line-of-sight to the failure mode. If this recurs after merge, the lint angle stays on the table.

## Testing

Skill text only — no automated test exists for skill compliance. The change is visible in the diff and follows the existing `<example>` block convention used elsewhere in the file.

---
Closes #320 — automated triage
