### PR TITLE
skills(triage): add rules against test-skip fixes and parallel same-root-cause PRs

### DIFF
--- a/plugins/tend-ci-runner/skills/triage/SKILL.md
+++ b/plugins/tend-ci-runner/skills/triage/SKILL.md
@@ -94,6 +94,14 @@ When the bug is about bot behavior (e.g., "bot didn't use links", "bot posted wr
 1. **Check ALL co-loaded skills** — Skills loaded together in the same workflow share context. If the guidance already exists in a co-loaded skill, the issue is behavioral compliance, not missing instructions.
 2. **Don't duplicate guidance across skills.**
 
+### Don't "fix" tests by adding skip guards
+
+If the proposed change removes coverage for the failing scenario instead of restoring the assertion, stop. Smell patterns: a newly-added early-return at the top of the test (`let Ok(_) = X else { return };`, `if !path.exists() { return; }`), a fresh `#[ignore]`, a newly-inserted `skipIf` / `pytest.skip` keyed on the failing condition. The fix belongs in production code or test setup, not in a guard that makes the test bail when the bug fires.
+
+### Defer to in-flight same-root-cause PRs
+
+Step 3's duplicate check catches identical fixes. It misses the *same root cause class, different surface* pattern: several failing tests share one underlying cause, and an outstanding PR fixes some of them but not the one being triaged. When the triage analysis itself names an existing PR as same-root-cause, that's the signal to wait for it to merge and re-run, or to mirror its approach for the remaining sites — not to open a parallel narrow workaround.
+
 ### If fixing
 
 1. Fix the root cause (not just the symptom)


### PR DESCRIPTION
## Problem

Triage feedback from a run in `max-sixty/worktrunk` (PR [#2633](https://github.com/max-sixty/worktrunk/pull/2633)) surfaced two patterns the bundled `triage` skill doesn't currently guard against:

1. The triage run "fixed" a failing test by inserting an early-return that silently bailed when the bug fired, removing coverage instead of restoring the assertion.
2. An outstanding PR ([worktrunk #2625](https://github.com/max-sixty/worktrunk/pull/2625)) had been merged ~3 minutes earlier with a production-code fix for the same root-cause class. The triage PR's own body even named it as same-root-cause — but Step 3's duplicate check only catches identical fixes, not the *same root cause class, different surface* pattern, so the run shipped a parallel narrow workaround anyway.

worktrunk's overlay captured both rules in [worktrunk PR #2639](https://github.com/max-sixty/worktrunk/pull/2639); both look generalizable to every tend consumer, hence promoting them to the bundled skill.

## Solution

Two new subsections under Step 6 of `plugins/tend-ci-runner/skills/triage/SKILL.md`:

- **Don't "fix" tests by adding skip guards** — names the smell patterns (newly-added early-returns, fresh `#[ignore]`, `pytest.skip` keyed on the failing condition).
- **Defer to in-flight same-root-cause PRs** — when triage analysis itself names an existing PR as same-root-cause, that's the signal to wait, not to ship a parallel workaround.

Both are strict additions. Step 3's existing duplicate-check guidance and Step 6's "Fix the root cause (not just the symptom)" remain in place; the new rules fill gaps neither covered.

## Testing

`pre-commit run --files plugins/tend-ci-runner/skills/triage/SKILL.md` passes (trim trailing whitespace, fix end of files, typos, forbid bang-backtick).

---
Closes #393 — automated triage