### PR TITLE
skills(running-tend): add weekly consumers.json refresh

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -74,5 +74,7 @@ mkdir -p data
 ```
 
 Open a PR titled `chore: refresh consumers.json` if the file changed. Skip
-the PR (no diff to land) if `git diff --quiet data/consumers.json`. Code
-search is 10 req/min — one call covers the whole list.
+the PR (no diff to land) when `git status --porcelain data/consumers.json`
+is empty — `git diff --quiet` returns 0 for untracked paths, so the
+first-run case would no-op. Code search is 10 req/min — one call covers
+the whole list.

--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -44,3 +44,35 @@ Artifact paths: `-home-runner-work-tend-tend/<session-id>.jsonl`
 
 `review-reviewers` runs produce 3 session logs per run (one per matrix repo:
 `max-sixty/worktrunk`, `max-sixty/tend`, `PRQL/prql`).
+
+## Weekly: refresh `data/consumers.json`
+
+Public repos that have installed tend. Read by the website build (see
+`WEBSITE.md`) for the stat strip and activity feed; needs no opt-in because
+the workflow files are public.
+
+```bash
+# 1. Discover consumer repos via code search. `max-sixty/tend@v1` only
+#    appears in generated tend-*.yaml workflow files.
+mapfile -t REPOS < <(
+  gh search code 'max-sixty/tend@v1' --limit 100 --json repository,path \
+    | jq -r '.[] | select(.path | startswith(".github/workflows/tend-")) | .repository.nameWithOwner' \
+    | sort -u
+)
+
+# 2. Resolve bot_name from each repo's .config/tend.toml.
+mkdir -p data
+{
+  for repo in "${REPOS[@]}"; do
+    bot=$(gh api "repos/$repo/contents/.config/tend.toml" --jq '.content' 2>/dev/null \
+      | base64 -d 2>/dev/null \
+      | sed -n 's/^bot_name *= *"\([^"]*\)".*/\1/p' | head -1)
+    [ -n "$bot" ] || continue
+    jq -nc --arg repo "$repo" --arg bot "$bot" '{repo: $repo, bot_name: $bot}'
+  done
+} | jq -s . > data/consumers.json
+```
+
+Open a PR titled `chore: refresh consumers.json` if the file changed. Skip
+the PR (no diff to land) if `git diff --quiet data/consumers.json`. Code
+search is 10 req/min — one call covers the whole list.


### PR DESCRIPTION
Adds a weekly task to tend's own `running-tend` overlay that discovers public repos using tend (via `gh search code 'max-sixty/tend@v1'`), resolves each repo's `bot_name` from its `.config/tend.toml`, and writes the list to `data/consumers.json`. Opens a PR if the file changed.

Lives in the overlay (not the bundled weekly skill) so only tend's own weekly run does the discovery — consumer repos don't pay for it. The bundled `weekly` skill already scans the overlay for repo-specific weekly tasks (`weekly/SKILL.md:43-47`), so no workflow or generator change is needed.

The output unblocks the WEBSITE.md "Live data" phase: the website build can read `data/consumers.json` to fan out per-bot `search/issues` queries for the stat strip and activity feed, instead of hardcoding `commenter:tend-agent` (which only covers tend itself and worktrunk).
