### PR TITLE
docs(design): list site/, worker/, data/, review-runs in structure tree

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -519,6 +519,7 @@ tend/
 │           ├── notifications/
 │           ├── review/
 │           ├── review-reviewers/
+│           ├── review-runs/
 │           ├── running-in-ci/
 │           ├── triage/
 │           └── weekly/
@@ -526,8 +527,12 @@ tend/
 ├── generator/                  # Python package (uvx tend@latest init)
 │   ├── pyproject.toml
 │   └── src/tend/
+├── site/                       # Astro marketing site (tend-src.com)
+├── worker/                     # Cloudflare Worker (api.tend-src.com)
+├── data/                       # consumers.json — Worker's input
 ├── docs/
-│   └── security-model.md
+│   ├── security-model.md
+│   └── website-data.md
 └── README.md
 ```
 


### PR DESCRIPTION
Refresh `DESIGN.md`'s repo-structure listing to match the current tree. Adds the three top-level dirs that landed over the past week (`site/`, `worker/`, `data/`) plus the `review-runs/` skill and `docs/website-data.md`. CLAUDE.md was already updated for this in #418; DESIGN.md's snapshot was missed in that pass.

Nothing else in DESIGN.md changes.
