### PR TITLE
site: serve from tend-src.com apex; wire CI deploy secrets

### DIFF
--- a/.github/workflows/publish-site.yaml
+++ b/.github/workflows/publish-site.yaml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'site/**'
+      - 'data/**'
   workflow_dispatch:
 
 concurrency:
@@ -32,8 +33,6 @@ jobs:
         working-directory: site
 
       - name: 🪴 Build site
-        env:
-          SITE_BASE: /tend/
         run: npm run build
         working-directory: site
 

--- a/.github/workflows/worker-deploy.yaml
+++ b/.github/workflows/worker-deploy.yaml
@@ -2,17 +2,9 @@ name: worker-deploy
 
 # Deploys the tend-currently Cloudflare Worker on push to main that touches
 # worker/** or this workflow. The Worker serves the "currently tending"
-# data stream — see worker/README.md.
-#
-# Prerequisites (one-time, manual):
-#   1. Sign up at cloudflare.com (free)
-#   2. cd worker && npx wrangler login
-#   3. npx wrangler kv:namespace create CACHE (paste id into wrangler.toml)
-#   4. npx wrangler secret put GITHUB_TOKEN (paste a read-only PAT)
-#   5. npx wrangler deploy (first deploy)
-#   6. Add CLOUDFLARE_API_TOKEN to repo secrets — generate at
-#      https://dash.cloudflare.com/profile/api-tokens using the
-#      "Edit Cloudflare Workers" template.
+# data stream. One-time account setup (KV namespace, GITHUB_TOKEN Worker
+# secret, CLOUDFLARE_API_TOKEN repo secret, custom domain) is documented
+# in worker/README.md and is already done for max-sixty/tend.
 
 on:
   push:

--- a/WEBSITE-live-data.md
+++ b/WEBSITE-live-data.md
@@ -141,8 +141,8 @@ the rest of the site is unaffected.
 GitHub Pages serves static only; static + a separate Worker origin is the
 combination that keeps the rest of `WEBSITE.md` (Zola → Pages from
 `website` branch) intact. The static Pages site calls the Worker via CORS;
-the Worker is on a `tend.workers.dev` subdomain (or attached to a custom
-sub-subdomain like `api.tend.dev` if we own the apex).
+the Worker is on `currently.tend-src.com` (the apex `tend-src.com` was
+registered for the project; `tend.dev` was taken).
 
 If we end up wanting **more** dynamic features later (search, write
 operations, per-viewer state), it would be worth re-evaluating moving the
@@ -159,11 +159,9 @@ deploy. Not necessary for MVP.
   already provisioned per consumer. (c) keeps blast radius separate from
   the bot's write-capable PAT — worth doing if the website's PAT will sit
   in Cloudflare and tend's bot PAT sits in Actions. **Recommended: (c).**
-- **Hosting target.** Static stays on GitHub Pages. The Worker means signing
-  up for Cloudflare (free) and registering the apex (`tend.dev` already
-  open in `WEBSITE.md`). Confirm you're OK adding Cloudflare to the stack
-  for just the "currently tending" feature; the alternative is dropping
-  that feature to a 15-minute static refresh and going Cloudflare-free.
+- **Hosting target.** Static on GitHub Pages, served from the apex
+  `tend-src.com` (with `currently.tend-src.com` for the Worker) on the
+  existing Cloudflare account.
 - **Opt-in from consumer repos.** The "currently tending" Worker needs to
   read `actions/runs` on each consumer repo. For public repos this is
   free-read; no opt-in needed. If we ever want to include **private** repos

--- a/WEBSITE.md
+++ b/WEBSITE.md
@@ -185,9 +185,8 @@ dependencies on each other and can run concurrently.
 
 ## Open questions (decide before phase 1)
 
-- **Domain.** `tend.dev` is the natural sibling to `worktrunk.dev` — check
-  availability. Fallbacks: `tend.bot`, `tend.maintainer.dev`. Affects copy
-  and OG metadata.
+- **Domain.** Settled: `tend-src.com` (apex), `currently.tend-src.com` for
+  the live-data Worker. `tend.dev` was taken.
 - **Sibling closeness.** Same worktrunk theme retinted (fast, reads as a
   visual family) vs. distinct visual identity (longer, more memorable).
   Recommend: start retinted, decide whether to diverge after phase 2.

--- a/site/NOTES.md
+++ b/site/NOTES.md
@@ -70,7 +70,7 @@ For the current scope (one page, five sections, one logo animation):
    generate dependency-update churn.
 3. **Tend's content surface is small.** The advantages Astro gives —
    components, MDX, JSX-shaped data — are most valuable when you have
-   many content shapes. tend.dev does not.
+   many content shapes. tend-src.com does not.
 
 **Astro becomes the better answer if either:**
 

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -1,7 +1,7 @@
 import { defineConfig } from "astro/config";
 
 export default defineConfig({
-  site: "https://tend.dev",
+  site: "https://tend-src.com",
   base: process.env.SITE_BASE ?? "/",
   server: {
     host: true,

--- a/site/public/CNAME
+++ b/site/public/CNAME
@@ -1,0 +1,1 @@
+tend-src.com

--- a/worker/README.md
+++ b/worker/README.md
@@ -35,7 +35,7 @@ Cloudflare edge cache both honor `Cache-Control: public, max-age=30`.
 
 The Worker reads `data/consumers.json` from `main` via
 `raw.githubusercontent.com` (KV-cached for 1 h), fans out parallel
-`GET /repos/{r}/actions/runs?status=in_progress&per_page=5` calls
+`GET /repos/{r}/actions/runs?status=in_progress&per_page=30` calls
 authenticated with a read-only PAT, filters to `tend-*` workflows, and
 returns the compact JSON above. The rendered response is edge-cached
 (`caches.default`) for 30 s, which both bounds GitHub fanout and dedupes
@@ -58,10 +58,12 @@ npx wrangler deploy                                 # first deploy
 
 The PAT needs `actions:read` + `metadata:read` on public repos. After first
 deploy, CI handles subsequent deploys via
-[`../.github/workflows/worker-deploy.yaml`](../.github/workflows/worker-deploy.yaml).
-That workflow needs `CLOUDFLARE_API_TOKEN` set as a repo secret — generate one
-at <https://dash.cloudflare.com/profile/api-tokens> with the "Edit Workers"
-template.
+[`../.github/workflows/worker-deploy.yaml`](../.github/workflows/worker-deploy.yaml),
+which authenticates with the `CLOUDFLARE_API_TOKEN` repo secret. That secret
+is a scoped token named `tend-ci-worker-deploy` (Workers Scripts + KV + Routes
+edit), generated to keep the account's Global API Key out of CI; regenerate at
+<https://dash.cloudflare.com/profile/api-tokens> with the "Edit Cloudflare
+Workers" template if it's ever lost.
 
 ## Local development
 


### PR DESCRIPTION
Follow-ups from #415 — completes the move to `tend-src.com`.

**What's in the diff:**
- `publish-site.yaml`: build with `base: "/"` (drop `SITE_BASE=/tend/`), add a `site/public/CNAME` (`tend-src.com`), and rebuild on `data/**` changes so the bot's nightly `activity.json`/`stats.json` commits refresh the site.
- `astro.config.mjs`: `site` → `https://tend-src.com`.
- `worker-deploy.yaml` / `worker/README.md`: trim the one-time-setup comment now that the `CLOUDFLARE_API_TOKEN` repo secret is set (scoped token `tend-ci-worker-deploy` — Workers Scripts + KV + Routes edit, so the account Global API Key stays out of CI). Also fixed a stale `per_page=5` → `per_page=30` in the README.
- `WEBSITE.md` / `WEBSITE-live-data.md`: domain settled as `tend-src.com` / `currently.tend-src.com`.

**Already done account-side (not in the diff):**
- GitHub Pages custom domain set to `tend-src.com`, HTTPS enforced. The DNS records (apex A/AAAA → Pages IPs, `www` CNAME → `max-sixty.github.io`) were already present in Cloudflare.
- `CLOUDFLARE_API_TOKEN` repo secret added.

**Note:** the live site at https://tend-src.com/ currently 404s its CSS — the deployed artifact still has `/tend/` asset paths. Merging this triggers `publish-site`, which rebuilds with `base: "/"` and fixes it.
