### PR TITLE
install-tend: convert remaining open-ended asks to AskUserQuestion

### DIFF
--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -5,7 +5,11 @@ description: Sets up tend — an autonomous junior maintainer for a GitHub repo,
 
 # Install Tend
 
-Set up tend on the current repo. Ask the user for the bot name if not provided.
+Set up tend on the current repo. If the user hasn't supplied a bot name,
+get one via `AskUserQuestion` before step 1 using the candidate-generation
+pattern from step 6 (`<repo>-bot`, `<repo>-tend`, `tend-<repo>`, parallel
+availability check, present available ones). The user can pick "Other"
+to supply a custom name.
 
 When asking the user questions during these steps, use the `AskUserQuestion`
 tool — present concrete options when there are clear choices (e.g. bio
@@ -135,7 +139,18 @@ watched_workflows = ["ci", "lint"]  # names of workflows to watch
 If no CI workflows exist, either skip ci-fix (`enabled = false`) or help the
 user create one first.
 
-Ask the user about other overrides (setup steps, workflow overrides).
+Ask via `AskUserQuestion` (`multiSelect: true`) which other overrides
+they want to set. Skip-all is fine — defaults are sensible:
+
+- Setup steps (system deps, language version, pre-build hooks)
+- Workflow conditions (e.g., skip review on `tend:dismissed` PRs — see below)
+- Schedule overrides (cron timing for nightly/weekly)
+- Permissions / timeouts on specific jobs
+- Top-level env vars
+
+For each selected category, follow up with a free-text ask, then write
+the override into `.config/tend.toml`. See the next subsection for
+override syntax.
 
 ### Customizing generated workflow YAML
 


### PR DESCRIPTION
## Summary

Two stragglers from the prior `AskUserQuestion` sweep — both were left as plain "Ask the user …" wording because the option set wasn't initially crisp. On a second look, both have natural option sets.

**Bot-name early ask (line 8).** Was: "Ask the user for the bot name if not provided." Now points at step 6's candidate-generation pattern (`<repo>-bot` / `<repo>-tend` / `tend-<repo>`, parallel availability check, present available ones), with "Other" as the escape hatch for custom names.

**Other-overrides ask (after CI workflow discovery).** Was: "Ask the user about other overrides (setup steps, workflow overrides)." Now a `multiSelect: true` `AskUserQuestion` over the five categories the very next subsection actually documents — setup steps, workflow conditions, schedule overrides, permissions/timeouts, top-level env vars. Skip-all is fine; for each selected category, follow up with a free-text ask.

> _This was written by Claude Code on behalf of max-sixty_