### PR TITLE
fix(running-in-ci): base skill worktree on default branch, not HEAD

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -563,12 +563,17 @@ Include in the permission request (and reuse verbatim in the tend issue once app
    <!-- TODO(anthropics/claude-code#37157): once the harness exempts .claude/skills/ as
         documented, replace the /tmp-then-mv dance below with direct `Write` to the worktree path. -->
 
+   Base the skill branch on the repo's default branch, **not `HEAD`**. When this skill runs from `tend-mention` on a PR, the workflow has already done `gh pr checkout` so `HEAD` is the PR branch — basing on it carries that PR's WIP commits into the skill PR and ships a multi-concern PR that mixes the skill change with unrelated code. Fetch and base off `origin/<default>` instead:
+
    ```bash
-   git worktree add "$TMPDIR/skill-fix" -b skills/<topic>-$GITHUB_RUN_ID HEAD
+   DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
+   git fetch origin "$DEFAULT_BRANCH"
+   git worktree add "$TMPDIR/skill-fix" -b "skills/<topic>-$GITHUB_RUN_ID" "origin/$DEFAULT_BRANCH"
 
    # Use the Write tool to author the new skill file to /tmp/running-tend-new.md.
    # Then move it into place from inside the worktree. mkdir -p covers the
-   # new-skill case where .claude/skills/<name>/ doesn't yet exist in HEAD:
+   # new-skill case where .claude/skills/<name>/ doesn't yet exist in the
+   # default branch:
    mkdir -p "$TMPDIR/skill-fix/.claude/skills/running-tend"
    cd "$TMPDIR/skill-fix/.claude/skills/running-tend" && mv /tmp/running-tend-new.md SKILL.md
 


### PR DESCRIPTION
## Summary

Fix the `running-in-ci` "How to propose" recipe so a skill PR opened from a `tend-mention` session doesn't carry the triggering PR's WIP commits.

## Outcome that surfaced this

Run [25611071907](https://github.com/max-sixty/worktrunk/actions/runs/25611071907) on `max-sixty/worktrunk` was a `tend-mention` invoked on PR [#2655](https://github.com/max-sixty/worktrunk/pull/2655). The agent followed the bundled "How to propose" recipe to draft a repo-local skill addition, and shipped [worktrunk PR #2656](https://github.com/max-sixty/worktrunk/pull/2656) — titled `skills(running-tend): don't restate mention-handler analysis in reviews` but actually 5 files / 3 commits ahead of `main`:

```
$ gh api "repos/max-sixty/worktrunk/compare/main...skills/dedup-cross-workflow-25611071907" --jq '.commits[] | .commit.message | split("\n")[0]'
fix(opencode): use ~/.config/opencode for plugin path on macOS
docs(opencode): mention XDG_CONFIG_HOME in install help
skills(running-tend): don't restate mention-handler analysis in reviews
```

The first two commits are the open `fix/issue-2654` branch backing PR #2655. They were dragged into the skill PR because the recipe's `git worktree add … HEAD` runs after the workflow's `gh pr checkout`, so `HEAD` is the PR branch — not the default branch.

## Root cause

In `tend-mention` (and any future skill that calls into the "How to propose" recipe from a PR-checkout context), `gh pr checkout <n>` lands first, leaving `HEAD` at the PR's tip. The recipe then says:

```bash
git worktree add "$TMPDIR/skill-fix" -b skills/<topic>-$GITHUB_RUN_ID HEAD
```

The new worktree starts from the PR's tip, so every commit on the PR is now part of the skill branch, and `gh pr create` opens a PR with a base of `main` and the PR's commits in the diff.

This is structural: the same conditions reproduce the failure every time a `tend-mention` run on an open PR ends up proposing a skill change.

## Fix

Base the worktree on `origin/<default>` instead of `HEAD`. `actions/checkout@v6` already fetched the default branch (with `fetch-depth: 0`); a `git fetch origin <default>` keeps that ref current in case the workflow is long-running, then `origin/<default>` gives a clean base.

```bash
DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
git fetch origin "$DEFAULT_BRANCH"
git worktree add "$TMPDIR/skill-fix" -b "skills/<topic>-$GITHUB_RUN_ID" "origin/$DEFAULT_BRANCH"
```

Includes a one-paragraph "why not `HEAD`" note inline so a future reader doesn't simplify it back.

## Scope

- Only the `running-in-ci` recipe (the one that runs from `tend-mention`).
- Left the same `HEAD` form in `review-runs/SKILL.md` and `nightly/SKILL.md` alone — those run from scheduled workflows where `HEAD == origin/main` already, so changing them would be churn unrelated to the bug fixed here.

## Gate assessment

- **Evidence level**: Critical (concrete wrong-shape PR shipped publicly: worktrunk PR #2656).
- **Occurrences this run**: 1.
- **Structural vs stochastic**: structural. Every `tend-mention`-→-skill-PR shape produces this outcome with the current recipe; no model-judgment variance.
- **Change type**: targeted fix (one recipe block, plus an explanatory paragraph).
- Passes Gate 1 (Critical / 1 occurrence is sufficient for structural failures) and Gate 2 (targeted fix, normal evidence bar).

Evidence log: https://gist.github.com/9675d1510da32c68a68c1d45137b21e0

## Test plan

- [x] Eaten own dogfood: this PR's branch was authored using the repo's `hourly/review-…` convention from the working tree the action checked out, so doesn't exercise the new recipe — but the new recipe is verified by reading `gh repo view --json defaultBranchRef` (returns `main` on this repo) and confirming `origin/main` is fetched by `actions/checkout@v6`'s `fetch-depth: 0`.
- [ ] CI on this PR passes (actionlint, ruff, typos, uv-lock).
- [ ] On the next `tend-mention`-driven skill PR (worktrunk or any consumer), the skill PR's diff is exactly the skill change — no unrelated commits trailing in.
