### PR TITLE
skills(review-reviewers,review-runs): retry tracking-issue lookup on empty result

### DIFF
--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -74,10 +74,17 @@ The tracking issue lives on tend (the current repo). It indexes gists via one co
 
 The matrix runs three targets concurrently on the same cron tick, so the first run of a new month races: all three targets can find no tracking issue and each create one. Sorting and picking the lowest-numbered match keeps later runs deterministic — maintainers can close any duplicates. `gh issue create` prints the new issue's URL; parse the number from its basename.
 
+The lookup retries on empty. GitHub's `/issues` endpoint intermittently returns `[]` even when matching issues exist — different read replicas/cached responses disagree (observable as different ETags on back-to-back requests). Without a retry, a single empty response would cause spurious duplicate tracking issues mid-month, each of which then triggers a `tend-triage` run that exits silently after burning an agent invocation.
+
 ```bash
-TRACKING_NUMBER=$(gh issue list --state open --label "$TRACKING_LABEL" \
-  --json number,title --jq ".[] | select(.title | contains(\"$MONTH\")) | .number" \
-  | sort -n | head -1)
+TRACKING_NUMBER=""
+for _ in 1 2 3; do
+  TRACKING_NUMBER=$(gh issue list --state open --label "$TRACKING_LABEL" \
+    --json number,title --jq ".[] | select(.title | contains(\"$MONTH\")) | .number" \
+    | sort -n | head -1)
+  [ -n "$TRACKING_NUMBER" ] && break
+  sleep 2
+done
 
 if [ -z "$TRACKING_NUMBER" ]; then
   cat > /tmp/tracking-body.md << 'EOF'

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -33,12 +33,19 @@ Each run only sees a window of CI sessions, but patterns emerge over days or wee
 
 `gh issue create` prints the new issue's URL; parse the number from its basename. Sort and pick the lowest-numbered match so later runs stay deterministic if the month ever has duplicate tracking issues.
 
+The lookup retries on empty. GitHub's `/issues` endpoint intermittently returns `[]` even when matching issues exist (read replicas/cached responses disagree). Without a retry, a single empty response would cause spurious duplicate tracking issues.
+
 ```bash
 MONTH=$(date +%Y-%m)
 TRACKING_LABEL="review-runs-tracking"
-TRACKING_NUMBER=$(gh issue list --state open --label "$TRACKING_LABEL" \
-  --json number,title --jq ".[] | select(.title | contains(\"$MONTH\")) | .number" \
-  | sort -n | head -1)
+TRACKING_NUMBER=""
+for _ in 1 2 3; do
+  TRACKING_NUMBER=$(gh issue list --state open --label "$TRACKING_LABEL" \
+    --json number,title --jq ".[] | select(.title | contains(\"$MONTH\")) | .number" \
+    | sort -n | head -1)
+  [ -n "$TRACKING_NUMBER" ] && break
+  sleep 2
+done
 
 if [ -z "$TRACKING_NUMBER" ]; then
   cat > /tmp/tracking-body.md << 'EOF'


### PR DESCRIPTION
## Summary

Retries the `gh issue list` tracking-issue lookup up to 3 times before treating empty as ground truth. Same fix applied to both `review-reviewers` and `review-runs` SKILL.md (identical lookup code in both).

## Evidence

GitHub's `/issues` endpoint is intermittently returning `[]` for queries whose matching issues clearly exist. Reproduced empirically during analysis run [25009161877](https://github.com/max-sixty/tend/actions/runs/25009161877):

```
=== gh issue list (5 attempts, same command) ===
Attempt 1: ''
Attempt 2: '133'
Attempt 3: ''
Attempt 4: ''
Attempt 5: '133'

=== Raw API count ===
Attempt 1: count=0, []
Attempt 2: count=0, []
Attempt 3: count=2, [#342, #133]
Attempt 4: count=2, [#342, #133]
Attempt 5: count=0, []
```

Response ETags differ between empty and populated responses, suggesting different read replicas/cache entries serve the same query inconsistently. `gh search issues`, `gh api search/issues`, and `gh api repos/.../issues` (with and without label filter) all show the same flake — it's at the GitHub API layer, not specific to one endpoint.

## Outcome impact (today, max-sixty/tend)

Two duplicate tracking issues created within one hour today on top of pre-existing tracking issue [#133](https://github.com/max-sixty/tend/issues/133):

- [#342](https://github.com/max-sixty/tend/issues/342) created at 16:18:06Z by review-reviewers run [25006456679](https://github.com/max-sixty/tend/actions/runs/25006456679) (max-sixty/worktrunk matrix cell)
- [#344](https://github.com/max-sixty/tend/issues/344) created at 17:16:05Z by review-reviewers run 25009161877 (max-sixty/tend matrix cell — this analysis run)

Each duplicate triggered a `tend-triage` run that exited silently after recognizing the tracking-label shape:

- [25006564650](https://github.com/max-sixty/tend/actions/runs/25006564650) — triage on #342, no comment posted, ~$0.10 wasted
- [25009220181](https://github.com/max-sixty/tend/actions/runs/25009220181) — triage on #344, same shape

## Gates

- **Confidence**: High — 2 occurrences in one hour today (independent matrix runs), reproduced live (3 of 5 manual attempts returned empty for known-existing issues).
- **Classification**: Structural — the script is non-resilient to a known API behavior; same conditions reproduce reliably.
- **Magnitude**: Targeted fix, ~6 added lines per file.
- Both gates pass.

## Evidence gist

https://gist.github.com/8f10d7c1abcb07c79bef00ee6d02d315

## Cleanup

[#342](https://github.com/max-sixty/tend/issues/342) and [#344](https://github.com/max-sixty/tend/issues/344) can be closed by a maintainer (both empty, the pre-existing [#133](https://github.com/max-sixty/tend/issues/133) is the canonical tracking issue for 2026-04 with all per-target gist references).
