### PR TITLE
skills(triage): drop exclamation marks from comment templates

### DIFF
--- a/plugins/tend-ci-runner/skills/triage/SKILL.md
+++ b/plugins/tend-ci-runner/skills/triage/SKILL.md
@@ -165,7 +165,7 @@ gh issue view $ARGUMENTS --json author,authorAssociation --jq '.authorAssociatio
 
 Use the heredoc pattern from `/tend-ci-runner:running-in-ci` for `--body` arguments to avoid shell quoting issues.
 
-**Do not introduce exclamation marks into the comment body.** The Bash tool rewrites every `!` to `\!` before bash parses the command, so a greeting like "Thanks for reporting this!" lands in the posted comment as "Thanks for reporting this\!" — quoting and heredoc form do not save you. The templates below intentionally end greetings with periods. If you must include an exclamation mark (e.g. quoting a user), author the comment with the Write tool and pass it via `gh issue comment --body-file`.
+**Do not introduce exclamation marks into the comment body.** The Bash tool rewrites every exclamation mark to a literal backslash-bang before bash parses the command, so a greeting like "Thanks for reporting this!" lands in the posted comment as "Thanks for reporting this\!" — quoting and heredoc form do not save you. The templates below intentionally end greetings with periods. If you must include an exclamation mark (e.g. quoting a user), author the comment with the Write tool and pass it via `gh issue comment --body-file`.
 
 Choose the appropriate template:
 

--- a/plugins/tend-ci-runner/skills/triage/SKILL.md
+++ b/plugins/tend-ci-runner/skills/triage/SKILL.md
@@ -165,23 +165,25 @@ gh issue view $ARGUMENTS --json author,authorAssociation --jq '.authorAssociatio
 
 Use the heredoc pattern from `/tend-ci-runner:running-in-ci` for `--body` arguments to avoid shell quoting issues.
 
+**Do not introduce exclamation marks into the comment body.** The Bash tool rewrites every `!` to `\!` before bash parses the command, so a greeting like "Thanks for reporting this!" lands in the posted comment as "Thanks for reporting this\!" — quoting and heredoc form do not save you. The templates below intentionally end greetings with periods. If you must include an exclamation mark (e.g. quoting a user), author the comment with the Write tool and pass it via `gh issue comment --body-file`.
+
 Choose the appropriate template:
 
 ### Fix PR created
 
-> Thanks for reporting this! I was able to reproduce the issue and identified the root cause: [one-sentence explanation].
+> Thanks for reporting this. I was able to reproduce the issue and identified the root cause: [one-sentence explanation].
 >
 > I've opened #PR_NUMBER with a fix. A maintainer will review it shortly.
 
 ### Reproduction test only (no fix attempted)
 
-> Thanks for reporting this! I was able to reproduce the issue — #PR_NUMBER adds a failing test that demonstrates the bug.
+> Thanks for reporting this. I was able to reproduce the issue — #PR_NUMBER adds a failing test that demonstrates the bug.
 >
 > Root cause appears to be [brief explanation if known, or "still under investigation"]. A maintainer will take a closer look.
 
 ### Could not reproduce
 
-> Thanks for reporting this! I tried to reproduce this but wasn't able to with the information provided.
+> Thanks for reporting this. I tried to reproduce this but wasn't able to with the information provided.
 >
 > Could you share [specific information needed — exact command, config file, OS, shell, etc.]? That would help narrow it down.
 >
@@ -189,25 +191,25 @@ Choose the appropriate template:
 
 ### Bug already fixed
 
-> Thanks for reporting this! I looked into this and it appears the behavior described may already be fixed on the default branch (the relevant test passes).
+> Thanks for reporting this. I looked into this and it appears the behavior described may already be fixed on the default branch (the relevant test passes).
 >
 > Could you confirm which version you're running? If you're on an older release, updating should resolve this. A maintainer will confirm.
 
 ### Feature may already exist
 
-> Thanks for the suggestion! It's possible that [existing feature — specific behavior, config/flag] already does what you're looking for: [brief description of how it works].
+> Thanks for the suggestion. It's possible that [existing feature — specific behavior, config/flag] already does what you're looking for: [brief description of how it works].
 >
 > If that's not quite what you had in mind, could you clarify what additional behavior you're looking for? A maintainer will take a look either way.
 
 ### Feature does not exist
 
-> Thanks for the suggestion! I searched the codebase and didn't find an existing implementation of this. [Optionally: the closest related functionality is X, which does Y.]
+> Thanks for the suggestion. I searched the codebase and didn't find an existing implementation of this. [Optionally: the closest related functionality is X, which does Y.]
 >
 > I'll leave it for a maintainer to evaluate and prioritize.
 
 ### Question
 
-> Thanks for reaching out! This looks like a usage question rather than a bug report.
+> Thanks for reaching out. This looks like a usage question rather than a bug report.
 >
 > [Brief answer if obvious from the codebase, or pointer to relevant docs/help text.]
 >
@@ -215,7 +217,7 @@ Choose the appropriate template:
 
 ### Duplicate
 
-> Thanks for reporting this! This appears to be related to #EXISTING_ISSUE [and/or PR #EXISTING_PR]. I'll leave it to a maintainer to confirm and link them.
+> Thanks for reporting this. This appears to be related to #EXISTING_ISSUE [and/or PR #EXISTING_PR]. I'll leave it to a maintainer to confirm and link them.
 
 ### Maintainer-filed request (feature example)
 


### PR DESCRIPTION
## Symptom

Triage bot posted [a comment on issue #360](https://github.com/max-sixty/tend/issues/360#issuecomment-4354610225) opening with `Thanks for the detailed write-up\!` — a literal backslash-bang where the template intends an exclamation mark. The Bash tool rewrites every `!` in a command string to `\!` before bash parses it, so any comment body posted via `gh issue comment --body "..."` (or `<<EOF` heredoc) that contains an exclamation mark ships visibly corrupted.

## Why this slipped past the existing guidance

[`running-in-ci/SKILL.md`](https://github.com/max-sixty/tend/blob/febec9d2839e8e78d5ca585451f63ce80850f31c/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md#L356) already warns: *"Use the Write tool for any comment body containing an exclamation mark, then pass the file to `gh ... --body-file`."* But the triage skill's own templates ([lines 172, 178, 184, 192, 198, 204, 210, 218](https://github.com/max-sixty/tend/blob/febec9d2839e8e78d5ca585451f63ce80850f31c/plugins/tend-ci-runner/skills/triage/SKILL.md#L172)) literally contain exclamation-mark greetings — *"Thanks for reporting this!"*, *"Thanks for the suggestion!"*, *"Thanks for reaching out!"* — so a bot following the template via the heredoc pattern recommended in the same skill at line 166 hits the rewrite. The trigger is in the template itself; the general warning fires too late.

## Evidence

Two confirmed user-facing corruptions in posted issue comments since 2026-04-01, both matching the template opener pattern:

- 2026-04-30 [issue #360 comment](https://github.com/max-sixty/tend/issues/360#issuecomment-4354610225): `Thanks for the detailed write-up\!` (this run, run [25179241285](https://github.com/max-sixty/tend/actions/runs/25179241285))
- 2026-04-10 [issue #221 comment](https://github.com/max-sixty/tend/issues/221#issuecomment-4224023360): `Thanks for the detailed writeup and cross-posted repro\!`

Scan recipe used:

```bash
gh api 'repos/max-sixty/tend/issues/comments?per_page=100&since=2026-04-01T00:00:00Z' \
  --paginate --jq '.[] | select(.user.login == "tend-agent")' \
  > /tmp/all-bot-comments.jsonl
grep -P '\\\\!' /tmp/all-bot-comments.jsonl
```

Three other matches in the [#217 thread](https://github.com/max-sixty/tend/issues/217) are intentional discussion of this same bug class (the issue was about the bash escape itself), not corruption.

## Fix

Replace `!` with `.` across all 8 templates in `plugins/tend-ci-runner/skills/triage/SKILL.md`, and add a short inline note explaining that the templates intentionally avoid exclamation marks. The note redirects future authors to the Write + `--body-file` path if they ever need an exclamation mark (e.g. quoting a user verbatim).

This is a structural fix at the trigger: removing the literal `!` characters the bot copies prevents the failure regardless of which post-path the bot chooses (heredoc vs. `--body-file`). It does not depend on the bot remembering the general warning.

## Gate assessment

- **Evidence level**: High — 2 confirmed user-facing comment corruptions traceable to the same templates, plus 11+ cumulative bang-escape occurrences across other surfaces (full audit in the [evidence gist](https://gist.github.com/8f10d7c1abcb07c79bef00ee6d02d315)).
- **Failure type**: Structural at the trigger (templates supply the `!`); stochastic at the bot (whether the bot recalls running-in-ci's general warning when composing the body). Removing the trigger eliminates the failure mode.
- **Magnitude**: Removal/simplification — Low evidence bar; passes both gates.

## Evidence

[Evidence gist for `max-sixty/tend` 2026-04](https://gist.github.com/8f10d7c1abcb07c79bef00ee6d02d315)
