### PR TITLE
skills(running-in-ci): extend bang-escape guidance to git commit -m

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -363,13 +363,13 @@ Always use markdown links for files, issues, PRs, and docs. **Any link containin
 gh pr create --title "$(cat /tmp/pr-title.txt)" --body-file /tmp/pr-body.md ...
 ```
 
-`git commit -m "..."` is the same trap: the message is a literal string argument, so any `!` in it (Rust's `assert!`/`format!`/`panic!`, a conventional-commits breaking-change marker like `feat(api)!:`) ships into permanent git history as backslash-bang. Write the message with the Write tool and pass it via `-F` — `git commit` reads the file directly, so the Bash-tool preprocessor never sees the bang:
+`git commit -m "..."` is the same trap: the message is a literal string argument, so any exclamation mark in it (Rust's `assert!(...)`, `format!(...)`, `panic!(...)`; a conventional-commits breaking-change marker like `feat(api)!:`) ships into permanent git history as backslash-bang. Write the message with the Write tool and pass it via `-F` — `git commit` reads the file directly, so the Bash-tool preprocessor never sees the bang:
 
 ```bash
 git commit -F /tmp/commit-msg.txt
 ```
 
-This applies to every git commit path the bot uses (fix PRs, skill PRs, conflict-resolution merges). A title without `!` may still ship a corrupted *body* if the body quotes any `!` token, so prefer `-F` whenever the message contains code references.
+This applies to every git commit path the bot uses (fix PRs, skill PRs, conflict-resolution merges). A title without an exclamation mark may still ship a corrupted *body* if the body contains one, so prefer `-F` whenever the message contains code references.
 
 - **File-level link (no `#L` anchor)**: `blob/main/src/foo.rs` is fine
 - **Line reference**: `blob/<sha>/src/foo.rs#L42` — commit SHA required, never `blob/main/...#L42`

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -363,6 +363,14 @@ Always use markdown links for files, issues, PRs, and docs. **Any link containin
 gh pr create --title "$(cat /tmp/pr-title.txt)" --body-file /tmp/pr-body.md ...
 ```
 
+`git commit -m "..."` is the same trap: the message is a literal string argument, so any `!` in it (Rust's `assert!`/`format!`/`panic!`, a conventional-commits breaking-change marker like `feat(api)!:`) ships into permanent git history as backslash-bang. Write the message with the Write tool and pass it via `-F` — `git commit` reads the file directly, so the Bash-tool preprocessor never sees the bang:
+
+```bash
+git commit -F /tmp/commit-msg.txt
+```
+
+This applies to every git commit path the bot uses (fix PRs, skill PRs, conflict-resolution merges). A title without `!` may still ship a corrupted *body* if the body quotes any `!` token, so prefer `-F` whenever the message contains code references.
+
 - **File-level link (no `#L` anchor)**: `blob/main/src/foo.rs` is fine
 - **Line reference**: `blob/<sha>/src/foo.rs#L42` — commit SHA required, never `blob/main/...#L42`
 - **Issues/PRs**: `#123` shorthand


### PR DESCRIPTION
## Problem

`running-in-ci`'s bang-escape paragraph covers `gh ... --body` / `gh pr create --title` corruption with `--body-file` and `$(cat …)` recipes, but does not cover `git commit -m "…"`. A bot-authored commit on `max-sixty/worktrunk` just shipped to permanent git history with backslash-bang corruption in both the title and body of the message:

```
test: hoist ansi_strip() out of assert\! args for coverage

Codecov treats expressions inside an assert\!'s panic-message arm as a
separate branch from the assertion itself, so the `result.ansi_strip()`
calls inside the format\! arguments registered as uncovered ...
```

Source: [`worktrunk@148a9f54`](https://github.com/max-sixty/worktrunk/commit/148a9f54b9040d65ebf7457ca54d9dd8f039fce3). Verified literal backslash-bang via `gh api repos/.../commits/<sha> --jq '.commit.message' | od -c` — bytes are `a s s e r t \ !` (not a JSON-escape artifact).

The mechanism is the same as the `--title` corruption tend#318 / #320 / #422 addressed: `git commit -m "msg"` passes the message as a literal string argument, the Bash-tool preprocessor rewrites every `!` to `\!` in command strings before bash parses, and git stores those argument bytes verbatim into the commit object. Rust code is especially exposed because `assert!`, `format!`, `panic!`, `eprintln!`, `vec!` are everywhere — a fix-test-coverage commit that quotes those identifiers will ship corrupted.

Prior `review-reviewers` evidence (April) explicitly claimed git commit was immune (*"the commit message on the same branch is clean ... confirming the corruption is specific to `--title` string arguments, not `git commit`"*). That claim was based on commits whose messages happened to have no `!` or were composed via `-F`. The corruption shape on `-m` is identical to `--title` and just hadn't been observed in the wild yet.

## Fix

Add a short paragraph after the existing `--title` recipe in the Comment Formatting section, explicitly calling out `git commit -m` and providing the `git commit -F /tmp/commit-msg.txt` recipe. `git commit -F` reads the file directly, so the preprocessor never sees the bang.

The example at line ~592 (`git commit -m "skills(running-tend): ..."`) is left as-is — its title has no `!`, so it's still safe, and the new paragraph clarifies that `-F` becomes mandatory only when the message contains code references or breaking-change markers.

## Evidence

- One fresh occurrence on a previously-uncovered surface (worktrunk commit `148a9f54`, 2026-05-11T21:47:22Z).
- Mechanism well-understood: identical to the `--title` rewrite (tend#318 / #320 / #422).
- Consequence is permanent — commit messages can't be edited without force-push, which the bot won't do.
- Recurrence likely: any Rust fix-test-coverage commit whose body quotes `assert!` / `format!` / etc.

Evidence gist for the worktrunk-bot run that produced this: https://gist.github.com/9675d1510da32c68a68c1d45137b21e0.

Related: tend#318 (`--body-file` workaround), tend#320 / tend#422 (`--title` workaround), tend#423 (bang-escape in single-quoted heredocs), tend#424 (review-reviewers backslash-backtick scan).
