### PR TITLE
install-tend: fix oauth-token.sh returning an invalid token on macOS

### DIFF
--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -315,22 +315,26 @@ gh secret list --repo "$REPO" --json name --jq '.[].name' | grep -q CLAUDE_CODE_
 ```
 
 If not set, ask the user via `AskUserQuestion` how to obtain it. Token is
-valid for 1 year. Detect `command -v claude` first — if missing,
-recommend Manual outright (point them at `https://claude.com/claude-code`
-to install).
+valid for 1 year. Before offering the CLI option, check:
 
-- **CLI (recommended when `claude` is on PATH)** — run the bundled
-  wrapper, which invokes `claude setup-token` (OAuth 2.0 PKCE, opens
-  browser):
+- `command -v claude` — if missing, only offer Manual (point them at
+  `https://claude.com/claude-code` to install).
+- `uname` — the bundled wrapper depends on `bash` + `script(1)` and
+  has only been validated on macOS and Linux. On anything else
+  (`MINGW*`, `CYGWIN*`, `MSYS*`, `Windows_NT`, etc.), only offer Manual.
+
+- **CLI (recommended on macOS/Linux when `claude` is on PATH)** — run
+  the bundled wrapper, which invokes `claude setup-token` (OAuth 2.0
+  PKCE, opens browser):
 
   ```bash
   TOKEN=$("${CLAUDE_SKILL_DIR}/scripts/oauth-token.sh")
   ```
 
-- **Manual** — have the user run `claude setup-token` in any terminal
-  themselves and paste the `sk-ant-oat01-…` token back. Use this if the
-  wrapper fails (its PTY trick can break in some shells) or `claude`
-  isn't installed locally.
+- **Manual** — have the user run `claude setup-token` in their own
+  terminal (any machine with Claude Code installed) and paste the
+  `sk-ant-oat01-…` token back. Use this on Windows or when the
+  wrapper errors out.
 
 Then store the secret:
 

--- a/plugins/install-tend/skills/install-tend/scripts/oauth-token.sh
+++ b/plugins/install-tend/skills/install-tend/scripts/oauth-token.sh
@@ -11,34 +11,52 @@ if ! command -v claude &>/dev/null; then
   exit 1
 fi
 
-# claude setup-token is a TUI that starts a localhost server for the OAuth PKCE
-# callback. It requires a real TTY — without one the server doesn't bind and the
-# browser gets "can't connect to localhost". Claude Code's Bash tool has no TTY.
+# claude setup-token renders its TUI with Ink, which only writes to stdout
+# when stdout.isTTY — so without a real TTY, the OAuth flow runs to
+# completion (the localhost callback server binds, the browser approves)
+# but the token is generated, displayed to nothing, and lost. We use
+# script(1) to give the child a PTY so Ink renders, and capture the
+# rendered output to a file.
 #
-# Fix: script(1) creates a PTY for the child, but fails with "tcgetattr:
-# Operation not supported on socket" when its own stdin is a socket (as in
-# Claude Code). Redirecting stdin from /dev/null avoids this — the child
-# still gets a real PTY.
+# script(1) itself fails with "tcgetattr: Operation not supported on
+# socket" when its own stdin is a socket (as in Claude Code's Bash tool).
+# Redirecting stdin from /dev/null avoids that — the child still gets a
+# real PTY for stdout.
 TMPFILE=$(mktemp)
 trap 'rm -f "$TMPFILE"' EXIT
 
 >&2 echo "Running claude setup-token (approve in browser)..."
+# Widen the PTY (default 80 cols) so Ink doesn't wrap the ~108-char token
+# across lines. With the token on its own logical line, end-of-line is a
+# natural right boundary for extraction.
+#
+# Redirect script(1)'s stdout passthrough to stderr (>&2): script writes
+# the captured session to both the file AND its stdout, and we don't want
+# that gunk leaking into our caller's `TOKEN=$(...)` capture. The user
+# still sees the TUI on their terminal via stderr.
 if [[ "$(uname)" == "Darwin" ]]; then
-  script -q "$TMPFILE" claude setup-token < /dev/null
+  script -q "$TMPFILE" /bin/sh -c 'stty cols 250 rows 50; exec claude setup-token' < /dev/null >&2
 else
-  script -qec "claude setup-token" "$TMPFILE" < /dev/null
+  script -qec 'stty cols 250 rows 50; exec claude setup-token' "$TMPFILE" < /dev/null >&2
 fi
 
-# Extract the token (sk-ant-oat01-...) from the captured output.
-# script(1) captures raw terminal output — ANSI codes and line wraps at the PTY
-# width (default 80 cols) can split the token across lines. Strip escape codes
-# and newlines so the full token is one continuous string for grep.
-TOKEN=$(sed $'s/\033\\[[^a-zA-Z]*[a-zA-Z]//g' "$TMPFILE" | tr -d '\r\n' \
-  | grep -o 'sk-ant-oat01-[A-Za-z0-9_-]*' | head -1)
+# Strip ANSI CSI sequences and CR. Then grep for the token: with the wide
+# PTY the token sits on its own line, and grep -oE doesn't cross
+# newlines, so the match can't run past the token into the next line
+# ("Store this token…") — the silent "Invalid bearer token" failure mode
+# that motivated this script.
+TOKEN=$(sed $'s/\033\\[[^a-zA-Z]*[a-zA-Z]//g' "$TMPFILE" | tr -d '\r' \
+  | grep -oE 'sk-ant-oat01-[A-Za-z0-9_-]+' | head -1)
 
 if [ -z "$TOKEN" ]; then
-  >&2 echo "Error: Could not extract token from output"
+  >&2 echo "Error: no sk-ant-oat01-… token found in TUI output"
   >&2 cat "$TMPFILE"
+  exit 1
+fi
+
+# Sanity check: real tokens are ~108 chars.
+if (( ${#TOKEN} < 80 || ${#TOKEN} > 200 )); then
+  >&2 echo "Error: extracted token has implausible length (${#TOKEN} chars)"
   exit 1
 fi
 


### PR DESCRIPTION
The wrapper's grep extraction ran past the token's last char into the next TUI line (`Store this token securely…`), returning a malformed bearer that `api.anthropic.com` rejected with `401 Invalid bearer token`. The token and the following line are joined in the captured TUI by ANSI styling alone — no whitespace — so after CSI strip + `tr -d '\r\n'`, the `[A-Za-z0-9_-]*` class greedily consumed `Store` too. Wrapper exited 0 and the bot got a token that looked plausible, silently bricking `tend install` runs that used the CLI path.

## Changes

- Widen the PTY to 250 cols via `stty` inside a shell wrapper, so Ink renders the ~108-char token on a single line. End-of-line then becomes a natural right boundary.
- Drop `tr -d '\n'`; rely on `grep -oE` not crossing newlines, which makes the "runs into Store" failure mode structurally impossible regardless of label wording.
- Redirect `script(1)`'s stdout passthrough to stderr — pre-existing leak that polluted `TOKEN=$(./oauth-token.sh)` callers; was masked by the broken extraction. The user still sees the TUI on their terminal via stderr.
- Length sanity check (80 ≤ len ≤ 200) as a safety net.
- Correct the in-script comment about why `script(1)` is needed. The OAuth callback server binds fine without a TTY (verified by running `claude setup-token` with no TTY — bound `localhost:50706` and connected to claude.com); what needs a TTY is stdout, because Ink only renders when `process.stdout.isTTY`.
- `SKILL.md`: route Windows sessions directly to the Manual fallback (the wrapper depends on `bash` + `script(1)`, validated only on macOS/Linux).

## Verification

End-to-end with a real `claude setup-token` burn: extracted token returns `"role":"assistant"` from `api.anthropic.com/v1/messages` with `Authorization: Bearer <token>` and `anthropic-beta: oauth-2025-04-20`. Confirms the original 401 failure mode is gone.

> _This was written by Claude Code on behalf of Max._