### PR TITLE
skills(review-reviewers): always record per-run heading, even all-clear

### DIFF
--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -151,6 +151,8 @@ LAST_GIST_ID=$(gh api /gists --paginate \
 
 ### Recording below-threshold findings
 
+**Append a `## Run <RUN_ID>` heading every run**, even when no problem finding exceeded a gate threshold. For all-clear hours, record a single Low-evidence "all-clear" entry as the body — runs analyzed, outcomes checked, no concerning signals. The heading per run is the audit trail that prior runs read to count cumulative occurrences and confirm which hours were analyzed; missing entries leave gaps that erode gate evaluation across runs.
+
 After applying the gates, write each run's new findings (format in `@review-gates.md`) to `/tmp/findings.md`, then append them to the gist's `findings.md`. Reuse the current content already fetched into `/tmp/current.md` in "Reading historical evidence", concatenate, and PATCH via the API (`--rawfile` preserves trailing newlines that command substitution would strip):
 
 ```bash


### PR DESCRIPTION
## Summary

The `### Recording below-threshold findings` section reads as "skip when no findings" — and the section heading reinforces that interpretation. The bot has been silently inheriting that read on all-clear runs, omitting the per-run `## Run <id>` heading. The shared `@review-gates.md` finding format spec actually says **each run** appends a heading, so the SKILL.md text is the source of the divergence.

This adds one paragraph at the top of the section making the always-record requirement explicit. Six lines, no logic change.

## Evidence

Cumulative occurrences of all-clear runs that completed analysis but skipped the gist `## Run <id>` recording on `max-sixty/tend`:

| # | Run | Time | Notes |
|---|---|---|---|
| 1 | [24965736233](https://github.com/max-sixty/tend/actions/runs/24965736233) | 2026-04-26T20:00Z | Surfaced by run 24968093086 |
| 2 | [24966937709](https://github.com/max-sixty/tend/actions/runs/24966937709) | 2026-04-26T21:00Z | Surfaced by run 24968093086 |
| 3 | [24972039459](https://github.com/max-sixty/tend/actions/runs/24972039459) | 2026-04-27T01:16Z | Surfaced by run 24974051333 |
| 4 | [24975936220](https://github.com/max-sixty/tend/actions/runs/24975936220) | 2026-04-27T04:02Z | Surfaced this run |
| 5 | [24978620309](https://github.com/max-sixty/tend/actions/runs/24978620309) | 2026-04-27T05:44Z | Surfaced this run |

Verified by `grep "^## Run \(<id>\)" findings.md` against the current evidence gist — none of the five appended a heading. All five completed `success` across all matrix cells; the omission is at the recording step, not the analysis step.

## Gate assessment

- **Confidence**: Medium evidence, **5 cumulative occurrences** — meets the 5+ threshold for stochastic findings per `review-gates.md`. The 3rd cumulative entry recorded by run 24974051333 explicitly recommended this fix once cumulative reaches 5+.
- **Classification**: Stochastic. The skill text is genuinely ambiguous between (a) always-record and (b) skip-when-empty. Past runs sometimes record, sometimes don't.
- **Magnitude**: Targeted fix — one paragraph clarifying intent. No section rename, no logic change.
- **Both gates pass.**

## Why this direction (not skip-when-empty)

[PR #35](https://github.com/max-sixty/tend/pull/35) (closed 2026-03-25) proposed the opposite — skip recording when no new findings — under the prior architecture, where evidence lived in a single tracking-issue comment and bloated past 34 KB. That bloat concern doesn't carry to the current per-month gist architecture: gists are rotated monthly and unbounded for practical purposes, so the audit-trail value of always-record outweighs the body-size cost. Each preserved heading is also load-bearing for **this skill itself** — gate evaluation reads prior `## Run <id>` entries to count cumulative occurrences, and missing headings make recurrence undercounted (the very dynamic that delayed acting on this finding). If the maintainer prefers the skip-when-empty direction, closing this PR is the cleanest signal — happy to reverse course.

## Evidence gist

`max-sixty/tend` 2026-04: https://gist.github.com/8f10d7c1abcb07c79bef00ee6d02d315

Linked from tracking issue [#133](https://github.com/max-sixty/tend/issues/133).
