### PR TITLE
skills(notifications): drop specific past-run reference from timeline-check rationale

### DIFF
--- a/plugins/tend-ci-runner/skills/notifications/SKILL.md
+++ b/plugins/tend-ci-runner/skills/notifications/SKILL.md
@@ -97,7 +97,7 @@ gh api "repos/{owner}/{repo}/pulls/{number}/reviews" \
   --jq "[.[] | select(.user.login == \"$BOT_LOGIN\" and .submitted_at > \"$NOTIF_UPDATED_AT\")] | length"
 ```
 
-For issue notifications, also check the timeline for bot-authored PRs that cross-reference the issue. `tend-mention` typically handles an `@`-mention-asking-for-a-PR by opening a PR with `Refs #N` in its body — *without* commenting on the issue. The comments check above misses that path, so without this timeline check the same notification races to a duplicate PR from this skill (observed in run 24438413763 which opened PR #278 duplicating PR #277):
+For issue notifications, also check the timeline for bot-authored PRs that cross-reference the issue. `tend-mention` typically handles an `@`-mention-asking-for-a-PR by opening a PR with `Refs #N` in its body — *without* commenting on the issue. The comments check above misses that path, so without this timeline check the same notification races to a duplicate PR from this skill:
 
 ```bash
 gh api "repos/{owner}/{repo}/issues/{number}/timeline" \


### PR DESCRIPTION
Surfaced by the rolling survey in `tend-nightly`. CLAUDE.md skill-authoring guidance is explicit: "No specific past-run references. Don't link GitHub Actions runs, cite session IDs, or quote durations from individual incidents. They age into trivia and aren't useful when the skill is reused."

The cross-reference timeline check rationale read `(observed in run 24438413763 which opened PR #278 duplicating PR #277)`. The structural rule — the comments-only check misses bot-authored PRs that touch the issue only via `Refs #N` in the body — survives without the run/PR numbers.

## Test plan

Pure documentation; pytest suite green locally (`164 passed`). No behavioral test feasible — the change is removing trivia from prose.
