### PR TITLE
Refresh descriptions and rename debug-ci-session → debug-tend-run

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,12 @@
     "email": "m@maxroos.com"
   },
   "metadata": {
-    "description": "Claude-powered CI skills for GitHub repos",
-    "version": "0.1.0"
+    "description": "An autonomous junior maintainer for GitHub repos, powered by Claude — reviews PRs, triages issues, fixes CI"
   },
   "plugins": [
     {
       "name": "install-tend",
-      "description": "Set up tend (Claude-powered CI) on a GitHub repo.",
+      "description": "Set up tend — an autonomous junior maintainer for your GitHub repo, powered by Claude.",
       "source": "./plugins/install-tend"
     },
     {

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -3,8 +3,9 @@
 ## What this is
 
 Two Claude Code plugins, a GitHub composite action, and a generator that add
-Claude-powered CI to any repo. Handles PR review, issue triage, @bot mentions,
-CI fixes, nightly sweeps, and weekly maintenance.
+an autonomous junior maintainer (powered by Claude) to any repo. Handles PR
+review, issue triage, @bot mentions, CI fixes, nightly sweeps, and weekly
+maintenance.
 
 ## Architecture
 
@@ -490,7 +491,7 @@ tend/
 │   │   ├── .claude-plugin/
 │   │   │   └── plugin.json
 │   │   └── skills/
-│   │       ├── debug-ci-session/
+│   │       ├── debug-tend-run/
 │   │       └── install-tend/
 │   └── tend-ci-runner/         # CI plugin (all CI skills)
 │       ├── .claude-plugin/

--- a/action.yaml
+++ b/action.yaml
@@ -1,6 +1,7 @@
 name: Tend
 description: >-
-  Claude-powered CI for GitHub repos. Loads CI skills via plugin,
+  An autonomous junior maintainer for GitHub repos, powered by Claude —
+  reviews PRs, triages issues, fixes CI. Loads CI skills via plugin,
   resolves bot identity, runs Claude Code, and uploads session logs.
 
 inputs:

--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "tend"
 version = "0.0.16"
-description = "Claude-powered CI for GitHub repos"
+description = "An autonomous junior maintainer for GitHub repos, powered by Claude — reviews PRs, triages issues, fixes CI"
 license = "MIT"
 requires-python = ">=3.11"
 authors = [{ name = "Maximilian Roos", email = "m@maxroos.com" }]

--- a/generator/src/tend/cli.py
+++ b/generator/src/tend/cli.py
@@ -51,7 +51,7 @@ def _print_check_results(results: list[CheckResult]) -> None:
 
 @click.group()
 def main() -> None:
-    """Generate Claude-powered CI workflows from .config/tend.toml."""
+    """An autonomous junior maintainer for GitHub repos, powered by Claude. Generates and manages workflows from .config/tend.toml."""
 
 
 @main.command()

--- a/plugins/install-tend/.claude-plugin/plugin.json
+++ b/plugins/install-tend/.claude-plugin/plugin.json
@@ -1,7 +1,6 @@
 {
   "name": "install-tend",
-  "version": "0.1.0",
-  "description": "Set up tend (Claude-powered CI) on a GitHub repo.",
+  "description": "Set up tend — an autonomous junior maintainer for your GitHub repo, powered by Claude.",
   "author": {
     "name": "Maximilian Roos",
     "url": "https://github.com/max-sixty"

--- a/plugins/install-tend/skills/debug-tend-run/SKILL.md
+++ b/plugins/install-tend/skills/debug-tend-run/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: debug-ci-session
-description: Debugs Claude CI runs by downloading and parsing session log artifacts from GitHub Actions. Use when asked to "debug a CI run", "check what the bot did", "look at session logs", "investigate a tend run", "why did the bot do X", "what happened in CI", or to trace bot behavior in a specific workflow run.
+name: debug-tend-run
+description: Investigates a specific tend GitHub Actions run by downloading its session-log artifacts and parsing the JSONL traces. Surfaces which skill tend loaded, what tools it called with what inputs, files it read or wrote, and where decisions went wrong. Use when asked to "debug a tend run", "investigate a tend run", "why did tend do X", "what did the bot do in CI", "look at the session logs", or to reconstruct tend's behavior step-by-step from a run ID, URL, or PR number.
 ---
 
-# Debug CI Session
+# Debug Tend Run
 
-Investigate what a Claude-powered CI bot did during a GitHub Actions run by
-downloading and parsing its session log artifacts.
+Investigate what tend did during a GitHub Actions run by downloading and
+parsing its session log artifacts.
 
 ## Identify the run
 
@@ -35,15 +35,16 @@ gh run list -R "$REPO" --branch "$HEAD" --limit 10 \
 
 ## Download session logs
 
-Session logs are uploaded as artifacts named `claude-session-logs*`. Each
-artifact contains one or more JSONL files — one per Claude session in that run.
+Session logs are uploaded as artifacts named `claude-session-logs*` (the name
+is set by `claude-code-action`, which tend wraps). Each artifact contains one
+or more JSONL files — one per agent session in that run.
 
 ```bash
 RUN_ID=<run-id>
 gh run download "$RUN_ID" -R "$REPO" --pattern 'claude-session-logs*' --dir /tmp/session-logs/"$RUN_ID"/
 ```
 
-If no artifacts exist, the run either had no Claude session or the session was
+If no artifacts exist, the run either had no agent session or the session was
 too short to produce logs. Check the run's console output as a fallback:
 
 ```bash

--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: install-tend
-description: Sets up tend (Claude-powered CI) on a GitHub repo. Creates config, generates workflows, configures secrets and branch protection via API, creates the bot account, and provisions the bot's auth token. Use when setting up tend on a new repo or when asked to install/configure tend.
+description: Sets up tend — an autonomous junior maintainer for a GitHub repo, powered by Claude — that reviews PRs, triages issues, and fixes CI. Creates config, generates workflows, configures secrets and branch protection via API, creates the bot account, and provisions the bot's auth token. Use when setting up tend on a new repo or when asked to install/configure tend.
 ---
 
 # Install Tend

--- a/plugins/tend-ci-runner/.claude-plugin/plugin.json
+++ b/plugins/tend-ci-runner/.claude-plugin/plugin.json
@@ -1,6 +1,5 @@
 {
   "name": "tend-ci-runner",
-  "version": "0.1.0",
   "description": "Internal CI skills loaded by tend's GitHub Action. Not for manual installation.",
   "author": {
     "name": "Maximilian Roos",

--- a/plugins/tend-ci-runner/scripts/list-recent-runs.sh
+++ b/plugins/tend-ci-runner/scripts/list-recent-runs.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Lists recently completed Claude CI runs.
+# Lists recently completed tend CI runs.
 #
 # Fetches runs started in the past 3 hours, then filters to only those that
 # are completed and whose updatedAt is within the past hour. This two-step

--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-reviewers
-description: Hourly outcome-based analysis of Claude CI behavior — checks whether bot outputs were accepted or rejected, escalating to session logs only when outcomes look wrong.
+description: Hourly outcome-based analysis of tend's CI behavior — checks whether tend's outputs were accepted or rejected, escalating to session logs only when outcomes look wrong.
 argument-hint: "<owner/repo>"
 metadata:
   internal: true
@@ -8,7 +8,7 @@ metadata:
 
 # Review Reviewers
 
-Analyze Claude-powered CI behavior on the target repo over the past hour. Focus on **outcomes** — what the bot produced publicly and whether it was accepted — rather than internal session mechanics. Create PRs or issues on tend when outcomes reveal behavioral problems.
+Analyze tend's CI behavior on the target repo over the past hour. Focus on **outcomes** — what the bot produced publicly and whether it was accepted — rather than internal session mechanics. Create PRs or issues on tend when outcomes reveal behavioral problems.
 
 ## First steps
 
@@ -188,7 +188,7 @@ gh api "repos/$ARGUMENTS/contents/.claude/skills/running-tend/SKILL.md" \
 
 If the file doesn't exist, try common alternatives (`.claude/skills/running-tend.md`, `.claude/CLAUDE.md`). Understanding the repo's guidance is essential context for evaluating outcomes — without it, you'll misjudge authorized behavior as a violation.
 
-Then list recently completed Claude CI runs on the target repo:
+Then list recently completed tend CI runs on the target repo:
 
 ```bash
 TARGET_REPO=$ARGUMENTS ${CLAUDE_PLUGIN_ROOT}/scripts/list-recent-runs.sh

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -7,7 +7,7 @@ metadata:
 
 # Review Runs
 
-Analyze the previous night's Claude CI runs in this repository. Identify behavioral problems, skill gaps, and workflow issues — then propose improvements to the repo's local skills and workflows.
+Analyze the previous night's tend CI runs in this repository. Identify behavioral problems, skill gaps, and workflow issues — then propose improvements to the repo's local skills and workflows.
 
 This skill runs **in the adopter repo**, not in tend. Improvements target `.claude/skills/` and `.config/tend.toml` in this repository.
 
@@ -112,7 +112,7 @@ If `EXISTING_COMMENT` is empty, create a new comment. See the finding format in 
 
 ## Step 1: Find recent runs
 
-List Claude CI runs that completed in the past 24 hours (the cron runs daily):
+List tend CI runs that completed in the past 24 hours (the cron runs daily):
 
 ```bash
 REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
@@ -157,9 +157,9 @@ Include the totals and per-workflow breakdown in the summary (Step 7). Flag any 
 
 ## Step 3: Download and analyze session logs
 
-Load `/install-tend:debug-ci-session` for download commands and JSONL parsing queries.
+Load `/install-tend:debug-tend-run` for download commands and JSONL parsing queries.
 
-Skip runs without artifacts. Trace decision chains: what did Claude decide, what evidence did it use, what was the outcome?
+Skip runs without artifacts. Trace decision chains: what did tend decide, what evidence did it use, what was the outcome?
 
 ## Step 4: Cross-check outcomes
 

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -383,7 +383,7 @@ Split unrelated changes into separate PRs — one concern per PR. If one change 
 
 ## Investigating Other CI Runs
 
-Load `/install-tend:debug-ci-session` for session log download, JSONL parsing queries, and diagnostic workflow. The primary evidence for diagnosing bot behavior is the session log artifact — not console output.
+Load `/install-tend:debug-tend-run` for session log download, JSONL parsing queries, and diagnostic workflow. The primary evidence for diagnosing bot behavior is the session log artifact — not console output.
 
 Review-response runs triggered by `pull_request_review` or `pull_request_review_comment` events sometimes produce no artifact when the session is very short.
 


### PR DESCRIPTION
## Summary

The `debug-ci-session` skill was named generically and described itself as debugging "Claude CI runs" — both undersold what it does and conflated tend (the agent) with Claude (the underlying model). Renamed to `debug-tend-run` with a description that explains the actual surface: session-log artifacts, JSONL traces, tool calls, decisions.

Same conflation appeared in `review-runs`, `review-reviewers`, and `list-recent-runs.sh` — "Claude CI runs" / "Claude CI behavior" replaced with "tend CI runs" / "tend's CI behavior".

Reframed top-level descriptions (`action.yaml`, `marketplace.json`, both `plugin.json` files, `pyproject.toml`, `install-tend` skill, `DESIGN.md`) from "Claude-powered CI" to **"an autonomous junior maintainer for GitHub repos, powered by Claude — reviews PRs, triages issues, fixes CI"**. The "CI" framing undersold tend; the new framing names what tend actually is.

Dropped placeholder `"0.1.0"` version fields from both `plugin.json` files and `marketplace.json` metadata — they were never bumped.

## Test plan

- [x] `pre-commit run --all-files` passes
- [ ] CI green