### PR TITLE
ci(publish-site): drop dead data/** path trigger

### DIFF
--- a/.github/workflows/publish-site.yaml
+++ b/.github/workflows/publish-site.yaml
@@ -6,7 +6,6 @@ on:
       - main
     paths:
       - 'site/**'
-      - 'data/**'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Drop the `data/**` path filter from `publish-site.yaml`. The site no longer reads `data/` at build time — `data/consumers.json` is now fetched at runtime by the Worker (`api.tend-src.com`), so rebuilding the site on a `consumers.json` push produces no output change.

Verified: `grep -rn 'data/\|consumers' site/ --include='*.astro' --include='*.ts'` returns nothing. The runtime fetch lives in `site/src/components/CurrentlyTending.astro`, `Stats.astro`, and `Activity.astro` — all via `WORKER_URL` from `site/src/lib/api.ts`.

The path trigger was a leftover from the pre-Worker build-time pipeline (removed in #428).
