### PR TITLE
action: poll for failure annotations with backoff

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -324,19 +324,26 @@ runs:
 
         TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-        # Fetch error annotations from the current job.
-        # Sleep briefly — GitHub indexes ##[error] annotations asynchronously
-        # and they may not be available via the API immediately after the step
-        # fails. Also match both in_progress (normal) and failure (if GitHub
-        # already transitioned the status) to handle matrix timing.
-        sleep 5
+        # Fetch error annotations from the current job. GitHub indexes
+        # ##[error] annotations asynchronously, so poll with backoff up to
+        # ~50s before giving up — a single 5s sleep was never long enough
+        # in practice. Also match both in_progress (normal) and failure
+        # (if GitHub already transitioned the status) to handle matrix
+        # timing.
         ERRORS=""
-        JOB_ID=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs" \
-          --jq '[.jobs[] | select(.status == "in_progress" or .conclusion == "failure")] | first | .id' 2>/dev/null || true)
-        if [ -n "$JOB_ID" ] && [ "$JOB_ID" != "null" ]; then
-          ERRORS=$(gh api "repos/${GITHUB_REPOSITORY}/check-runs/${JOB_ID}/annotations" \
-            --jq '[.[] | select(.annotation_level == "failure") | .message | select(test("^Process completed") | not)] | join("\n")' 2>/dev/null || true)
-        fi
+        JOB_ID=""
+        for delay in 5 15 30; do
+          sleep "$delay"
+          if [ -z "$JOB_ID" ] || [ "$JOB_ID" = "null" ]; then
+            JOB_ID=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs" \
+              --jq '[.jobs[] | select(.status == "in_progress" or .conclusion == "failure")] | first | .id' 2>/dev/null || true)
+          fi
+          if [ -n "$JOB_ID" ] && [ "$JOB_ID" != "null" ]; then
+            ERRORS=$(gh api "repos/${GITHUB_REPOSITORY}/check-runs/${JOB_ID}/annotations" \
+              --jq '[.[] | select(.annotation_level == "failure") | .message | select(test("^Process completed") | not)] | join("\n")' 2>/dev/null || true)
+            [ -n "$ERRORS" ] && break
+          fi
+        done
 
         ERROR_BLOCK=""
         if [ -n "$ERRORS" ]; then


### PR DESCRIPTION
GitHub indexes `##[error]` annotations asynchronously, so the 5s sleep before fetching them was always racing the indexer. I checked the last ~28 outage comments across issues #1995, #2048, #2069, #2070, #2208 — every one had an empty error block (`hasError=false`). Re-running the same `gh api .../check-runs/<job>/annotations | jq` pipeline post-hoc against #2208's run cleanly extracts the SDK error, so the parser was right and the timing was wrong.

This replaces the single sleep with a 5/15/30 backoff loop that breaks early on the first non-"Process completed" failure annotation. Worst case adds ~45s on the bad path; the bot is already broken at this point so the latency is fine.

Won't have a real signal until the next outage produces a comment with an `Error details` block.