### PR TITLE
fix(action): sum usage and num_turns across all result entries

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -259,23 +259,27 @@ runs:
 
         # claude-code-action writes the full SDK message stream to
         # $RUNNER_TEMP/claude-execution-output.json and exposes the path as
-        # its `execution_file` output. The array ends with a
-        # `type: "result"` entry that carries total_cost_usd, num_turns,
-        # and the per-session usage totals across all models — so cost
-        # stays accurate regardless of which model the session used.
+        # its `execution_file` output. The stream contains one or more
+        # `type: "result"` entries. Sessions that use `run_in_background:
+        # true` Bash emit a second `result` (origin.kind ==
+        # "task-notification") on wakeup; `usage.*` and `num_turns` are
+        # per-event in each `result`, while `total_cost_usd` is cumulative.
+        # Sum the per-event fields across all entries and take cost from
+        # the last.
         if [ -n "$EXECUTION_FILE" ] && [ -f "$EXECUTION_FILE" ]; then
           USAGE=$(jq -c --arg model "$MODEL" '
-            (map(select(.type == "result")) | last) as $r |
-            if $r == null then
+            (map(select(.type == "result"))) as $rs |
+            if ($rs | length) == 0 then
               {input_tokens:0, output_tokens:0, cache_creation_input_tokens:0,
                cache_read_input_tokens:0, turns:0, model:$model, cost_usd:0}
             else
+              ($rs | last) as $r |
               {
-                input_tokens: ($r.usage.input_tokens // 0),
-                output_tokens: ($r.usage.output_tokens // 0),
-                cache_creation_input_tokens: ($r.usage.cache_creation_input_tokens // 0),
-                cache_read_input_tokens: ($r.usage.cache_read_input_tokens // 0),
-                turns: ($r.num_turns // 0),
+                input_tokens: ([$rs[].usage.input_tokens // 0] | add),
+                output_tokens: ([$rs[].usage.output_tokens // 0] | add),
+                cache_creation_input_tokens: ([$rs[].usage.cache_creation_input_tokens // 0] | add),
+                cache_read_input_tokens: ([$rs[].usage.cache_read_input_tokens // 0] | add),
+                turns: ([$rs[].num_turns // 0] | add),
                 model: $model,
                 cost_usd: (($r.total_cost_usd // 0) * 100 | round / 100)
               }


### PR DESCRIPTION
## Summary

Fixes #302. When a session uses `Bash` with `run_in_background: true`, the SDK emits a second `type: "result"` entry on wakeup (`origin.kind == "task-notification"`). `usage.*` and `num_turns` are **per-event** in each result; only `total_cost_usd` is cumulative. The current jq filter picks the last result and captures just the trailing turn's usage and turn count, so backgrounded sessions report a few hundred `output_tokens` and 2-3 `turns` regardless of session length (cost stays correct because it's cumulative).

The fix sums `input_tokens`, `output_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`, and `num_turns` across every `result` entry; `cost_usd` continues to come from the last entry.

## Diagnosis from captured execution-output.json

Three runs from the `claude-session-logs` artifact, post-[#408](https://github.com/max-sixty/tend/pull/408):

| Run | result entries | Before (turns / output) | After (turns / output) | cost | assistant entries in JSONL |
|---|---:|---:|---:|---:|---:|
| [25710799595](https://github.com/max-sixty/tend/actions/runs/25710799595) (tend-review) | 2 | 2 / 182 | 19 / 4373 | $1.04 | 26 |
| [25707130169](https://github.com/max-sixty/tend/actions/runs/25707130169) (tend-review) | 2 | 2 / 203 | 41 / 20886 | $2.36 | 56 |
| [25738925390](https://github.com/max-sixty/tend/actions/runs/25738925390) (tend-mention, no background) | 1 | 6 / 1028 | 6 / 1028 | $0.29 | — |

<details><summary>Per-result inspection of run 25710799595</summary>

```
[
  {"num_turns": 17, "output_tokens": 4191, "total_cost_usd": 0.967,  "origin": null},
  {"num_turns":  2, "output_tokens":  182, "total_cost_usd": 1.037,  "origin": {"kind": "task-notification"}}
]
```

The second entry is the post-background-wakeup turn. Its `usage.*` only covers that one turn; its `total_cost_usd` is the running session total.

</details>

Single-result runs are unaffected by the change — `sum == last` when length is 1.

## Follow-up

The diagnostic `cp "$EXECUTION_FILE" "$LOGS_DIR/claude-execution-output.json"` block added in #408 is no longer needed and can be removed in a separate PR.

## Test plan

- [ ] After merge, watch a tend-review or tend-mention run that polls CI in the background land a `token-usage.json` with `turns` and `output_tokens` proportional to session length rather than the 2-3 / few-hundred floor.
- [ ] Confirm runs without `run_in_background: true` (e.g. tend-triage, tend-nightly) report the same numbers as before.
