### PR TITLE
running-in-ci: verify external-tool behavior by run or clone, not just hand-test

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -501,8 +501,7 @@ copy-pasted.
 ### Verifying external-tool behavior
 
 When a claim turns on how an external CLI, API, or system behaves, verify by running the
-code. Upstream docs for fast-moving tools lag or describe flags that were removed or
-renamed — don't treat them as proof on their own.
+code.
 
 Two paths, in order of preference:
 

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -498,6 +498,41 @@ If you can't find source evidence for a specific detail, say so ("I'm not sure o
 syntax") rather than guessing. An honest gap is fixable; a confident hallucination gets
 copy-pasted.
 
+### External-tool behavioral claims need a hand-test
+
+When a review or triage turns on how an external CLI, API, or system behaves — and that tool
+is not installed in CI and not exercised by automated tests — the "run the command yourself"
+fallback above doesn't apply. Upstream docs for fast-moving tools lag or describe flags that
+were removed or renamed, and reading the tool's source isn't an option when it lives in a
+separate project. Do not post a confident claim or commit code/doc changes that depend on
+the behavior.
+
+1. Name the gap. Quote the question back and state that the behavior needs hand-testing on
+   a machine with the tool installed.
+2. If you have partial evidence (upstream docs, a commit, a linked issue), cite it and
+   hedge: "According to X's docs, Y — but I haven't verified on a real install. Could
+   someone with X installed confirm before I push a change?"
+3. Don't ship a doc or code change whose correctness depends on the claim until a human
+   confirms. In triage, the same rule applies: if a repro uses a tool not in CI, flag the
+   repro as unverified rather than asserting a fix.
+
+<example>
+<bad reason="Trusted upstream docs for a fast-moving external CLI and shipped a broken recipe">
+
+Bad: Review asked whether `cmux list-workspaces` had structured output. Read a mintlify
+page describing `--json` → rewrote the recipe to `cmux list-workspaces --json | jq ...` →
+committed. The installed cmux had no `--json` flag; every reader hit a broken recipe.
+
+</bad>
+<good reason="Named the verification gap and deferred to a human with the tool installed">
+
+Good: Same question. Read the docs → replied: "The docs describe `--json`, but cmux isn't
+installed in CI so I can't verify against your version. Could you confirm
+`cmux list-workspaces --help` shows `--json` before I push the change?" Waited.
+
+</good>
+</example>
+
 ### Rewriting is authoring
 
 Cross-posting, summarizing, or paraphrasing is not copying — any new content you add requires the

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -498,23 +498,23 @@ If you can't find source evidence for a specific detail, say so ("I'm not sure o
 syntax") rather than guessing. An honest gap is fixable; a confident hallucination gets
 copy-pasted.
 
-### External-tool behavioral claims need a hand-test
+### Verifying external-tool behavior
 
-When a review or triage turns on how an external CLI, API, or system behaves — and that tool
-is not installed in CI and not exercised by automated tests — the "run the command yourself"
-fallback above doesn't apply. Upstream docs for fast-moving tools lag or describe flags that
-were removed or renamed, and reading the tool's source isn't an option when it lives in a
-separate project. Do not post a confident claim or commit code/doc changes that depend on
-the behavior.
+When a claim turns on how an external CLI, API, or system behaves, verify by running the
+code. Upstream docs for fast-moving tools lag or describe flags that were removed or
+renamed — don't treat them as proof on their own.
 
-1. Name the gap. Quote the question back and state that the behavior needs hand-testing on
-   a machine with the tool installed.
-2. If you have partial evidence (upstream docs, a commit, a linked issue), cite it and
-   hedge: "According to X's docs, Y — but I haven't verified on a real install. Could
-   someone with X installed confirm before I push a change?"
-3. Don't ship a doc or code change whose correctness depends on the claim until a human
-   confirms. In triage, the same rule applies: if a repro uses a tool not in CI, flag the
-   repro as unverified rather than asserting a fix.
+Two paths, in order of preference:
+
+1. **Run the tool.** If it's installable in this environment, install it and invoke the
+   specific command or flag in question. Link the output in your reply.
+2. **Read the source.** Tend can clone any public repo. `gh repo clone <owner>/<repo>`
+   then grep for the flag or behavior. Source doesn't lag itself, and a flag that isn't
+   defined in the parser doesn't exist.
+
+If both paths fail (GUI-only tool, private repo, environment-specific behavior), cite
+what you found, name the remaining gap, and ask a human with the tool installed to
+confirm before shipping a dependent change.
 
 <example>
 <bad reason="Trusted upstream docs for a fast-moving external CLI and shipped a broken recipe">
@@ -524,11 +524,11 @@ page describing `--json` → rewrote the recipe to `cmux list-workspaces --json 
 committed. The installed cmux had no `--json` flag; every reader hit a broken recipe.
 
 </bad>
-<good reason="Named the verification gap and deferred to a human with the tool installed">
+<good reason="Cloned the upstream source and verified the flag before shipping">
 
-Good: Same question. Read the docs → replied: "The docs describe `--json`, but cmux isn't
-installed in CI so I can't verify against your version. Could you confirm
-`cmux list-workspaces --help` shows `--json` before I push the change?" Waited.
+Good: Same question. Cloned cmux's source repo → grepped the CLI parser for
+`list-workspaces` → saw no `--json` flag defined → replied with the source link and
+proposed an alternative that matched the actual CLI surface.
 
 </good>
 </example>


### PR DESCRIPTION
## Problem

The bundled `running-in-ci` skill's Grounded Analysis section covers behavioral claims by telling the bot to "run the command yourself" or hedge — but that fallback doesn't obviously apply to external CLIs and APIs that aren't installed in CI and aren't exercised by automated tests. In [worktrunk#1907](https://github.com/max-sixty/worktrunk/pull/1907#issuecomment-4292844468) the bot read upstream mintlify docs describing a `cmux list-workspaces --json` flag, believed it, and committed a recipe that broke for every reader — the installed cmux had no such flag.

## Solution

Adds a new `### Verifying external-tool behavior` subsection under Grounded Analysis. It points at two concrete verification paths in order of preference: install and run the tool, or clone its public repo and grep the source. Deferring to a human with the tool installed is the fallback only when both paths fail. The "don't make overconfident claims" framing already lives in the preceding `### User-facing comments require source evidence` subsection.

Bad/good example is drawn from the cmux incident: the good path now shows cloning the upstream repo and checking the CLI parser, not asking a human to confirm.

## Testing

Skill text only. `pre-commit run` on the modified file passes (typos, trim-whitespace, bang-backtick, end-of-files).

---
Closes #326 — automated triage
