### PR TITLE
skills(review-runs): close prior-month tracking issues

### DIFF
--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -44,7 +44,7 @@ if [ -z "$TRACKING_NUMBER" ]; then
   cat > /tmp/tracking-body.md << 'EOF'
 Monthly tracking issue for below-threshold findings. Each run appends findings as a comment. Future runs read these to build cumulative evidence.
 
-**Do not close manually** — a new issue is created each month.
+**Do not close manually** — a new issue is created each month, and prior months are closed automatically.
 EOF
   TRACKING_URL=$(gh issue create \
     --title "$TRACKING_LABEL: $MONTH" \
@@ -56,6 +56,18 @@ EOF
   fi
   TRACKING_NUMBER=$(basename "$TRACKING_URL")
 fi
+```
+
+### Closing prior-month tracking issues
+
+Once a new month's issue exists, close any open tracking issues from earlier months. Run this unconditionally — it's a no-op when nothing's stale, and self-heals if a previous run failed to close.
+
+```bash
+gh issue list --state open --label "$TRACKING_LABEL" \
+  --json number,title --jq ".[] | select(.title | contains(\"$MONTH\") | not) | .number" \
+  | while read -r OLD; do
+      gh issue close "$OLD" --comment "Superseded by #$TRACKING_NUMBER ($MONTH)."
+    done
 ```
 
 ### Reading historical evidence


### PR DESCRIPTION
## Summary
- Adds an idempotent closure step to `review-runs` so old `review-runs-tracking` issues don't accumulate as months roll over (e.g. [worktrunk#1889](https://github.com/max-sixty/worktrunk/issues/1889) is the 2026-04 issue still open in 2026-05).
- The new step closes any open tracking issues whose title doesn't contain the current month, with a `Superseded by #N (YYYY-MM).` link to the new one.
- Tweaks the body template's "Do not close manually" line to acknowledge the auto-close so it stays accurate.

## Test plan
- [ ] First review-runs run after merge closes prior-month tracking issues across consumer repos.
- [ ] Subsequent same-month runs are no-ops (no extra closures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)