### PR TITLE
running-in-ci: call out URL-not-fetched and "likely" hedge anti-patterns

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -397,6 +397,12 @@ When a project has user-facing documentation (a docs site, `--help` pages, a wik
 
 If you can't find source evidence for a specific detail, say so ("I'm not sure of the exact syntax") rather than guessing. An honest gap is fixable; a confident hallucination gets copy-pasted.
 
+### Two specific failure modes
+
+**Links must be fetched, not guessed.** Before pasting any URL in a comment, run `curl -sI <url> | head -1` and confirm `200`. Docs-site slugs are particularly treacherous — `escaping.html` and `quoting.html` and `quote-strings.html` are all plausible nushell page names; only one (or none) actually exists. The canonical source for that project's docs sidebar will tell you which.
+
+**"Likely" is a stop-sign.** If a draft contains "likely works", "probably parses as", "should behave like", or "I think" in a user-facing claim, you have two options: verify and replace the hedge with the answer, or hedge explicitly ("I haven't tested this — would appreciate if you can confirm") and don't dress up the guess as analysis. Posting an unverified guess as confident-sounding analysis is the hallucination shape that erodes trust the fastest.
+
 ### Verifying external-tool behavior
 
 When a claim turns on how an external CLI, API, or system behaves, verify by running the code.


### PR DESCRIPTION
## Summary

Adds a "Two specific failure modes" subsection under the existing "User-facing comments require source evidence" guidance in the `running-in-ci` bundled skill.

The two failure modes both fired in a single bot comment on [worktrunk#2410](https://github.com/max-sixty/worktrunk/issues/2410#issuecomment-4327305668):

1. A link to `https://www.nushell.sh/book/escaping.html` that returns `HTTP/2 404` — a copy-pasted plausible-looking URL that was never fetched.
2. The phrase "`git commit --message="…"` likely works because the `=` form is parsed differently" — an unverified guess dressed up as analysis. The bot had nushell available via a release tarball but did not install or run it.

The existing "Grounded Analysis" / "User-facing comments require source evidence" / "Verifying external-tool behavior" sections covered the principle (*"It is always better to take longer and produce a correct response than to respond quickly with fabricated details"*) but did not produce the right behaviour for these two specific shapes. The new subsection adds concrete, actionable rules:

- Run `curl -sI <url> | head -1` against any URL before pasting it; confirm `200`.
- Treat "likely", "probably", "should", and "I think" in user-facing prose as a stop-sign — either verify and replace the hedge with the answer, or hedge explicitly ("I haven't tested this") and don't dress up the guess as analysis.

Wording is taken from the proposal in the issue, reformatted to one-paragraph-per-line to match the file's wrapping convention (per #339).

Closes #337.

## Test plan

- [ ] Maintainer reviews the framing.
- [ ] No code changes — `pre-commit` should pass cleanly on the prose-only diff.

## Run reference

- Triggered by a maintainer comment on #337: https://github.com/max-sixty/tend/issues/337#issuecomment-4328686319
