### PR TITLE
running-in-ci: check upstream status before designing transient-flake workarounds

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -403,6 +403,30 @@ If you can't find source evidence for a specific detail, say so ("I'm not sure o
 
 **"Likely" is a stop-sign.** If a draft contains "likely works", "probably parses as", "should behave like", or "I think" in a user-facing claim, you have two options: verify and replace the hedge with the answer, or hedge explicitly ("I haven't tested this — would appreciate if you can confirm") and don't dress up the guess as analysis. Posting an unverified guess as confident-sounding analysis is the hallucination shape that erodes trust the fastest.
 
+### Distinguish transient incidents from durable bugs
+
+Intermittent or inconsistent behavior — the same query returning different results within seconds, an API silently returning empty when records demonstrably exist, a CLI flag working sometimes — points more strongly at an active upstream incident than at a CLI or skill bug. Reproducing the flake confirms the symptom but not the cause; the cause is often a current incident on the upstream service, in which case the right disposition is to wait for resolution rather than commit a code workaround that outlives the incident. Before designing a workaround, check upstream status. For GitHub-side symptoms:
+
+```bash
+curl -s 'https://www.githubstatus.com/api/v2/incidents/unresolved.json' \
+  | jq '.incidents[] | {created_at, name, impact, components: [.components[].name]}'
+```
+
+If the response is non-empty and the components/timing match the symptom (e.g. Issues / Pull Requests / Actions during a search-degradation incident), record the symptom in the run's evidence log and exit without a PR. Sibling matrix legs that hit different surface symptoms of the same incident otherwise each open their own near-duplicate workaround PR — title and file dedup don't catch them because each leg picks a different command to mitigate.
+
+<example>
+<bad reason="Reproduced an API flake during an active incident, opened code workarounds without checking upstream status">
+
+Bad: 2026-04-27 — `gh issue list` returned `[]` for queries whose matching issues clearly existed (3 of 5 attempts). Bot opened [PR #345](https://github.com/max-sixty/tend/pull/345) adding a 3-attempt retry. An hour later, a sibling matrix leg saw the same shape on `gh run list --workflow X --created Y` and opened [PR #348](https://github.com/max-sixty/tend/pull/348) swapping to client-side filtering. Both were workarounds for the [GitHub search-degradation incident at 16:31–22:46 UTC](https://stspg.io/x5cnngb211t7); both were closed by the maintainer ("close it, any variants of it") once the incident link surfaced.
+
+</bad>
+<good reason="Checked status.github.com first, treated the symptom as transient">
+
+Good: Same flake → `curl /api/v2/incidents/unresolved.json` returns an active "GitHub search is degraded" incident touching Issues + Pull Requests → record the symptom in the evidence log, skip the PR, let the incident resolve.
+
+</good>
+</example>
+
 ### Verifying external-tool behavior
 
 When a claim turns on how an external CLI, API, or system behaves, verify by running the code.


### PR DESCRIPTION
## Summary

Add a `Grounded Analysis` subsection that tells future runs to check `https://www.githubstatus.com/api/v2/incidents/unresolved.json` before designing a code workaround for an intermittent flake. Reproducing the flake confirms the symptom but not the cause; when the cause is an active upstream incident, a workaround PR outlives the incident and gets rejected.

## Evidence

In the past 24 hours, two `review-reviewers` runs in different matrix legs each opened a separate workaround PR for the same root cause — the GitHub search-degradation incident on 2026-04-27 (16:31–22:46 UTC, components: Issues / Pull Requests / Actions / Packages, [stspg.io/x5cnngb211t7](https://stspg.io/x5cnngb211t7)).

| Run | Cell | Symptom reproduced | PR opened | Outcome |
|---|---|---|---|---|
| [25009161877](https://github.com/max-sixty/tend/actions/runs/25009161877) | max-sixty/tend leg | `gh issue list` returns `[]` (3 of 5 attempts) | [#345](https://github.com/max-sixty/tend/pull/345) (3-attempt retry) | Closed by maintainer |
| [25011739890](https://github.com/max-sixty/tend/actions/runs/25011739890) | max-sixty/worktrunk leg | `gh run list --workflow X --created Y` returns `[]` | [#348](https://github.com/max-sixty/tend/pull/348) (swap to unfiltered list) | Closed by maintainer ("variant of #345") |

Maintainer's [closing instruction on #345](https://github.com/max-sixty/tend/pull/345#issuecomment-4332788551): *"close it, any variants of it"* — the workarounds aren't worth keeping once the cause is identified as a server-side incident.

The bot self-recognised this when closing #348: *"Closing as a variant of #345 ... — same GitHub search-degradation incident on 2026-04-27 (16:31–22:46 UTC) caused the workflow-filter flakiness reproduced here. The unfiltered-list workaround is mitigating a server-side incident, not a gh bug."* The check the bot eventually performed (curl status.github.com) is what should have happened up front.

The bot has correctly identified upstream incidents in past tracking entries (Anthropic rate limit, "Request interrupted" harness bursts) — but those had explicit error strings. GitHub-search degradation surfaces as silent stale-or-empty responses, which look like CLI bugs unless you check the status page.

## Why this isn't a `gh` retry instead

Adding retries would mitigate one cache-shard flake during one incident, but every defensive code path stays in the repo long after the incident resolves. The maintainer's pushback was specifically that. Checking the status feed before designing the workaround is the cheaper signal — `curl /api/v2/incidents/unresolved.json` returns `{"incidents":[]}` (length 1 byte after jq) outside incidents, so the check is near-free in the steady state.

## Gates

- **Confidence**: Critical — two PRs closed by maintainer in 24h with explicit "close any variants" feedback; clearly-rejected outcomes meet the 1-occurrence-is-enough bar.
- **Classification**: Structural — the skill lacks a step to check upstream status before designing workarounds; adding the step would change behaviour next time the same shape fires.
- **Magnitude**: Targeted fix — one focused subsection inside the existing `Grounded Analysis` section, reusing the section's existing example pattern. No structural reorganisation.

## Test plan

- [ ] Maintainer reads the new subsection and decides whether the framing matches their position from #345.
- [ ] Spot-check that `curl -s 'https://www.githubstatus.com/api/v2/incidents/unresolved.json' | jq '.incidents'` returns `[]` outside incidents (verified at PR-creation time).
