### PR TITLE
docs(security-model): rename stale Renovate column to Weekly

### DIFF
--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -178,14 +178,14 @@ passing between them.
 
 ### What each workflow needs to do
 
-| Capability | Triage | Mention | Review | CI Fix | Nightly | Renovate |
+| Capability | Triage | Mention | Review | CI Fix | Nightly | Weekly |
 |------------|:---:|:---:|:---:|:---:|:---:|:---:|
-| Read issues/PRs | Yes | Yes | Yes | Yes | Yes | — |
-| Comment on issues | Yes | Yes | Yes | — | Yes | — |
+| Read issues/PRs | Yes | Yes | Yes | Yes | Yes | Yes |
+| Comment on issues | Yes | Yes | Yes | — | Yes | Yes |
 | Create branches | Yes | Yes | Yes | Yes | Yes | Yes |
 | Push commits | Yes | Yes | Yes | Yes | Yes | Yes |
 | Create PRs | Yes | Yes | — | Yes | Yes | Yes |
-| Post PR reviews | — | — | Yes | — | — | — |
+| Post PR reviews | — | — | Yes | — | — | Yes |
 | Resolve review threads | — | — | Yes | — | — | — |
 | Monitor CI | Yes | Yes | Yes | Yes | Yes | Yes |
 | **Pushes must trigger CI** | **Yes** | **Yes** | **Yes** | **Yes** | **Yes** | **Yes** |


### PR DESCRIPTION
## Summary

The "What each workflow needs to do" table in `docs/security-model.md` still listed "Renovate" as the rightmost column. PR #106 renamed `tend-renovate` to `tend-weekly` and broadened the workflow's scope, but missed updating this table. The column values (no read, no comment, no review-posting) reflected the narrow `tend-renovate` capabilities and don't match what `tend-weekly` actually does today.

Per `plugins/tend-ci-runner/skills/weekly/SKILL.md`, the weekly workflow:

- Lists and reads dependency PRs (Read PRs)
- Comments on PRs about CI failures or major version bumps (Comment)
- Approves PRs via `gh pr review --approve` (Post PR reviews)
- Already had Yes for Create branches / Push commits / Create PRs / Monitor CI (used for repo-specific weekly tasks defined in `running-tend`)

Found in nightly rolling-survey of `docs/security-model.md`.

## Test plan

- [ ] No code changes — table edit only
- [ ] Verify column values against `plugins/tend-ci-runner/skills/weekly/SKILL.md`
