### PR TITLE
fix(triage): skip auto-created tend-outage tracker issues

### DIFF
--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -504,6 +504,13 @@ concurrency:
 
 jobs:
   triage:
+    # Skip the auto-created "Bot temporarily unavailable" tracker issue:
+    # action.yaml's "Report failure" step creates it with label tend-outage,
+    # and without this guard every creation event invokes Claude for a
+    # guaranteed silent-exit (the prompt's self-conversation guard fires
+    # because the bot is the issue author). Mirrors #268's tend-mention
+    # guard for the new-issue side of the same loop.
+    if: ${{{{ !contains(github.event.issue.labels.*.name, 'tend-outage') }}}}
     runs-on: ubuntu-24.04
     permissions:
 {perms}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[triage].out
@@ -17,6 +17,13 @@ concurrency:
 
 jobs:
   triage:
+    # Skip the auto-created "Bot temporarily unavailable" tracker issue:
+    # action.yaml's "Report failure" step creates it with label tend-outage,
+    # and without this guard every creation event invokes Claude for a
+    # guaranteed silent-exit (the prompt's self-conversation guard fires
+    # because the bot is the issue author). Mirrors #268's tend-mention
+    # guard for the new-issue side of the same loop.
+    if: ${{ !contains(github.event.issue.labels.*.name, 'tend-outage') }}
     runs-on: ubuntu-24.04
     permissions:
       contents: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[triage].out
@@ -17,6 +17,13 @@ concurrency:
 
 jobs:
   triage:
+    # Skip the auto-created "Bot temporarily unavailable" tracker issue:
+    # action.yaml's "Report failure" step creates it with label tend-outage,
+    # and without this guard every creation event invokes Claude for a
+    # guaranteed silent-exit (the prompt's self-conversation guard fires
+    # because the bot is the issue author). Mirrors #268's tend-mention
+    # guard for the new-issue side of the same loop.
+    if: ${{ !contains(github.event.issue.labels.*.name, 'tend-outage') }}
     runs-on: ubuntu-24.04
     permissions:
       contents: write


### PR DESCRIPTION
## Problem

The action's `Report failure` step in `action.yaml` creates a "Bot temporarily unavailable" tracker issue with the `tend-outage` label whenever a Claude invocation fails. That issue's `issues.opened` event then triggers `tend-triage`, which invokes Claude on a self-authored issue. The agent reaches the self-conversation guard, decides not to comment, and exits — having burned ~1m45s of Opus runtime per occurrence.

#268 added the analogous label-based skip to `tend-mention`'s `issue_comment` path; the new-issue path in `tend-triage` was not covered.

## Evidence

8 `tend-outage` issues opened on `max-sixty/worktrunk` in April 2026 (#1883, #1973, #1995, #2048, #2069, #2070, #2208, #2456). Each one triggered a `tend-triage` run. Today's run [25111001894](https://github.com/max-sixty/worktrunk/actions/runs/25111001894) on issue #2456 is the latest occurrence — the session log shows the agent ran 9 tool calls, identified the auto-tracker, and exited via the self-conversation guard with no public output.

This is the structural new-issue counterpart of the loop #268 already documented in code:

> The action's Report-failure step auto-comments on those when Claude invocation fails, and without this guard those comments re-trigger tend-mention during a persistent outage … producing a self-sustaining ~1 run/minute loop until the outage clears.

The same wording applies — swap "auto-comments" for "auto-creates issues" and "tend-mention" for "tend-triage". The `Report failure` step's check-then-act logic only creates a new issue when no open `tend-outage` issue exists; once one is open, subsequent failures land as comments (which #268 already handles). So the unguarded new-issue path mostly fires on the first failure of a fresh outage, but that's still 8 occurrences this month.

## Change

Add `if: ${{ !contains(github.event.issue.labels.*.name, 'tend-outage') }}` to the generated `tend-triage` job. Mirrors #268's gate on the comment-loop path.

Regtest fixtures regenerated; full generator suite passes (164 tests). Actionlint clean on the rendered output.

Findings: https://gist.github.com/44ab1483b29406255dd36141650c894d
