### PR TITLE
workflows: bind bot token to GITHUB_TOKEN, not GH_TOKEN

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -63,7 +63,7 @@ runs:
         fi
         echo "Security preflight passed: default branch '${DEFAULT_BRANCH}' is protected"
       env:
-        GH_TOKEN: ${{ inputs.github_token }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}
 
     - name: Rate limit preflight
       shell: bash
@@ -111,14 +111,14 @@ runs:
         fi
         echo "Rate limit check passed"
       env:
-        GH_TOKEN: ${{ inputs.github_token }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}
 
     - name: Resolve bot ID
       id: bot
       shell: bash
       run: echo "id=$(gh api users/${{ inputs.bot_name }} --jq '.id')" >> "$GITHUB_OUTPUT"
       env:
-        GH_TOKEN: ${{ inputs.github_token }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}
 
     # Ensure uv/uvx is on PATH for Claude sessions. The nightly skill runs
     # `uvx tend@latest init` to regenerate workflow files, and mention/review
@@ -234,7 +234,7 @@ runs:
               gh api "notifications/threads/$tid" -X PATCH || true
             done) || echo "::warning::Failed to mark notification as read (non-fatal)"
       env:
-        GH_TOKEN: ${{ inputs.github_token }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}
 
     - name: Append skill step summary
       if: always()
@@ -373,7 +373,7 @@ runs:
           gh issue create --title "$TITLE" --label "$LABEL" -F /tmp/body.md
         fi
       env:
-        GH_TOKEN: ${{ inputs.github_token }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}
 
     - name: Compute artifact name
       if: always()

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -161,7 +161,7 @@ infrastructure overhead for self-hosted setups.
 `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB`, which strips sensitive environment
 variables before spawning subprocesses. Currently only activated when
 `allowed_non_write_users` is set. Could be enabled for all fork PRs to make
-naive `echo $GH_TOKEN` attacks fail — though a subprocess can read the
+naive `echo $GITHUB_TOKEN` attacks fail — though a subprocess can read the
 parent's unscrubbed environment via `/proc/$PPID/environ` (same-user, no
 privilege barrier on GitHub-hosted runners).
 
@@ -234,6 +234,12 @@ independent authentication paths exist in every workflow:
    the `GITHUB_TOKEN` env var with its `github_token` input.
 
 All workflows should pass the bot token to both paths.
+
+**Env var binding in shell steps.** Bind the bot token to `GITHUB_TOKEN`, not
+`GH_TOKEN`. `GITHUB_TOKEN` is auto-injected by GitHub Actions and read by most
+third-party tools — overriding it gives one bot identity everywhere in the
+job. `GH_TOKEN` only overrides the `gh` CLI; anything else still sees the
+auto-injected `github-actions[bot]` token.
 
 ### GitHub API: event types for PR comments
 

--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -213,7 +213,7 @@ jobs:
       - name: Resolve PR checkout ref
         id: pr_ref
         env:
-          GH_TOKEN: {bt}
+          GITHUB_TOKEN: {bt}
           PR: ${{{{ github.event.pull_request.number }}}}
         run: |
           if gh api "repos/${{{{ github.repository }}}}/git/ref/pull/$PR/merge" --silent 2>/dev/null; then
@@ -374,7 +374,7 @@ jobs:
 
           echo "should_run=false" >> "$GITHUB_OUTPUT"
         env:
-          GH_TOKEN: {bt}
+          GITHUB_TOKEN: {bt}
           EVENT_NAME: ${{{{ github.event_name }}}}
           COMMENT_BODY: ${{{{ github.event.comment.body || github.event.review.body }}}}
           ISSUE_BODY: ${{{{ github.event.issue.body }}}}
@@ -395,7 +395,7 @@ jobs:
         env:
           REPO: ${{{{ github.repository }}}}
           COMMENT_ID: ${{{{ github.event.comment.id }}}}
-          GH_TOKEN: {bt}
+          GITHUB_TOKEN: {bt}
 
   handle:
     needs: verify
@@ -426,7 +426,7 @@ jobs:
             echo "::warning::PR is $PR_STATE — staying on default branch"
           fi
         env:
-          GH_TOKEN: {bt}
+          GITHUB_TOKEN: {bt}
           PR_NUMBER: ${{{{ github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number }}}}
 {setup}
       - name: Compute queue delay
@@ -750,7 +750,7 @@ jobs:
             echo "$COUNT processable notification(s) — proceeding"
           fi
         env:
-          GH_TOKEN: {bt}
+          GITHUB_TOKEN: {bt}
 
       - uses: actions/checkout@v6
         if: {skip_condition}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
@@ -122,7 +122,7 @@ jobs:
 
           echo "should_run=false" >> "$GITHUB_OUTPUT"
         env:
-          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}
           COMMENT_BODY: ${{ github.event.comment.body || github.event.review.body }}
           ISSUE_BODY: ${{ github.event.issue.body }}
@@ -143,7 +143,7 @@ jobs:
         env:
           REPO: ${{ github.repository }}
           COMMENT_ID: ${{ github.event.comment.id }}
-          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
 
   handle:
     needs: verify
@@ -178,7 +178,7 @@ jobs:
             echo "::warning::PR is $PR_STATE ? staying on default branch"
           fi
         env:
-          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
           PR_NUMBER: ${{ github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number }}
 
       - name: Compute queue delay

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
@@ -86,7 +86,7 @@ jobs:
             echo "$COUNT processable notification(s) ? proceeding"
           fi
         env:
-          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
 
       - uses: actions/checkout@v6
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review].out
@@ -32,7 +32,7 @@ jobs:
       - name: Resolve PR checkout ref
         id: pr_ref
         env:
-          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
         run: |
           if gh api "repos/${{ github.repository }}/git/ref/pull/$PR/merge" --silent 2>/dev/null; then

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
@@ -122,7 +122,7 @@ jobs:
 
           echo "should_run=false" >> "$GITHUB_OUTPUT"
         env:
-          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}
           COMMENT_BODY: ${{ github.event.comment.body || github.event.review.body }}
           ISSUE_BODY: ${{ github.event.issue.body }}
@@ -143,7 +143,7 @@ jobs:
         env:
           REPO: ${{ github.repository }}
           COMMENT_ID: ${{ github.event.comment.id }}
-          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
 
   handle:
     needs: verify
@@ -178,7 +178,7 @@ jobs:
             echo "::warning::PR is $PR_STATE ? staying on default branch"
           fi
         env:
-          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
           PR_NUMBER: ${{ github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number }}
 
       - uses: astral-sh/setup-uv@v6

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
@@ -86,7 +86,7 @@ jobs:
             echo "$COUNT processable notification(s) ? proceeding"
           fi
         env:
-          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
 
       - uses: actions/checkout@v6
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review].out
@@ -32,7 +32,7 @@ jobs:
       - name: Resolve PR checkout ref
         id: pr_ref
         env:
-          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
         run: |
           if gh api "repos/${{ github.repository }}/git/ref/pull/$PR/merge" --silent 2>/dev/null; then


### PR DESCRIPTION
## Summary

- Tend's design intent is one bot identity everywhere in a job. Setting `GH_TOKEN` only overrides the `gh` CLI — third-party actions and subprocesses still see the auto-injected `github-actions[bot]` token.
- `GITHUB_TOKEN` is auto-injected by GitHub Actions and read by most tools, and `claude-code-action` already overwrites it internally, so binding the bot token there gives consistent identity across the job.
- Updates the generator templates and the composite action's own shell steps. Adds a paragraph to `docs/security-model.md` "Token assignment" explaining the convention.
- The generated `tend-*.yaml` workflows are not touched here — they regenerate from the next published release via the nightly `uvx tend@latest init`.

## Test plan

- [x] `uv run pytest` (164 passed)
- [x] `pre-commit run --all-files` (clean)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)