### PR TITLE
diag(action): upload execution-output.json so #302 can be diagnosed

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -288,6 +288,16 @@ runs:
         echo "$USAGE" > "$LOGS_DIR/token-usage.json"
         echo "usage=$(jq -c . <<< "$USAGE")" >> "$GITHUB_OUTPUT"
 
+        # Preserve the raw SDK message stream alongside the session JSONL so
+        # the under-reporting in #302 can be diagnosed against an actual
+        # execution-output.json. Without this, $RUNNER_TEMP is wiped at job
+        # end and the only retained artifact is the session JSONL — which
+        # has no `type:"result"` entries (those live only here). Drop this
+        # copy once #302 is resolved.
+        if [ -n "$EXECUTION_FILE" ] && [ -f "$EXECUTION_FILE" ]; then
+          cp "$EXECUTION_FILE" "$LOGS_DIR/claude-execution-output.json" || true
+        fi
+
         jq -r '
           def usd: tostring | if test("\\.") then split(".") | "\(.[0]).\((.[1] + "00")[:2])" else . + ".00" end | "$" + .;
           "## Token Usage",

--- a/action.yaml
+++ b/action.yaml
@@ -292,9 +292,11 @@ runs:
         # the under-reporting in #302 can be diagnosed against an actual
         # execution-output.json. Without this, $RUNNER_TEMP is wiped at job
         # end and the only retained artifact is the session JSONL — which
-        # has no `type:"result"` entries (those live only here). Drop this
-        # copy once #302 is resolved.
-        if [ -n "$EXECUTION_FILE" ] && [ -f "$EXECUTION_FILE" ]; then
+        # has no `type:"result"` entries (those live only here). Gated to
+        # tend's own repo so consumers don't pay for an upload that only
+        # serves a tend-internal diagnostic. Drop once #302 is resolved.
+        if [ "$GITHUB_REPOSITORY" = "max-sixty/tend" ] \
+           && [ -n "$EXECUTION_FILE" ] && [ -f "$EXECUTION_FILE" ]; then
           cp "$EXECUTION_FILE" "$LOGS_DIR/claude-execution-output.json" || true
         fi
 


### PR DESCRIPTION
## Summary

- Copy `$EXECUTION_FILE` into `$LOGS_DIR/claude-execution-output.json` from the Token usage step so it ships with the existing `claude-session-logs` artifact.
- Targeted at #302: the action reads `type:"result"` entries from `$RUNNER_TEMP/claude-execution-output.json`, but that file is wiped at job end and the session JSONL we currently retain contains zero `result` entries — so we have no way to inspect what the SDK actually emits in an under-reporting run.

## Why this and not the fix itself

The proposed aggregation fix (sum `usage.*` across all `result` entries, keep `total_cost_usd` from the last) is plausible but unverified. Without a real execution-output.json from a `run_in_background: true` session it's not knowable whether `num_turns` is per-event or cumulative-in-each-entry, so summing could under-correct or double-count. One under-reporting sample is enough to pin down the semantics and ship a regression-tested fix.

## Test plan

- [ ] Merge, then wait for any tend-mention or tend-review run that polls CI in the background to land an under-reporting `token-usage.json`.
- [ ] Download the run's `claude-session-logs*` artifact, confirm `claude-execution-output.json` is present.
- [ ] Run `jq '[.[] | select(.type == "result")] | length' claude-execution-output.json` — if more than 1, also dump each entry's `num_turns` and `usage.*` to determine the aggregation rule.
- [ ] Open the follow-up PR with the corrected jq filter and a fixture from the captured file.
