### PR TITLE
chore: release 0.0.17

### DIFF
--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tend"
-version = "0.0.16"
+version = "0.0.17"
 description = "An autonomous junior maintainer for GitHub repos, powered by Claude — reviews PRs, triages issues, fixes CI"
 license = "MIT"
 requires-python = ">=3.11"

--- a/generator/uv.lock
+++ b/generator/uv.lock
@@ -144,7 +144,7 @@ wheels = [
 
 [[package]]
 name = "tend"
-version = "0.0.16"
+version = "0.0.17"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Bumps generator version 0.0.16 → 0.0.17
- 57 commits since 0.0.16; the headline change is #375 (gate fork-exposed scheduled workflows on `github.repository_owner` so consumer-repo forks no-op on the cron and stop generating cross-repo CheckSuite notifications back to `tend-agent`)
- Other notable changes: workflow header stamps tend version (#316), bot-token rebound to `GITHUB_TOKEN` (#373), review skill draft/light-mode + polling improvements (#308, #311, #315, #362)

## Test plan

- [x] `uv run pytest` — 188 passed
- [x] `pre-commit run --all-files` — clean
- [ ] After merge: tag 0.0.17, PyPI publishes, regenerate tend's own workflows with `uvx tend@latest init`