### PR TITLE
skills(review): echo approve confirmation to prevent silent-retry duplicates

### DIFF
--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -157,7 +157,7 @@ Flag duplicates — reuse is almost always better than a parallel implementation
 gh pr review <number> --approve -b "" && echo "✓ approved"
 ```
 
-The trailing `&& echo` is intentional: `gh pr review --approve` produces no stdout on success, and prior runs that omitted the echo have re-issued the verb on seeing a silent tool-result and posted a duplicate APPROVED on the same commit. The visible success signal prevents the retry. Apply the same pattern to any other silent-success verb on the posting path (e.g. dismissal `PUT`s).
+The trailing `&& echo` is intentional: `gh pr review --approve` produces no stdout on success, and prior runs that omitted the echo have re-issued the verb on seeing a silent tool-result and posted a duplicate APPROVED on the same commit. The visible success signal prevents the retry.
 
 If there are actionable findings, submit as a review with inline suggestions for concrete fixes. Every comment must give the author something to act on:
 

--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -157,8 +157,6 @@ Flag duplicates — reuse is almost always better than a parallel implementation
 gh pr review <number> --approve -b "" && echo "✓ approved"
 ```
 
-The trailing `&& echo` is intentional: `gh pr review --approve` produces no stdout on success, and prior runs that omitted the echo have re-issued the verb on seeing a silent tool-result and posted a duplicate APPROVED on the same commit. The visible success signal prevents the retry.
-
 If there are actionable findings, submit as a review with inline suggestions for concrete fixes. Every comment must give the author something to act on:
 
 | Don't post (internal analysis) | Post (actionable) |

--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -154,8 +154,10 @@ Flag duplicates — reuse is almost always better than a parallel implementation
 **If there are no issues, approve with an empty body — silence means correct.**
 
 ```bash
-gh pr review <number> --approve -b ""
+gh pr review <number> --approve -b "" && echo "✓ approved"
 ```
+
+The trailing `&& echo` is intentional: `gh pr review --approve` produces no stdout on success, and prior runs that omitted the echo have re-issued the verb on seeing a silent tool-result and posted a duplicate APPROVED on the same commit. The visible success signal prevents the retry. Apply the same pattern to any other silent-success verb on the posting path (e.g. dismissal `PUT`s).
 
 If there are actionable findings, submit as a review with inline suggestions for concrete fixes. Every comment must give the author something to act on:
 


### PR DESCRIPTION
## Outcome evidence

`tend-review` run [25499066953](https://github.com/max-sixty/worktrunk/actions/runs/25499066953) on worktrunk PR [#2641](https://github.com/max-sixty/worktrunk/pull/2641) posted **two `APPROVED` reviews 4 seconds apart** from a single completed session — review [4244431335](https://github.com/max-sixty/worktrunk/pull/2641#pullrequestreview-4244431335) at 13:35:57Z and [4244431873](https://github.com/max-sixty/worktrunk/pull/2641#pullrequestreview-4244431873) at 13:36:01Z, both empty-body, both on the same head SHA `55ef4fba`. Only one `tend-review` run touched this SHA, so this is not the documented concurrency-cancel `Non-issue` (no SIGTERM'd siblings here).

Decision chain in session log `bcfcce99-ae59-4201-a411-fe82f2b074bc.jsonl`:

1. **13:35:55Z** — bot ran a guarded combined script: `read CURRENT_HEAD/PR_STATE`, HEAD-match check, OPEN-state check, `ALREADY_POSTED` check, then `gh pr review 2641 --approve -b ""` as the script's last command. The first `APPROVED` posted at 13:35:57Z. Tool-result showed only the prelude's `echo` lines (`CURRENT_HEAD=… PR_STATE=OPEN ALREADY_POSTED=`); the approve itself produces no stdout on success.
2. **13:36:00Z** (5s later) — bot issued a bare standalone `gh pr review 2641 --approve -b ""` with no preceding text. The second `APPROVED` posted at 13:36:01Z.
3. **13:36:04Z** — bot queried `reviews[-1]`, saw the latest entry was `APPROVED`, and wrote "Approval posted on HEAD" (singular) to the conversation log, never noticing the duplicate.

The prelude's silence was indistinguishable from "approve didn't fire", so the model retried "to be sure".

## Root cause

The `### 5. Submit` recipe in `plugins/tend-ci-runner/skills/review/SKILL.md` shows `gh pr review --approve -b ""` with no positive confirmation. `gh pr review --approve` is silent on success, so combining it into a guarded script (where the only stdout is the prelude's `echo`) leaves the model with no visible success signal. The retry follows.

## Fix

Append `&& echo "✓ approved"` to the recipe so the tool-result shows explicit confirmation, and add one sentence explaining why future maintainers should not strip the echo as cosmetic noise. One-line code change, one sentence of explanation.

## Gate assessment

Evidence: https://gist.github.com/9675d1510da32c68a68c1d45137b21e0 (current month) plus prior month's gist `44ab1483b29406255dd36141650c894d`.

Three cumulative occurrences of single-session duplicate-review-POST across the past two months, all from `tend-review` sessions, all on `worktrunk`:

| Date | Run | PR | Review type | Notes |
|---|---|---|---|---|
| 2026-04-29 | [25089599666](https://github.com/max-sixty/worktrunk/actions/runs/25089599666) | [#2454](https://github.com/max-sixty/worktrunk/pull/2454) (Dependabot) | 2 × `APPROVED`, empty-body | Same combined-script-then-bare-retry shape; explicitly proposed `&& echo` as the fix |
| 2026-05-06 | [25454510442](https://github.com/max-sixty/worktrunk/actions/runs/25454510442) | [#1320](https://github.com/max-sixty/worktrunk/pull/1320) | 2 × `COMMENTED`, byte-identical 2476-byte bodies | Different verb path (`gh api .../reviews POST`) but same single-session-duplicate-POST signature |
| 2026-05-07 | [25499066953](https://github.com/max-sixty/worktrunk/actions/runs/25499066953) | [#2641](https://github.com/max-sixty/worktrunk/pull/2641) | 2 × `APPROVED`, empty-body | This run; recipe-level `--approve` shape, identical to the April 29 case |

- **Classification**: stochastic (model has decision points; not every replay would retry). Restricted to the recipe-level `--approve` shape: 2 cumulative occurrences (April 29, today). Across the broader single-session-duplicate-POST family: 3 occurrences.
- **Gate 1 (Confidence)**: stochastic with 3 cumulative occurrences ≥ High threshold (2-3). For the narrower `--approve`-only shape, 2 occurrences also meets the High threshold.
- **Gate 2 (Magnitude)**: targeted recipe fix (one line of code, one sentence of explanation) — Normal evidence bar, met by Gate 1 outcome.
- **Both gates pass**, with the April 29 entry's own forward statement: "if a second occurrence appears … warrant a PR even at the stochastic tier (and 2 would also satisfy the 'High' 2-3 threshold)."

## Why now

The April 29 entry recorded the exact same root cause and the exact same fix this PR applies, and put the bot on a watch-list pending a second occurrence. Today's run on PR #2641 is that second `--approve` occurrence (third cumulative across all single-session duplicate review shapes). The watch-list has tripped.

## Why not broader

Scope is constrained to the `--approve` recipe because that is where the evidence concentrates and where the call site is unambiguous. The COMMENTED API path (`gh api .../reviews POST`) returns JSON on success, so the silent-success-retry mechanism does not apply directly there; if its single occurrence recurs, a follow-up PR can address that path. Same for `gh api .../dismissals -X PUT` — referenced in the new explanatory sentence as guidance, not modified directly. Smallest change that addresses the observed pattern.
