### PR TITLE
running-in-ci: lead bang-escape paragraph with universal rule

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -377,13 +377,14 @@ expanded** — if you see a literal `${GITHUB_REPOSITORY}` in the rendered comme
 single-quoted heredoc (`<< 'EOF'`) which disables expansion. Rewrite using an unquoted `<<EOF`
 (so `${GITHUB_REPOSITORY}` interpolates) or compose the body with the Write tool.
 
-**If a Bash-tool command string contains a literal `!` — comment body, jq script, markdown
-heredoc, anything — use the Write tool. Heredocs and quoting do not save you.** The Bash
-tool rewrites every exclamation mark to a literal backslash-bang before bash parses the
-command, so a greeting like "Thanks for the suggestion!" renders as "Thanks for the
-suggestion\!" in the posted comment. Quoting and heredoc form don't matter: `<< 'EOF'`,
-`<<EOF`, plain single-quoted, and double-quoted arguments all lose the character. Use the
-Write tool for any comment body containing an exclamation mark, then pass the file to
+**If a Bash-tool command string contains a literal exclamation mark — comment body, jq
+script, markdown heredoc, anything — use the Write tool. Heredocs and quoting do not save
+you.** The Bash tool rewrites every exclamation mark to a literal backslash-bang before
+bash parses the command, so a greeting like "Thanks for the suggestion!" renders as "Thanks
+for the suggestion\!" in the posted comment. Quoting and heredoc form don't matter:
+`<< 'EOF'`, `<<EOF`, plain single-quoted, and double-quoted arguments all lose the
+character. Use the Write tool for any comment body containing an exclamation mark, then pass
+the file to
 `gh ... --body-file`. The same trap applies to `jq` and `--jq` filters with `!=` — either
 avoid the `!=` operator (rephrase as `== "x" | not`), filter client-side after fetching, or
 load the jq script from a file written with the Write tool via `jq -f`.

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -377,14 +377,16 @@ expanded** — if you see a literal `${GITHUB_REPOSITORY}` in the rendered comme
 single-quoted heredoc (`<< 'EOF'`) which disables expansion. Rewrite using an unquoted `<<EOF`
 (so `${GITHUB_REPOSITORY}` interpolates) or compose the body with the Write tool.
 
-The Bash tool rewrites every exclamation mark to a literal backslash-bang before bash parses
-the command, so a greeting like "Thanks for the suggestion!" renders as "Thanks for the
+**If a Bash-tool command string contains a literal `!` — comment body, jq script, markdown
+heredoc, anything — use the Write tool. Heredocs and quoting do not save you.** The Bash
+tool rewrites every exclamation mark to a literal backslash-bang before bash parses the
+command, so a greeting like "Thanks for the suggestion!" renders as "Thanks for the
 suggestion\!" in the posted comment. Quoting and heredoc form don't matter: `<< 'EOF'`,
 `<<EOF`, plain single-quoted, and double-quoted arguments all lose the character. Use the
 Write tool for any comment body containing an exclamation mark, then pass the file to
-`gh ... --body-file`. The same trap applies to `--jq` filters with `!=` — either avoid the
-`!=` operator (rephrase as `== "x" | not`), filter client-side after fetching, or load the
-jq script from a file written with the Write tool via `jq -f`.
+`gh ... --body-file`. The same trap applies to `jq` and `--jq` filters with `!=` — either
+avoid the `!=` operator (rephrase as `== "x" | not`), filter client-side after fetching, or
+load the jq script from a file written with the Write tool via `jq -f`.
 
 `gh pr create` / `gh pr edit` / `gh issue create` / `gh issue edit` have no
 `--title-file` flag, so a title containing an exclamation mark (e.g. the


### PR DESCRIPTION
## What

Lead the Bash-tool `!`-rewrite paragraph in `running-in-ci` with a universal bolded rule, and widen the existing `--jq` sentence to `jq` and `--jq`.

## Why

Run [24934825484](https://github.com/max-sixty/tend/actions/runs/24934825484) (the prior `review-reviewers` tick) produced the 7th cumulative occurrence of this trap, this time in the `max-sixty/worktrunk` matrix cell. The analyzing agent ran:

```
echo "$all_runs" | jq --argjson cutoff "$COMPLETED_AFTER" '
  [ .[] | select(.conclusion != null and .conclusion != "") | select((.updatedAt | fromdateiso8601) >= $cutoff) ]
'
```

The Bash tool rewrote `!=` to `\!=` and jq errored: `syntax error, unexpected INVALID_CHARACTER`. The agent self-corrected, but at the cost of extra tool calls.

This is a `jq` (positional script after a pipe), not `--jq`. The existing guidance specifically said "`--jq` filters with `!=`", so the bot's pattern-match — "I'm using `jq`, not `--jq`, doesn't apply" — slipped past it.

## Evidence (cumulative bang-escape)

| # | Run | Surface |
|---|-----|---------|
| 1 | 24600425777 | `--jq` |
| 2 | 24601383739 | `--jq` |
| 3 | 24800211802 | `--jq` |
| 4–5 | 24853949956 | `--jq` (×2) |
| 6 | 24886530908 | markdown heredoc body |
| 7 | 24934825484 | `jq` (positional, after pipe) |

Run 24886530908 explicitly committed: *"if a 7th occurrence appears in any surface, propose a one-line bolded callout at the top of the 'Comment Formatting' bang-escape paragraph distilling the rule to 'if your text contains a literal `!`, use the Write tool — heredocs do not save you'."* This PR delivers that.

## Gate assessment

- **Confidence**: stochastic lapse, 7 cumulative occurrences (≥ 5+ threshold for stochastic).
- **Magnitude**: targeted fix — leads existing paragraph with a bolded one-liner, widens `--jq` → `jq` and `--jq`. Two-line addition, one-word substitution.
- **Both gates pass.**

## Evidence log

[`review-reviewers` evidence gist for `max-sixty/tend` 2026-04](https://gist.github.com/8f10d7c1abcb07c79bef00ee6d02d315). The 7th occurrence will be appended after this run.
