### PR TITLE
docs(claude.md): list site/, worker/, scripts/, data/ in Structure tree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,8 +30,13 @@ tend/
 │   │   ├── checks.py     # Security checks (branch protection, secrets)
 │   │   └── cli.py        # Click CLI (init, check)
 │   └── tests/
+├── site/                 # Astro marketing site (tend-src.com)
+├── worker/               # Cloudflare Worker (currently.tend-src.com)
+├── scripts/              # fetch_website_data.py — nightly activity/stats refresh
+├── data/                 # consumers.json, activity.json, stats.json — site inputs
 └── docs/
-    └── security-model.md
+    ├── security-model.md
+    └── website-data.md
 ```
 
 ## Key details


### PR DESCRIPTION
CLAUDE.md's Structure block hadn't kept up with the website-related additions. `site/`, `worker/`, `scripts/`, and `data/` are all production paths now, and `docs/website-data.md` is the architecture reference for the live data streams. Adding them so future Claude sessions don't have to rediscover the tree from `ls`.

No code or config changes — docs only.
