### PR TITLE
action: extend failure-annotation polling to ~8 min

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -326,13 +326,15 @@ runs:
 
         # Fetch error annotations from the current job. GitHub indexes
         # ##[error] annotations asynchronously, so poll with backoff up to
-        # ~50s before giving up — a single 5s sleep was never long enough
-        # in practice. Also match both in_progress (normal) and failure
-        # (if GitHub already transitioned the status) to handle matrix
-        # timing.
+        # ~8 min before giving up — earlier 50s and 5s windows lost the
+        # race on slow-indexing runs. The loop breaks as soon as an
+        # annotation surfaces, so the long tail is only paid when the
+        # annotation never indexes. Also match both in_progress (normal)
+        # and failure (if GitHub already transitioned the status) to
+        # handle matrix timing.
         ERRORS=""
         JOB_ID=""
-        for delay in 5 15 30; do
+        for delay in 5 15 30 60 120 240; do
           sleep "$delay"
           if [ -z "$JOB_ID" ] || [ "$JOB_ID" = "null" ]; then
             JOB_ID=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs" \


### PR DESCRIPTION
## Summary

Extends the failure-annotation polling backoff in the `Report failure` step of `action.yaml` from `5 15 30` (~50s total) to `5 15 30 60 120 240` (~8 min total). The loop already breaks as soon as an annotation surfaces, so the longer tail is only paid when GitHub's annotation indexing is slow — exactly the case we're trying to catch.

## Why

Requested by @max-sixty in [worktrunk#2456](https://github.com/max-sixty/worktrunk/issues/2456#issuecomment-3245892450). On that run the underlying error annotation was visible later but hadn't been indexed within the existing 50s window, so the outage tracking issue was filed without inline error details. This is a "let's see if a much longer timeout helps" experiment; we can dial it back if the new total is excessive in practice.

## Test plan

- [ ] Wait for the next failure-path invocation (likely an outage on a consumer repo) and confirm the tracking issue body includes the `<details>Error details</details>` block when the annotation indexes within ~8 min.
