### PR TITLE
fix(scripts): use unfiltered gh run list to dodge workflow-filter index lag

### DIFF
--- a/plugins/tend-ci-runner/scripts/list-recent-runs.sh
+++ b/plugins/tend-ci-runner/scripts/list-recent-runs.sh
@@ -1,11 +1,19 @@
 #!/usr/bin/env bash
 # Lists recently completed Claude CI runs.
 #
-# Fetches runs started in the past 3 hours, then filters to only those that
-# are completed and whose updatedAt is within the past hour. This two-step
-# approach is needed because `gh run list --created` filters by *start* time,
-# not *end* time — a run started 2h ago may have just finished, and a run
-# started 50min ago may still be running. See #1301 for details.
+# Fetches a window of recent runs via one global `gh run list` call and
+# filters client-side by workflow name prefix and updatedAt timestamp. The
+# script keeps the past-1-hour completion cutoff: a run started 2h ago may
+# have just finished, and a run started 50min ago may still be running, so
+# we filter on updatedAt rather than createdAt.
+#
+# Why a global call instead of `--workflow X --created Y` per workflow:
+# combining `--workflow` with secondary filters (`--created`, `--status`,
+# `--branch`) is unreliable on gh 2.89.0. The same query can return [],
+# return a stale subset, or return the correct set across consecutive calls
+# — likely a workflow-scoped index lag in the GitHub Actions API. When the
+# call returns [], this script silently produces zero runs and the analysis
+# bypasses the entire window. Filtering client-side avoids the broken path.
 #
 # Environment variables:
 #   TARGET_REPO - Query a different repo (default: current repo)
@@ -22,7 +30,7 @@ if [ -n "${TARGET_REPO:-}" ]; then
   repo_args=(-R "$TARGET_REPO")
 fi
 
-# Dynamically discover workflows by prefix. Multiple prefixes supported.
+# Filter by workflow name prefix. Multiple prefixes supported.
 # Usage: ./list-recent-runs.sh [prefix ...]
 if [ $# -eq 0 ]; then
   PREFIXES=("tend-")
@@ -30,31 +38,21 @@ else
   PREFIXES=("$@")
 fi
 
-WORKFLOWS=()
-for prefix in "${PREFIXES[@]}"; do
-  mapfile -t matches < <(gh workflow list "${repo_args[@]}" --json name --jq ".[].name | select(startswith(\"$prefix\"))")
-  WORKFLOWS+=("${matches[@]}")
-done
-
-CREATED_SINCE=$(date -d '3 hours ago' +%Y-%m-%dT%H:%M:%S)
 COMPLETED_AFTER=$(date -d '1 hour ago' +%s)
 
-all_runs="[]"
+prefixes_json=$(printf '%s\n' "${PREFIXES[@]}" | jq -R . | jq -s .)
 
-for wf in "${WORKFLOWS[@]}"; do
-  runs=$(gh run list \
-    "${repo_args[@]}" \
-    --workflow "${wf}" \
-    --created ">=${CREATED_SINCE}" \
-    --json databaseId,conclusion,createdAt,updatedAt \
-    --limit 50 2>/dev/null || echo "[]")
-  all_runs=$(echo "$all_runs" "$runs" | jq -s 'add')
-done
-
-# Filter: drop in-progress (empty conclusion), keep only recently finished
-echo "$all_runs" | jq --argjson cutoff "$COMPLETED_AFTER" '
-  [ .[]
-    | select(.conclusion != null and .conclusion != "")
-    | select((.updatedAt | fromdateiso8601) >= $cutoff)
-  ]
-'
+# --limit 200 covers a few hours of activity even on busy repos. The 1-hour
+# updatedAt cutoff bounds the output regardless.
+gh run list \
+  "${repo_args[@]}" \
+  --limit 200 \
+  --json databaseId,workflowName,conclusion,createdAt,updatedAt \
+  | jq --argjson prefixes "$prefixes_json" --argjson cutoff "$COMPLETED_AFTER" '
+    [ .[]
+      | select(.conclusion != null and .conclusion != "")
+      | select((.updatedAt | fromdateiso8601) >= $cutoff)
+      | select(.workflowName as $n | $prefixes | any(. as $p | $n | startswith($p)))
+      | {databaseId, conclusion, createdAt, updatedAt}
+    ]
+  '


### PR DESCRIPTION
## Summary

`scripts/list-recent-runs.sh` invokes `gh run list --workflow X --created ">=Y"` once per discovered workflow. On gh 2.89.0 (released 2026-03-26) that combination is unreliable — the same query intermittently returns `[]`, returns a stale subset, or returns the correct set across consecutive calls. When it returns `[]`, the script silently produces zero runs and the calling skill's analysis bypasses the entire window without reporting the gap.

This swap replaces the per-workflow loop with one global `gh run list --limit 200` call (no `--workflow`, no `--created`) and filters by workflow name prefix and updatedAt timestamp client-side. The unfiltered call returns the correct, fresh set every time.

## Reproducer

On a repo with recent `tend-*` activity (e.g. `max-sixty/worktrunk` at the time of writing — current `gh` 2.89.0):

```
$ for i in 1 2 3; do
    gh run list -R max-sixty/worktrunk --workflow tend-notifications \
      --created '>=2026-04-27T00:00:00' --limit 50 --json databaseId | wc -c
  done
3        # []
3        # []
1117     # partial set, missing the most recent runs
```

vs. the unfiltered call which returns the same fresh result on every retry:

```
$ for i in 1 2 3; do
    gh run list -R max-sixty/worktrunk --workflow tend-notifications \
      --limit 50 --json databaseId | wc -c
  done
3101
3101
3101
```

The same flakiness reproduces with `--workflow X --status Y` and `--workflow X --branch Y`, so this is a workflow-scoped index lag in the GitHub Actions API rather than a `--created` quirk specifically.

## Evidence

- review-reviewers run [25011739890](https://github.com/max-sixty/tend/actions/runs/25011739890) (this PR) — `list-recent-runs.sh` returned `[]` despite 9 in-window `tend-*` runs on `max-sixty/worktrunk`. Worked around by issuing the global call and filtering client-side, which surfaced 4 fresh runs to analyze.
- review-reviewers run [25009161877](https://github.com/max-sixty/tend/actions/runs/25009161877) (~1h earlier on the same target) hit the same silent-empty behavior. That run noted it as a "Bonus observation" without a tend-side action because the failure mode wasn't reproducible at the time. The clean three-try reproducer above closes that gap.

Evidence gist: https://gist.github.com/44ab1483b29406255dd36141650c894d (this run's entry records the 2nd occurrence and pass through both gates).

## Gate assessment

- **Confidence**: High — structural failure (deterministic enough to reproduce on demand), 2 occurrences within a few hours.
- **Magnitude**: Targeted fix — one script, narrow change.
- Both gates pass.

## Test plan

- [x] `TARGET_REPO=max-sixty/worktrunk bash plugins/tend-ci-runner/scripts/list-recent-runs.sh` returns the 4 expected in-window runs (verified against `gh run list --limit 100` cross-check).
- [x] Passing a prefix arg (`tend-notifications`) narrows the result correctly.
- [x] `pre-commit run --files plugins/tend-ci-runner/scripts/list-recent-runs.sh` passes.
- [ ] Next review-reviewers run on a target with recent `tend-*` activity returns a non-empty list rather than silently exiting.
