### PR TITLE
action: drop in_progress log polling; enrich tend-outage issues nightly

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -325,50 +325,24 @@ runs:
 
         TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-        # Fetch error annotations from the current job. GitHub indexes
-        # ##[error] annotations asynchronously, so poll with backoff up to
-        # ~8 min before giving up — earlier 50s and 5s windows lost the
-        # race on slow-indexing runs. The loop breaks as soon as an
-        # annotation surfaces, so the long tail is only paid when the
-        # annotation never indexes. Also match both in_progress (normal)
-        # and failure (if GitHub already transitioned the status) to
-        # handle matrix timing.
-        ERRORS=""
-        JOB_ID=""
-        for delay in 5 15 30 60 120 240; do
-          sleep "$delay"
-          if [ -z "$JOB_ID" ] || [ "$JOB_ID" = "null" ]; then
-            JOB_ID=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs" \
-              --jq '[.jobs[] | select(.status == "in_progress" or .conclusion == "failure")] | first | .id' 2>/dev/null || true)
-          fi
-          if [ -n "$JOB_ID" ] && [ "$JOB_ID" != "null" ]; then
-            ERRORS=$(gh api "repos/${GITHUB_REPOSITORY}/check-runs/${JOB_ID}/annotations" \
-              --jq '[.[] | select(.annotation_level == "failure") | .message | select(test("^Process completed") | not)] | join("\n")' 2>/dev/null || true)
-            [ -n "$ERRORS" ] && break
-          fi
-        done
-
-        ERROR_BLOCK=""
-        if [ -n "$ERRORS" ]; then
-          printf -v ERROR_BLOCK '\n<details><summary>Error details</summary>\n\n```\n%s\n```\n\n</details>\n' "$ERRORS"
-        fi
-
-        # Prepare issue body before the check so the TOCTOU window is minimal
+        # Just record the run link. Error annotations and logs are not
+        # reliably available while the job is in_progress, so the nightly
+        # skill enriches these issues after the fact, when the run has
+        # completed and the APIs return stable data.
         gh label create "$LABEL" --description "Tracks bot outage incidents" --color "d93f0b" 2>/dev/null || true
-        printf '%s\n\n%s\n%s\n%s\n%s\n%s\n' \
+        printf '%s\n\n%s\n%s\n%s\n\n%s\n' \
           "The bot failed to process a request. This issue tracks failures until the underlying cause is resolved." \
           "| When | Run | Trigger |" \
           "|------|-----|---------|" \
           "| ${TIMESTAMP} | [workflow run](${RUN_URL}) | ${REF:-N/A} |" \
-          "$ERROR_BLOCK" \
           "This issue was created automatically. Close it once the outage is resolved." > /tmp/body.md
 
         # Check-then-act with minimal gap
         EXISTING=$(gh issue list --label "$LABEL" --state open --json number --jq '.[0].number // empty')
 
         if [ -n "$EXISTING" ]; then
-          printf 'Failed run at %s: [workflow run](%s)%s\n%s\n' \
-            "$TIMESTAMP" "$RUN_URL" "${REF:+ (triggered by ${REF})}" "$ERROR_BLOCK" > /tmp/comment.md
+          printf 'Failed run at %s: [workflow run](%s)%s\n' \
+            "$TIMESTAMP" "$RUN_URL" "${REF:+ (triggered by ${REF})}" > /tmp/comment.md
           gh issue comment "$EXISTING" -F /tmp/comment.md
         else
           gh issue create --title "$TITLE" --label "$LABEL" -F /tmp/body.md

--- a/plugins/tend-ci-runner/scripts/enrich-tend-outage-issues.sh
+++ b/plugins/tend-ci-runner/scripts/enrich-tend-outage-issues.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Enriches open tend-outage issues with failure details from referenced runs.
+#
+# action.yaml's "Report failure" step records only the workflow run link —
+# error annotations and job logs are not reliably available while the job is
+# in_progress, so the action can't extract them at the time of failure.
+#
+# This script runs nightly: for each open tend-outage issue, it finds run IDs
+# in the body and comments, fetches failure annotations for each failed job
+# in those runs, and posts a comment with the details. Already-processed
+# runs are skipped via an `<!-- enriched-run:RUN_ID -->` marker in prior
+# comments — the marker is posted even when no annotations were found, so
+# unenrichable runs aren't retried every night.
+
+set -euo pipefail
+
+LABEL="tend-outage"
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+
+gh issue list --label "$LABEL" --state open --json number --jq '.[].number' \
+  | while read -r ISSUE; do
+    RAW=$(gh issue view "$ISSUE" --repo "$REPO" --json body,comments)
+
+    REFERENCED=$(echo "$RAW" | jq -r '
+      [.body, (.comments[].body)] | .[] | scan("/actions/runs/([0-9]+)")[0]
+    ' | sort -u)
+    ENRICHED=$(echo "$RAW" | jq -r '
+      .comments[].body | scan("<!-- enriched-run:([0-9]+) -->")[0]
+    ' | sort -u)
+
+    comm -23 <(echo "$REFERENCED") <(echo "$ENRICHED") \
+      | while read -r RUN_ID; do
+        [ -z "$RUN_ID" ] && continue
+
+        : > /tmp/enrich-errors.md
+        # Capture jobs first so a 404 (deleted/expired run) doesn't trip
+        # `set -e` via the pipe's exit status.
+        JOBS=$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs" \
+          --jq '.jobs[] | select(.conclusion == "failure") | "\(.id)\t\(.name)"' \
+          2>/dev/null || true)
+        while IFS=$'\t' read -r JOB_ID JOB_NAME; do
+          [ -z "$JOB_ID" ] && continue
+          MSG=$(gh api "repos/$REPO/check-runs/$JOB_ID/annotations" \
+            --jq '[.[] | select(.annotation_level == "failure") | .message
+                  | select(test("^Process completed") | not)] | join("\n\n")' \
+            2>/dev/null || true)
+          [ -n "$MSG" ] && printf '### %s\n\n```\n%s\n```\n\n' "$JOB_NAME" "$MSG" \
+            >> /tmp/enrich-errors.md
+        done <<< "$JOBS"
+
+        RUN_URL="https://github.com/$REPO/actions/runs/$RUN_ID"
+        if [ -s /tmp/enrich-errors.md ]; then
+          {
+            echo "Error details for [run $RUN_ID]($RUN_URL):"
+            echo
+            cat /tmp/enrich-errors.md
+            echo "<!-- enriched-run:$RUN_ID -->"
+          } > /tmp/enrich-comment.md
+        else
+          {
+            echo "No failure details could be extracted for [run $RUN_ID]($RUN_URL)."
+            echo "<!-- enriched-run:$RUN_ID -->"
+          } > /tmp/enrich-comment.md
+        fi
+        gh issue comment "$ISSUE" --repo "$REPO" -F /tmp/enrich-comment.md
+      done
+  done

--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -76,6 +76,14 @@ For each open issue, check whether recent commits or the current codebase state 
 
 Otherwise, leave it open for a maintainer to close.
 
+### Enrich tend-outage issues
+
+The action's "Report failure" step records only a workflow run link in `tend-outage` issues — annotations and job logs aren't reliably available while the job is in_progress. Run the enrichment script to fetch failure details for each newly referenced run and post them as a comment. The script is idempotent: it skips runs already marked with `<!-- enriched-run:RUN_ID -->`.
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/enrich-tend-outage-issues.sh"
+```
+
 ## Step 5: Rolling survey
 
 Run the survey script to get today's file list (rotating through the full repo over 28 days):


### PR DESCRIPTION
The action's \"Report failure\" step polled the annotations API (later the logs API) with backoff to attach error details to tend-outage issues. Both endpoints are unreliable while the job is in_progress: annotations index asynchronously and lagged past the 8-min budget on real failures, and the logs API returns 404 entirely for in_progress jobs. The result was tend-outage issues with no error block.

This PR strips the polling from action.yaml — the issue/comment now records only the run link — and adds a nightly enrichment pass: `plugins/tend-ci-runner/scripts/enrich-tend-outage-issues.sh` iterates open tend-outage issues, extracts run IDs from body and comments, and posts the failure annotations as a comment per run. The script is idempotent via an `<!-- enriched-run:RUN_ID -->` marker that's posted even when no annotations were found, so unenrichable runs aren't retried every night.

The annotations API is the only data path now; the logs-API fallback was only needed because annotations weren't reliable during in_progress, and the nightly script processes completed runs.