### PR TITLE
skills(review): skip approval when PR is no longer OPEN

### DIFF
--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -149,19 +149,23 @@ gh api "repos/$REPO/issues/<number>/reactions" -f content="+1"
 
 #### Posting mechanics
 
-Before posting, verify HEAD hasn't moved and no review was already posted for this commit:
+Before posting, verify HEAD hasn't moved, the PR is still open, and no review was already posted for this commit:
 
 ```bash
 REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
 BOT_LOGIN=$(gh api user --jq '.login')
-CURRENT_HEAD=$(gh pr view <number> --json commits --jq '.commits[-1].oid')
+read -r CURRENT_HEAD PR_STATE < <(gh pr view <number> --json commits,state \
+  --jq '"\(.commits[-1].oid) \(.state)"')
 [ "$CURRENT_HEAD" != "$HEAD_SHA" ] && echo "HEAD moved — skipping" && exit 0
+[ "$PR_STATE" != "OPEN" ] && echo "PR is $PR_STATE — skipping" && exit 0
 
 # NOTE: REST API uses .commit_id (not .commit.oid from gh pr view --json)
 ALREADY_POSTED=$(gh api "repos/$REPO/pulls/<number>/reviews" \
   --jq "[.[] | select(.user.login == \"$BOT_LOGIN\" and .commit_id == \"$HEAD_SHA\")] | last | .submitted_at // empty")
 [ -n "$ALREADY_POSTED" ] && echo "Already reviewed — skipping" && exit 0
 ```
+
+The state check matters because the maintainer may close (or another path may merge) the PR while a review is in flight — `pull_request_target` reviews routinely run for 5–10 minutes between fetching `HEAD_SHA` and posting the verdict, and HEAD doesn't move when the PR is closed. Approving a CLOSED or MERGED PR creates a confusing artifact (an approval timestamped after the close).
 
 Post exactly one review per run. Always give a verdict: **approve** or **comment** (never "request changes"). Use `gh pr review` for reviews, not `gh pr comment`. Note: `--comment` requires a non-empty body — if there's nothing to say, use the approve-with-empty-body pattern.
 


### PR DESCRIPTION
## Summary

The pre-approval guard in `tend-ci-runner:review` checks whether HEAD has moved and whether a review for the current SHA was already posted, but it does not check whether the PR is still open. If the maintainer (or another path) closes or merges the PR while the review is in flight, the bot's `gh pr review --approve` still goes through.

## Evidence

Run [25065178381](https://github.com/max-sixty/worktrunk/actions/runs/25065178381) (`tend-review` on max-sixty/worktrunk PR [#2353](https://github.com/max-sixty/worktrunk/pull/2353)) on 2026-04-28:

- 16:31:32Z — review job starts, fetches `HEAD_SHA = e05a5ec1` (pull_request_target on a force-push merging main into the PR).
- 16:31–16:38Z — bot runs ~7 minutes of analysis (fetched commits, walked merge resolution, queried review threads via GraphQL).
- **16:37:52Z — max-sixty closes the PR** with a complete rationale ("main has since merged a stack of dispatch optimizations… already eliminate the rev-parse fork…").
- 16:38:53Z — bot runs the pre-approval guard. `gh pr view 2353 --json commits` returns the unchanged `e05a5ec1`, and no prior bot review exists at that SHA, so both checks pass.
- **16:38:55Z — bot posts APPROVED on the now-CLOSED PR**, ~63 seconds after the maintainer's close.

The PR is now [a CLOSED PR with a worktrunk-bot APPROVED review timestamped after the close](https://github.com/max-sixty/worktrunk/pull/2353) — a confusing artifact that reads as if the bot is still trying to merge a PR the maintainer deliberately abandoned.

Two concurrent `tend-mention` runs in the same session ([25065482100](https://github.com/max-sixty/worktrunk/actions/runs/25065482100) at 16:38, [25065531221](https://github.com/max-sixty/worktrunk/actions/runs/25065531221) at 16:39) **did** detect the close and exited silently — they re-fetched state because they had decision points in the running-in-ci "Recheck Before Posting" path. Only the `tend-review` pre-approval guard missed it.

## Root cause

[`plugins/tend-ci-runner/skills/review/SKILL.md`](https://github.com/max-sixty/tend/blob/main/plugins/tend-ci-runner/skills/review/SKILL.md#L154-L164) lines 154–164 read commits but not state:

```bash
CURRENT_HEAD=$(gh pr view <number> --json commits --jq '.commits[-1].oid')
[ "$CURRENT_HEAD" != "$HEAD_SHA" ] && echo "HEAD moved — skipping" && exit 0
```

A close does not move HEAD, so the guard waves the approval through.

## Fix

Add `state` to the same `gh pr view` call (no extra round-trip) and skip the approval if the PR is no longer `OPEN`. This covers both CLOSED (maintainer abandoned) and MERGED (another path landed it) before the review finished.

```bash
read -r CURRENT_HEAD PR_STATE < <(gh pr view <number> --json commits,state \
  --jq '"\(.commits[-1].oid) \(.state)"')
[ "$CURRENT_HEAD" != "$HEAD_SHA" ] && echo "HEAD moved — skipping" && exit 0
[ "$PR_STATE" != "OPEN" ] && echo "PR is $PR_STATE — skipping" && exit 0
```

## Gate assessment

- **Evidence level**: High (1 occurrence, but **structural** — the same race always produces the same outcome; no decision point lets the bot recover). Per `review-gates.md`, "One clear occurrence is sufficient evidence for a targeted fix" for structural failures.
- **Magnitude**: Targeted fix (one extra field on the existing `gh pr view` call + one skip clause). No new section, no behavior change for the open-PR happy path.
- **Both gates pass.**

Evidence log: [secret gist](https://gist.github.com/44ab1483b29406255dd36141650c894d).
