### PR TITLE
site: render the "currently tending" indicator from the live-data Worker

### DIFF
--- a/docs/website-data.md
+++ b/docs/website-data.md
@@ -82,9 +82,10 @@ Source: `GET /repos/{owner}/{repo}/actions/runs?status=in_progress` per
 consumer, filtered to workflows whose `name` starts with `tend-`.
 
 **UI fallback:** when `currently_tending` is empty or the Worker request
-fails, the UI should fall back to showing the most recent event from
-`/activity` as "last action N min ago" — the indicator never breaks the
-page. The fallback lives in the rendering layer, not the data layer.
+fails, the UI falls back to showing the most recent event from `/activity`
+as "last tended N min ago" — the indicator never breaks the page. This
+fallback lives in the rendering layer (`site/src/components/CurrentlyTending.astro`),
+not the data layer.
 
 ### `/activity`
 

--- a/site/README.md
+++ b/site/README.md
@@ -11,9 +11,9 @@ npm install
 npm run dev
 ```
 
-Then open <http://localhost:4321/>. Live-data sections (stats, activity)
-fetch the Worker at `api.tend-src.com`; set `PUBLIC_WORKER_URL` in
-`.env.local` to point elsewhere (see `.env.example`).
+Then open <http://localhost:4321/>. The live-data elements (currently-tending
+indicator, stats strip, activity feed) fetch the Worker at `api.tend-src.com`;
+set `PUBLIC_WORKER_URL` in `.env.local` to point elsewhere (see `.env.example`).
 
 ## Build
 
@@ -28,6 +28,7 @@ npm run preview    # serve the built site
 - `src/components/Logo.astro` — animated SVG of the tend mark: a pen traces the outline, the colour floods in behind it, then it settles with a faint breath; pass `static` for the header lockup
 - `src/layouts/Base.astro` — page shell, header, footer, font preconnect
 - `src/styles/global.css` — palette, typography, marginalia grid, all layout
-- `src/components/Stats.astro`, `src/components/Activity.astro` — runtime-fetch the live-data Worker; hidden when empty or the fetch fails
+- `src/components/CurrentlyTending.astro`, `src/components/Stats.astro`, `src/components/Activity.astro` — runtime-fetch the live-data Worker; hidden when empty or the fetch fails
 - `src/lib/api.ts` — Worker base URL (overridable via `PUBLIC_WORKER_URL`)
+- `src/lib/time.ts` — compact relative-time formatter shared by the live-data components
 - `public/logo.png`, `public/favicon.png` — copied from `../assets/`

--- a/site/src/components/Activity.astro
+++ b/site/src/components/Activity.astro
@@ -18,6 +18,7 @@
 
 <script>
   import { WORKER_URL } from "../lib/api";
+  import { relativeTime } from "../lib/time";
 
   const ENDPOINT = `${WORKER_URL}/activity`;
 
@@ -35,19 +36,6 @@
     review: "review",
     triage: "triage",
   };
-
-  function relative(iso: string): string {
-    const then = new Date(iso).getTime();
-    if (!Number.isFinite(then)) return "";
-    const seconds = Math.max(0, Math.round((Date.now() - then) / 1000));
-    const minutes = Math.round(seconds / 60);
-    const hours = Math.round(minutes / 60);
-    const days = Math.round(hours / 24);
-    if (seconds < 90) return "just now";
-    if (minutes < 90) return `${minutes} min ago`;
-    if (hours < 36) return `${hours} h ago`;
-    return `${days} d ago`;
-  }
 
   async function load(): Promise<void> {
     let data: { events?: Event[] };
@@ -86,7 +74,7 @@
       const time = document.createElement("time");
       time.className = "at";
       time.dateTime = e.at;
-      time.textContent = relative(e.at);
+      time.textContent = relativeTime(e.at);
 
       li.append(kind, repo, link, time);
       ul.appendChild(li);

--- a/site/src/components/CurrentlyTending.astro
+++ b/site/src/components/CurrentlyTending.astro
@@ -1,0 +1,64 @@
+---
+// "Currently tending" pulse — runtime-fetched from api.tend-src.com/currently-tending.
+// When nothing is in progress it falls back to /activity's most recent event
+// ("last tended N min ago"), per docs/website-data.md, so the indicator stays
+// live between runs. Hidden only when both requests fail.
+---
+
+<p id="now-tending" class="now-tending" hidden></p>
+
+<script>
+  import { WORKER_URL } from "../lib/api";
+  import { relativeTime } from "../lib/time";
+
+  interface Run {
+    repo: string;
+    workflow: string;
+  }
+  interface Event {
+    at: string;
+  }
+
+  async function getJson<T>(path: string): Promise<T | null> {
+    try {
+      const resp = await fetch(`${WORKER_URL}${path}`, {
+        headers: { Accept: "application/json" },
+      });
+      return resp.ok ? ((await resp.json()) as T) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  function render(el: HTMLElement, state: "live" | "idle", text: string): void {
+    const dot = document.createElement("span");
+    dot.className = `now-dot now-dot-${state}`;
+    const label = document.createElement("span");
+    label.textContent = text;
+    el.replaceChildren(dot, label);
+    el.hidden = false;
+  }
+
+  async function load(): Promise<void> {
+    const el = document.getElementById("now-tending");
+    if (!el) return;
+
+    const current = await getJson<{ currently_tending?: Run[] }>("/currently-tending");
+    const runs = current?.currently_tending ?? [];
+    if (runs.length > 0) {
+      const r = runs[0];
+      const workflow = r.workflow.replace(/^tend-/, "");
+      const more = runs.length > 1 ? ` (+${runs.length - 1} more)` : "";
+      render(el, "live", `tending ${r.repo} · ${workflow}${more}`);
+      return;
+    }
+
+    const activity = await getJson<{ events?: Event[] }>("/activity");
+    const last = activity?.events?.[0];
+    if (!last) return;
+    const ago = relativeTime(last.at);
+    if (ago) render(el, "idle", `last tended ${ago}`);
+  }
+
+  load();
+</script>

--- a/site/src/lib/time.ts
+++ b/site/src/lib/time.ts
@@ -1,0 +1,13 @@
+// Compact relative-time formatter for live-data timestamps ("12 min ago").
+export function relativeTime(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (!Number.isFinite(then)) return "";
+  const seconds = Math.max(0, Math.round((Date.now() - then) / 1000));
+  const minutes = Math.round(seconds / 60);
+  const hours = Math.round(minutes / 60);
+  const days = Math.round(hours / 24);
+  if (seconds < 90) return "just now";
+  if (minutes < 90) return `${minutes} min ago`;
+  if (hours < 36) return `${hours} h ago`;
+  return `${days} d ago`;
+}

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import Base from "../layouts/Base.astro";
 import Logo from "../components/Logo.astro";
+import CurrentlyTending from "../components/CurrentlyTending.astro";
 import Stats from "../components/Stats.astro";
 import Activity from "../components/Activity.astro";
 
@@ -75,6 +76,8 @@ claude /install-tend</code></pre>
         </a>
         <span class="note">already in production, albeit early days</span>
       </div>
+
+      <CurrentlyTending />
     </div>
     <div class="logo-frame">
       <Logo size={260} />

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -342,7 +342,9 @@ hr::after {
 
 /* ---------- "Currently tending" indicator ---------- */
 
-.now-tending {
+/* Scoped to :not([hidden]) so the layout rules don't defeat the UA
+   [hidden] { display: none } default before the fetch resolves. */
+.now-tending:not([hidden]) {
   display: flex;
   align-items: center;
   gap: 0.5rem;

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -340,6 +340,39 @@ hr::after {
   height: auto;
 }
 
+/* ---------- "Currently tending" indicator ---------- */
+
+.now-tending {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 1.4rem 0 0;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.03em;
+  color: var(--ink-soft);
+}
+
+.now-dot {
+  flex: none;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+}
+.now-dot-live { background: var(--moss); }
+.now-dot-idle {
+  background: transparent;
+  border: 1px solid var(--oak-deep);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .now-dot-live { animation: now-pulse 2.6s ease-in-out infinite; }
+}
+@keyframes now-pulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.35; }
+}
+
 /* ---------- "What tend tends" ---------- */
 
 .section-eyebrow {


### PR DESCRIPTION
## Summary

Adds the third live-data element to the marketing site: a "currently tending" indicator in the hero. It fetches `api.tend-src.com/currently-tending` and shows `● tending owner/repo · review` while a tend workflow is running. When nothing is in progress — the common case — it falls back to `/activity`'s newest event as `○ last tended N min ago`, per the UI-fallback contract already written into `docs/website-data.md`. If both requests fail it stays hidden, like the existing stats strip and activity feed.

Also extracts the relative-time formatter (`relativeTime`) — previously duplicated inside `Activity.astro` — into `site/src/lib/time.ts`, now shared by both components.

## Files

- `site/src/components/CurrentlyTending.astro` — new component (server-rendered hidden `<p>` + client `<script>`, same pattern as `Stats.astro` / `Activity.astro`)
- `site/src/lib/time.ts` — new; `relativeTime(iso)` shared helper
- `site/src/components/Activity.astro` — now imports `relativeTime` instead of its local copy
- `site/src/pages/index.astro` — renders `<CurrentlyTending />` after the hero badges
- `site/src/styles/global.css` — `.now-tending` / `.now-dot{-live,-idle}` + a `now-pulse` keyframe gated behind `prefers-reduced-motion: no-preference`
- `site/README.md`, `docs/website-data.md` — doc updates

## Test plan

- `npm run build` clean; `pre-commit run --all-files` green
- Verified in a browser against the production Worker: idle state renders "last tended N min ago"; activity feed still renders after the `relativeTime` refactor; no console errors
- The live state (filled moss dot + pulse) wasn't reproduced in-browser — it needs a tend workflow actually running — but the code path is symmetric with the verified idle path
