### PR TITLE
site: use BASE_URL for favicon and wordmark links

### DIFF
--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -19,7 +19,7 @@ const {
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{title}</title>
     <meta name="description" content={description} />
-    <link rel="icon" type="image/png" href="/favicon.png" />
+    <link rel="icon" type="image/png" href={`${import.meta.env.BASE_URL}favicon.png`} />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -29,7 +29,7 @@ const {
   </head>
   <body>
     <header class="site-header">
-      <a href="/" class="wordmark">tend</a>
+      <a href={import.meta.env.BASE_URL} class="wordmark">tend</a>
       <nav>
         <a href="#what-tend-tends">What it tends</a>
         <a href="#quick-start">Quick start</a>


### PR DESCRIPTION
Both were hardcoded as absolute paths (`/favicon.png` and `/`), so under GitHub Pages at `max-sixty.github.io/tend/` the favicon 404s and the wordmark links out of the site. Astro exposes `import.meta.env.BASE_URL` (whatever `base` is configured to, with a trailing slash), which works under both `/tend/` and `/` (custom domain later).

Verified both build modes from #413's astro config:

- `SITE_BASE=/tend/ npm run build` → favicon `/tend/favicon.png`, wordmark `/tend/`
- `npm run build` (no env var) → favicon `/favicon.png`, wordmark `/`
