### PR TITLE
skills(review-reviewers): drop past-PR reference from backslash-backtick grep

### DIFF
--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -268,7 +268,7 @@ Use `Agent` with `model: "haiku"` and a prompt like:
 > done
 > grep -nF '${' /tmp/bot-output/all.txt        # literal ${...} interpolation failure
 > grep -nP '\\!' /tmp/bot-output/all.txt       # backslash-bang corruption
-> grep -nP '\\`' /tmp/bot-output/all.txt       # backslash-backtick corruption (see tend#422)
+> grep -nP '\\`' /tmp/bot-output/all.txt       # backslash-backtick corruption
 > grep -nE 'blob/main/.*#L[0-9]' /tmp/bot-output/all.txt  # un-pinned line links
 > grep -nF 'anthropics/' /tmp/bot-output/all.txt         # wrong-owner URL
 > ```


### PR DESCRIPTION
Drop the `(see tend#422)` reference from the backslash-backtick grep — CLAUDE.md's "no specific past-case references" rule says skills shouldn't cite individual PRs/issues as precedent. The grep line plus its comment already state the structural rule: scan for `\\``, that's a corruption shape we don't want shipped. The PR pointer adds nothing the grep doesn't and will rot into trivia.
