### PR TITLE
running-in-ci: add rerun-job polling recipe

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -208,8 +208,9 @@ gh run rerun <run-id> --failed --repo "$REPO"
 # the next query can see only the prior `failure` rows and exit immediately.
 sleep 10
 
-# `?filter=latest` returns each job's most recent attempt. Avoid `!=` in
-# --jq filters: the Bash tool rewrites `!` to `\!`, which jq rejects. Use
+# `?filter=latest` returns each job's most recent attempt. Avoid the
+# `!=` operator in --jq filters — the Bash tool rewrites the exclamation
+# mark to a backslash-escape, which jq rejects. Use
 # `== "completed" | not` instead.
 JOB_IDS=$(gh api "repos/$REPO/actions/runs/<run-id>/jobs?filter=latest" \
   --jq '.jobs[] | select((.status == "completed") | not) | .id')

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -197,6 +197,39 @@ gh api "repos/{owner}/{repo}/actions/runs?branch=main&status=completed&per_page=
 
 If you cannot verify, say "I haven't confirmed whether these failures are pre-existing."
 
+### Polling `gh run rerun --failed`
+
+After `gh run rerun <run-id> --failed`, poll the rerun jobs directly. The parent run's `.status` stays `in_progress` until every sibling job finishes, including unrelated long-running ones, and the `pending()` recipe above also doesn't help — sibling check-runs on the head SHA still appear pending. Polling specific job IDs is the only fix.
+
+```bash
+gh run rerun <run-id> --failed --repo "$REPO"
+
+# New attempt records take a few seconds to surface; without this sleep,
+# the next query can see only the prior `failure` rows and exit immediately.
+sleep 10
+
+# `?filter=latest` returns each job's most recent attempt. Avoid `!=` in
+# --jq filters: the Bash tool rewrites `!` to `\!`, which jq rejects. Use
+# `== "completed" | not` instead.
+JOB_IDS=$(gh api "repos/$REPO/actions/runs/<run-id>/jobs?filter=latest" \
+  --jq '.jobs[] | select((.status == "completed") | not) | .id')
+
+# Rollup poll: one pass checks all reran jobs together and exits when the
+# last one is terminal.
+pending_jobs() {
+  local n=0
+  for id in $JOB_IDS; do
+    s=$(gh api "repos/$REPO/actions/jobs/$id" --jq '.status')
+    [ "$s" = "completed" ] || n=$((n + 1))
+  done
+  echo "$n"
+}
+for i in $(seq 1 15); do
+  [ "$(pending_jobs)" -eq 0 ] && break
+  sleep 60
+done
+```
+
 ## Replying to Comments
 
 Reply in context rather than creating new top-level comments:


### PR DESCRIPTION
## Summary

After `gh run rerun <run-id> --failed`, the bot has been polling the parent run's `.status` for `completed`. That status stays `in_progress` until every sibling job finishes — including unrelated long-running ones — so the rerun loop blocks waiting on jobs the bot does not care about.

Add a recipe to bundled `running-in-ci` showing how to poll the rerun job IDs via `repos/.../actions/jobs/<id>`, and note that the existing `pending()` (statusCheckRollup) recipe doesn't help because sibling check-runs on the head SHA still appear pending.

## Context

Per max-sixty's request in [worktrunk#2449](https://github.com/max-sixty/worktrunk/pull/2449#issuecomment-3478432580) and [worktrunk#2451](https://github.com/max-sixty/worktrunk/pull/2451#issuecomment-3478641821): the same recipe was originally landed as a worktrunk overlay, but the rule is universal across consumers, so it belongs in the bundled skill. The overlay is being removed in worktrunk#2451.
