### PR TITLE
feat(notifications): drop cross-repo CheckSuite notifications in pre-check

### DIFF
--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -737,7 +737,20 @@ jobs:
             done
           fi
 
-          # --- Layer C: drop notifications on bot-authored closed PRs ---
+          # --- Layer C: drop cross-repo CheckSuite notifications ---
+          # `ci_activity` notifications from other repos (typically forks
+          # whose own tend-* workflows fire and notify the canonical bot)
+          # are categorically unactionable per the notifications skill —
+          # cross-repo non-mention non-fork-PR-comment items get marked read
+          # without response. Filtering at the pre-check avoids invoking
+          # Claude just to silently mark them read.
+          NOTIFS=$(gh api notifications)
+          echo "$NOTIFS" | jq -r --arg repo "$GITHUB_REPOSITORY" '.[] | select(.repository.full_name != $repo and .subject.type == "CheckSuite") | .id' | while read -r tid; do
+            [ -n "$tid" ] || continue
+            gh api "notifications/threads/$tid" -X PATCH || true
+          done
+
+          # --- Layer D: drop notifications on bot-authored closed PRs ---
           # The bot auto-subscribes to its own PRs. After merge/close, leftover
           # subscription notifications are pure noise — no action needed.
           NOTIFS=$(gh api notifications)
@@ -752,7 +765,7 @@ jobs:
             fi
           done
 
-          # --- Layer D: count processable notifications ---
+          # --- Layer E: count processable notifications ---
           # Same-repo notifications younger than 10 minutes are deferred: a
           # dedicated workflow (tend-review/mention/triage/ci-fix) is likely
           # still starting up or mid-flight and hasn't posted its response yet.

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
@@ -51,7 +51,20 @@ jobs:
             done
           fi
 
-          # --- Layer C: drop notifications on bot-authored closed PRs ---
+          # --- Layer C: drop cross-repo CheckSuite notifications ---
+          # `ci_activity` notifications from other repos (typically forks
+          # whose own tend-* workflows fire and notify the canonical bot)
+          # are categorically unactionable per the notifications skill ?
+          # cross-repo non-mention non-fork-PR-comment items get marked read
+          # without response. Filtering at the pre-check avoids invoking
+          # Claude just to silently mark them read.
+          NOTIFS=$(gh api notifications)
+          echo "$NOTIFS" | jq -r --arg repo "$GITHUB_REPOSITORY" '.[] | select(.repository.full_name != $repo and .subject.type == "CheckSuite") | .id' | while read -r tid; do
+            [ -n "$tid" ] || continue
+            gh api "notifications/threads/$tid" -X PATCH || true
+          done
+
+          # --- Layer D: drop notifications on bot-authored closed PRs ---
           # The bot auto-subscribes to its own PRs. After merge/close, leftover
           # subscription notifications are pure noise ? no action needed.
           NOTIFS=$(gh api notifications)
@@ -66,7 +79,7 @@ jobs:
             fi
           done
 
-          # --- Layer D: count processable notifications ---
+          # --- Layer E: count processable notifications ---
           # Same-repo notifications younger than 10 minutes are deferred: a
           # dedicated workflow (tend-review/mention/triage/ci-fix) is likely
           # still starting up or mid-flight and hasn't posted its response yet.

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
@@ -50,7 +50,20 @@ jobs:
             done
           fi
 
-          # --- Layer C: drop notifications on bot-authored closed PRs ---
+          # --- Layer C: drop cross-repo CheckSuite notifications ---
+          # `ci_activity` notifications from other repos (typically forks
+          # whose own tend-* workflows fire and notify the canonical bot)
+          # are categorically unactionable per the notifications skill ?
+          # cross-repo non-mention non-fork-PR-comment items get marked read
+          # without response. Filtering at the pre-check avoids invoking
+          # Claude just to silently mark them read.
+          NOTIFS=$(gh api notifications)
+          echo "$NOTIFS" | jq -r --arg repo "$GITHUB_REPOSITORY" '.[] | select(.repository.full_name != $repo and .subject.type == "CheckSuite") | .id' | while read -r tid; do
+            [ -n "$tid" ] || continue
+            gh api "notifications/threads/$tid" -X PATCH || true
+          done
+
+          # --- Layer D: drop notifications on bot-authored closed PRs ---
           # The bot auto-subscribes to its own PRs. After merge/close, leftover
           # subscription notifications are pure noise ? no action needed.
           NOTIFS=$(gh api notifications)
@@ -65,7 +78,7 @@ jobs:
             fi
           done
 
-          # --- Layer D: count processable notifications ---
+          # --- Layer E: count processable notifications ---
           # Same-repo notifications younger than 10 minutes are deferred: a
           # dedicated workflow (tend-review/mention/triage/ci-fix) is likely
           # still starting up or mid-flight and hasn't posted its response yet.

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
@@ -50,7 +50,20 @@ jobs:
             done
           fi
 
-          # --- Layer C: drop notifications on bot-authored closed PRs ---
+          # --- Layer C: drop cross-repo CheckSuite notifications ---
+          # `ci_activity` notifications from other repos (typically forks
+          # whose own tend-* workflows fire and notify the canonical bot)
+          # are categorically unactionable per the notifications skill ?
+          # cross-repo non-mention non-fork-PR-comment items get marked read
+          # without response. Filtering at the pre-check avoids invoking
+          # Claude just to silently mark them read.
+          NOTIFS=$(gh api notifications)
+          echo "$NOTIFS" | jq -r --arg repo "$GITHUB_REPOSITORY" '.[] | select(.repository.full_name != $repo and .subject.type == "CheckSuite") | .id' | while read -r tid; do
+            [ -n "$tid" ] || continue
+            gh api "notifications/threads/$tid" -X PATCH || true
+          done
+
+          # --- Layer D: drop notifications on bot-authored closed PRs ---
           # The bot auto-subscribes to its own PRs. After merge/close, leftover
           # subscription notifications are pure noise ? no action needed.
           NOTIFS=$(gh api notifications)
@@ -65,7 +78,7 @@ jobs:
             fi
           done
 
-          # --- Layer D: count processable notifications ---
+          # --- Layer E: count processable notifications ---
           # Same-repo notifications younger than 10 minutes are deferred: a
           # dedicated workflow (tend-review/mention/triage/ci-fix) is likely
           # still starting up or mid-flight and hasn't posted its response yet.


### PR DESCRIPTION
## Summary

Adds a pre-check layer to `tend-notifications` that drops cross-repo `CheckSuite` notifications (`reason: ci_activity` from forks) before counting unread items. Without this filter, a forked repo whose own `tend-*` workflows fail keeps generating `ci_activity` notifications to the canonical bot, each of which forces a Claude invocation that loads the notifications skill, classifies the item as "cross-repo, not actionable", and marks it read — work that can be done in YAML for cents-on-the-dollar.

The notifications skill is the sole handler for: fork PR inline comments, cross-repo `@`-mentions, and stale same-repo items. Cross-repo `CheckSuite` items aren't in any of those categories — the bundled skill explicitly tells Claude to mark them read without action. Filtering at the pre-check makes the YAML do what Claude was already doing.

## Evidence

In one hour on `max-sixty/worktrunk` (runs [25461250978](https://github.com/max-sixty/worktrunk/actions/runs/25461250978), [25462624978](https://github.com/max-sixty/worktrunk/actions/runs/25462624978), [25463750952](https://github.com/max-sixty/worktrunk/actions/runs/25463750952)), three consecutive scheduled `tend-notifications` runs each:

1. Saw exactly 1 unread notification — a `ci_activity` `CheckSuite` from `lucaspimentel/worktrunk` reporting that fork's own `tend-notifications` failed on its `main`.
2. Passed the YAML pre-check (Layer A's `count > 0`; Layers B/C/D don't filter cross-repo CheckSuite).
3. Invoked Claude (~26–33 KB session log per run).
4. Loaded `running-in-ci` and `running-tend`, classified the item as cross-repo CI activity, marked it read, exited.

Cumulative occurrences of the same shape across the bot's evidence gists (this month + last): 80+. Pattern is structural: same input → same paid-but-no-op outcome every time.

Linked evidence gist: https://gist.github.com/9675d1510da32c68a68c1d45137b21e0

## Gate assessment

- **Gate 1 (Confidence)**: High — structural failure, 80+ historical occurrences.
- **Gate 2 (Magnitude)**: Targeted fix — one new pre-check layer. Normal threshold; passes.
- **Structural vs. stochastic**: Structural — Layer A only checks `count > 0`, so any cross-repo CheckSuite always reaches Claude.

## Why filter `subject.type == "CheckSuite"` rather than `reason == "ci_activity"`

`CheckSuite` is the typed subject GitHub assigns to all CI-related notifications and matches the same set in practice. Filtering by subject type keeps the predicate close in spirit to existing Layer C (`subject.type == "PullRequest"`) and avoids depending on the `reason` enum.

## Why drop only cross-repo, not same-repo

Same-repo CI failures are handled by `tend-ci-fix` on the `workflow_run` event (immediate, deterministic). The notifications-skill "stale unanswered items" path explicitly carries the case where a dedicated workflow failed or was skipped. Same-repo `ci_activity` therefore stays in scope; only cross-repo (which has no dedicated handler and is out-of-scope per the skill's scope rules) is filtered.

## Test plan

- [x] `uv run pytest` — 188 passed
- [x] Regtest snapshots regenerated and the diff is constrained to the three notifications-related fixtures
- [ ] Forked-repo `tend-notifications` runs no longer trigger Claude on `lucaspimentel`-style fork CI failures (verifiable next hour after this lands and a release ships)
