### PR TITLE
skills(review-reviewers): scan PR/issue bodies and reviews for corruption

### DIFF
--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -247,11 +247,16 @@ Use `Agent` with `model: "haiku"` and a prompt like:
 >     --jq "select(.user.login == \"$BOT_LOGIN\" and .created_at > \"<window-start>\") | \"=== ISSUE #$n body ===\n\(.body)\n\"" \
 >     >> /tmp/bot-output/all.txt
 > done
-> # PR bodies (when bot opened the PR this window) + reviews + inline review comments
+> # PR bodies (only when bot opened the PR this window)
 > for n in <bot-opened-prs>; do
 >   gh api "repos/$ARGUMENTS/pulls/$n" \
 >     --jq "select(.user.login == \"$BOT_LOGIN\" and .created_at > \"<window-start>\") | \"=== PR #$n body ===\n\(.body)\n\"" \
 >     >> /tmp/bot-output/all.txt
+> done
+> # Reviews + inline review comments — scan ALL PRs in the window, not just bot-opened.
+> # tend-review's output ships in reviews/inline comments on human-authored PRs, which
+> # are the most common bot-review surface and would never appear in <bot-opened-prs>.
+> for n in <pr-numbers>; do
 >   gh api "repos/$ARGUMENTS/pulls/$n/reviews" \
 >     --jq ".[] | select(.user.login == \"$BOT_LOGIN\" and .submitted_at > \"<window-start>\") | \"=== PR #$n review \(.id) state=\(.state) ===\n\(.body)\n\"" \
 >     >> /tmp/bot-output/all.txt

--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -235,9 +235,28 @@ Use `Agent` with `model: "haiku"` and a prompt like:
 >
 > ```bash
 > mkdir -p /tmp/bot-output && : > /tmp/bot-output/all.txt
-> for n in <pr-numbers>; do
+> # Issue/PR comments (issue_comment endpoint)
+> for n in <pr-or-issue-numbers>; do
 >   gh api "repos/$ARGUMENTS/issues/$n/comments?per_page=100" \
->     --jq ".[] | select(.user.login == \"$BOT_LOGIN\" and .created_at > \"<window-start>\") | \"=== #$n \(.id) ===\n\(.body)\n\"" \
+>     --jq ".[] | select(.user.login == \"$BOT_LOGIN\" and .created_at > \"<window-start>\") | \"=== #$n issue-comment \(.id) ===\n\(.body)\n\"" \
+>     >> /tmp/bot-output/all.txt
+> done
+> # Issue bodies (when bot opened the issue this window)
+> for n in <bot-opened-issues>; do
+>   gh api "repos/$ARGUMENTS/issues/$n" \
+>     --jq "select(.user.login == \"$BOT_LOGIN\" and .created_at > \"<window-start>\") | \"=== ISSUE #$n body ===\n\(.body)\n\"" \
+>     >> /tmp/bot-output/all.txt
+> done
+> # PR bodies (when bot opened the PR this window) + reviews + inline review comments
+> for n in <bot-opened-prs>; do
+>   gh api "repos/$ARGUMENTS/pulls/$n" \
+>     --jq "select(.user.login == \"$BOT_LOGIN\" and .created_at > \"<window-start>\") | \"=== PR #$n body ===\n\(.body)\n\"" \
+>     >> /tmp/bot-output/all.txt
+>   gh api "repos/$ARGUMENTS/pulls/$n/reviews" \
+>     --jq ".[] | select(.user.login == \"$BOT_LOGIN\" and .submitted_at > \"<window-start>\") | \"=== PR #$n review \(.id) state=\(.state) ===\n\(.body)\n\"" \
+>     >> /tmp/bot-output/all.txt
+>   gh api "repos/$ARGUMENTS/pulls/$n/comments?per_page=100" \
+>     --jq ".[] | select(.user.login == \"$BOT_LOGIN\" and .created_at > \"<window-start>\") | \"=== PR #$n inline-comment \(.id) ===\n\(.body)\n\"" \
 >     >> /tmp/bot-output/all.txt
 > done
 > grep -nF '${' /tmp/bot-output/all.txt        # literal ${...} interpolation failure
@@ -245,6 +264,8 @@ Use `Agent` with `model: "haiku"` and a prompt like:
 > grep -nE 'blob/main/.*#L[0-9]' /tmp/bot-output/all.txt  # un-pinned line links
 > grep -nF 'anthropics/' /tmp/bot-output/all.txt         # wrong-owner URL
 > ```
+>
+> Cover all four bot-output surfaces: issue comments, issue bodies, PR bodies, and reviews/inline review comments. Comments-only scans miss corruption that ships in a survey-issue or PR body — those are composed via `gh issue create --body` / `gh pr create --body`, exactly the surface the Bash-tool preprocessor hits.
 >
 > **Report format** — return a structured summary:
 > ```

--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -253,10 +253,10 @@ Use `Agent` with `model: "haiku"` and a prompt like:
 >     --jq "select(.user.login == \"$BOT_LOGIN\" and .created_at > \"<window-start>\") | \"=== PR #$n body ===\n\(.body)\n\"" \
 >     >> /tmp/bot-output/all.txt
 > done
-> # Reviews + inline review comments — scan ALL PRs in the window, not just bot-opened.
-> # tend-review's output ships in reviews/inline comments on human-authored PRs, which
-> # are the most common bot-review surface and would never appear in <bot-opened-prs>.
-> for n in <pr-numbers>; do
+> # PR reviews + inline review comments — any PR the bot reviewed/commented on, not just
+> # bot-opened. tend-review's output ships on human-authored PRs (the most common surface)
+> # which would never appear in <bot-opened-prs>.
+> for n in <pr-numbers-bot-reviewed>; do
 >   gh api "repos/$ARGUMENTS/pulls/$n/reviews" \
 >     --jq ".[] | select(.user.login == \"$BOT_LOGIN\" and .submitted_at > \"<window-start>\") | \"=== PR #$n review \(.id) state=\(.state) ===\n\(.body)\n\"" \
 >     >> /tmp/bot-output/all.txt


### PR DESCRIPTION
## Problem

The corruption-scan recipe in `review-reviewers` only fetches issue comments (`/issues/$n/comments`). Bot-authored issue bodies, PR bodies, review bodies, and inline review comments live on different endpoints and are not scanned. A survey-issue body composed by `gh issue create --body "$(cat <<EOF ... EOF)"` containing code references with `!` ships visibly corrupted backslash-bang to GitHub, and prior `review-reviewers` runs miss it.

## Evidence

This run found 5 backslash-bang corruption sites in the body of [worktrunk issue #2663](https://github.com/max-sixty/worktrunk/issues/2663) ("Nightly drift cleanup", opened by `worktrunk-bot`). Examples (shown raw from `gh issue view 2663 --json body --jq .body`):

- `<\!-- ⚠️ AUTO-GENERATED ... -->`
- `eprintln\!("---")`
- `assert\!(\!repo.root_path().join("marker.txt").exists())`
- `anyhow::ensure\!(...)`, `\!= ErrorKind::NotFound`
- `\!self.dirty_files()`

The existing recipe didn't catch any of these because it doesn't fetch `/issues/$n` (body) or `/pulls/$n` (body) at all. The maintainer engaged with the issue and merged five resulting fix PRs, so this didn't block the workflow — but every code reference in the issue rendered with literal backslashes.

The watch item ["review-reviewers corruption-scan recipe doesn't cover PR/issue bodies"](https://gist.github.com/9675d1510da32c68a68c1d45137b21e0) carried in evidence for prior months awaiting concrete recurrence; this run provides it.

## Fix

Extend the recipe to fetch four endpoints, not one:

1. `/issues/$n/comments` — existing; covers issue and PR comments via the issue_comment surface.
2. `/issues/$n` (body) — for bot-opened issues this window.
3. `/pulls/$n` (body) — for bot-opened PRs this window.
4. `/pulls/$n/reviews` and `/pulls/$n/comments` — review bodies and inline review comments.

The four greps (`${`, backslash-bang, `blob/main/...#L`, `anthropics/`) stay the same. The change is purely about *what* is scanned, not *how*.

## Companion to #404

[PR #404](https://github.com/max-sixty/tend/pull/404) extends the `running-in-ci` bang-escape rule to enumerate issue/PR bodies (preventative). This PR extends the scan recipe to detect them (detective). Either lands independently — they are reverted independently and address different concerns.
