### PR TITLE
docs(scripts): drop stale #1301 reference from list-recent-runs.sh

### DIFF
--- a/plugins/tend-ci-runner/scripts/list-recent-runs.sh
+++ b/plugins/tend-ci-runner/scripts/list-recent-runs.sh
@@ -5,7 +5,7 @@
 # are completed and whose updatedAt is within the past hour. This two-step
 # approach is needed because `gh run list --created` filters by *start* time,
 # not *end* time — a run started 2h ago may have just finished, and a run
-# started 50min ago may still be running. See #1301 for details.
+# started 50min ago may still be running.
 #
 # Environment variables:
 #   TARGET_REPO - Query a different repo (default: current repo)


### PR DESCRIPTION
## Summary

Drops the `See #1301 for details.` reference from `list-recent-runs.sh`. Issue/PR #1301 doesn't exist in this repo (current numbers are around #380); the reference was carried over from the script's initial commit and has been a dead pointer the whole time. The surrounding comment already explains the rationale, so removing the reference loses no information.

## Test plan

- [x] `gh issue view 1301` confirms the issue does not exist in this repo
- [x] No other files reference `#1301`
- [x] CI passes
