### PR TITLE
review-reviewers: switch bot_name to tend-agent

### DIFF
--- a/.github/workflows/review-reviewers.yaml
+++ b/.github/workflows/review-reviewers.yaml
@@ -39,5 +39,5 @@ jobs:
         with:
           github_token: ${{ secrets.BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          bot_name: continuous-bot
+          bot_name: tend-agent
           prompt: /tend-ci-runner:review-reviewers ${{ matrix.repo }}


### PR DESCRIPTION
## Summary

`review-reviewers.yaml` is hand-authored (not generated by `tend init`) and was missed in the `continuous-bot` → `tend-agent` cutover. The `BOT_TOKEN` secret was already re-pointed at tend-agent's PAT in #14, but the `bot_name` input still said `continuous-bot`, so PRs from this workflow opened as `continuous-bot` (e.g. #335).

One-line change: `bot_name: continuous-bot` → `bot_name: tend-agent`.

## Test plan

- [ ] Next scheduled run (cron `47 * * * *`) opens any PRs/issues as `tend-agent`