### PR TITLE
site: extract shared liveData/fetchJson helpers for the live-data components

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -29,6 +29,6 @@ npm run preview    # serve the built site
 - `src/layouts/Base.astro` — page shell, header, footer, font preconnect
 - `src/styles/global.css` — palette, typography, marginalia grid, all layout
 - `src/components/CurrentlyTending.astro`, `src/components/Stats.astro`, `src/components/Activity.astro` — runtime-fetch the live-data Worker; hidden when empty or the fetch fails
-- `src/lib/api.ts` — Worker base URL (overridable via `PUBLIC_WORKER_URL`)
+- `src/lib/api.ts` — live-data Worker client: `fetchJson` + `liveData` (the fetch/render/reveal cycle the three components share); base URL overridable via `PUBLIC_WORKER_URL`
 - `src/lib/time.ts` — compact relative-time formatter shared by the live-data components
 - `public/logo.png`, `public/favicon.png` — copied from `../assets/`

--- a/site/src/components/Activity.astro
+++ b/site/src/components/Activity.astro
@@ -17,10 +17,8 @@
 </section>
 
 <script>
-  import { WORKER_URL } from "../lib/api";
+  import { liveData } from "../lib/api";
   import { relativeTime } from "../lib/time";
-
-  const ENDPOINT = `${WORKER_URL}/activity`;
 
   type Kind = "review" | "triage" | "ci-fix";
   interface Event {
@@ -37,22 +35,12 @@
     triage: "triage",
   };
 
-  async function load(): Promise<void> {
-    let data: { events?: Event[] };
-    try {
-      const resp = await fetch(ENDPOINT, { headers: { Accept: "application/json" } });
-      if (!resp.ok) return;
-      data = (await resp.json()) as { events?: Event[] };
-    } catch {
-      return;
-    }
-    const events = data.events ?? [];
-    if (events.length === 0) return;
+  liveData<{ events?: Event[] }>("/activity", "recent-activity", (data) => {
+    const events = data?.events ?? [];
+    if (events.length === 0) return false;
 
     const ul = document.querySelector("[data-activity-rows]");
-    const section = document.getElementById("recent-activity");
-    if (!ul || !section) return;
-
+    if (!ul) return false;
     for (const e of events) {
       const li = document.createElement("li");
       li.className = "activity-row";
@@ -79,8 +67,6 @@
       li.append(kind, repo, link, time);
       ul.appendChild(li);
     }
-    section.hidden = false;
-  }
-
-  load();
+    return true;
+  });
 </script>

--- a/site/src/components/CurrentlyTending.astro
+++ b/site/src/components/CurrentlyTending.astro
@@ -8,7 +8,7 @@
 <p id="now-tending" class="now-tending" hidden></p>
 
 <script>
-  import { WORKER_URL } from "../lib/api";
+  import { fetchJson, liveData } from "../lib/api";
   import { relativeTime } from "../lib/time";
 
   interface Run {
@@ -19,46 +19,34 @@
     at: string;
   }
 
-  async function getJson<T>(path: string): Promise<T | null> {
-    try {
-      const resp = await fetch(`${WORKER_URL}${path}`, {
-        headers: { Accept: "application/json" },
-      });
-      return resp.ok ? ((await resp.json()) as T) : null;
-    } catch {
-      return null;
-    }
-  }
-
-  function render(el: HTMLElement, state: "live" | "idle", text: string): void {
+  function paint(el: HTMLElement, state: "live" | "idle", text: string): void {
     const dot = document.createElement("span");
     dot.className = `now-dot now-dot-${state}`;
     const label = document.createElement("span");
     label.textContent = text;
     el.replaceChildren(dot, label);
-    el.hidden = false;
   }
 
-  async function load(): Promise<void> {
-    const el = document.getElementById("now-tending");
-    if (!el) return;
+  liveData<{ currently_tending?: Run[] }>(
+    "/currently-tending",
+    "now-tending",
+    async (data, el) => {
+      const runs = data?.currently_tending ?? [];
+      if (runs.length > 0) {
+        const r = runs[0];
+        const workflow = r.workflow.replace(/^tend-/, "");
+        const more = runs.length > 1 ? ` (+${runs.length - 1} more)` : "";
+        paint(el, "live", `tending ${r.repo} · ${workflow}${more}`);
+        return true;
+      }
 
-    const current = await getJson<{ currently_tending?: Run[] }>("/currently-tending");
-    const runs = current?.currently_tending ?? [];
-    if (runs.length > 0) {
-      const r = runs[0];
-      const workflow = r.workflow.replace(/^tend-/, "");
-      const more = runs.length > 1 ? ` (+${runs.length - 1} more)` : "";
-      render(el, "live", `tending ${r.repo} · ${workflow}${more}`);
-      return;
-    }
-
-    const activity = await getJson<{ events?: Event[] }>("/activity");
-    const last = activity?.events?.[0];
-    if (!last) return;
-    const ago = relativeTime(last.at);
-    if (ago) render(el, "idle", `last tended ${ago}`);
-  }
-
-  load();
+      const activity = await fetchJson<{ events?: Event[] }>("/activity");
+      const last = activity?.events?.[0];
+      if (!last) return false;
+      const ago = relativeTime(last.at);
+      if (!ago) return false;
+      paint(el, "idle", `last tended ${ago}`);
+      return true;
+    },
+  );
 </script>

--- a/site/src/components/Stats.astro
+++ b/site/src/components/Stats.astro
@@ -9,9 +9,7 @@
 </section>
 
 <script>
-  import { WORKER_URL } from "../lib/api";
-
-  const ENDPOINT = `${WORKER_URL}/stats`;
+  import { liveData } from "../lib/api";
 
   interface Stats {
     reviews_total: number;
@@ -25,27 +23,17 @@
     return n.toLocaleString();
   }
 
-  async function load(): Promise<void> {
-    let data: Stats;
-    try {
-      const resp = await fetch(ENDPOINT, { headers: { Accept: "application/json" } });
-      if (!resp.ok) return;
-      data = (await resp.json()) as Stats;
-    } catch {
-      return;
-    }
-
+  liveData<Stats>("/stats", "stats", (data) => {
+    if (!data) return false;
     const cells = [
       { n: data.reviews_total, week: data.reviews_this_week, label: "reviews" },
       { n: data.ci_fixes_total, week: data.ci_fixes_this_week, label: "ci fixes" },
       { n: data.triage_comments_total, week: null, label: "triage notes" },
     ];
-    if (cells.every((c) => !c.n)) return; // all zero — hide entirely
+    if (cells.every((c) => !c.n)) return false; // all zero — hide entirely
 
     const strip = document.querySelector("[data-stat-strip]");
-    const section = document.getElementById("stats");
-    if (!strip || !section) return;
-
+    if (!strip) return false;
     for (const cell of cells) {
       const div = document.createElement("div");
       div.className = "stat-cell";
@@ -69,8 +57,6 @@
 
       strip.appendChild(div);
     }
-    section.hidden = false;
-  }
-
-  load();
+    return true;
+  });
 </script>

--- a/site/src/lib/api.ts
+++ b/site/src/lib/api.ts
@@ -1,6 +1,34 @@
-// Base URL of the live-data Worker (the tend-website Cloudflare Worker).
-// Override via PUBLIC_WORKER_URL in .env.local — e.g. http://localhost:8787
-// against a local `wrangler dev`.
-export const WORKER_URL =
+// Talks to the live-data Worker (the tend-website Cloudflare Worker, served at
+// api.tend-src.com). Override the base URL via PUBLIC_WORKER_URL in .env.local
+// — e.g. http://localhost:8787 against a local `wrangler dev`.
+const WORKER_URL =
   (import.meta.env.PUBLIC_WORKER_URL as string | undefined) ??
   "https://api.tend-src.com";
+
+// Fetch JSON from a Worker route. Returns null on any non-OK response or
+// network error so callers can degrade gracefully rather than throwing.
+export async function fetchJson<T>(path: string): Promise<T | null> {
+  try {
+    const resp = await fetch(`${WORKER_URL}${path}`, {
+      headers: { Accept: "application/json" },
+    });
+    return resp.ok ? ((await resp.json()) as T) : null;
+  } catch {
+    return null;
+  }
+}
+
+// Drives a runtime-fetched section: fetch `path`, hand the parsed body (or
+// null on failure) to `render`, and reveal the element with id `sectionId`
+// only if `render` returns true. `render` owns the DOM and the "is this worth
+// showing" decision, and may issue further fetches (e.g. a fallback endpoint).
+export async function liveData<T>(
+  path: string,
+  sectionId: string,
+  render: (data: T | null, el: HTMLElement) => boolean | Promise<boolean>,
+): Promise<void> {
+  const el = document.getElementById(sectionId);
+  if (!el) return;
+  const shown = await render(await fetchJson<T>(path), el);
+  if (shown) el.hidden = false;
+}


### PR DESCRIPTION
## Summary

Pure refactor — no behavior change. `Stats.astro`, `Activity.astro`, and `CurrentlyTending.astro` each carried their own copy of the same runtime-fetch boilerplate (fetch with `Accept` header, `resp.ok` guard, `try/catch → bail`, `hidden = false` on success). A prior review on #433 flagged the duplication. This lifts it into `site/src/lib/api.ts`:

- `fetchJson<T>(path): Promise<T | null>` — the fetch wrapper (null on non-OK / network error). Was `getJson` inside `CurrentlyTending`.
- `liveData<T>(path, sectionId, render)` — looks up `getElementById(sectionId)`, calls `fetchJson(path)`, hands the parsed body (or `null` on failure) to `render(data, el)`, and reveals the element only if `render` returns `true`. `render` owns the DOM and the "is this worth showing?" decision, and may issue further fetches — `CurrentlyTending` passes an `async render` that does its `/activity` fallback this way.

`WORKER_URL` is now module-private to `api.ts` (only `fetchJson` uses it). Renamed `CurrentlyTending`'s local `render` helper to `paint` so it doesn't overlap with `liveData`'s `render` parameter. README line updated.

Net −12 lines; bundles shrink slightly (a shared `api.*.js` chunk replaces the per-component copies).

## Test plan

- `npm run build` clean; `pre-commit run --all-files` green; `tsc --noEmit` passes (checked via reviewer)
- Verified in a browser against the production Worker: all three sections render — saw both `CurrentlyTending`'s live state (`tending owner/repo · review (+2 more)`) and idle fallback (`last tended N min ago`), the stat strip, and the 10-row activity feed — no console errors
- Behavior preserved: `CurrentlyTending` still falls back to `/activity` when `/currently-tending` *fails* (not only when it's empty); each section still hides in exactly the cases it did before
