### PR TITLE
skills(weekly): skip approval when bot already approved this commit

### DIFF
--- a/plugins/tend-ci-runner/skills/weekly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/weekly/SKILL.md
@@ -24,9 +24,18 @@ If no dependency PRs are open, note "0 dependency PRs to process" and continue t
 
 1. Check CI status: `gh pr checks <number>`
 2. If CI is passing, review the diff for breaking changes (major version bumps, API changes, deprecation warnings)
-3. If the update is safe (patch/minor with green CI), approve:
+3. If the update is safe (patch/minor with green CI), check whether the bot has already approved this commit before approving — a dependabot PR open across multiple weekly runs (or already approved by `tend-review` on creation) would otherwise accumulate redundant approvals on the same `commit_id`:
    ```bash
-   gh pr review <number> --approve --body "Automated dependency update — CI passing, no breaking changes."
+   HEAD_SHA=$(gh pr view <number> --json commits --jq '.commits[-1].oid')
+   BOT_LOGIN=$(gh api user --jq '.login')
+   LAST_APPROVAL_SHA=$(gh pr view <number> --json reviews \
+     --jq "[.reviews[] | select(.author.login == \"$BOT_LOGIN\" and .state == \"APPROVED\")] | last | .commit.oid // empty")
+
+   if [ "$LAST_APPROVAL_SHA" = "$HEAD_SHA" ]; then
+     echo "Already approved on this commit; skipping."
+   else
+     gh pr review <number> --approve --body "Automated dependency update — CI passing, no breaking changes."
+   fi
    ```
 4. If CI is failing, comment with the failure summary and skip
 5. If a major version bump, comment noting it needs manual review and skip


### PR DESCRIPTION
## Problem

The bundled `tend-ci-runner:weekly` skill instructs the bot to approve any safe dependency PR with green CI, without checking whether it has already approved that exact commit. Long-open dependabot PRs (or PRs already approved by `tend-review` on creation) accumulate redundant `APPROVED` reviews on the same `commit_id` each weekly run.

The bundled `review` skill already has a symmetric guard (`LAST_REVIEW_SHA == HEAD_SHA` check at `plugins/tend-ci-runner/skills/review/SKILL.md` lines 39–43); the `weekly` skill was missing it.

Observed in `PRQL/prql` per [#384](https://github.com/max-sixty/tend/issues/384): PR `PRQL/prql#5816` was approved by `prql-bot` via `tend-review` on creation, then re-approved by `tend-weekly` on the same commit ten days later.

## Solution

Add the same prior-approval guard to `plugins/tend-ci-runner/skills/weekly/SKILL.md` step 2.3 — read the head SHA, find the bot's last `APPROVED` review, and skip if they match.

## Testing

Skill text is not unit-testable. The reproduction is the production occurrence cited in the issue (dual approvals on `PRQL/prql#5816`); the guard mirrors a pattern already proven in the review skill. `uv run pytest` (188 tests) and `pre-commit run --files plugins/tend-ci-runner/skills/weekly/SKILL.md` both pass.

---
Closes #384 — automated triage
