### PR TITLE
skills(running-in-ci): require ID in --jq projection when composing per-item URLs

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -435,6 +435,8 @@ If you can't find source evidence for a specific detail, say so ("I'm not sure o
 
 **Links must be fetched, not guessed.** Before pasting any URL in a comment, run `curl -sI <url> | head -1` and confirm `200`. Docs-site slugs are particularly treacherous — `escaping.html` and `quoting.html` and `quote-strings.html` are all plausible nushell page names; only one (or none) actually exists. The canonical source for that project's docs sidebar will tell you which.
 
+**`--jq` projections must include the ID when downstream URLs cite individual items.** Composing `actions/runs/<id>`, `#issuecomment-<id>`, or `pull/<n>` URLs from `gh run list` / `gh api .../comments` / `gh pr list` results requires the ID field in the projection (`databaseId` for runs, `id` for comments, `number` for PRs/issues). If the projection kept only timestamps, titles, or bodies, the bot composes the URL from what it has and fabricates the missing ID — the link 404s. Re-query with the ID field rather than guessing.
+
 **"Likely" is a stop-sign.** If a draft contains "likely works", "probably parses as", "should behave like", or "I think" in a user-facing claim, you have two options: verify and replace the hedge with the answer, or hedge explicitly ("I haven't tested this — would appreciate if you can confirm") and don't dress up the guess as analysis. Posting an unverified guess as confident-sounding analysis is the hallucination shape that erodes trust the fastest.
 
 ### Distinguish transient incidents from durable bugs

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -431,7 +431,7 @@ When a project has user-facing documentation (a docs site, `--help` pages, a wik
 
 If you can't find source evidence for a specific detail, say so ("I'm not sure of the exact syntax") rather than guessing. An honest gap is fixable; a confident hallucination gets copy-pasted.
 
-### Two specific failure modes
+### Specific failure modes
 
 **Links must be fetched, not guessed.** Before pasting any URL in a comment, run `curl -sI <url> | head -1` and confirm `200`. Docs-site slugs are particularly treacherous — `escaping.html` and `quoting.html` and `quote-strings.html` are all plausible nushell page names; only one (or none) actually exists. The canonical source for that project's docs sidebar will tell you which.
 


### PR DESCRIPTION
## Problem

`tend-nightly` run [25306277429](https://github.com/max-sixty/tend/actions/runs/25306277429) closed `tend-outage` issue [#380](https://github.com/max-sixty/tend/issues/380) with this comment:

> Outage resolved. Subsequent tend runs on `main` have succeeded:
> - [tend-notifications 2026-05-04T01:09Z](https://github.com/max-sixty/tend/actions/runs/25295464928) — success (first success after the failure burst)
> - Continuous successful tend-notifications and review-reviewers runs through 2026-05-04T06:55Z
> - [ci 2026-05-04T05:52Z](https://github.com/max-sixty/tend/actions/runs/25300290927) — success on commit 32d5218 (main)

Both cited URLs 404 — the run IDs are fabricated. Real values: `25296207697` for that 01:09Z tend-notifications run, `25303358445` for the 05:52Z ci run.

## Root cause (structural)

Session log inspection: the bot ran two `gh run list` queries while preparing the comment, both with `--jq` projections that excluded `databaseId`:

```
gh run list --limit 20 --json status,conclusion,createdAt,name,workflowName --jq '.[] | "\(.createdAt) \(.conclusion // .status) \(.workflowName)"'
gh run list --branch main --workflow ci.yaml --limit 5 --json conclusion,createdAt,headSha --jq '.[] | "\(.createdAt) \(.conclusion) \(.headSha[0:7])"'
```

Output had timestamps and workflow names but no run IDs. When composing the URLs in the closure comment, the bot filled in plausible-looking 11-digit numbers from the surrounding pattern. Same shape as last month's gist entry where a tend-mention run shipped a fabricated `#issuecomment-3245892450` anchor in PR [#355](https://github.com/max-sixty/tend/pull/355) — `gh api .../comments --jq '{author, created_at, body}'` dropped `id` and the URL was composed without it.

PR [#253](https://github.com/max-sixty/tend/pull/253) addressed a similar shape on a different surface (the evidence-gist heading template's `<run-id>` placeholder) by anchoring `RUN_ID="$GITHUB_RUN_ID"` in `review-gates.md`. This PR adds the corresponding general rule for the broader `--jq`-then-compose-URL pattern that appears in user-facing comments.

## Fix

One paragraph added to `running-in-ci`'s "Two specific failure modes" subsection: when downstream URLs cite individual items, the listing tool's projection must include the ID field. Names the three common surfaces (`databaseId` for runs, `id` for comments, `number` for PRs/issues).

## Gate assessment

- **Confidence**: Critical — clearly wrong public output (two broken markdown links shipped on a tracking issue). One occurrence sufficient per Gate 1; cumulative count on the "fabricated user-facing identifier" surface is now 2 (this run plus the PR #355 case).
- **Magnitude**: Targeted fix, one paragraph, normal evidence bar.
- **Structural vs stochastic**: Structural — once the projection drops the ID and the comment template requires the URL, fabrication follows. The same bot facing the same scenario will hit the same shape unless the projection is fixed.
- **Both gates**: PASS.

## Evidence

- Bot comment: https://github.com/max-sixty/tend/issues/380#issuecomment-4369023145
- Triggering run: https://github.com/max-sixty/tend/actions/runs/25306277429
- Session log artifact: `claude-session-logs-1ab5c315`, file `63ea40a4-2909-449a-935a-9474371ec8c2.jsonl` — Write tool input at `/tmp/claude/issue-380-close.md` contains both fabricated URLs verbatim.
- Evidence gist (this month): https://gist.github.com/436c053100e5a44cdac646c9ebd3ebeb
- Prior occurrence write-up (last month's gist, PR #355 fabricated comment-ID): https://gist.github.com/8f10d7c1abcb07c79bef00ee6d02d315
- Prior related fix (different surface): [#253](https://github.com/max-sixty/tend/pull/253)
