### PR TITLE
skills(nightly): drop marker, dedup PAT-scope-audit by title

### DIFF
--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -22,16 +22,58 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/pat-scope-audit.sh
 
 The script prints `key=value` lines. Act on `STATUS`:
 
-- `STATUS=ok`: all scopes present. Search for an open tracking issue whose
-  body contains the marker `<!-- tend-pat-scope-audit -->`; if found, close it
-  with a comment noting the scopes are now granted.
+- `STATUS=ok`: all scopes present. Search for an open tracking issue (see
+  "Marker handling" below); if found, close it with a comment noting the
+  scopes are now granted.
 - `STATUS=fine-grained`: no `X-OAuth-Scopes` header. Fine-grained PATs have
   no documented self-introspection endpoint — skip.
 - `STATUS=missing`: open a tracking issue (or update an existing one matched
-  by the marker). The issue body must include the marker on its own line
-  for dedup, list the values from `MISSING=`, and link step 8 of the
-  `install-tend` skill for remediation:
+  by the marker). The issue body must include the marker
+  `<!-- tend-pat-scope-audit -->` on its own line for dedup, list the values
+  from `MISSING=`, and link step 8 of the `install-tend` skill for
+  remediation:
   https://github.com/max-sixty/tend/blob/main/plugins/install-tend/skills/install-tend/SKILL.md#8-bot-pat-and-secret
+
+### Marker handling — bang-escape mitigation
+
+The marker `<!-- tend-pat-scope-audit -->` contains an exclamation mark,
+which the Bash tool rewrites to backslash-bang before bash parses the
+command — the universal hazard documented in `running-in-ci`. Both
+directions of the dedup workflow are broken if you put `<!--` in any
+Bash-tool command string:
+
+- **Body composition** via `gh issue create --body "..."` or a Bash heredoc
+  ships the marker with the exclamation mark backslash-escaped — visible
+  corruption in the posted body, and future runs searching for the intact
+  marker will not match it.
+- **Search** via `jq '... contains("<!-- tend-pat-scope-audit -->")'`
+  rewrites the exclamation mark; jq fails to parse the backslash-bang
+  sequence as an escape and the search silently returns nothing — so the
+  agent concludes no audit issue exists and opens a duplicate.
+
+Use the bang-safe forms instead:
+
+- **Search by the bang-free substring** `tend-pat-scope-audit` (the
+  identifier is unique on its own — the `<!--` wrapping is purely for
+  human-invisibility in the rendered issue):
+
+  ```bash
+  gh issue list --state open --search "tend-pat-scope-audit in:body" \
+    --json number,title,body \
+    --jq '.[] | select(.body | contains("tend-pat-scope-audit"))'
+  ```
+
+- **Compose the body with the Write tool** to a file, then pass via
+  `--body-file`. Authoring through the Write tool preserves `<!--`
+  verbatim:
+
+  ```bash
+  # Author /tmp/pat-scope-body.md with the Write tool. The body must
+  # include the literal marker line: <!-- tend-pat-scope-audit -->
+  gh issue create --title "..." --body-file /tmp/pat-scope-body.md ...
+  # When updating an existing tracking issue:
+  gh issue edit <number> --body-file /tmp/pat-scope-body.md
+  ```
 
 ## Step 2: Resolve conflicts on bot PRs
 

--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -22,58 +22,19 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/pat-scope-audit.sh
 
 The script prints `key=value` lines. Act on `STATUS`:
 
-- `STATUS=ok`: all scopes present. Search for an open tracking issue (see
-  "Marker handling" below); if found, close it with a comment noting the
-  scopes are now granted.
-- `STATUS=fine-grained`: no `X-OAuth-Scopes` header. Fine-grained PATs have
-  no documented self-introspection endpoint — skip.
-- `STATUS=missing`: open a tracking issue (or update an existing one matched
-  by the marker). The issue body must include the marker
-  `<!-- tend-pat-scope-audit -->` on its own line for dedup, list the values
-  from `MISSING=`, and link step 8 of the `install-tend` skill for
-  remediation:
+- `STATUS=ok`: all scopes present. Search open issues for a PAT scope
+  audit tracking issue (`gh issue list --state open --search "PAT
+  in:title"`); if found, close it with a comment noting the scopes are
+  now granted.
+- `STATUS=fine-grained`: no `X-OAuth-Scopes` header. Fine-grained PATs
+  have no documented self-introspection endpoint — skip.
+- `STATUS=missing`: open or update a tracking issue. Use a title
+  containing "PAT" (e.g. `Bot PAT: missing scopes`) so future runs can
+  dedup by title search. Before creating, run `gh issue list --state open
+  --search "PAT in:title"` and update the existing issue with `gh issue
+  edit` if one is already open. The body lists the values from `MISSING=`
+  and links step 8 of the `install-tend` skill for remediation:
   https://github.com/max-sixty/tend/blob/main/plugins/install-tend/skills/install-tend/SKILL.md#8-bot-pat-and-secret
-
-### Marker handling — bang-escape mitigation
-
-The marker `<!-- tend-pat-scope-audit -->` contains an exclamation mark,
-which the Bash tool rewrites to backslash-bang before bash parses the
-command — the universal hazard documented in `running-in-ci`. Both
-directions of the dedup workflow are broken if you put `<!--` in any
-Bash-tool command string:
-
-- **Body composition** via `gh issue create --body "..."` or a Bash heredoc
-  ships the marker with the exclamation mark backslash-escaped — visible
-  corruption in the posted body, and future runs searching for the intact
-  marker will not match it.
-- **Search** via `jq '... contains("<!-- tend-pat-scope-audit -->")'`
-  rewrites the exclamation mark; jq fails to parse the backslash-bang
-  sequence as an escape and the search silently returns nothing — so the
-  agent concludes no audit issue exists and opens a duplicate.
-
-Use the bang-safe forms instead:
-
-- **Search by the bang-free substring** `tend-pat-scope-audit` (the
-  identifier is unique on its own — the `<!--` wrapping is purely for
-  human-invisibility in the rendered issue):
-
-  ```bash
-  gh issue list --state open --search "tend-pat-scope-audit in:body" \
-    --json number,title,body \
-    --jq '.[] | select(.body | contains("tend-pat-scope-audit"))'
-  ```
-
-- **Compose the body with the Write tool** to a file, then pass via
-  `--body-file`. Authoring through the Write tool preserves `<!--`
-  verbatim:
-
-  ```bash
-  # Author /tmp/pat-scope-body.md with the Write tool. The body must
-  # include the literal marker line: <!-- tend-pat-scope-audit -->
-  gh issue create --title "..." --body-file /tmp/pat-scope-body.md ...
-  # When updating an existing tracking issue:
-  gh issue edit <number> --body-file /tmp/pat-scope-body.md
-  ```
 
 ## Step 2: Resolve conflicts on bot PRs
 


### PR DESCRIPTION
## Summary

Per review feedback: drop the `<!-- tend-pat-scope-audit -->` marker entirely and dedup the PAT-scope-audit tracking issue by title instead. The agent searches `PAT in:title` before creating a new issue and updates the existing one if found. Less robust against title edits, but materially simpler — and removes the bang-escape surface that motivated the original PR.

## Why this changed direction

The original PR added a "Marker handling — bang-escape mitigation" section to teach the agent which forms to use when the marker is bang-bearing. Maintainer feedback: easier to remove the bang-bearing literal from the recipe than to teach two safe forms around it. Title-based dedup costs robustness when the title is edited, but no marker means no Bash-tool exclamation-mark hazard, which removes the failure mode that triggered the PR.

## Evidence the original failure was real

Run [24950611809](https://github.com/max-sixty/worktrunk/actions/runs/24950611809) on `max-sixty/worktrunk` (2026-04-26 06:55Z): the nightly bot's marker-quoting search recipe was rewritten by the Bash preprocessor (`<!--` → `<\!--`); jq raised `invalid escape sequence "\!"` and the search returned empty; the bot opened [#2421](https://github.com/max-sixty/worktrunk/issues/2421) (body shipped with `<\!--` corruption) and self-closed it as a duplicate of [#2273](https://github.com/max-sixty/worktrunk/issues/2273) seven minutes later. Title-based dedup avoids both failure modes.

## Test plan

- [ ] CI pre-commit's `forbid bang-backtick in plugin skill files` guard passes (verified locally — 0 hits)
- [ ] Next nightly on a worktrunk-shape adopter dedups against an existing PAT-scope-audit issue by title without creating a new one
- [ ] No `<!--` markers appear in newly opened PAT-scope-audit issues
