### PR TITLE
skills(review,notifications): unify comment fetches via gh ... --json

### DIFF
--- a/plugins/tend-ci-runner/skills/notifications/SKILL.md
+++ b/plugins/tend-ci-runner/skills/notifications/SKILL.md
@@ -85,16 +85,17 @@ If `IN_PROGRESS > 0`, **skip without marking read** — the next poll will see t
 BOT_LOGIN=$(gh api user --jq '.login')
 NOTIF_UPDATED_AT=<updated_at from the notification>
 
-# Conversation comments (covers issues and PR conversation, not PR reviews)
-gh api "repos/{owner}/{repo}/issues/{number}/comments" \
-  --jq "[.[] | select(.user.login == \"$BOT_LOGIN\" and .created_at > \"$NOTIF_UPDATED_AT\")] | length"
-```
+# Conversation comments — issues and PR conversation
+gh issue view {number} -R {owner}/{repo} --json comments \
+  --jq "[.comments[] | select(.author.login == \"$BOT_LOGIN\"
+                              and .createdAt > \"$NOTIF_UPDATED_AT\")] | length"
 
-For PR notifications, also check reviews (a separate endpoint):
-
-```bash
-gh api "repos/{owner}/{repo}/pulls/{number}/reviews" \
-  --jq "[.[] | select(.user.login == \"$BOT_LOGIN\" and .submitted_at > \"$NOTIF_UPDATED_AT\")] | length"
+# For PR notifications, fold reviews into one gh pr view --json call
+gh pr view {number} -R {owner}/{repo} --json comments,reviews \
+  --jq "{comments: [.comments[] | select(.author.login == \"$BOT_LOGIN\"
+                                         and .createdAt > \"$NOTIF_UPDATED_AT\")] | length,
+         reviews:  [.reviews[]  | select(.author.login == \"$BOT_LOGIN\"
+                                         and .submittedAt > \"$NOTIF_UPDATED_AT\")] | length}"
 ```
 
 For issue notifications, also check the timeline for bot-authored PRs that cross-reference the issue. `tend-mention` typically handles an `@`-mention-asking-for-a-PR by opening a PR with `Refs #N` in its body — *without* commenting on the issue. The comments check above misses that path, so without this timeline check the same notification races to a duplicate PR from this skill:

--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -57,17 +57,33 @@ If the incremental changes are trivial, skip the full review — go directly to 
 Then read all previous bot feedback and conversation:
 
 ```bash
-REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
 BOT_LOGIN=$(gh api user --jq '.login')
-# Previous review bodies
-gh api "repos/$REPO/pulls/<number>/reviews" \
-  --jq ".[] | select(.user.login == \"$BOT_LOGIN\" and (.body | length > 0)) | {state, body}"
-# Inline review comments
-gh api "repos/$REPO/pulls/<number>/comments" --paginate \
-  --jq ".[] | select(.user.login == \"$BOT_LOGIN\") | {path, line, body}"
-# Conversation (catch questions directed at the bot)
-gh api "repos/$REPO/issues/<number>/comments" --paginate \
-  --jq '.[] | {author: .user.login, body: .body}'
+# Conversation comments + previous review bodies (one fetch)
+gh pr view <number> --json comments,reviews \
+  --jq "{prev_reviews:  [.reviews[]  | select(.author.login == \"$BOT_LOGIN\"
+                                              and (.body | length > 0)) | {state, body}],
+         conversation:  [.comments[] | {author: .author.login, body}]}"
+
+# Inline review comments — separate path (gh pr view --json doesn't include them)
+cat > /tmp/inline-prev.graphql <<'GRAPHQL'
+query($owner:String!,$repo:String!,$number:Int!) {
+  repository(owner:$owner,name:$repo) {
+    pullRequest(number:$number) {
+      reviewThreads(first:100) {
+        nodes { comments(first:100) { nodes {
+          author { login } path line body
+        } } }
+      }
+    }
+  }
+}
+GRAPHQL
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+OWNER=${REPO%/*}; NAME=${REPO#*/}
+gh api graphql -F query=@/tmp/inline-prev.graphql -f owner="$OWNER" -f repo="$NAME" -F number=<number> \
+  --jq ".data.repository.pullRequest.reviewThreads.nodes[].comments.nodes[]
+        | select(.author.login == \"$BOT_LOGIN\")
+        | {path, line, body}"
 ```
 
 **Do not repeat any point from previous reviews** — cross-reference previous bot comments before posting inline comments. When concurrent runs race (a new push while the first run is still responding), both see the same unanswered question — check whether a bot reply exists after the question's timestamp before answering. Address unanswered questions in the review body (not via `gh pr comment`).


### PR DESCRIPTION
Collapses three separate REST endpoints (`gh api .../issues/<n>/comments`, `.../pulls/<n>/comments`, `.../pulls/<n>/reviews`) into a single `gh pr view --json comments,reviews` call, plus one GraphQL query for inline review threads. The notifications dedup check goes from two REST calls to one `gh pr view --json comments,reviews` (plus a `gh issue view --json comments` for issue notifications).