### PR TITLE
skills(review-reviewers): add bash-tool-safe corruption-scan recipe

### DIFF
--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -235,8 +235,8 @@ Use `Agent` with `model: "haiku"` and a prompt like:
 > mkdir -p /tmp/bot-output && : > /tmp/bot-output/all.txt
 > for n in <pr-numbers>; do
 >   gh api "repos/$ARGUMENTS/issues/$n/comments?per_page=100" \
->     --jq '.[] | select(.user.login == $BOT and .created_at > $WIN) | "=== #'$n' \(.id) ===\n\(.body)\n"' \
->     --arg BOT "$BOT_LOGIN" --arg WIN "<window-start>" >> /tmp/bot-output/all.txt
+>     --jq ".[] | select(.user.login == \"$BOT_LOGIN\" and .created_at > \"<window-start>\") | \"=== #$n \(.id) ===\n\(.body)\n\"" \
+>     >> /tmp/bot-output/all.txt
 > done
 > grep -nF '${' /tmp/bot-output/all.txt        # literal ${...} interpolation failure
 > grep -nP '\\!' /tmp/bot-output/all.txt       # backslash-bang corruption

--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -229,6 +229,21 @@ Use `Agent` with `model: "haiku"` and a prompt like:
 > - Human replied to bot with correction or complaint
 > - Bot comment contains corruption (literal `${`, unescaped bangs, broken heredoc markers)
 >
+> **Corruption-scan recipe.** Inline `jq` filters or `grep` regexes whose pattern is a literal backslash-bang are mangled by the Bash-tool preprocessor (every literal exclamation mark in the command string gets rewritten to backslash-bang, including inside the regex), so a `jq` filter aborts with `Invalid escape` and the scan silently passes zero matches. Save bot bodies to a file first, then scan the file with `grep -F` for fixed strings and `grep -P` for backslash-bang:
+>
+> ```bash
+> mkdir -p /tmp/bot-output && : > /tmp/bot-output/all.txt
+> for n in <pr-numbers>; do
+>   gh api "repos/$ARGUMENTS/issues/$n/comments?per_page=100" \
+>     --jq '.[] | select(.user.login == $BOT and .created_at > $WIN) | "=== #'$n' \(.id) ===\n\(.body)\n"' \
+>     --arg BOT "$BOT_LOGIN" --arg WIN "<window-start>" >> /tmp/bot-output/all.txt
+> done
+> grep -nF '${' /tmp/bot-output/all.txt        # literal ${...} interpolation failure
+> grep -nP '\\!' /tmp/bot-output/all.txt       # backslash-bang corruption
+> grep -nE 'blob/main/.*#L[0-9]' /tmp/bot-output/all.txt  # un-pinned line links
+> grep -nF 'anthropics/' /tmp/bot-output/all.txt         # wrong-owner URL
+> ```
+>
 > **Report format** — return a structured summary:
 > ```
 > ## Runs with no bot output (skipped)


### PR DESCRIPTION
## Problem

The Step-2 subagent prompt in `review-reviewers` lists "Bot comment contains corruption (literal `${`, unescaped bangs, broken heredoc markers)" as a negative outcome signal but doesn't say *how* to scan. Each run improvises the scan inline, and the natural authorings — `jq` regex like `test("\\!")` or `grep -P '\\!'` written directly in a Bash command — get mangled by the same Bash-tool exclamation-mark preprocessor the scan is trying to detect: `\!` rewrites to `\\!`, jq aborts with `Invalid escape "\!"`, the scan reports "zero matches", and the run silently passes a corrupted comment.

## Evidence

Two concrete cases observed today (run [25155760186](https://github.com/max-sixty/tend/actions/runs/25155760186) on `max-sixty/worktrunk`):

1. **Detection failure.** The prior `review-reviewers` run [25153406082](https://github.com/max-sixty/tend/actions/runs/25153406082) listed `worktrunk-bot` comment [4350585541](https://github.com/max-sixty/worktrunk/pull/2474#issuecomment-4350585541) ("Good news — the spike at...") in its corruption scan and reported "zero matches" for `\!`. Today's grep on the same comment body finds clear `\!` corruption mid-comment inside a code span: `` The PR is already a substantive `\!` refactor ``. My own first-pass inline-jq scan reproduced the trap immediately — `jq: error: Invalid escape "\!"`. Switching to `grep -F` and `grep -P '\\!'` against a file-dumped body found the corruption that the prior scan missed.

2. **Underlying recurrence (not fixed in this PR).** Comment 4350585541 itself is the 2nd wild post-#318 occurrence of the bot shipping `\!` corruption to a public comment (1st was [issue #2309](https://github.com/max-sixty/worktrunk/issues/2309#issuecomment-4277108328) on 2026-04-20, recorded in the gist). Recorded in the evidence gist for the recurrence-rate counter. Not addressed here because the existing skill warning already directs the right behavior; the bot just lapsed.

## Fix

Add one paragraph + one code block to the Step-2 subagent prompt: dump bot bodies to a file, then scan with `grep -F` (literal `${`, `anthropics/`) and `grep -P '\\!'` for backslash-bang. The file-then-scan two-step keeps the regex out of the bash-tool input where the preprocessor would touch it, and `grep -P` is robust to the rewrite — `\!` in the source becomes `\\!` after rewrite, and PCRE `\\!` still matches literal `\!` because `!` is not a regex metacharacter.

## Gate assessment

- **Evidence level**: Medium — 2 documented occurrences (prior run's silent miss + today's reproduction in the same skill).
- **Failure class**: structural — the Bash-tool preprocessor consistently rewrites every `\!` regardless of quoting form, so any inline scan authored with `\!` in its pattern will hit the same trap.
- **Magnitude**: targeted fix — adding a missing step to an existing recipe (not new conceptual guidance).
- **Both gates**: PASS.

Evidence gist (current month): https://gist.github.com/44ab1483b29406255dd36141650c894d
