### PR TITLE
skills(ci-fix): defer transient-failure disposition to overlay

### DIFF
--- a/plugins/tend-ci-runner/skills/ci-fix/SKILL.md
+++ b/plugins/tend-ci-runner/skills/ci-fix/SKILL.md
@@ -84,7 +84,7 @@ Use this path when:
 - The failure shape is filesystem/network-level, not anything the project's code does
 - An upstream status incident matches the timing and components
 
-**Overlay overrides.** If the consuming repo's `running-tend` overlay prefers a different disposition for transient failures — e.g., "comment on the failing run" or "exit silently" — follow the overlay. The open-and-close pattern above is the bundled default; some maintainers treat the resulting self-closed issues as tracker noise and prefer no issue at all. Overlay-wins applies here as everywhere.
+**Overlay overrides.** If the consuming repo's `running-tend` overlay prescribes a different disposition for transient failures (e.g. comment on the run, exit silently), follow the overlay.
 
 If you can't tell whether it's transient, treat it as durable and create a fix PR.
 

--- a/plugins/tend-ci-runner/skills/ci-fix/SKILL.md
+++ b/plugins/tend-ci-runner/skills/ci-fix/SKILL.md
@@ -84,6 +84,8 @@ Use this path when:
 - The failure shape is filesystem/network-level, not anything the project's code does
 - An upstream status incident matches the timing and components
 
+**Overlay overrides.** If the consuming repo's `running-tend` overlay prefers a different disposition for transient failures — e.g., "comment on the failing run" or "exit silently" — follow the overlay. The open-and-close pattern above is the bundled default; some maintainers treat the resulting self-closed issues as tracker noise and prefer no issue at all. Overlay-wins applies here as everywhere.
+
 If you can't tell whether it's transient, treat it as durable and create a fix PR.
 
 Skip step 4 — there's no PR to monitor.


### PR DESCRIPTION
## Problem

The bundled `ci-fix` skill section 3a (added in #367) instructs the bot to open an issue and immediately self-close it whenever a CI failure is diagnosed as transient. The rationale was that this keeps the analysis "discoverable and off the commit timeline."

Worktrunk's `running-tend` overlay, which predates section 3a, says the opposite: for transient infrastructure failures, the bot should "comment on the failing run or exit silently" rather than open an issue. The overlay was authored after maintainers closed bot-opened transient-failure PRs as churn.

Per the general overlay-wins rule, the overlay should take precedence. In practice, section 3a's prescriptive template is being followed instead — over 24 hours on `max-sixty/worktrunk`, the bot has opened-and-self-closed three transient-flake issues in a row that the overlay would have suppressed.

## Evidence

Three structurally identical self-opened-and-self-closed issues on `max-sixty/worktrunk`, all from `tend-ci-fix`, none touched by a human after the bot's own "Transient — closing as diagnosed." comment:

| Issue | Opened | Closed | Gap | Cause classified |
|---|---|---|---|---|
| [#2694](https://github.com/max-sixty/worktrunk/issues/2694) | 2026-05-11T07:45:51Z | 2026-05-11T07:45:55Z | 4s | crates.io index-fetch blip |
| [#2716](https://github.com/max-sixty/worktrunk/issues/2716) | 2026-05-11T19:15:54Z | 2026-05-11T19:15:58Z | 4s | macOS test_pre_merge_hook_receives_sigterm flake |
| [#2720](https://github.com/max-sixty/worktrunk/issues/2720) | 2026-05-11T20:07:13Z | 2026-05-11T20:07:17Z | 4s | Windows test_prune_json_orphan_branch flake |

Pattern is structural — same title shape (`ci-fix: transient ... on <run-id>`), same closing comment ("Transient — closing as diagnosed."), same ~4s open-to-close window. Session-log investigation of run [25693862593](https://github.com/max-sixty/worktrunk/actions/runs/25693862593) (the most recent occurrence) confirmed the bot correctly classified the failure as transient before opening the issue and followed section 3a's template verbatim.

Worktrunk's existing overlay text ([`.claude/skills/running-tend/SKILL.md`](https://github.com/max-sixty/worktrunk/blob/main/.claude/skills/running-tend/SKILL.md)):

> **Transient infrastructure** ... — do **not** create a PR. The maintainer will rerun CI. Comment on the run or exit silently; a permanent config change for a one-off timeout is churn the maintainer will close.

The overlay was added in worktrunk PR [#2050](https://github.com/max-sixty/worktrunk/pull/2050) on 2026-04-10, ~3 weeks before bundled section 3a landed (tend #367, 2026-05-02). The overlay didn't anticipate the new bundled instruction and didn't explicitly forbid issue creation, but its intent ("exit silently") is clear and the three test cases above are exactly what the overlay was trying to prevent.

## Gate assessment

- **Evidence level**: High (3 structural occurrences in 24h, same shape, zero maintainer engagement on any).
- **Classification**: Structural — section 3a's template is so prescriptive that the model follows it even when the overlay's general preference contradicts it.
- **Change type**: Targeted fix (one short paragraph added to section 3a).
- **Both gates pass.**

## Change

Add a short "Overlay overrides" paragraph to section 3a making it explicit that the open-and-close template is the bundled default, not a hard requirement, and that overlays preferring exit-silently or commenting-on-the-run win.

This is the minimal change that resolves the conflict without flipping defaults for repos that may genuinely want the open-and-close audit trail.

## Evidence gist

Full hourly evidence log with cumulative-occurrence tracking: https://gist.github.com/9675d1510da32c68a68c1d45137b21e0
