### PR TITLE
running-in-ci: fix jq inequality rewrite in same-workflow filter

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -205,7 +205,7 @@ pending() {
     | jq --arg own "/runs/$GITHUB_RUN_ID/" --arg wf "$GITHUB_WORKFLOW" '
       [.statusCheckRollup[]
        | select((.detailsUrl // .targetUrl // "") | test($own) | not)
-       | select((.workflowName // "") != $wf)
+       | select((.workflowName // "") == $wf | not)
        | (.status // .state)
        | select(. == "IN_PROGRESS" or . == "QUEUED" or . == "PENDING" or . == "WAITING" or . == "REQUESTED" or . == "EXPECTED")
       ] | length'


### PR DESCRIPTION
## Summary

Fix the same-workflow filter in `pending()` from #333 — the merged version uses jq's inequality operator, which the Bash tool preprocessor mangles before jq sees it. The helper fails on every poll iteration and the wait loop runs out the 15-minute clock instead of converging.

## Why

The skill itself documents this trap further down ("The same trap applies to `jq` and `--jq` filters"), and the previous line in `pending()` already uses `| not` for the same reason. #333 reintroduced the operator inside a `select(...)` and shipped without a runtime test of the rewritten command.

Reproduction (fails under the Bash tool):

```bash
echo '{"workflowName":"tend-mention"}' | jq --arg wf "tend-review" 'select((.workflowName // "") != $wf)'
# jq: error: syntax error, unexpected INVALID_CHARACTER ... \!= $wf
```

Same input with the fix:

```bash
echo '{"workflowName":"tend-mention"}' | jq --arg wf "tend-review" 'select((.workflowName // "") == $wf | not)'
# {"workflowName":"tend-mention"}
```

Net effect of the broken version in production: every `pending()` call returns empty stdout; both `[ ... -gt 0 ]` and `[ ... -eq 0 ]` error with `integer expression expected`; the loop falls through `|| continue` on every iteration and eventually prints "CI still running after 15 minutes" — defeating the entire fix #333 was supposed to deliver, in addition to leaving the original `tend-mention` deadlock unfixed.

## Fix

One-character class change: replace `!= $wf` with `== $wf | not`. Matches the existing style on line 207. No comment changes — the existing block already explains the filter; the operator choice is a quoting workaround, not new behavior.

## Test plan

- [ ] CI passes (lint, test).
- [ ] Manual repro above shows the fixed jq filter parses and selects correctly.
