### PR TITLE
chore: refresh consumers.json

### DIFF
--- a/data/consumers.json
+++ b/data/consumers.json
@@ -1,0 +1,22 @@
+[
+  {
+    "repo": "PRQL/prql",
+    "bot_name": "prql-bot"
+  },
+  {
+    "repo": "max-sixty/cargo-affected",
+    "bot_name": "cargo-affected-bot"
+  },
+  {
+    "repo": "max-sixty/tend",
+    "bot_name": "tend-agent"
+  },
+  {
+    "repo": "max-sixty/worktrunk",
+    "bot_name": "worktrunk-bot"
+  },
+  {
+    "repo": "numbagg/numbagg",
+    "bot_name": "numbagg-bot"
+  }
+]


### PR DESCRIPTION
Refresh `data/consumers.json` from a code search for `max-sixty/tend@v1` in `.github/workflows/tend-*.yaml`, with `bot_name` resolved from each repo's `.config/tend.toml`.

5 consumer repos discovered: PRQL/prql, max-sixty/cargo-affected, max-sixty/tend, max-sixty/worktrunk, numbagg/numbagg.

First run since the weekly refresh task was added in #410 — file did not previously exist.