### PR TITLE
skills: extend dedup rule to cover review body and cross-workflow overlap

### DIFF
--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -86,7 +86,7 @@ gh api graphql -F query=@/tmp/inline-prev.graphql -f owner="$OWNER" -f repo="$NA
         | {path, line, body}"
 ```
 
-**Do not repeat any point from previous reviews** — cross-reference previous bot comments before posting inline comments. When concurrent runs race (a new push while the first run is still responding), both see the same unanswered question — check whether a bot reply exists after the question's timestamp before answering. Address unanswered questions in the review body (not via `gh pr comment`).
+**Apply the sibling-workflow dedup rule from `running-in-ci`** to both the review body and inline comments. If a prior bot comment in the conversation already covers a point — a previous review on this or an earlier commit, a `tend-mention` reply, a `tend-triage` post, anything from a tend workflow — omit it from this review and stick to diff-grounded findings. When concurrent runs race (a new push while the first run is still responding), both see the same unanswered question — check whether a bot reply exists after the question's timestamp before answering. Address remaining unanswered questions in the review body (not via `gh pr comment`).
 
 #### Draft mode
 

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -279,7 +279,10 @@ If you are responding to your own prior comment or review (not a human's reply t
 
 ## Recheck Before Posting
 
-**Before posting any comment or review**, re-fetch the current conversation state. Other participants may comment while you work — even in short sessions, context can change between when you read a thread and when you reply:
+**Before posting any comment, review, or inline reply**, re-fetch the conversation and check whether the response would duplicate something already there. Two duplication paths:
+
+- **New entries arrived during the session.** Other participants may comment while the bot works. Compare counts against what was read at session start.
+- **A sibling tend workflow already responded.** `tend-mention`, `tend-triage`, and `tend-review` all post as the same bot account; a comment from one can pre-empt another (a `tend-mention` reply followed by a `synchronize`-triggered `tend-review` is the common pattern). The earlier comment may already be in the conversation at session start, so a stale-count check alone is not enough — scan for prior bot comments newer than the maintainer message being responded to.
 
 ```bash
 # For issues
@@ -290,11 +293,9 @@ gh pr view <number> --json comments,reviews \
   --jq '{comments: (.comments | length), reviews: (.reviews | length)}'
 ```
 
-Compare with the count you saw when you first read the context. If new comments or reviews appeared:
+If any prior entry — from a human or another tend workflow — already addresses a point the response would make, omit that point. The dedup applies equally to comment bodies, review bodies, and inline replies. If the response is now entirely redundant, don't post it.
 
-1. **Read the new comments** to understand what changed.
-2. **Adjust or skip your response.** If someone already answered, don't repeat them. If the author resolved the issue, acknowledge that instead of posting a stale analysis. If new information contradicts your findings, update your response before posting.
-3. **If your response is now entirely redundant, don't post it.**
+If the author resolved the issue, acknowledge it rather than post stale analysis. If new information contradicts the findings, update before posting.
 
 ### Dedup check for inline review comment replies
 


### PR DESCRIPTION
The dedup rule at `plugins/tend-ci-runner/skills/review/SKILL.md:89` was scoped to inline comments and review-to-review overlap, missing the case where `tend-mention` answers a maintainer question and `tend-review` then re-answers it in the **review body** on the resulting `synchronize` event. Surfaced on [worktrunk#2655](https://github.com/max-sixty/worktrunk/pull/2655) per #400.

Two changes:

- **`running-in-ci` — Recheck Before Posting** is restructured to name two duplication paths explicitly: (1) new entries arriving during the session, and (2) a sibling tend workflow having already responded before the session even started. The rule applies equally to comment bodies, review bodies, and inline replies.
- **`review` skill** drops the inline-only / review-to-review scoping and defers to the running-in-ci rule, listing the workflow sources it covers (previous review on this or earlier commit, `tend-mention`, `tend-triage`, any tend workflow). The race-condition guidance and the "use the review body, not `gh pr comment`" guidance are preserved.

The fetch in step 1 of the review skill (lines 60–66) already pulls `conversation` comments alongside `prev_reviews`, so no new data is needed — only the consume-step rule was too narrow.

The event-pair-specific subsection ("Dedup check for inline review comment replies") is left in place — it covers a different concern (`pull_request_review` ↔ `pull_request_review_comment` race), not content overlap.

Closes #400
