### PR TITLE
skills(review-reviewers): scan for backslash-backtick corruption

### DIFF
--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -268,6 +268,7 @@ Use `Agent` with `model: "haiku"` and a prompt like:
 > done
 > grep -nF '${' /tmp/bot-output/all.txt        # literal ${...} interpolation failure
 > grep -nP '\\!' /tmp/bot-output/all.txt       # backslash-bang corruption
+> grep -nP '\\`' /tmp/bot-output/all.txt       # backslash-backtick corruption (see tend#422)
 > grep -nE 'blob/main/.*#L[0-9]' /tmp/bot-output/all.txt  # un-pinned line links
 > grep -nF 'anthropics/' /tmp/bot-output/all.txt         # wrong-owner URL
 > ```


### PR DESCRIPTION
## Problem

The corruption-scan recipe in `review-reviewers` checks for un-escaped bangs, broken `${...}` interpolation, un-pinned `blob/main/...#L` line links, and wrong-owner `anthropics/...` URLs — but not for backslash-backtick. That pattern has been shipping in bot-authored bodies and is the subject of tend#422 / tend#423.

Two consecutive `review-reviewers` runs on `max-sixty/worktrunk` flagged the gap:

- Previous hour: PR #2697 body shipped with 36 occurrences rendered visibly (literal backslashes in front of code spans). Not caught by the four standard scans; recorded as Medium-evidence cross-run carry.
- This hour: worktrunk-bot's own diagnosis in tend#422 counted four corrupted bodies between 07:54Z and 09:26Z (PR #2697 body, PR #2698 body, issue #2693 comment, PR #2699 comment), after only one such body in the previous ten days.

Each occurrence renders as literal escaped-name instead of `name` on GitHub.

## Why this is structural

The scan recipe omits the pattern entirely; the same recipe will continue to miss it every run until the line is added. Independent of tend#423 (which extends the prevention rule in `running-in-ci`): prevention reduces future corruption, detection catches anything that slips through and confirms the rule is landing.

## Gate assessment

- **Evidence level**: High (2 `review-reviewers` sessions; 4 instances in the bot's own count).
- **Failure class**: Structural — recipe gap, not a model lapse.
- **Change type**: Targeted fix (one line). Normal threshold per Gate 2.
- **Passes both gates**: yes.

## Change

Add one line to the corruption-scan recipe in `plugins/tend-ci-runner/skills/review-reviewers/SKILL.md`, alongside the existing bang check:

```
grep -nP '\\`' /tmp/bot-output/all.txt       # backslash-backtick corruption (see tend#422)
```

Same shape, same surface, same fix.

## Evidence

[review-reviewers evidence gist for max-sixty/worktrunk, 2026-05](https://gist.github.com/9675d1510da32c68a68c1d45137b21e0).

Related: tend#422 (the bot's own corruption analysis), tend#423 (running-in-ci prevention-rule extension).
