### PR TITLE
running-in-ci: filter same-workflow checks in CI poller

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -185,15 +185,27 @@ background task completes you will be notified — check the result and take any
 # `gh pr checks` shows the job name (e.g. "review"), which does not match
 # $GITHUB_WORKFLOW ("tend-review").
 #
+# Also exclude same-workflow check runs ($GITHUB_WORKFLOW). When the current
+# session pushes a commit or replies to an inline review comment, GitHub
+# fires events that trigger a *sibling* run of the same workflow on the same
+# PR. For workflows whose handle job uses `cancel-in-progress: false` (e.g.
+# tend-mention's `tend-mention-handle-{PR#}` group), the sibling's handle job
+# queues behind the current one — its CheckRun shows PENDING in the rollup
+# but it can't start until the current run exits. Polling for it deadlocks
+# until the 15-min cap breaks it ($1+ wasted per occurrence). For workflows
+# with `cancel-in-progress: true`, the older sibling is cancelled and
+# wouldn't gate polling anyway, so this filter is a no-op there.
+#
 # Don't use mergeStateStatus as an exit signal. BLOCKED is a catch-all:
 # required checks pending, branch out of date (`type: update` rulesets),
 # required reviews missing, or our own check still running — all produce
 # BLOCKED, indistinguishable without admin scope on branch protection.
 pending() {
   gh pr view <number> --json statusCheckRollup \
-    | jq --arg own "/runs/$GITHUB_RUN_ID/" '
+    | jq --arg own "/runs/$GITHUB_RUN_ID/" --arg wf "$GITHUB_WORKFLOW" '
       [.statusCheckRollup[]
        | select((.detailsUrl // .targetUrl // "") | test($own) | not)
+       | select((.workflowName // "") != $wf)
        | (.status // .state)
        | select(. == "IN_PROGRESS" or . == "QUEUED" or . == "PENDING" or . == "WAITING" or . == "REQUESTED" or . == "EXPECTED")
       ] | length'
@@ -213,7 +225,10 @@ exit 1
 1. Poll every 60 seconds (up to ~15 minutes) until all non-own check-runs on the commit are
    terminal. **Filter out the current run's URL (`/runs/$GITHUB_RUN_ID/`)** — the current
    workflow's own check is always pending while polling and must be excluded to avoid a
-   deadlock. The 30s grace re-check catches late-registering omnibus checks.
+   deadlock. **Also filter same-workflow check runs (`$GITHUB_WORKFLOW`)** — sibling runs of
+   the same workflow on the same PR are subject to concurrency rules (queueing or
+   cancel-in-progress) and don't represent independent CI signals. The 30s grace re-check
+   catches late-registering omnibus checks.
 2. If a required check fails, diagnose with `gh run view <run-id> --log-failed`, fix, commit,
    push, repeat.
 3. Report completion only after all required checks pass.


### PR DESCRIPTION
## Summary

Extend the CI-polling helper's exclusion filter so it also drops check runs whose `workflowName` matches `$GITHUB_WORKFLOW`. Without this, a `tend-mention` session that pushes a commit or replies to an inline review comment ends up polling for its own queued sibling — a deadlock that only the 15-min cap breaks.

## Why

Run [24927643947](https://github.com/max-sixty/tend/actions/runs/24927643947) (`tend-mention` on PR [#328](https://github.com/max-sixty/tend/pull/328)) ran 18 minutes / $1.16 — about 4× the cost of an equivalent fix-and-reply session. The session log shows ~3 minutes of productive work followed by 15 minutes of polling that never converged, with the bot logging:

> CI still running after 15 minutes
> ...
> handle tend-mention PENDING

The PENDING `handle` job belonged to a *sibling* `tend-mention` run [24927689625](https://github.com/max-sixty/tend/actions/runs/24927689625), triggered by the bot's own reply to the inline review comment via `POST /pulls/{n}/comments/{id}/replies`. `tend-mention.yaml`'s handle job uses concurrency group `tend-mention-handle-{PR#}` with `cancel-in-progress: false`, which queued the sibling behind the current run. Result: the sibling waited for the current run to finish; the current run's polling waited for the sibling's `handle` to start — a guaranteed deadlock until the 15-min timer expired.

Verified the chain:

- 09:19:50Z — `tend-mention` 24927643947 started (review submission with inline comment).
- 09:21Z — bot pushed `fd3f7a6` and posted reply via the `/replies` endpoint.
- 09:22:23Z — `tend-mention` 24927689625 created (`pull_request_review` event, queued by concurrency group).
- 09:22:29Z — `ci` for the new commit completed.
- 09:23:55Z — `tend-review` 24927685808 completed.
- 09:23Z onwards — only thing left non-terminal in the rollup was sibling 24927689625's `handle` job.
- 09:37:59Z — current run timed out after 15 minutes of polling.
- 09:39:10Z — sibling 24927689625 finally ran (4 turns, silent self-conversation exit, $0.30) once the concurrency lock cleared.

The sibling's `verify` job (no concurrency) ran promptly and was COMPLETED by ~09:23, so it didn't gate polling. Only the queued `handle` job did.

`tend-mention.yaml` already documents (lines ~17–28) that GitHub fires both `pull_request_review` and `pull_request_review_comment` for every newly-created inline comment, and the workflow correctly avoids the duplicate by *not* subscribing to `pull_request_review_comment.created`. The remaining `pull_request_review.submitted` subscription is the trigger for the sibling, and silencing that would drop legitimate user follow-up reviews. The proportionate fix is at the polling helper.

## Fix

Add a same-workflow filter to `pending()` in `plugins/tend-ci-runner/skills/running-in-ci/SKILL.md`:

```jq
| select((.workflowName // "") != $wf)
```

with `$wf = $GITHUB_WORKFLOW`. Same-workflow check runs are subject to concurrency rules (queueing for `cancel-in-progress: false` workflows like `tend-mention`, or cancelled-on-supersede for `cancel-in-progress: true` workflows like `tend-review`) and don't represent independent CI signals. For `cancel-in-progress: true` workflows, the filter is a no-op — older siblings are cancelled and already not in IN_PROGRESS state. The fix is targeted to the deadlock case while remaining benign elsewhere.

The accompanying comment block explains the failure mode in-place so a future reader doesn't re-derive it from the symptom.

## Gate assessment

- **Evidence level**: Critical — 1 occurrence sufficient. Concrete cost ($1.46 across the deadlocked pair), reproducible from the workflow's documented event-firing behavior plus its handle-job concurrency group. Same-condition runs are guaranteed to repeat the failure.
- **Classification**: Structural. The deadlock is not a model decision — it's a deterministic consequence of two GitHub Actions properties (event firing on bot replies; serialized concurrency group with `cancel-in-progress: false`).
- **Change type**: Targeted (one extra `jq` filter line + comment). Normal evidence bar; passes.
- **Both gates**: pass.

## Test plan

- [ ] CI on this PR passes (lint, test).
- [ ] Next time `tend-mention` replies to an inline review comment + polls CI on the same PR, the polling helper exits within 1–2 minutes after non-mention checks complete (rather than timing out at 15 min).
