### PR TITLE
skills(notifications): add in-flight-run check to dedup gate

### DIFF
--- a/plugins/tend-ci-runner/skills/notifications/SKILL.md
+++ b/plugins/tend-ci-runner/skills/notifications/SKILL.md
@@ -80,8 +80,39 @@ or failed.
 
 Cross-repo notifications are exempt from the freshness gate — no dedicated workflow handles them.
 
-**Dedup check:** For same-repo notifications older than 10 minutes, check whether the bot already
-responded:
+**In-flight check (same-repo only):** The freshness gate is a time-based proxy; dedicated workflows
+that implement real code changes (especially `tend-mention`) routinely run well past 10 minutes. If
+the bot proceeds, it duplicates in-progress work — observed on worktrunk run 24742688091, which
+spent ~79 min / ~$25 re-implementing [PR #2361](https://github.com/max-sixty/worktrunk/pull/2361)
+because dedup at minute 43 saw nothing (the dedicated run didn't push until minute 65). For
+same-repo notifications past the freshness gate, check for a concurrent `tend-*` run on the same
+subject:
+
+```bash
+# $NOTIF_SUBJECT_URL is .subject.url from the notification record
+SUBJECT_TITLE=$(gh api "$NOTIF_SUBJECT_URL" --jq '.title')
+IN_PROGRESS=$(gh api \
+  "repos/$GITHUB_REPOSITORY/actions/runs?status=in_progress&per_page=50" \
+  | jq --arg title "$SUBJECT_TITLE" --argjson own "$GITHUB_RUN_ID" \
+      '[.workflow_runs[]
+        | select(.name | startswith("tend-"))
+        | select(.id != $own)
+        | select(.display_title == $title)
+       ] | length')
+```
+
+If `IN_PROGRESS > 0`, **skip without marking read** — same behavior as the freshness gate. The next
+scheduled poll picks it up once the dedicated run succeeds (dedup below finds its response and
+marks read) or fails (stale-items path in 4b processes it).
+
+Match on `display_title` because the `workflow_run` payload does not expose the triggering issue
+number for `issue_comment` / `pull_request_review` events; `display_title` equals the issue/PR
+title for those events. Title collisions across unrelated subjects are rare enough that skipping
+one unrelated notification is cheaper than one duplicate implementation session. Note also that
+`gh api --jq` does not accept `--arg`/`--argjson` — pipe to a standalone `jq` as above.
+
+**Dedup check:** For same-repo notifications older than 10 minutes with no in-flight dedicated run,
+check whether the bot already responded:
 
 ```bash
 BOT_LOGIN=$(gh api user --jq '.login')

--- a/plugins/tend-ci-runner/skills/notifications/SKILL.md
+++ b/plugins/tend-ci-runner/skills/notifications/SKILL.md
@@ -96,7 +96,7 @@ IN_PROGRESS=$(gh api \
   | jq --arg title "$SUBJECT_TITLE" --argjson own "$GITHUB_RUN_ID" \
       '[.workflow_runs[]
         | select(.name | startswith("tend-"))
-        | select(.id != $own)
+        | select((.id == $own) | not)
         | select(.display_title == $title)
        ] | length')
 ```
@@ -108,8 +108,12 @@ marks read) or fails (stale-items path in 4b processes it).
 Match on `display_title` because the `workflow_run` payload does not expose the triggering issue
 number for `issue_comment` / `pull_request_review` events; `display_title` equals the issue/PR
 title for those events. Title collisions across unrelated subjects are rare enough that skipping
-one unrelated notification is cheaper than one duplicate implementation session. Note also that
-`gh api --jq` does not accept `--arg`/`--argjson` — pipe to a standalone `jq` as above.
+one unrelated notification is cheaper than one duplicate implementation session.
+
+Two bash-tool gotchas in the query above: `gh api --jq` does not accept `--arg`/`--argjson`, so
+pipe to a standalone `jq`. Avoid jq's not-equal operator (bang-equals) in filters authored via the
+Bash tool — the tool can still rewrite a bare bang to backslash-bang outside heredocs, which
+breaks the filter; use the `(X) | not` form as above.
 
 **Dedup check:** For same-repo notifications older than 10 minutes with no in-flight dedicated run,
 check whether the bot already responded:

--- a/plugins/tend-ci-runner/skills/notifications/SKILL.md
+++ b/plugins/tend-ci-runner/skills/notifications/SKILL.md
@@ -80,13 +80,9 @@ or failed.
 
 Cross-repo notifications are exempt from the freshness gate — no dedicated workflow handles them.
 
-**In-flight check (same-repo only):** The freshness gate is a time-based proxy; dedicated workflows
-that implement real code changes (especially `tend-mention`) routinely run well past 10 minutes. If
-the bot proceeds, it duplicates in-progress work — observed on worktrunk run 24742688091, which
-spent ~79 min / ~$25 re-implementing [PR #2361](https://github.com/max-sixty/worktrunk/pull/2361)
-because dedup at minute 43 saw nothing (the dedicated run didn't push until minute 65). For
-same-repo notifications past the freshness gate, check for a concurrent `tend-*` run on the same
-subject:
+**In-flight check (same-repo only):** A dedicated workflow can still be executing past the
+freshness gate. For notifications older than 10 minutes, check for a concurrent `tend-*` run on the
+same subject:
 
 ```bash
 # $NOTIF_SUBJECT_URL is .subject.url from the notification record
@@ -101,19 +97,13 @@ IN_PROGRESS=$(gh api \
        ] | length')
 ```
 
-If `IN_PROGRESS > 0`, **skip without marking read** — same behavior as the freshness gate. The next
-scheduled poll picks it up once the dedicated run succeeds (dedup below finds its response and
-marks read) or fails (stale-items path in 4b processes it).
+If `IN_PROGRESS > 0`, **skip without marking read** — the next poll will see the completed response
+via the dedup check below. Match on `display_title` because the `workflow_run` payload does not
+expose the triggering issue number for `issue_comment` / `pull_request_review` events.
 
-Match on `display_title` because the `workflow_run` payload does not expose the triggering issue
-number for `issue_comment` / `pull_request_review` events; `display_title` equals the issue/PR
-title for those events. Title collisions across unrelated subjects are rare enough that skipping
-one unrelated notification is cheaper than one duplicate implementation session.
-
-Two bash-tool gotchas in the query above: `gh api --jq` does not accept `--arg`/`--argjson`, so
-pipe to a standalone `jq`. Avoid jq's not-equal operator (bang-equals) in filters authored via the
-Bash tool — the tool can still rewrite a bare bang to backslash-bang outside heredocs, which
-breaks the filter; use the `(X) | not` form as above.
+`gh api --jq` does not accept `--arg`/`--argjson` — pipe to standalone `jq`. Avoid jq's not-equal
+operator in filters authored via the Bash tool (a bare bang can get rewritten outside heredocs);
+use `(X) | not`.
 
 **Dedup check:** For same-repo notifications older than 10 minutes with no in-flight dedicated run,
 check whether the bot already responded:


### PR DESCRIPTION
## Summary

Upstreams the fix from worktrunk PR [max-sixty/worktrunk#2386](https://github.com/max-sixty/worktrunk/pull/2386) into the bundled notifications skill.

Step 4a of the dedup check currently finds *completed* bot activity (comments, reviews, timeline cross-references). It does not see a dedicated workflow that is still running. `tend-mention` sessions that involve real implementation routinely run past the 10-minute freshness gate — when the notifications bot proceeds, it re-implements in-progress work.

Evidence (from worktrunk, finding in #2386):

- Run [24742688091](https://github.com/max-sixty/worktrunk/actions/runs/24742688091) — ~79 min, ~$25, 279 turns. Re-implemented [PR #2361](https://github.com/max-sixty/worktrunk/pull/2361) while tend-mention was still pushing; last-step dedup caught the collision and cleaned up, but the session cost had already been incurred.
- Run [24519963858](https://github.com/max-sixty/worktrunk/actions/runs/24519963858) — ~16 min, ~$9, 168 turns. Same pattern on PR #2263 / issue #2261.

## Change

Adds an **In-flight check** sub-step to step 4a of `plugins/tend-ci-runner/skills/notifications/SKILL.md`, sitting between the freshness gate and the dedup check. It queries `actions/runs?status=in_progress`, filters to `tend-*` runs, excludes `$GITHUB_RUN_ID`, and matches on `display_title` (the workflow_run payload does not expose the triggering issue number for `issue_comment` / `pull_request_review` events without an extra API call per run). On hit, skip without marking read — same disposition as the freshness gate.

The two bash-tool caveats from the overlay are preserved inline: `gh api --jq` does not accept `--arg`/`--argjson`, and the Bash tool's bang rewriting can still bite outside heredocs, so the jq uses `(X) | not` rather than the not-equal operator.

## Why this lives in tend, not as a per-repo overlay

The precedence rule codified in CLAUDE.md ("Skill precedence: repo > bundled") and in `running-in-ci/SKILL.md` ([#306](https://github.com/max-sixty/tend/pull/306)) says overlays are for repo-specific policy/convention/taste. This fix is generic: any tend consumer whose `tend-mention` runs can exceed 10 minutes will hit the same race. That makes it a bundled-skill defect, not an overlay.

## Follow-up on worktrunk

Once this lands, [worktrunk#2386](https://github.com/max-sixty/worktrunk/pull/2386) is redundant — the bundled skill now covers what its overlay added. A human should close #2386 and revert the overlay section it added to `.claude/skills/running-tend/SKILL.md`. I have not touched worktrunk.

## Test plan

- [x] `pre-commit run --all-files` passes
- [x] jq query verified against worktrunk's `actions/runs?status=in_progress` (returns 0 when no concurrent tend run matches the subject title, which is the current state)
- [ ] Next time a same-repo mention triggers a long `tend-mention` run, verify a concurrent notifications run sees `IN_PROGRESS > 0` and exits cleanly

> _This was written by Claude Code on behalf of @max-sixty_