### PR TITLE
Add wt.toml: dev server per worktree

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,0 +1,27 @@
+# Dev server per worktree — each branch gets a deterministic port from
+# `branch | hash_port` (range 10000-19999).
+# https://worktrunk.dev/tips-patterns/#dev-server-per-worktree
+
+# Share node_modules and other untracked files from the primary worktree
+# so cold starts don't pay for a full `npm install`.
+[[post-start]]
+copy = "wt step copy-ignored"
+
+# Restore anything copy-ignored didn't bring over. --prefer-offline keeps it
+# off the network once the shared npm cache is warm; --no-audit/--no-fund
+# skip the slow, noisy bits of an otherwise-empty run.
+[[post-start]]
+install = "cd site && npm install --prefer-offline --no-audit --no-fund"
+
+# Astro dev server in the background. Output lands in `.git/wt/logs/`
+# (find via `wt config state logs`).
+[[post-start]]
+server = "cd site && npm run dev -- --port {{ branch | hash_port }}"
+
+# Surface the URL in `wt list` — the column dims when nothing is listening.
+[list]
+url = "http://localhost:{{ branch | hash_port }}"
+
+# Stop the dev server when the worktree is removed.
+[[pre-remove]]
+server = "lsof -ti :{{ branch | hash_port }} -sTCP:LISTEN | xargs kill 2>/dev/null || true"


### PR DESCRIPTION
Adds `.config/wt.toml` so each new worktree of this repo boots the Astro dev server (`site/`) automatically. The port is `branch | hash_port` (deterministic, range 10000–19999), so simultaneous worktrees don't collide. `wt list` shows each worktree's URL (dimmed when the port isn't listening), and a `pre-remove` hook kills the server when the worktree is removed.

The `post-start` pipeline runs `wt step copy-ignored` first to bring `node_modules` over from the primary worktree, then `npm install --prefer-offline --no-audit --no-fund` to restore anything missing (steady-state cost ~0.2s, no network once the shared npm cache is warm), then `astro dev --port <port>`.

Heads-up on one rough edge: `wt remove` reads project config from the *primary* worktree, so the `pre-remove` cleanup hook only takes effect once this `.config/wt.toml` is on the default branch — i.e. after this merges. Until then, leftover dev servers need a manual `kill`. (A sibling investigation into whether worktrunk should change that is in flight.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
