### PR TITLE
site: deploy to GitHub Pages

### DIFF
--- a/.github/workflows/publish-site.yaml
+++ b/.github/workflows/publish-site.yaml
@@ -1,0 +1,67 @@
+name: publish-site
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'site/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-site:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: 📂 Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: site/package-lock.json
+
+      - name: Install dependencies
+        run: npm install
+        working-directory: site
+
+      - name: 🪴 Build site
+        env:
+          SITE_BASE: /tend/
+        run: npm run build
+        working-directory: site
+
+      - uses: actions/upload-pages-artifact@v5
+        with:
+          path: site/dist/
+          retention-days: 1
+
+  deploy-site:
+    needs: build-site
+    runs-on: ubuntu-24.04
+
+    # Don't attempt to publish if on a fork
+    if: ${{ github.repository_owner == 'max-sixty' }}
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v6
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/publish-site.yaml
+++ b/.github/workflows/publish-site.yaml
@@ -28,7 +28,7 @@ jobs:
           cache-dependency-path: site/package-lock.json
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
         working-directory: site
 
       - name: 🪴 Build site

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -2,6 +2,7 @@ import { defineConfig } from "astro/config";
 
 export default defineConfig({
   site: "https://tend.dev",
+  base: process.env.SITE_BASE ?? "/",
   server: {
     host: true,
   },


### PR DESCRIPTION
Mirrors worktrunk's `publish-docs.yaml` design: push-to-main + `workflow_dispatch` triggers, concurrency group, `build`/`deploy` split with `deploy-pages@v5`, fork-owner guard. Pages is enabled in repo settings with GitHub Actions as the source; first deploy lands at `https://max-sixty.github.io/tend/`.

`SITE_BASE=/tend/` is set on the build step so Astro emits asset paths under the sub-path. `astro.config.mjs` reads `SITE_BASE` with a `/` fallback, so local `npm run dev` / `npm run build` keep working at root. Wiring up the `tend.dev` custom domain later means dropping the env var from the workflow — no config revert.

Known limitation: `site/src/layouts/Base.astro` has two hardcoded absolute paths (`href="/favicon.png"` and the wordmark `href="/"`) that won't resolve under `/tend/`. They'll need either the custom domain or an `import.meta.env.BASE_URL` swap; left alone in this PR.
