### PR TITLE
docs(claude.md): add skill-authoring guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,23 @@ formats, label names, branch routing) belongs in an overlay. Tend has its
 own overlay at `.claude/skills/running-tend/SKILL.md` — use it for guidance
 that only applies to developing tend itself.
 
+### Authoring skills
+
+When adding to or editing files in `plugins/tend-ci-runner/skills/` or
+`.claude/skills/`:
+
+- **Be brief.** Skills are loaded into every relevant session — extra prose
+  is overhead. Lead with the rule or recipe; cut motivation, anecdotes, and
+  historical context unless required to apply the rule.
+- **No specific past-run references.** Don't link GitHub Actions runs, cite
+  session IDs, or quote durations from individual incidents. They age into
+  trivia and aren't useful when the skill is reused. State the structural
+  rule without the run links.
+- **Date-stamp only when the value depends on time.** A baseline number
+  expected to drift can be dated; a one-shot incident citation should not be.
+- **Prefer recipe over narrative.** A code block plus a one-sentence framing
+  beats a multi-paragraph explanation.
+
 ## Agent-driven vs deterministic steps
 
 Tend's workflows invoke Claude through `max-sixty/tend@v1`. When adding new


### PR DESCRIPTION
## Summary

Add an "Authoring skills" subsection to `CLAUDE.md` codifying the four rules max-sixty raised in [worktrunk#2449](https://github.com/max-sixty/worktrunk/pull/2449#issuecomment-3478432580): be brief, no specific past-run references, date-stamp only when time-dependent, prefer recipe over narrative.

## Context

The same guidance was originally drafted into worktrunk's `CLAUDE.md` ([commit 585ece7e](https://github.com/max-sixty/worktrunk/commit/585ece7e), since force-pushed away). Per max-sixty's note in [worktrunk#2449](https://github.com/max-sixty/worktrunk/pull/2449#issuecomment-3478623958) (`I think this guidance should go into _tend_'s guidance`), the rule belongs here — `tend-ci-runner` skills are bundled and shared across consumers, so the authoring style applies to every consumer's overlays as well as tend's own bundled skills.

Placed under the existing "Skill design: bundled for everyone, overlay for one" heading. Scoped to `plugins/tend-ci-runner/skills/` (bundled) and `.claude/skills/` (overlays).
