### PR TITLE
worker+site: /activity → primitive buckets, drop /stats

### DIFF
--- a/docs/activity-stream-design.md
+++ b/docs/activity-stream-design.md
@@ -1,0 +1,100 @@
+# Activity stream design
+
+`/activity` is the "what tend has *done*" stream on the marketing site — recent
+PRs tend opened and merged, reviews and comments it left, commits it pushed,
+issues it closed, dependency bumps it cleared. It's built from each bot's public
+event timeline plus one merged-PR search; `docs/website-data.md` documents the
+live shape, kinds, and sources. This doc records why that design, what it
+deliberately can't show, and what's still open.
+
+## Decision: per-actor events API
+
+`/activity` fans out `GET /users/<bot>/events/public` (one cheap REST call per
+bot, already discriminated by event type) plus `author:<bot> is:pr is:merged`
+(one Search call per bot — the merge is usually performed by a human, so it
+isn't in the bot's own event stream). Rows are merged across bots, comments and
+pushes to the same PR/branch collapse with a `count`, sorted newest-first,
+capped at 40.
+
+This replaced the original `/activity`, which ran three Search queries per bot
+(`author:<bot> is:pr` → `ci-fix`, `commenter:<bot> is:pr -author:<bot>` →
+`review`, `commenter:<bot> is:issue` → `triage`). That feed was keyed on
+*issue/PR touched*, not *action taken*, so it collapsed distinct things — a CI
+fix, a nightly conflict resolution, a weekly dependency bump, a workflow
+self-edit were all "ci fix"; merged-or-not was invisible; dependency-PR
+approvals (authored by `dependabot[bot]`, not the bot) barely registered; issue
+closes and pushed commits didn't appear at all.
+
+Alternatives considered and rejected:
+
+- **More Search queries (extend the original).** Search bursts (kinds × N
+  concurrent requests) against GitHub's 30/min Search cap; the original 3-kind
+  feed already neared that around N≈10, and a richer one would hit it sooner.
+  Multiple `author:` qualifiers AND to nothing, so the per-bot fanout can't be
+  collapsed. The events API moves the bulk onto the 5,000/hr REST budget
+  instead, raising the ceiling.
+- **Per-repo events / issue timeline (`GET /repos/<repo>/events`).** Same cost
+  as the events API but a busy repo's 30 most-recent events can contain zero bot
+  events, forcing pagination. The per-actor stream doesn't have that problem —
+  every event in it is the bot's.
+- **tend emits its own activity log.** Each workflow run appends a one-line
+  record of what it did, in tend's own words ("fixed flaky test: race in cache
+  TTL — #441"). The only source that captures *content*, not just titles and
+  URLs — but it needs a home (a long-lived "tend log" issue per consumer repo, a
+  Worker write endpoint, …), all of which add a visible artifact or new surface.
+  Deferred; the natural next step if breadth (more kinds) isn't enough and
+  people want depth (tend's own summaries).
+
+## What the feed still can't show
+
+Some tend behaviours aren't reliably attributable from public APIs:
+
+- "resolved a merge conflict" vs. "pushed a normal fix" — both are a `PushEvent`
+  with a merge commit; the event doesn't say the merge had conflicts. The feed
+  shows both as `pr-commits`.
+- "swept these 4 files and found nothing" — a nightly survey that produced no PR
+  leaves no trace.
+- *what* a review actually said, in tend's words — the API gives the comment
+  body, not a one-line summary. (Only the tend-emitted log would.)
+
+## Cost & headroom
+
+Per `/activity` refresh: N REST (events) + N Search (merged) requests, paid once
+per 5-min cache window — worst case 12 refreshes/hr.
+
+| | per refresh | per hour | Search burst | headroom |
+| --- | --- | --- | --- | --- |
+| N=5 | 5 REST + 5 Search | ≤60 REST + ≤60 Search | 5 / 30 | comfortable |
+| N=20 | 20 REST + 20 Search | ≤240 REST + ≤240 Search | 20 / 30 | comfortable |
+| N=40 | 40 REST + 40 Search | ≤480 REST + ≤480 Search | 40 / 30 | over Search burst — drop the merge-Search, or move the route to a scheduled refresh |
+
+`/currently-tending` (N REST every 30 s → 120N REST/hr) hits the 5,000/hr REST
+budget around N≈40 on its own, so N≈40 is a cliff for the *whole* system, not
+this route, and crossing it means a scheduled-refresh rearchitecture regardless.
+
+`/stats` is the nearer problem: 5 Search counters × N concurrent reaches the
+30/min cap at N=6 and goes over at N=7 — past which queries get 429'd and the
+Worker degrades them to zero, undercounting silently. Fix independent of this
+route: serialise the per-bot calls, or move `/stats` to a Worker cron refresh
+into KV (a Cloudflare `scheduled` handler running the fanout every ~30 min,
+serialised; the fetch handler just reads KV — the escape hatch for any route
+that outgrows a cheap single fanout).
+
+## Still open
+
+- **Where it lives.** Today it's the hero-adjacent `Activity.astro` section,
+  rendering the new kinds and showing the first 12 rows (the Worker returns up
+  to 40). A dedicated `/activity` page is cheap (a second Astro route → GitHub
+  Pages) and would have room for a day-grouped digest header ("Mon — tend opened
+  3 PRs (2 merged), reviewed 5, closed 1 issue, cleared 2 dependency bumps"),
+  the full feed, and a repo filter. Build it when there's appetite.
+- **Per-kind styling.** `Activity.astro` tags each row with a `kind-<kind>` class
+  but the CSS only styles `.kind` generically — distinct chip colours/glyphs per
+  kind (merged green, changes-requested amber, …) are an easy follow-up.
+- **Digest cadence.** If a digest happens — daily rollups (changelog-like) or a
+  single "this week" line (one cheap `total_count` query set)?
+- **`/stats` Search burst.** Fold the serialise-or-cron fix into this work, or
+  track it separately? It's a today-problem at N=6.
+- **`consumers.json` additions.** A repo display name would let the feed show
+  "worktrunk" not "max-sixty/worktrunk". A tend-log issue number per repo would
+  be needed if the tend-emitted-log option is ever pursued.

--- a/docs/activity-stream-design.md
+++ b/docs/activity-stream-design.md
@@ -1,100 +1,41 @@
 # Activity stream design
 
-`/activity` is the "what tend has *done*" stream on the marketing site — recent
-PRs tend opened and merged, reviews and comments it left, commits it pushed,
-issues it closed, dependency bumps it cleared. It's built from each bot's public
-event timeline plus one merged-PR search; `docs/website-data.md` documents the
-live shape, kinds, and sources. This doc records why that design, what it
-deliberately can't show, and what's still open.
+`/activity` reports recent activity in **primitive buckets** — `prs` (PRs the
+bot opened), `issues` (issues the bot opened), `comments` (PRs/issues the bot
+chimed in on) — each with a lifetime `count`, a `count_this_week`, and a short
+`recent` list. `docs/website-data.md` has the live shape and the queries; this
+note records why it's shaped that way.
 
-## Decision: per-actor events API
+## Why primitive buckets, not a job taxonomy
 
-`/activity` fans out `GET /users/<bot>/events/public` (one cheap REST call per
-bot, already discriminated by event type) plus `author:<bot> is:pr is:merged`
-(one Search call per bot — the merge is usually performed by a human, so it
-isn't in the bot's own event stream). Rows are merged across bots, comments and
-pushes to the same PR/branch collapse with a `count`, sorted newest-first,
-capped at 40.
+GitHub gives us *mechanical* facts — a PR was opened, a review was submitted, a
+comment was created — but tend's *jobs* (reviewing PRs, triaging issues, fixing
+CI, nightly/weekly maintenance, dependency bumps) don't map onto them cleanly:
+a PR on `fix/ci-*` vs `fix/issue-*` vs `tend/update-workflows` is the same event
+type, and some jobs (a nightly survey that finds nothing) leave no trace at all.
+An earlier cut tried to reverse-engineer the jobs into a `kind` enum
+(`ci-fix`/`review`/`triage`, then a richer `pr-opened`/`pr-merged`/… set) — every
+version needed branch-name heuristics and still mislabelled things.
 
-This replaced the original `/activity`, which ran three Search queries per bot
-(`author:<bot> is:pr` → `ci-fix`, `commenter:<bot> is:pr -author:<bot>` →
-`review`, `commenter:<bot> is:issue` → `triage`). That feed was keyed on
-*issue/PR touched*, not *action taken*, so it collapsed distinct things — a CI
-fix, a nightly conflict resolution, a weekly dependency bump, a workflow
-self-edit were all "ci fix"; merged-or-not was invisible; dependency-PR
-approvals (authored by `dependabot[bot]`, not the bot) barely registered; issue
-closes and pushed commits didn't appear at all.
+So: don't reverse-engineer. Report the mechanical buckets honestly, cheaply
+(one Search query per bucket per bot — the page gives the recent items *and* the
+count), and leave the "what's tend been up to" narrative to a later layer.
 
-Alternatives considered and rejected:
+## Phase 2: an LLM summary
 
-- **More Search queries (extend the original).** Search bursts (kinds × N
-  concurrent requests) against GitHub's 30/min Search cap; the original 3-kind
-  feed already neared that around N≈10, and a richer one would hit it sooner.
-  Multiple `author:` qualifiers AND to nothing, so the per-bot fanout can't be
-  collapsed. The events API moves the bulk onto the 5,000/hr REST budget
-  instead, raising the ceiling.
-- **Per-repo events / issue timeline (`GET /repos/<repo>/events`).** Same cost
-  as the events API but a busy repo's 30 most-recent events can contain zero bot
-  events, forcing pagination. The per-actor stream doesn't have that problem —
-  every event in it is the bot's.
-- **tend emits its own activity log.** Each workflow run appends a one-line
-  record of what it did, in tend's own words ("fixed flaky test: race in cache
-  TTL — #441"). The only source that captures *content*, not just titles and
-  URLs — but it needs a home (a long-lived "tend log" issue per consumer repo, a
-  Worker write endpoint, …), all of which add a visible artifact or new surface.
-  Deferred; the natural next step if breadth (more kinds) isn't enough and
-  people want depth (tend's own summaries).
+The buckets are the *data*; the *narrative* — a short prose "here's what tend's
+been doing" — is deferred to a consumer that reads `/activity` and writes a
+summary into KV (a scheduled job, or the Worker calling Claude). That's tracked
+as the TODO in `docs/website-data.md`. Until it exists, the site renders the
+buckets directly (a stat strip from the counts, a recent feed from the `recent`
+lists).
 
-## What the feed still can't show
+## Considered and dropped
 
-Some tend behaviours aren't reliably attributable from public APIs:
-
-- "resolved a merge conflict" vs. "pushed a normal fix" — both are a `PushEvent`
-  with a merge commit; the event doesn't say the merge had conflicts. The feed
-  shows both as `pr-commits`.
-- "swept these 4 files and found nothing" — a nightly survey that produced no PR
-  leaves no trace.
-- *what* a review actually said, in tend's words — the API gives the comment
-  body, not a one-line summary. (Only the tend-emitted log would.)
-
-## Cost & headroom
-
-Per `/activity` refresh: N REST (events) + N Search (merged) requests, paid once
-per 5-min cache window — worst case 12 refreshes/hr.
-
-| | per refresh | per hour | Search burst | headroom |
-| --- | --- | --- | --- | --- |
-| N=5 | 5 REST + 5 Search | ≤60 REST + ≤60 Search | 5 / 30 | comfortable |
-| N=20 | 20 REST + 20 Search | ≤240 REST + ≤240 Search | 20 / 30 | comfortable |
-| N=40 | 40 REST + 40 Search | ≤480 REST + ≤480 Search | 40 / 30 | over Search burst — drop the merge-Search, or move the route to a scheduled refresh |
-
-`/currently-tending` (N REST every 30 s → 120N REST/hr) hits the 5,000/hr REST
-budget around N≈40 on its own, so N≈40 is a cliff for the *whole* system, not
-this route, and crossing it means a scheduled-refresh rearchitecture regardless.
-
-`/stats` is the nearer problem: 5 Search counters × N concurrent reaches the
-30/min cap at N=6 and goes over at N=7 — past which queries get 429'd and the
-Worker degrades them to zero, undercounting silently. Fix independent of this
-route: serialise the per-bot calls, or move `/stats` to a Worker cron refresh
-into KV (a Cloudflare `scheduled` handler running the fanout every ~30 min,
-serialised; the fetch handler just reads KV — the escape hatch for any route
-that outgrows a cheap single fanout).
-
-## Still open
-
-- **Where it lives.** Today it's the hero-adjacent `Activity.astro` section,
-  rendering the new kinds and showing the first 12 rows (the Worker returns up
-  to 40). A dedicated `/activity` page is cheap (a second Astro route → GitHub
-  Pages) and would have room for a day-grouped digest header ("Mon — tend opened
-  3 PRs (2 merged), reviewed 5, closed 1 issue, cleared 2 dependency bumps"),
-  the full feed, and a repo filter. Build it when there's appetite.
-- **Per-kind styling.** `Activity.astro` tags each row with a `kind-<kind>` class
-  but the CSS only styles `.kind` generically — distinct chip colours/glyphs per
-  kind (merged green, changes-requested amber, …) are an easy follow-up.
-- **Digest cadence.** If a digest happens — daily rollups (changelog-like) or a
-  single "this week" line (one cheap `total_count` query set)?
-- **`/stats` Search burst.** Fold the serialise-or-cron fix into this work, or
-  track it separately? It's a today-problem at N=6.
-- **`consumers.json` additions.** A repo display name would let the feed show
-  "worktrunk" not "max-sixty/worktrunk". A tend-log issue number per repo would
-  be needed if the tend-emitted-log option is ever pursued.
+- **A per-event `/activity` feed with a `kind` taxonomy** (events API +
+  branch-name categories + collapsing) — the mapping was the problem, see above.
+- **Aggregate-only `/stats`** — folded into `/activity` (its `count` /
+  `count_this_week`); one fewer route, one fewer fetch from the site.
+- **A KV/D1 accumulator that appends activity as it arrives** — only worth it if
+  the Phase-2 summary needs a span longer than GitHub's ~90-day events window or
+  one Search page; demand-fetch is cheap enough until then.

--- a/docs/website-data.md
+++ b/docs/website-data.md
@@ -17,13 +17,13 @@ Base URL: `https://api.tend-src.com`.
 Unauthenticated GitHub REST is 60 req/hour/IP. A single currently-tending
 poll fans out one `actions/runs` call per consumer repo every 30 s, so one
 browser tab would exhaust the IP quota in under a minute — and the Search
-API used by `/activity` and `/stats` is capped at 10 req/min/IP
-unauthenticated, shared across everyone behind a NAT. The Worker holds an
-authenticated token (5,000 req/hour, 30 Search req/min) and edge-caches each
-route, so origin load is bounded by the TTL, not by viewer count. Static
-nightly JSON would cover `/stats` and `/activity` but can't meet
-currently-tending's sub-minute freshness budget, so all three live on the
-one Worker for consistency.
+API used by `/stats` (and `/activity`'s merged-PR lookups) is capped at 10
+req/min/IP unauthenticated, shared across everyone behind a NAT. The Worker
+holds an authenticated token (5,000 req/hour, 30 Search req/min) and edge-
+caches each route, so origin load is bounded by the TTL, not by viewer
+count. Static nightly JSON would cover `/stats` and `/activity` but can't
+meet currently-tending's sub-minute freshness budget, so all three live on
+the one Worker for consistency.
 
 ## Input: `data/consumers.json`
 
@@ -45,9 +45,12 @@ the hour.
 ## Multi-bot semantics
 
 Counts are **summed** across bots: `reviews_total` is the union of reviews
-authored by *any* tend bot. Activity events are merged and deduped by URL,
-with the first kind seen winning when the same PR appears in multiple
-queries (declared order: ci-fix → review → triage).
+authored by *any* tend bot. Activity events are merged across bots: each
+bot's event timeline and merged-PR search contribute rows, comments and
+pushes to the same PR/branch collapse into one row with a `count`, and
+same-kind rows for the same URL dedup (newest wins). A single PR
+legitimately appears under several kinds — `pr-opened`, then `pr-commented`,
+then `pr-merged` — those are distinct rows, not duplicates.
 
 ## Caching
 
@@ -89,28 +92,39 @@ not the data layer.
 
 ### `/activity`
 
+Recent things tend has *done* — built from each bot's public event timeline
+(`GET /users/<bot>/events/public`, one cheap REST call per bot, already
+discriminated by event type) plus one Search query per bot for merged PRs
+(`author:<bot> is:pr is:merged` — the merge is usually performed by a human,
+so it isn't in the bot's own event stream). Merged across bots, collapsed,
+sorted newest-first, capped at 40.
+
 ```jsonc
 {
   "generated_at": "2026-05-10T17:30:00Z",
-  "events": [                                       // sorted newest first; capped at 10
+  "events": [                                       // sorted newest first; capped at 40
     {
       "repo": "max-sixty/tend",
-      "kind": "review",                             // "review" | "triage" | "ci-fix"
-      "title": "feat: add foo support",
-      "url": "https://github.com/max-sixty/tend/pull/123",
-      "at": "2026-05-09T14:22:00Z"                  // issue/PR updated_at
+      "kind": "pr-commented",
+      "title": "fix: race in cache TTL",
+      "url": "https://github.com/max-sixty/tend/pull/441",
+      "at": "2026-05-10T16:02:00Z",
+      "detail": { "count": 6 }                      // kind-specific (see below); absent for kinds that carry none
     }
   ]
 }
 ```
 
-Source — 3 queries × N bots, deduped by URL:
-
-| `kind`   | Source query                                          |
-| -------- | ----------------------------------------------------- |
-| `ci-fix` | `author:<bot> is:pr`                                  |
-| `review` | `commenter:<bot> is:pr -author:<bot>`                 |
-| `triage` | `commenter:<bot> is:issue`                            |
+| `kind`            | Meaning                                                      | Source / `detail`                                                                 |
+| ----------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------- |
+| `pr-opened`       | tend opened a PR (CI fix, issue fix, maintenance, workflow self-edit, …) | `PullRequestEvent` action=opened · `detail.category`: `ci-fix`\|`issue-fix`\|`workflow`\|`maintenance`\|`other`, inferred from the head-branch name |
+| `pr-merged`       | a tend-authored PR shipped                                    | Search `author:<bot> is:pr is:merged` (`at` = PR `closed_at` ≈ merge time)         |
+| `pr-reviewed`     | tend approved or requested changes on a PR                    | `PullRequestReviewEvent` · `detail.verdict`: `approved`\|`changes_requested`       |
+| `pr-commented`    | tend left comments on a PR (review bodies, inline, conversation) | `PullRequestReviewEvent`(commented) / `PullRequestReviewCommentEvent` / `IssueCommentEvent` on a PR, collapsed per PR · `detail.count` |
+| `pr-commits`      | tend pushed commits to a PR branch (review fixes, conflict resolution) | `PushEvent` to a non-default branch, collapsed per branch · `detail.count`; `url` = head commit |
+| `issue-commented` | tend commented on an issue (triage, mention answer)           | `IssueCommentEvent` on an issue, collapsed per issue · `detail.count`             |
+| `issue-closed`    | tend closed a resolved issue                                  | `IssuesEvent` action=closed                                                       |
+| `dep-approved`    | tend cleared a dependency bump                                | `PullRequestReviewEvent` on a `dependabot[bot]`/`renovate[bot]` PR                 |
 
 ### `/stats`
 
@@ -143,7 +157,7 @@ data/consumers.json on main
 Cloudflare Worker (tend-website)
   ├─ reads data/consumers.json via raw URL (KV-cached 1 h)
   ├─ /currently-tending: fans out to actions/runs per repo
-  ├─ /activity:          fans out 3 Search queries per bot, dedupes
+  ├─ /activity:          fans out events-timeline + merged-PR search per bot
   ├─ /stats:             5 Search queries per bot, sums total_count
   └─ each route edge-cached at its own TTL, served at api.tend-src.com
 ```

--- a/docs/website-data.md
+++ b/docs/website-data.md
@@ -1,29 +1,27 @@
 # Website data
 
-All three data streams the tend site renders are served by one Cloudflare
-Worker. The Worker reads a small input file (`data/consumers.json`) from
-this repo, fans out to GitHub, and serves CORS-enabled JSON to the site.
+Both data streams the tend site renders are served by one Cloudflare Worker.
+The Worker reads a small input file (`data/consumers.json`) from this repo, fans
+out to GitHub, and serves CORS-enabled JSON to the site.
 
 | Stream | Endpoint | Edge TTL | Fallback TTL |
 | --- | --- | --- | --- |
 | Currently tending | `/currently-tending` (also `/`) | 30 s | 5 s |
 | Activity | `/activity` | 5 min | 30 s |
-| Stats | `/stats` | 1 h | 60 s |
 
 Base URL: `https://api.tend-src.com`.
 
 ## Why a Worker, not browser-direct
 
-Unauthenticated GitHub REST is 60 req/hour/IP. A single currently-tending
-poll fans out one `actions/runs` call per consumer repo every 30 s, so one
-browser tab would exhaust the IP quota in under a minute — and the Search
-API used by `/stats` (and `/activity`'s merged-PR lookups) is capped at 10
-req/min/IP unauthenticated, shared across everyone behind a NAT. The Worker
-holds an authenticated token (5,000 req/hour, 30 Search req/min) and edge-
-caches each route, so origin load is bounded by the TTL, not by viewer
-count. Static nightly JSON would cover `/stats` and `/activity` but can't
-meet currently-tending's sub-minute freshness budget, so all three live on
-the one Worker for consistency.
+Unauthenticated GitHub REST is 60 req/hour/IP and the Search API is 10
+req/min/IP — both shared across everyone behind a NAT. A single
+currently-tending poll fans out one `actions/runs` call per consumer repo every
+30 s; `/activity` fans out one Search query per bucket per bot. One browser tab
+would exhaust those quotas in minutes. The Worker holds an authenticated token
+(5,000 req/hour, 30 Search req/min) and edge-caches each route, so origin load
+is bounded by the TTL, not by viewer count. Static nightly JSON would cover
+`/activity` but can't meet currently-tending's sub-minute freshness budget, so
+both live on the one Worker.
 
 ## Input: `data/consumers.json`
 
@@ -44,13 +42,13 @@ the hour.
 
 ## Multi-bot semantics
 
-Counts are **summed** across bots: `reviews_total` is the union of reviews
-authored by *any* tend bot. Activity events are merged across bots: each
-bot's event timeline and merged-PR search contribute rows, comments and
-pushes to the same PR/branch collapse into one row with a `count`, and
-same-kind rows for the same URL dedup (newest wins). A single PR
-legitimately appears under several kinds — `pr-opened`, then `pr-commented`,
-then `pr-merged` — those are distinct rows, not duplicates.
+Everything is **merged across bots**: each `/activity` bucket sums `count` and
+`count_this_week` over all tend bots, and its `recent` list is the union of all
+bots' recent items, sorted newest-first; `currently_tending` is the union of all
+bots' in-progress runs. Activity is *not* scoped to consumer repos — `count`
+comes from Search's `total_count`, which can't be filtered post-hoc — but a tend
+bot only acts in its own repo, so this is a distinction without a difference in
+practice.
 
 ## Caching
 
@@ -85,62 +83,45 @@ Source: `GET /repos/{owner}/{repo}/actions/runs?status=in_progress` per
 consumer, filtered to workflows whose `name` starts with `tend-`.
 
 **UI fallback:** when `currently_tending` is empty or the Worker request
-fails, the UI falls back to showing the most recent event from `/activity`
-as "last tended N min ago" — the indicator never breaks the page. This
+fails, the UI falls back to showing "last tended N min ago" from the most
+recent item in `/activity` — the indicator never breaks the page. This
 fallback lives in the rendering layer (`site/src/components/CurrentlyTending.astro`),
 not the data layer.
 
 ### `/activity`
 
-Recent things tend has *done* — built from each bot's public event timeline
-(`GET /users/<bot>/events/public`, one cheap REST call per bot, already
-discriminated by event type) plus one Search query per bot for merged PRs
-(`author:<bot> is:pr is:merged` — the merge is usually performed by a human,
-so it isn't in the bot's own event stream). Merged across bots, collapsed,
-sorted newest-first, capped at 40.
+Recent things tend has done, in primitive buckets — one Search query per bucket
+per bot (`sort=updated`): the page yields both the `recent` items and the
+lifetime `count` (`total_count`); `count_this_week` is counted off the page, so
+it saturates around one page (~100) per bot per bucket — fine for a headline
+number. The fanout is 3·N concurrent Search requests, which stays under the
+30 req/min cap up to ~10 bots; past that, the per-bot calls would need
+staggering or a scheduled refresh (see the Phase-2 note).
 
 ```jsonc
 {
   "generated_at": "2026-05-10T17:30:00Z",
-  "events": [                                       // sorted newest first; capped at 40
-    {
-      "repo": "max-sixty/tend",
-      "kind": "pr-commented",
-      "title": "fix: race in cache TTL",
-      "url": "https://github.com/max-sixty/tend/pull/441",
-      "at": "2026-05-10T16:02:00Z",
-      "detail": { "count": 6 }                      // kind-specific (see below); absent for kinds that carry none
-    }
-  ]
+  "prs":      { "count": 980,  "count_this_week": 12, "recent": [ /* RecentItem */ ] },
+  "issues":   { "count": 41,   "count_this_week": 1,  "recent": [ ... ] },
+  "comments": { "count": 1530, "count_this_week": 36, "recent": [ ... ] }
 }
 ```
 
-| `kind`            | Meaning                                                      | Source / `detail`                                                                 |
-| ----------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------- |
-| `pr-opened`       | tend opened a PR (CI fix, issue fix, maintenance, workflow self-edit, …) | `PullRequestEvent` action=opened · `detail.category`: `ci-fix`\|`issue-fix`\|`workflow`\|`maintenance`\|`other`, inferred from the head-branch name |
-| `pr-merged`       | a tend-authored PR shipped                                    | Search `author:<bot> is:pr is:merged` (`at` = PR `closed_at` ≈ merge time)         |
-| `pr-reviewed`     | tend approved or requested changes on a PR                    | `PullRequestReviewEvent` · `detail.verdict`: `approved`\|`changes_requested`       |
-| `pr-commented`    | tend left comments on a PR (review bodies, inline, conversation) | `PullRequestReviewEvent`(commented) / `PullRequestReviewCommentEvent` / `IssueCommentEvent` on a PR, collapsed per PR · `detail.count` |
-| `pr-commits`      | tend pushed commits to a PR branch (review fixes, conflict resolution) | `PushEvent` to a non-default branch, collapsed per branch · `detail.count`; `url` = head commit |
-| `issue-commented` | tend commented on an issue (triage, mention answer)           | `IssueCommentEvent` on an issue, collapsed per issue · `detail.count`             |
-| `issue-closed`    | tend closed a resolved issue                                  | `IssuesEvent` action=closed                                                       |
-| `dep-approved`    | tend cleared a dependency bump                                | `PullRequestReviewEvent` on a `dependabot[bot]`/`renovate[bot]` PR                 |
+`RecentItem` = `{ repo, title, url, at }` (`at` is the issue/PR `updated_at`),
+newest-first, ≤10 per bucket.
 
-### `/stats`
+| bucket | Search query | "the bot …" |
+| --- | --- | --- |
+| `prs` | `author:<bot> is:pr` | opened these PRs (any state) |
+| `issues` | `author:<bot> is:issue` | opened these issues — mostly tend's own trackers (missing PAT scopes, "nightly tests failed", `tend-outage`), so this bucket leans "tend flagged a problem" |
+| `comments` | `commenter:<bot> -author:<bot>` | chimed in on these PRs/issues (not its own) |
 
-```jsonc
-{
-  "generated_at": "2026-05-10T17:30:00Z",
-  "reviews_total": 1199,
-  "reviews_this_week": 111,
-  "ci_fixes_total": 944,
-  "ci_fixes_this_week": 55,
-  "triage_comments_total": 331
-}
-```
-
-All counts come from the Search API's `total_count`. "This week" means the
-last 7 days by issue/PR `updated`.
+> **TODO — Phase 2:** a consumer (a scheduled job, or the Worker calling Claude)
+> reads `/activity` and writes a short prose summary of what tend's been up to;
+> the summary lives in KV and is what the site renders. If that summary wants a
+> longer span than the last week (beyond GitHub's ~90-day events window or one
+> Search page), that's when a KV/D1 accumulator that appends activity as it
+> arrives earns its keep — until then, demand-fetch is cheap enough.
 
 ## Topology
 
@@ -156,9 +137,8 @@ data/consumers.json on main
 
 Cloudflare Worker (tend-website)
   ├─ reads data/consumers.json via raw URL (KV-cached 1 h)
-  ├─ /currently-tending: fans out to actions/runs per repo
-  ├─ /activity:          fans out events-timeline + merged-PR search per bot
-  ├─ /stats:             5 Search queries per bot, sums total_count
+  ├─ /currently-tending: fans out actions/runs per repo (in-progress, tend-*)
+  ├─ /activity:          fans out one Search query per bucket per bot
   └─ each route edge-cached at its own TTL, served at api.tend-src.com
 ```
 

--- a/site/src/components/Activity.astro
+++ b/site/src/components/Activity.astro
@@ -20,67 +20,45 @@
   import { liveData } from "../lib/api";
   import { relativeTime } from "../lib/time";
 
-  const MAX_ROWS = 12; // the Worker returns up to 40; this section shows a slice
+  const MAX_ROWS = 12; // the buckets hold up to ~10 each; this section shows a merged slice
 
-  type Kind =
-    | "pr-opened"
-    | "pr-merged"
-    | "pr-reviewed"
-    | "pr-commented"
-    | "pr-commits"
-    | "issue-commented"
-    | "issue-closed"
-    | "dep-approved";
-
-  interface Event {
+  interface RecentItem {
     repo: string;
-    kind: Kind;
     title: string;
     url: string;
     at: string;
-    detail?: {
-      count?: number;
-      verdict?: "approved" | "changes_requested";
-      category?: string;
-    };
+  }
+  interface Bucket {
+    recent?: RecentItem[];
+  }
+  interface Activity {
+    prs?: Bucket;
+    issues?: Bucket;
+    comments?: Bucket;
   }
 
-  const KIND_LABELS: Record<Kind, string> = {
-    "pr-opened": "pr opened",
-    "pr-merged": "merged",
-    "pr-reviewed": "reviewed",
-    "pr-commented": "commented",
-    "pr-commits": "pushed",
-    "issue-commented": "triage",
-    "issue-closed": "closed",
-    "dep-approved": "deps",
-  };
+  type Kind = "pr" | "issue" | "comment";
+  const KIND_LABELS: Record<Kind, string> = { pr: "PR", issue: "issue", comment: "comment" };
 
-  function kindLabel(e: Event): string {
-    if (e.kind === "pr-reviewed" && e.detail?.verdict) {
-      return e.detail.verdict === "approved" ? "approved" : "changes";
-    }
-    return KIND_LABELS[e.kind] ?? e.kind;
-  }
-
-  function titleText(e: Event): string {
-    const count = e.detail?.count ?? 0;
-    return count > 1 ? e.title + " ×" + count : e.title;
-  }
-
-  liveData<{ events?: Event[] }>("/activity", "recent-activity", (data) => {
-    const events = (data?.events ?? []).slice(0, MAX_ROWS);
-    if (events.length === 0) return false;
+  liveData<Activity>("/activity", "recent-activity", (data) => {
+    const rows: Array<RecentItem & { kind: Kind }> = [
+      ...(data?.prs?.recent ?? []).map((r) => ({ ...r, kind: "pr" as const })),
+      ...(data?.issues?.recent ?? []).map((r) => ({ ...r, kind: "issue" as const })),
+      ...(data?.comments?.recent ?? []).map((r) => ({ ...r, kind: "comment" as const })),
+    ];
+    rows.sort((a, b) => (a.at < b.at ? 1 : a.at > b.at ? -1 : 0));
+    const top = rows.slice(0, MAX_ROWS);
+    if (top.length === 0) return false;
 
     const ul = document.querySelector("[data-activity-rows]");
     if (!ul) return false;
-    for (const e of events) {
+    for (const e of top) {
       const li = document.createElement("li");
       li.className = "activity-row";
 
       const kind = document.createElement("span");
       kind.className = `kind kind-${e.kind}`;
-      kind.textContent = kindLabel(e);
+      kind.textContent = KIND_LABELS[e.kind];
 
       const repo = document.createElement("span");
       repo.className = "repo";
@@ -89,7 +67,7 @@
       const link = document.createElement("a");
       link.className = "title";
       link.href = e.url;
-      link.textContent = titleText(e);
+      link.textContent = e.title;
       link.rel = "noopener";
 
       const time = document.createElement("time");

--- a/site/src/components/Activity.astro
+++ b/site/src/components/Activity.astro
@@ -21,21 +21,53 @@
   import { relativeTime } from "../lib/time";
 
   const ENDPOINT = `${WORKER_URL}/activity`;
+  const MAX_ROWS = 12; // the Worker returns up to 40; this section shows a slice
 
-  type Kind = "review" | "triage" | "ci-fix";
+  type Kind =
+    | "pr-opened"
+    | "pr-merged"
+    | "pr-reviewed"
+    | "pr-commented"
+    | "pr-commits"
+    | "issue-commented"
+    | "issue-closed"
+    | "dep-approved";
+
   interface Event {
     repo: string;
     kind: Kind;
     title: string;
     url: string;
     at: string;
+    detail?: {
+      count?: number;
+      verdict?: "approved" | "changes_requested";
+      category?: string;
+    };
   }
 
   const KIND_LABELS: Record<Kind, string> = {
-    "ci-fix": "ci fix",
-    review: "review",
-    triage: "triage",
+    "pr-opened": "pr opened",
+    "pr-merged": "merged",
+    "pr-reviewed": "reviewed",
+    "pr-commented": "commented",
+    "pr-commits": "pushed",
+    "issue-commented": "triage",
+    "issue-closed": "closed",
+    "dep-approved": "deps",
   };
+
+  function kindLabel(e: Event): string {
+    if (e.kind === "pr-reviewed" && e.detail?.verdict) {
+      return e.detail.verdict === "approved" ? "approved" : "changes";
+    }
+    return KIND_LABELS[e.kind] ?? e.kind;
+  }
+
+  function titleText(e: Event): string {
+    const count = e.detail?.count ?? 0;
+    return count > 1 ? e.title + " ×" + count : e.title;
+  }
 
   async function load(): Promise<void> {
     let data: { events?: Event[] };
@@ -46,7 +78,7 @@
     } catch {
       return;
     }
-    const events = data.events ?? [];
+    const events = (data.events ?? []).slice(0, MAX_ROWS);
     if (events.length === 0) return;
 
     const ul = document.querySelector("[data-activity-rows]");
@@ -59,7 +91,7 @@
 
       const kind = document.createElement("span");
       kind.className = `kind kind-${e.kind}`;
-      kind.textContent = KIND_LABELS[e.kind] ?? e.kind;
+      kind.textContent = kindLabel(e);
 
       const repo = document.createElement("span");
       repo.className = "repo";
@@ -68,7 +100,7 @@
       const link = document.createElement("a");
       link.className = "title";
       link.href = e.url;
-      link.textContent = e.title;
+      link.textContent = titleText(e);
       link.rel = "noopener";
 
       const time = document.createElement("time");

--- a/site/src/components/CurrentlyTending.astro
+++ b/site/src/components/CurrentlyTending.astro
@@ -1,8 +1,8 @@
 ---
 // "Currently tending" pulse — runtime-fetched from api.tend-src.com/currently-tending.
-// When nothing is in progress it falls back to /activity's most recent event
-// ("last tended N min ago"), per docs/website-data.md, so the indicator stays
-// live between runs. Hidden only when both requests fail.
+// When nothing is in progress it falls back to the most recent item in
+// /activity ("last tended N min ago"), per docs/website-data.md, so the
+// indicator stays live between runs. Hidden only when both requests fail.
 ---
 
 <p id="now-tending" class="now-tending" hidden></p>
@@ -15,8 +15,13 @@
     repo: string;
     workflow: string;
   }
-  interface Event {
-    at: string;
+  interface Bucket {
+    recent?: Array<{ at: string }>;
+  }
+  interface Activity {
+    prs?: Bucket;
+    issues?: Bucket;
+    comments?: Bucket;
   }
 
   function paint(el: HTMLElement, state: "live" | "idle", text: string): void {
@@ -40,10 +45,14 @@
         return true;
       }
 
-      const activity = await fetchJson<{ events?: Event[] }>("/activity");
-      const last = activity?.events?.[0];
-      if (!last) return false;
-      const ago = relativeTime(last.at);
+      const activity = await fetchJson<Activity>("/activity");
+      const newest = [activity?.prs, activity?.issues, activity?.comments]
+        .map((b) => b?.recent?.[0]?.at)
+        .filter((at): at is string => !!at)
+        .sort()
+        .at(-1);
+      if (!newest) return false;
+      const ago = relativeTime(newest);
       if (!ago) return false;
       paint(el, "idle", `last tended ${ago}`);
       return true;

--- a/site/src/components/Stats.astro
+++ b/site/src/components/Stats.astro
@@ -1,7 +1,7 @@
 ---
-// Stat strip — runtime-fetched from api.tend-src.com/stats.
-// Hidden until the fetch returns non-zero values, so a cold deploy with
-// empty data doesn't render a row of zeros.
+// Stat strip — runtime-fetched from api.tend-src.com/activity (the bucket
+// counts). Hidden until the fetch returns non-zero values, so a cold deploy
+// with empty data doesn't render a row of zeros.
 ---
 
 <section id="stats" class="stats" hidden>
@@ -11,24 +11,26 @@
 <script>
   import { liveData } from "../lib/api";
 
-  interface Stats {
-    reviews_total: number;
-    reviews_this_week: number;
-    ci_fixes_total: number;
-    ci_fixes_this_week: number;
-    triage_comments_total: number;
+  interface Bucket {
+    count: number;
+    count_this_week: number;
+  }
+  interface Activity {
+    prs: Bucket;
+    issues: Bucket;
+    comments: Bucket;
   }
 
   function format(n: number): string {
     return n.toLocaleString();
   }
 
-  liveData<Stats>("/stats", "stats", (data) => {
+  liveData<Activity>("/activity", "stats", (data) => {
     if (!data) return false;
     const cells = [
-      { n: data.reviews_total, week: data.reviews_this_week, label: "reviews" },
-      { n: data.ci_fixes_total, week: data.ci_fixes_this_week, label: "ci fixes" },
-      { n: data.triage_comments_total, week: null, label: "triage notes" },
+      { n: data.prs?.count ?? 0, week: data.prs?.count_this_week ?? 0, label: "PRs" },
+      { n: data.comments?.count ?? 0, week: data.comments?.count_this_week ?? 0, label: "comments" },
+      { n: data.issues?.count ?? 0, week: data.issues?.count_this_week ?? 0, label: "issues" },
     ];
     if (cells.every((c) => !c.n)) return false; // all zero — hide entirely
 
@@ -48,7 +50,7 @@
 
       div.append(num, label);
 
-      if (cell.week !== null && cell.week > 0) {
+      if (cell.week > 0) {
         const week = document.createElement("div");
         week.className = "stat-week";
         week.textContent = `+${format(cell.week)} this week`;

--- a/worker/README.md
+++ b/worker/README.md
@@ -1,14 +1,15 @@
 # tend-website Worker
 
-Cloudflare Worker that serves all three data streams the tend marketing site
-renders — currently-tending, activity, and stats — each at its own route with
-its own edge TTL. See [`../docs/website-data.md`](../docs/website-data.md) for
-the route table, shapes, and the rate-limit reasoning.
+Cloudflare Worker that serves the data the tend marketing site renders —
+`/currently-tending` (in-progress tend-* runs) and `/activity` (recent PRs /
+issues / comments + lifetime counts) — each at its own route with its own edge
+TTL. See [`../docs/website-data.md`](../docs/website-data.md) for the route
+table, shapes, and the rate-limit reasoning.
 
 ## Endpoint
 
 ```
-GET https://api.tend-src.com/{currently-tending|activity|stats}
+GET https://api.tend-src.com/{currently-tending|activity}
 ```
 
 Example (`/currently-tending`) returns:

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,22 +1,21 @@
 // Cloudflare Worker that serves the tend website's live data streams.
 //
-// Three routes, all CORS-enabled JSON, each with its own edge-cache TTL
+// Two routes, both CORS-enabled JSON, each with its own edge-cache TTL
 // matched to the freshness budget:
 //
 //   /currently-tending   30 s   in-progress tend-* workflow runs
-//   /activity            5 min  recent things tend has done (PRs, reviews,
-//                               comments, pushes, issue closes, dep approvals)
-//   /stats               1 h    lifetime + this-week counters
+//   /activity            5 min  recent PRs / issues / comments + lifetime
+//                               counts, per primitive bucket
 //
-// All three read the consumer list (`consumers.json`) from the repo, KV-
-// cached for an hour, and fan out to GitHub. The edge cache coalesces
-// concurrent misses — origin load is bounded by TTL, not viewer count.
+// Both read the consumer list (`consumers.json`) from the repo, KV-cached
+// for an hour, and fan out to GitHub. The edge cache coalesces concurrent
+// misses — origin load is bounded by TTL, not viewer count.
 //
-// `/activity` is built from each bot's public event timeline
-// (`GET /users/<bot>/events/public`) — one cheap REST call per bot, already
-// discriminated by event type — plus one Search query per bot for merged
-// PRs (the one "tend did this" milestone the bot's own event stream can't
-// see, since the merge is usually performed by a human).
+// `/activity` is one Search query per bucket per bot (`sort=updated`): the
+// page yields both the recent items and the lifetime `total_count`; "this
+// week" is counted off the page, so it saturates around one page (~100) per
+// bot per bucket — fine for a headline number. The fanout is 3·N concurrent
+// Search requests, under the 30/min cap up to ~10 bots.
 //
 // See docs/website-data.md for architecture and the rate-limit reasoning
 // behind the TTLs.
@@ -55,77 +54,30 @@ interface CurrentlyTendingResponse {
   currently_tending: CurrentlyTendingEntry[];
 }
 
-type ActivityKind =
-  | "pr-opened" // tend opened a PR (CI fix, maintenance, workflow self-edit, …)
-  | "pr-merged" // a tend-authored PR shipped
-  | "pr-reviewed" // tend approved / requested changes on a PR
-  | "pr-commented" // tend left comments on a PR (review bodies, inline, conversation)
-  | "pr-commits" // tend pushed commits to a PR branch (review fixes, conflict resolution)
-  | "issue-commented" // tend commented on an issue (triage, mention answer)
-  | "issue-closed" // tend closed a resolved issue
-  | "dep-approved"; // tend cleared a dependency bump (dependabot/renovate PR)
+// /activity: one bucket per primitive Search query, named off the query.
+type ActivityBucketName = "prs" | "issues" | "comments";
 
-type ReviewVerdict = "approved" | "changes_requested";
-type PrCategory = "ci-fix" | "issue-fix" | "workflow" | "maintenance" | "other";
-
-interface ActivityDetail {
-  count?: number; // pr-commented / issue-commented / pr-commits — how many
-  verdict?: ReviewVerdict; // pr-reviewed
-  category?: PrCategory; // pr-opened — inferred from the head-branch name
-}
-
-interface ActivityEvent {
-  repo: string;
-  kind: ActivityKind;
+interface RecentItem {
+  repo: string; // "owner/name"
   title: string;
   url: string;
-  at: string; // ISO; for collapsed kinds, the most recent constituent event
-  detail?: ActivityDetail;
+  at: string; // issue/PR updated_at, ISO
 }
 
-interface ActivityResponse {
+interface ActivityBucket {
+  count: number; // lifetime — Search total_count, summed across bots
+  count_this_week: number; // last 7 days; saturates ~one page per bot per bucket
+  recent: RecentItem[]; // newest-first, merged across bots
+}
+
+type ActivityResponse = {
   generated_at: string;
-  events: ActivityEvent[];
-}
-
-// Slim view of a `GET /users/<bot>/events` item — every field optional
-// because the payload shape varies by `type` and the events API serves
-// trimmed-down webhook payloads.
-interface GitHubEvent {
-  type?: string;
-  created_at?: string;
-  repo?: { name?: string }; // "owner/name"
-  payload?: {
-    action?: string;
-    pull_request?: {
-      html_url?: string;
-      title?: string;
-      user?: { login?: string };
-      head?: { ref?: string };
-    };
-    issue?: { html_url?: string; title?: string; pull_request?: unknown };
-    review?: { state?: string };
-    ref?: string;
-    head?: string;
-    size?: number;
-    commits?: Array<{ sha?: string; message?: string }>;
-  };
-}
-
-interface StatsResponse {
-  generated_at: string;
-  reviews_total: number;
-  reviews_this_week: number;
-  ci_fixes_total: number;
-  ci_fixes_this_week: number;
-  triage_comments_total: number;
-}
+} & Record<ActivityBucketName, ActivityBucket>;
 
 interface SearchItem {
   html_url: string;
   title: string;
   updated_at: string;
-  closed_at?: string | null; // present (≈ merge time) for merged PRs
   repository_url: string;
 }
 
@@ -142,23 +94,27 @@ const WORKFLOW_PREFIX = "tend-";
 // repo, then we filter to tend-* client-side. 30 (GitHub's default) is
 // cheap and avoids tend runs being pushed off by busier non-tend traffic.
 const PER_PAGE_RUNS = 30;
-// /activity: cap the merged feed, pull one page (~100) of each bot's event
-// timeline, and the ~10 most-recent merged PRs per bot. Together that covers
-// roughly a week at current volume; the events API only serves the last 30
-// days regardless, so the feed is inherently bounded.
-const ACTIVITY_LIMIT = 40;
-const EVENTS_PER_PAGE = 100;
-const MERGED_PR_LIMIT = 10;
-const DEPENDENCY_BOTS = new Set(["dependabot[bot]", "renovate[bot]"]);
+// /activity: one Search page per bucket per bot. 100 is Search's max page
+// and one request; we keep the newest RECENT_PER_BUCKET for the feed and
+// count the rest of the page towards "this week".
+const SEARCH_PAGE = 100;
+const RECENT_PER_BUCKET = 10;
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 const GITHUB_API = "https://api.github.com";
 const USER_AGENT = "tend-website-worker";
+
+// `q` for each /activity bucket — "the bot …":
+const BUCKET_QUERIES: Record<ActivityBucketName, (bot: string) => string> = {
+  prs: (b) => `author:${b} is:pr`, // …opened these PRs
+  issues: (b) => `author:${b} is:issue`, // …opened these issues
+  comments: (b) => `commenter:${b} -author:${b}`, // …chimed in on these PRs/issues
+};
 
 // Per-route TTLs. The fallback TTL (used when refresh throws) is shorter
 // so a transient outage clears quickly.
 const TTL = {
   "currently-tending": { ok: 30, fallback: 5 },
   activity: { ok: 300, fallback: 30 },
-  stats: { ok: 3600, fallback: 60 },
 } as const;
 
 // owner/name — alphanumerics + `_-.`, no leading `.`/`-`, no `..` anywhere,
@@ -202,14 +158,7 @@ export default {
           cacheKeyPath: "/activity",
           ttl: TTL.activity,
           refresh: () => refreshActivity(env),
-          empty: () => ({ generated_at: nowIso(), events: [] }),
-        });
-      case "/stats":
-        return serveCached(url, env, ctx, {
-          cacheKeyPath: "/stats",
-          ttl: TTL.stats,
-          refresh: () => refreshStats(env),
-          empty: () => emptyStats(),
+          empty: emptyActivity,
         });
       default:
         return withCors(new Response("Not Found", { status: 404 }), env);
@@ -326,267 +275,51 @@ async function fetchRepoRuns(
 // /activity
 
 async function refreshActivity(env: Env): Promise<ActivityResponse> {
-  const consumers = await getConsumers(env);
-  const bots = botNames(consumers);
-  if (bots.length === 0) {
-    return { generated_at: nowIso(), events: [] };
-  }
-  const consumerRepos = new Set(consumers.map((c) => c.repo));
+  const out = emptyActivity();
+  const bots = botNames(await getConsumers(env));
+  if (bots.length === 0) return out;
+  const weekAgoMs = Date.now() - WEEK_MS;
 
-  // Per bot: one page of its public event timeline (cheap REST), plus one
-  // Search for its recently-merged PRs (the merge event's actor is usually a
-  // human, so it isn't in the bot's own stream).
-  const perBot = await Promise.all(
-    bots.map(async (bot) => {
-      const [events, merged] = await Promise.all([
-        fetchBotEvents(bot, env.GITHUB_TOKEN),
-        searchIssues(
-          `author:${bot} is:pr is:merged`,
-          env.GITHUB_TOKEN,
-          MERGED_PR_LIMIT,
-        ),
-      ]);
-      return { events, merged };
+  await Promise.all(
+    (Object.keys(BUCKET_QUERIES) as ActivityBucketName[]).map(async (name) => {
+      const pages = await Promise.all(
+        bots.map((b) => searchIssues(BUCKET_QUERIES[name](b), env.GITHUB_TOKEN)),
+      );
+      const items: SearchItem[] = [];
+      let count = 0;
+      let countThisWeek = 0;
+      for (const page of pages) {
+        count += page.total_count ?? 0;
+        for (const it of page.items ?? []) {
+          items.push(it);
+          if (Date.parse(it.updated_at) >= weekAgoMs) countThisWeek++;
+        }
+      }
+      items.sort((a, b) =>
+        a.updated_at < b.updated_at ? 1 : a.updated_at > b.updated_at ? -1 : 0,
+      );
+      out[name] = {
+        count,
+        count_this_week: countThisWeek,
+        recent: items.slice(0, RECENT_PER_BUCKET).map((it) => ({
+          repo: repoFromApiUrl(it.repository_url),
+          title: it.title,
+          url: it.html_url,
+          at: it.updated_at,
+        })),
+      };
     }),
   );
-
-  const fromEvents = eventsToActivity(
-    perBot.flatMap((b) => b.events),
-    consumerRepos,
-  );
-  const fromMerges: ActivityEvent[] = perBot
-    .flatMap((b) => b.merged)
-    .map((item) => ({
-      repo: repoFromApiUrl(item.repository_url),
-      kind: "pr-merged" as const,
-      title: item.title,
-      url: item.html_url,
-      at: item.closed_at ?? item.updated_at, // closed_at ≈ merge time
-    }))
-    .filter((e) => consumerRepos.has(e.repo));
-
-  // Dedup by kind+url (a PR legitimately recurs across kinds — opened, then
-  // commented, then merged — those stay; only same-kind dups collapse).
-  const byKey = new Map<string, ActivityEvent>();
-  for (const e of [...fromEvents, ...fromMerges]) {
-    const key = `${e.kind}|${e.url}`;
-    const prev = byKey.get(key);
-    if (!prev || e.at > prev.at) byKey.set(key, e);
-  }
-  const events = [...byKey.values()]
-    .sort((a, b) => (a.at < b.at ? 1 : a.at > b.at ? -1 : 0))
-    .slice(0, ACTIVITY_LIMIT);
-  return { generated_at: nowIso(), events };
-}
-
-async function fetchBotEvents(
-  bot: string,
-  token: string,
-): Promise<GitHubEvent[]> {
-  if (!isValidBotName(bot)) {
-    console.error(`skipping malformed bot: ${bot}`);
-    return [];
-  }
-  const url = `${GITHUB_API}/users/${bot}/events/public?per_page=${EVENTS_PER_PAGE}`;
-  const resp = await fetchWithTimeout(url, { headers: githubHeaders(token) });
-  if (!resp.ok) {
-    if (resp.status === 401 || resp.status === 403) {
-      throw new Error(`events auth failure for ${bot}: ${resp.status}`);
-    }
-    console.error(`events fetch skipped for ${bot}: ${resp.status}`);
-    return [];
-  }
-  const data = await resp.json();
-  return Array.isArray(data) ? (data as GitHubEvent[]) : [];
-}
-
-// Map a flat list of GitHub events (any bots, any repos) to activity rows,
-// keeping only events in consumer repos. Comments and pushes to the same
-// PR/branch collapse into one row with a count.
-function eventsToActivity(
-  events: GitHubEvent[],
-  consumerRepos: Set<string>,
-): ActivityEvent[] {
-  const out: ActivityEvent[] = [];
-  // Collapse keys: PR url for comments, repo@branch for pushes.
-  const prComments = new Map<string, ActivityEvent>();
-  const issueComments = new Map<string, ActivityEvent>();
-  const branchPushes = new Map<string, ActivityEvent>();
-
-  const bump = (
-    bucket: Map<string, ActivityEvent>,
-    key: string,
-    seed: ActivityEvent,
-    add = 1,
-  ) => {
-    const existing = bucket.get(key);
-    if (!existing) {
-      seed.detail = { ...seed.detail, count: add };
-      bucket.set(key, seed);
-      return;
-    }
-    existing.detail = { ...existing.detail, count: (existing.detail?.count ?? 0) + add };
-    if (seed.at > existing.at) {
-      existing.at = seed.at;
-      existing.url = seed.url;
-      existing.title = seed.title;
-    }
-  };
-
-  for (const e of events) {
-    const repo = e.repo?.name;
-    const at = e.created_at;
-    const p = e.payload;
-    if (!repo || !at || !p || !consumerRepos.has(repo)) continue;
-
-    switch (e.type) {
-      case "PullRequestEvent": {
-        const pr = p.pull_request;
-        if (p.action !== "opened" || !pr?.html_url) break;
-        out.push({
-          repo,
-          kind: "pr-opened",
-          title: pr.title ?? "",
-          url: pr.html_url,
-          at,
-          detail: { category: prCategory(pr.head?.ref) },
-        });
-        break;
-      }
-      case "PullRequestReviewEvent": {
-        const pr = p.pull_request;
-        if (p.action !== "created" || !pr?.html_url) break;
-        const state = p.review?.state;
-        if (
-          state === "approved" &&
-          pr.user?.login &&
-          DEPENDENCY_BOTS.has(pr.user.login)
-        ) {
-          out.push({
-            repo,
-            kind: "dep-approved",
-            title: pr.title ?? "",
-            url: pr.html_url,
-            at,
-          });
-          break;
-        }
-        if (state === "approved" || state === "changes_requested") {
-          out.push({
-            repo,
-            kind: "pr-reviewed",
-            title: pr.title ?? "",
-            url: pr.html_url,
-            at,
-            detail: { verdict: state },
-          });
-        } else {
-          bump(prComments, pr.html_url, {
-            repo,
-            kind: "pr-commented",
-            title: pr.title ?? "",
-            url: pr.html_url,
-            at,
-          });
-        }
-        break;
-      }
-      case "PullRequestReviewCommentEvent": {
-        const pr = p.pull_request;
-        if (p.action !== "created" || !pr?.html_url) break;
-        bump(prComments, pr.html_url, {
-          repo,
-          kind: "pr-commented",
-          title: pr.title ?? "",
-          url: pr.html_url,
-          at,
-        });
-        break;
-      }
-      case "IssueCommentEvent": {
-        const issue = p.issue;
-        if (p.action !== "created" || !issue?.html_url) break;
-        if (issue.pull_request) {
-          bump(prComments, issue.html_url, {
-            repo,
-            kind: "pr-commented",
-            title: issue.title ?? "",
-            url: issue.html_url,
-            at,
-          });
-        } else {
-          bump(issueComments, issue.html_url, {
-            repo,
-            kind: "issue-commented",
-            title: issue.title ?? "",
-            url: issue.html_url,
-            at,
-          });
-        }
-        break;
-      }
-      case "IssuesEvent": {
-        const issue = p.issue;
-        if (p.action !== "closed" || !issue?.html_url) break;
-        out.push({
-          repo,
-          kind: "issue-closed",
-          title: issue.title ?? "",
-          url: issue.html_url,
-          at,
-        });
-        break;
-      }
-      case "PushEvent": {
-        const branch = branchFromRef(p.ref);
-        const size = p.size ?? 1;
-        if (!branch || size < 1) break; // default branch, tag, or no-op push
-        const head = p.head;
-        const url = head
-          ? `https://github.com/${repo}/commit/${head}`
-          : `https://github.com/${repo}/commits/${branch}`;
-        const headCommit =
-          (p.commits ?? []).find((c) => c.sha === head) ??
-          (p.commits ?? []).at(-1);
-        const title = firstLine(headCommit?.message) || `pushed to ${branch}`;
-        bump(
-          branchPushes,
-          `${repo}|${branch}`,
-          { repo, kind: "pr-commits", title, url, at },
-          size,
-        );
-        break;
-      }
-    }
-  }
-
-  for (const m of [prComments, issueComments, branchPushes]) {
-    out.push(...m.values());
-  }
   return out;
 }
 
-// Best-effort: tend's branch conventions are fix/ci-<run> (ci-fix),
-// fix/issue-<n> and repro/issue-<n> (issue-fix), tend/update-workflows
-// (workflow self-edit), and tend/<task> (other maintenance).
-function prCategory(ref?: string): PrCategory {
-  if (!ref) return "other";
-  if (ref.startsWith("fix/ci")) return "ci-fix";
-  if (ref.startsWith("fix/") || ref.startsWith("repro/")) return "issue-fix";
-  if (ref.includes("update-workflows") || ref.includes("workflow")) return "workflow";
-  if (ref.startsWith("tend/")) return "maintenance";
-  return "other";
-}
-
-function branchFromRef(ref?: string): string | null {
-  if (!ref?.startsWith("refs/heads/")) return null;
-  const branch = ref.slice("refs/heads/".length);
-  if (!branch || branch === "main" || branch === "master") return null;
-  return branch;
-}
-
-function firstLine(s?: string): string {
-  return (s?.split("\n", 1)[0] ?? "").trim();
+function emptyActivity(): ActivityResponse {
+  return {
+    generated_at: nowIso(),
+    prs: { count: 0, count_this_week: 0, recent: [] },
+    issues: { count: 0, count_this_week: 0, recent: [] },
+    comments: { count: 0, count_this_week: 0, recent: [] },
+  };
 }
 
 function repoFromApiUrl(repositoryUrl: string): string {
@@ -596,86 +329,18 @@ function repoFromApiUrl(repositoryUrl: string): string {
 }
 
 // ---------------------------------------------------------------------------
-// /stats
-
-async function refreshStats(env: Env): Promise<StatsResponse> {
-  const bots = botNames(await getConsumers(env));
-  if (bots.length === 0) {
-    return emptyStats();
-  }
-  const weekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
-    .toISOString()
-    .slice(0, 10);
-
-  // Each stat is summed across bots via Search's `total_count` (no
-  // pagination needed). Five stats × N bots queries per refresh — cheap
-  // because the TTL is an hour.
-  const counters: Record<keyof Omit<StatsResponse, "generated_at">, (b: string) => string> = {
-    reviews_total: (b) => `commenter:${b} is:pr -author:${b}`,
-    reviews_this_week: (b) => `commenter:${b} is:pr -author:${b} updated:>=${weekAgo}`,
-    ci_fixes_total: (b) => `author:${b} is:pr`,
-    ci_fixes_this_week: (b) => `author:${b} is:pr updated:>=${weekAgo}`,
-    triage_comments_total: (b) => `commenter:${b} is:issue`,
-  };
-
-  const keys = Object.keys(counters) as Array<keyof typeof counters>;
-  const totals = await Promise.all(
-    keys.map(async (key) => {
-      const perBot = await Promise.all(
-        bots.map((b) => searchCount(counters[key](b), env.GITHUB_TOKEN)),
-      );
-      return [key, perBot.reduce((a, b) => a + b, 0)] as const;
-    }),
-  );
-
-  const out: StatsResponse = { generated_at: nowIso(), ...emptyCounts() };
-  for (const [k, v] of totals) {
-    out[k] = v;
-  }
-  return out;
-}
-
-function emptyStats(): StatsResponse {
-  return { generated_at: nowIso(), ...emptyCounts() };
-}
-
-function emptyCounts() {
-  return {
-    reviews_total: 0,
-    reviews_this_week: 0,
-    ci_fixes_total: 0,
-    ci_fixes_this_week: 0,
-    triage_comments_total: 0,
-  };
-}
-
-// ---------------------------------------------------------------------------
 // Search API
 
-async function searchIssues(
-  query: string,
-  token: string,
-  perPage: number,
-): Promise<SearchItem[]> {
-  const data = await searchRaw(query, token, perPage);
-  return data.items ?? [];
-}
-
-async function searchCount(query: string, token: string): Promise<number> {
-  const data = await searchRaw(query, token, 1);
-  return data.total_count ?? 0;
-}
-
-async function searchRaw(
-  query: string,
-  token: string,
-  perPage: number,
-): Promise<SearchResponse> {
-  const params = new URLSearchParams({ q: query, per_page: String(perPage) });
-  if (perPage > 1) {
-    params.set("sort", "updated");
-    params.set("order", "desc");
-  }
+// One Search page, newest-first — the page yields both `items` (recent) and
+// `total_count` (lifetime). 401/403 throws (sinks the refresh → short fallback
+// TTL); 422/429/other degrade to `{}` so one bad bucket doesn't sink the rest.
+async function searchIssues(query: string, token: string): Promise<SearchResponse> {
+  const params = new URLSearchParams({
+    q: query,
+    per_page: String(SEARCH_PAGE),
+    sort: "updated",
+    order: "desc",
+  });
   const resp = await fetchWithTimeout(`${GITHUB_API}/search/issues?${params}`, {
     headers: githubHeaders(token),
   });
@@ -683,9 +348,6 @@ async function searchRaw(
     if (resp.status === 401 || resp.status === 403) {
       throw new Error(`search auth failure: ${resp.status}`);
     }
-    // Other failures (incl. 422 — malformed query, 429 — rate-limited)
-    // degrade to an empty result for this query so a single bad bot name
-    // doesn't sink the whole refresh.
     console.error(`search failed (${resp.status}): ${query}`);
     return {};
   }
@@ -791,11 +453,7 @@ function corsPreflight(env: Env): Response {
 export const __test = {
   refreshCurrentlyTending,
   refreshActivity,
-  refreshStats,
   fetchRepoRuns,
-  fetchBotEvents,
-  eventsToActivity,
-  prCategory,
   getConsumers,
   isConsumerArray,
   isValidRepo,

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -4,12 +4,19 @@
 // matched to the freshness budget:
 //
 //   /currently-tending   30 s   in-progress tend-* workflow runs
-//   /activity            5 min  recent PR reviews / triage / CI-fix events
+//   /activity            5 min  recent things tend has done (PRs, reviews,
+//                               comments, pushes, issue closes, dep approvals)
 //   /stats               1 h    lifetime + this-week counters
 //
 // All three read the consumer list (`consumers.json`) from the repo, KV-
 // cached for an hour, and fan out to GitHub. The edge cache coalesces
 // concurrent misses — origin load is bounded by TTL, not viewer count.
+//
+// `/activity` is built from each bot's public event timeline
+// (`GET /users/<bot>/events/public`) — one cheap REST call per bot, already
+// discriminated by event type — plus one Search query per bot for merged
+// PRs (the one "tend did this" milestone the bot's own event stream can't
+// see, since the merge is usually performed by a human).
 //
 // See docs/website-data.md for architecture and the rate-limit reasoning
 // behind the TTLs.
@@ -48,19 +55,61 @@ interface CurrentlyTendingResponse {
   currently_tending: CurrentlyTendingEntry[];
 }
 
-type ActivityKind = "review" | "triage" | "ci-fix";
+type ActivityKind =
+  | "pr-opened" // tend opened a PR (CI fix, maintenance, workflow self-edit, …)
+  | "pr-merged" // a tend-authored PR shipped
+  | "pr-reviewed" // tend approved / requested changes on a PR
+  | "pr-commented" // tend left comments on a PR (review bodies, inline, conversation)
+  | "pr-commits" // tend pushed commits to a PR branch (review fixes, conflict resolution)
+  | "issue-commented" // tend commented on an issue (triage, mention answer)
+  | "issue-closed" // tend closed a resolved issue
+  | "dep-approved"; // tend cleared a dependency bump (dependabot/renovate PR)
+
+type ReviewVerdict = "approved" | "changes_requested";
+type PrCategory = "ci-fix" | "issue-fix" | "workflow" | "maintenance" | "other";
+
+interface ActivityDetail {
+  count?: number; // pr-commented / issue-commented / pr-commits — how many
+  verdict?: ReviewVerdict; // pr-reviewed
+  category?: PrCategory; // pr-opened — inferred from the head-branch name
+}
 
 interface ActivityEvent {
   repo: string;
   kind: ActivityKind;
   title: string;
   url: string;
-  at: string;
+  at: string; // ISO; for collapsed kinds, the most recent constituent event
+  detail?: ActivityDetail;
 }
 
 interface ActivityResponse {
   generated_at: string;
   events: ActivityEvent[];
+}
+
+// Slim view of a `GET /users/<bot>/events` item — every field optional
+// because the payload shape varies by `type` and the events API serves
+// trimmed-down webhook payloads.
+interface GitHubEvent {
+  type?: string;
+  created_at?: string;
+  repo?: { name?: string }; // "owner/name"
+  payload?: {
+    action?: string;
+    pull_request?: {
+      html_url?: string;
+      title?: string;
+      user?: { login?: string };
+      head?: { ref?: string };
+    };
+    issue?: { html_url?: string; title?: string; pull_request?: unknown };
+    review?: { state?: string };
+    ref?: string;
+    head?: string;
+    size?: number;
+    commits?: Array<{ sha?: string; message?: string }>;
+  };
 }
 
 interface StatsResponse {
@@ -76,6 +125,7 @@ interface SearchItem {
   html_url: string;
   title: string;
   updated_at: string;
+  closed_at?: string | null; // present (≈ merge time) for merged PRs
   repository_url: string;
 }
 
@@ -92,7 +142,14 @@ const WORKFLOW_PREFIX = "tend-";
 // repo, then we filter to tend-* client-side. 30 (GitHub's default) is
 // cheap and avoids tend runs being pushed off by busier non-tend traffic.
 const PER_PAGE_RUNS = 30;
-const ACTIVITY_LIMIT = 10;
+// /activity: cap the merged feed, pull one page (~100) of each bot's event
+// timeline, and the ~10 most-recent merged PRs per bot. Together that covers
+// roughly a week at current volume; the events API only serves the last 30
+// days regardless, so the feed is inherently bounded.
+const ACTIVITY_LIMIT = 40;
+const EVENTS_PER_PAGE = 100;
+const MERGED_PR_LIMIT = 10;
+const DEPENDENCY_BOTS = new Set(["dependabot[bot]", "renovate[bot]"]);
 const GITHUB_API = "https://api.github.com";
 const USER_AGENT = "tend-website-worker";
 
@@ -269,47 +326,267 @@ async function fetchRepoRuns(
 // /activity
 
 async function refreshActivity(env: Env): Promise<ActivityResponse> {
-  const bots = botNames(await getConsumers(env));
+  const consumers = await getConsumers(env);
+  const bots = botNames(consumers);
   if (bots.length === 0) {
     return { generated_at: nowIso(), events: [] };
   }
-  // 3 queries × N bots, deduped by URL. First kind seen wins (matches the
-  // pre-Worker Python fetcher's behavior so the UI doesn't shift on
-  // cutover.) Order of kinds: ci-fix → review → triage.
-  const kinds: Array<{ kind: ActivityKind; q: (bot: string) => string }> = [
-    { kind: "ci-fix", q: (b) => `author:${b} is:pr` },
-    { kind: "review", q: (b) => `commenter:${b} is:pr -author:${b}` },
-    { kind: "triage", q: (b) => `commenter:${b} is:issue` },
-  ];
+  const consumerRepos = new Set(consumers.map((c) => c.repo));
 
-  type Batch = { kind: ActivityKind; items: SearchItem[] };
-  const batches: Batch[] = await Promise.all(
-    kinds.flatMap(({ kind, q }) =>
-      bots.map(async (bot) => ({
-        kind,
-        items: await searchIssues(q(bot), env.GITHUB_TOKEN, ACTIVITY_LIMIT),
-      })),
-    ),
+  // Per bot: one page of its public event timeline (cheap REST), plus one
+  // Search for its recently-merged PRs (the merge event's actor is usually a
+  // human, so it isn't in the bot's own stream).
+  const perBot = await Promise.all(
+    bots.map(async (bot) => {
+      const [events, merged] = await Promise.all([
+        fetchBotEvents(bot, env.GITHUB_TOKEN),
+        searchIssues(
+          `author:${bot} is:pr is:merged`,
+          env.GITHUB_TOKEN,
+          MERGED_PR_LIMIT,
+        ),
+      ]);
+      return { events, merged };
+    }),
   );
 
-  // Walk batches in declared order to preserve "first kind seen wins".
-  const seen = new Set<string>();
-  const events: ActivityEvent[] = [];
-  for (const { kind, items } of batches) {
-    for (const item of items) {
-      if (seen.has(item.html_url)) continue;
-      seen.add(item.html_url);
-      events.push({
-        repo: repoFromApiUrl(item.repository_url),
-        kind,
-        title: item.title,
-        url: item.html_url,
-        at: item.updated_at,
-      });
+  const fromEvents = eventsToActivity(
+    perBot.flatMap((b) => b.events),
+    consumerRepos,
+  );
+  const fromMerges: ActivityEvent[] = perBot
+    .flatMap((b) => b.merged)
+    .map((item) => ({
+      repo: repoFromApiUrl(item.repository_url),
+      kind: "pr-merged" as const,
+      title: item.title,
+      url: item.html_url,
+      at: item.closed_at ?? item.updated_at, // closed_at ≈ merge time
+    }))
+    .filter((e) => consumerRepos.has(e.repo));
+
+  // Dedup by kind+url (a PR legitimately recurs across kinds — opened, then
+  // commented, then merged — those stay; only same-kind dups collapse).
+  const byKey = new Map<string, ActivityEvent>();
+  for (const e of [...fromEvents, ...fromMerges]) {
+    const key = `${e.kind}|${e.url}`;
+    const prev = byKey.get(key);
+    if (!prev || e.at > prev.at) byKey.set(key, e);
+  }
+  const events = [...byKey.values()]
+    .sort((a, b) => (a.at < b.at ? 1 : a.at > b.at ? -1 : 0))
+    .slice(0, ACTIVITY_LIMIT);
+  return { generated_at: nowIso(), events };
+}
+
+async function fetchBotEvents(
+  bot: string,
+  token: string,
+): Promise<GitHubEvent[]> {
+  if (!isValidBotName(bot)) {
+    console.error(`skipping malformed bot: ${bot}`);
+    return [];
+  }
+  const url = `${GITHUB_API}/users/${bot}/events/public?per_page=${EVENTS_PER_PAGE}`;
+  const resp = await fetchWithTimeout(url, { headers: githubHeaders(token) });
+  if (!resp.ok) {
+    if (resp.status === 401 || resp.status === 403) {
+      throw new Error(`events auth failure for ${bot}: ${resp.status}`);
+    }
+    console.error(`events fetch skipped for ${bot}: ${resp.status}`);
+    return [];
+  }
+  const data = await resp.json();
+  return Array.isArray(data) ? (data as GitHubEvent[]) : [];
+}
+
+// Map a flat list of GitHub events (any bots, any repos) to activity rows,
+// keeping only events in consumer repos. Comments and pushes to the same
+// PR/branch collapse into one row with a count.
+function eventsToActivity(
+  events: GitHubEvent[],
+  consumerRepos: Set<string>,
+): ActivityEvent[] {
+  const out: ActivityEvent[] = [];
+  // Collapse keys: PR url for comments, repo@branch for pushes.
+  const prComments = new Map<string, ActivityEvent>();
+  const issueComments = new Map<string, ActivityEvent>();
+  const branchPushes = new Map<string, ActivityEvent>();
+
+  const bump = (
+    bucket: Map<string, ActivityEvent>,
+    key: string,
+    seed: ActivityEvent,
+    add = 1,
+  ) => {
+    const existing = bucket.get(key);
+    if (!existing) {
+      seed.detail = { ...seed.detail, count: add };
+      bucket.set(key, seed);
+      return;
+    }
+    existing.detail = { ...existing.detail, count: (existing.detail?.count ?? 0) + add };
+    if (seed.at > existing.at) {
+      existing.at = seed.at;
+      existing.url = seed.url;
+      existing.title = seed.title;
+    }
+  };
+
+  for (const e of events) {
+    const repo = e.repo?.name;
+    const at = e.created_at;
+    const p = e.payload;
+    if (!repo || !at || !p || !consumerRepos.has(repo)) continue;
+
+    switch (e.type) {
+      case "PullRequestEvent": {
+        const pr = p.pull_request;
+        if (p.action !== "opened" || !pr?.html_url) break;
+        out.push({
+          repo,
+          kind: "pr-opened",
+          title: pr.title ?? "",
+          url: pr.html_url,
+          at,
+          detail: { category: prCategory(pr.head?.ref) },
+        });
+        break;
+      }
+      case "PullRequestReviewEvent": {
+        const pr = p.pull_request;
+        if (p.action !== "created" || !pr?.html_url) break;
+        const state = p.review?.state;
+        if (
+          state === "approved" &&
+          pr.user?.login &&
+          DEPENDENCY_BOTS.has(pr.user.login)
+        ) {
+          out.push({
+            repo,
+            kind: "dep-approved",
+            title: pr.title ?? "",
+            url: pr.html_url,
+            at,
+          });
+          break;
+        }
+        if (state === "approved" || state === "changes_requested") {
+          out.push({
+            repo,
+            kind: "pr-reviewed",
+            title: pr.title ?? "",
+            url: pr.html_url,
+            at,
+            detail: { verdict: state },
+          });
+        } else {
+          bump(prComments, pr.html_url, {
+            repo,
+            kind: "pr-commented",
+            title: pr.title ?? "",
+            url: pr.html_url,
+            at,
+          });
+        }
+        break;
+      }
+      case "PullRequestReviewCommentEvent": {
+        const pr = p.pull_request;
+        if (p.action !== "created" || !pr?.html_url) break;
+        bump(prComments, pr.html_url, {
+          repo,
+          kind: "pr-commented",
+          title: pr.title ?? "",
+          url: pr.html_url,
+          at,
+        });
+        break;
+      }
+      case "IssueCommentEvent": {
+        const issue = p.issue;
+        if (p.action !== "created" || !issue?.html_url) break;
+        if (issue.pull_request) {
+          bump(prComments, issue.html_url, {
+            repo,
+            kind: "pr-commented",
+            title: issue.title ?? "",
+            url: issue.html_url,
+            at,
+          });
+        } else {
+          bump(issueComments, issue.html_url, {
+            repo,
+            kind: "issue-commented",
+            title: issue.title ?? "",
+            url: issue.html_url,
+            at,
+          });
+        }
+        break;
+      }
+      case "IssuesEvent": {
+        const issue = p.issue;
+        if (p.action !== "closed" || !issue?.html_url) break;
+        out.push({
+          repo,
+          kind: "issue-closed",
+          title: issue.title ?? "",
+          url: issue.html_url,
+          at,
+        });
+        break;
+      }
+      case "PushEvent": {
+        const branch = branchFromRef(p.ref);
+        const size = p.size ?? 1;
+        if (!branch || size < 1) break; // default branch, tag, or no-op push
+        const head = p.head;
+        const url = head
+          ? `https://github.com/${repo}/commit/${head}`
+          : `https://github.com/${repo}/commits/${branch}`;
+        const headCommit =
+          (p.commits ?? []).find((c) => c.sha === head) ??
+          (p.commits ?? []).at(-1);
+        const title = firstLine(headCommit?.message) || `pushed to ${branch}`;
+        bump(
+          branchPushes,
+          `${repo}|${branch}`,
+          { repo, kind: "pr-commits", title, url, at },
+          size,
+        );
+        break;
+      }
     }
   }
-  events.sort((a, b) => (a.at < b.at ? 1 : a.at > b.at ? -1 : 0));
-  return { generated_at: nowIso(), events: events.slice(0, ACTIVITY_LIMIT) };
+
+  for (const m of [prComments, issueComments, branchPushes]) {
+    out.push(...m.values());
+  }
+  return out;
+}
+
+// Best-effort: tend's branch conventions are fix/ci-<run> (ci-fix),
+// fix/issue-<n> and repro/issue-<n> (issue-fix), tend/update-workflows
+// (workflow self-edit), and tend/<task> (other maintenance).
+function prCategory(ref?: string): PrCategory {
+  if (!ref) return "other";
+  if (ref.startsWith("fix/ci")) return "ci-fix";
+  if (ref.startsWith("fix/") || ref.startsWith("repro/")) return "issue-fix";
+  if (ref.includes("update-workflows") || ref.includes("workflow")) return "workflow";
+  if (ref.startsWith("tend/")) return "maintenance";
+  return "other";
+}
+
+function branchFromRef(ref?: string): string | null {
+  if (!ref?.startsWith("refs/heads/")) return null;
+  const branch = ref.slice("refs/heads/".length);
+  if (!branch || branch === "main" || branch === "master") return null;
+  return branch;
+}
+
+function firstLine(s?: string): string {
+  return (s?.split("\n", 1)[0] ?? "").trim();
 }
 
 function repoFromApiUrl(repositoryUrl: string): string {
@@ -516,6 +793,9 @@ export const __test = {
   refreshActivity,
   refreshStats,
   fetchRepoRuns,
+  fetchBotEvents,
+  eventsToActivity,
+  prCategory,
   getConsumers,
   isConsumerArray,
   isValidRepo,

--- a/worker/test/worker.test.ts
+++ b/worker/test/worker.test.ts
@@ -159,17 +159,298 @@ describe("refreshCurrentlyTending", () => {
   });
 });
 
-describe("refreshActivity", () => {
-  it("merges across kinds + bots, dedupes by URL (first kind wins), caps and sorts", async () => {
+function byAtDesc(a: { at: string }, b: { at: string }) {
+  return a.at < b.at ? 1 : a.at > b.at ? -1 : 0;
+}
+
+describe("eventsToActivity", () => {
+  it("maps each event type, filters foreign repos, collapses comments and pushes", async () => {
     const { __test } = await import("../src/index");
-    // ci-fix for bot-a returns a PR; review for bot-b returns the SAME PR
-    // (bot-b commented on bot-a's CI-fix). Dedup must keep the ci-fix entry.
-    const dup = {
-      html_url: "https://github.com/o/r/pull/100",
-      title: "fix: x",
-      updated_at: "2026-05-09T12:00:00Z",
-      repository_url: "https://api.github.com/repos/o/r",
+    const repos = new Set(["o/r"]);
+    const ev = <P>(type: string, created_at: string, payload: P) => ({
+      type,
+      created_at,
+      repo: { name: "o/r" },
+      payload,
+    });
+    const out = __test
+      .eventsToActivity(
+        [
+          // foreign repo — dropped entirely
+          {
+            type: "PullRequestEvent",
+            created_at: "2026-05-10T00:00:00Z",
+            repo: { name: "someone/else" },
+            payload: {
+              action: "opened",
+              pull_request: { html_url: "https://github.com/someone/else/pull/1", title: "nope" },
+            },
+          },
+          ev("PullRequestEvent", "2026-05-10T09:00:00Z", {
+            action: "opened",
+            pull_request: {
+              html_url: "https://github.com/o/r/pull/10",
+              title: "fix: flaky test",
+              head: { ref: "fix/ci-12345" },
+            },
+          }),
+          ev("PullRequestReviewEvent", "2026-05-10T08:00:00Z", {
+            action: "created",
+            review: { state: "approved" },
+            pull_request: { html_url: "https://github.com/o/r/pull/11", title: "feat: x" },
+          }),
+          // dependabot PR review → dep-approved, not pr-reviewed
+          ev("PullRequestReviewEvent", "2026-05-10T07:30:00Z", {
+            action: "created",
+            review: { state: "approved" },
+            pull_request: {
+              html_url: "https://github.com/o/r/pull/12",
+              title: "Bump serde 1.0.1 to 1.0.2",
+              user: { login: "dependabot[bot]" },
+            },
+          }),
+          // a "commented" review + an inline comment + a conversation comment, all on #11 → collapse to count 3
+          ev("PullRequestReviewEvent", "2026-05-10T08:05:00Z", {
+            action: "created",
+            review: { state: "commented" },
+            pull_request: { html_url: "https://github.com/o/r/pull/11", title: "feat: x" },
+          }),
+          ev("PullRequestReviewCommentEvent", "2026-05-10T08:10:00Z", {
+            action: "created",
+            pull_request: { html_url: "https://github.com/o/r/pull/11", title: "feat: x" },
+          }),
+          ev("IssueCommentEvent", "2026-05-10T08:20:00Z", {
+            action: "created",
+            issue: {
+              html_url: "https://github.com/o/r/pull/11",
+              title: "feat: x",
+              pull_request: { url: "..." },
+            },
+          }),
+          // triage comment on a real issue
+          ev("IssueCommentEvent", "2026-05-10T06:00:00Z", {
+            action: "created",
+            issue: { html_url: "https://github.com/o/r/issues/20", title: "bug report" },
+          }),
+          ev("IssuesEvent", "2026-05-10T05:00:00Z", {
+            action: "closed",
+            issue: { html_url: "https://github.com/o/r/issues/21", title: "resolved bug" },
+          }),
+          // two pushes to the same PR branch → collapse, count 1+2=3, newest at/url wins
+          ev("PushEvent", "2026-05-10T04:00:00Z", {
+            ref: "refs/heads/fix/ci-12345",
+            head: "aaa",
+            size: 1,
+            commits: [{ sha: "aaa", message: "first\n\nbody" }],
+          }),
+          ev("PushEvent", "2026-05-10T04:30:00Z", {
+            ref: "refs/heads/fix/ci-12345",
+            head: "bbb",
+            size: 2,
+            commits: [{ sha: "ccc", message: "mid" }, { sha: "bbb", message: "second commit" }],
+          }),
+          // push to the default branch → ignored
+          ev("PushEvent", "2026-05-10T03:00:00Z", {
+            ref: "refs/heads/main",
+            head: "ddd",
+            size: 1,
+            commits: [{ sha: "ddd", message: "direct to main" }],
+          }),
+        ],
+        repos,
+      )
+      .sort(byAtDesc);
+
+    expect(out).toEqual([
+      {
+        repo: "o/r",
+        kind: "pr-opened",
+        title: "fix: flaky test",
+        url: "https://github.com/o/r/pull/10",
+        at: "2026-05-10T09:00:00Z",
+        detail: { category: "ci-fix" },
+      },
+      {
+        repo: "o/r",
+        kind: "pr-commented",
+        title: "feat: x",
+        url: "https://github.com/o/r/pull/11",
+        at: "2026-05-10T08:20:00Z",
+        detail: { count: 3 },
+      },
+      {
+        repo: "o/r",
+        kind: "pr-reviewed",
+        title: "feat: x",
+        url: "https://github.com/o/r/pull/11",
+        at: "2026-05-10T08:00:00Z",
+        detail: { verdict: "approved" },
+      },
+      {
+        repo: "o/r",
+        kind: "dep-approved",
+        title: "Bump serde 1.0.1 to 1.0.2",
+        url: "https://github.com/o/r/pull/12",
+        at: "2026-05-10T07:30:00Z",
+      },
+      {
+        repo: "o/r",
+        kind: "issue-commented",
+        title: "bug report",
+        url: "https://github.com/o/r/issues/20",
+        at: "2026-05-10T06:00:00Z",
+        detail: { count: 1 },
+      },
+      {
+        repo: "o/r",
+        kind: "issue-closed",
+        title: "resolved bug",
+        url: "https://github.com/o/r/issues/21",
+        at: "2026-05-10T05:00:00Z",
+      },
+      {
+        repo: "o/r",
+        kind: "pr-commits",
+        title: "second commit",
+        url: "https://github.com/o/r/commit/bbb",
+        at: "2026-05-10T04:30:00Z",
+        detail: { count: 3 },
+      },
+    ]);
+  });
+});
+
+describe("prCategory", () => {
+  it("infers PR category from the head-branch name", async () => {
+    const { __test } = await import("../src/index");
+    expect(__test.prCategory("fix/ci-99887")).toBe("ci-fix");
+    expect(__test.prCategory("tend/update-workflows")).toBe("workflow");
+    expect(__test.prCategory("tend/msrv-bump")).toBe("maintenance");
+    expect(__test.prCategory("dependabot/cargo/serde-1.2")).toBe("other");
+    expect(__test.prCategory(undefined)).toBe("other");
+  });
+});
+
+describe("fetchBotEvents", () => {
+  it("returns the event array on success", async () => {
+    const { __test } = await import("../src/index");
+    globalThis.fetch = makeFetch(
+      new Map<string, unknown>([
+        [
+          "https://api.github.com/users/bot-a/events/public?per_page=100",
+          [{ type: "PushEvent", created_at: "2026-05-10T00:00:00Z" }],
+        ],
+      ]),
+    ) as unknown as typeof fetch;
+    expect(await __test.fetchBotEvents("bot-a", "tok")).toEqual([
+      { type: "PushEvent", created_at: "2026-05-10T00:00:00Z" },
+    ]);
+  });
+
+  it("returns empty on 404; throws on 401/403", async () => {
+    const { __test } = await import("../src/index");
+    globalThis.fetch = vi.fn(
+      async () => new Response("not found", { status: 404 }),
+    ) as unknown as typeof fetch;
+    expect(await __test.fetchBotEvents("bot-a", "tok")).toEqual([]);
+
+    globalThis.fetch = vi.fn(
+      async () => new Response("bad credentials", { status: 401 }),
+    ) as unknown as typeof fetch;
+    await expect(__test.fetchBotEvents("bot-a", "tok")).rejects.toThrow(
+      /auth failure/,
+    );
+  });
+});
+
+describe("refreshActivity", () => {
+  it("fans out events + merged-PR search per bot, sorts newest first, keeps a PR that both opened and merged", async () => {
+    const { __test } = await import("../src/index");
+    const responses = new Map<string, unknown>([
+      [
+        "https://raw.githubusercontent.com/max-sixty/tend/main/data/consumers.json",
+        [{ repo: "o/r", bot_name: "bot-a" }],
+      ],
+      [
+        "https://api.github.com/users/bot-a/events/public?per_page=100",
+        [
+          {
+            type: "PullRequestEvent",
+            created_at: "2026-05-09T10:00:00Z",
+            repo: { name: "o/r" },
+            payload: {
+              action: "opened",
+              pull_request: {
+                html_url: "https://github.com/o/r/pull/30",
+                title: "fix: thing",
+                head: { ref: "fix/ci-7" },
+              },
+            },
+          },
+          {
+            type: "IssuesEvent",
+            created_at: "2026-05-11T10:00:00Z",
+            repo: { name: "o/r" },
+            payload: {
+              action: "closed",
+              issue: { html_url: "https://github.com/o/r/issues/31", title: "stale issue" },
+            },
+          },
+        ],
+      ],
+      [
+        "https://api.github.com/search/issues?q=author%3Abot-a+is%3Apr+is%3Amerged&per_page=10&sort=updated&order=desc",
+        {
+          items: [
+            {
+              html_url: "https://github.com/o/r/pull/30",
+              title: "fix: thing",
+              updated_at: "2026-05-10T12:00:00Z",
+              repository_url: "https://api.github.com/repos/o/r",
+            },
+          ],
+        },
+      ],
+    ]);
+    globalThis.fetch = makeFetch(responses) as unknown as typeof fetch;
+
+    const env = {
+      GITHUB_TOKEN: "tok",
+      CACHE: makeFakeKv(),
+      ALLOWED_ORIGIN: "*",
+      REPOS_URL:
+        "https://raw.githubusercontent.com/max-sixty/tend/main/data/consumers.json",
     };
+    const out = await __test.refreshActivity(env);
+    expect(out.events).toEqual([
+      {
+        repo: "o/r",
+        kind: "issue-closed",
+        title: "stale issue",
+        url: "https://github.com/o/r/issues/31",
+        at: "2026-05-11T10:00:00Z",
+      },
+      {
+        repo: "o/r",
+        kind: "pr-merged",
+        title: "fix: thing",
+        url: "https://github.com/o/r/pull/30",
+        at: "2026-05-10T12:00:00Z",
+      },
+      {
+        repo: "o/r",
+        kind: "pr-opened",
+        title: "fix: thing",
+        url: "https://github.com/o/r/pull/30",
+        at: "2026-05-09T10:00:00Z",
+        detail: { category: "ci-fix" },
+      },
+    ]);
+    expect(out.generated_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+  });
+
+  it("merges two bots' streams, dedups same-kind/url rows (newest wins), drops foreign repos", async () => {
+    const { __test } = await import("../src/index");
     const responses = new Map<string, unknown>([
       [
         "https://raw.githubusercontent.com/max-sixty/tend/main/data/consumers.json",
@@ -178,39 +459,75 @@ describe("refreshActivity", () => {
           { repo: "o/r", bot_name: "bot-b" },
         ],
       ],
-      // bots are sorted alphabetically internally → bot-a, bot-b
-      // kinds iterate in declared order: ci-fix → review → triage
       [
-        "https://api.github.com/search/issues?q=author%3Abot-a+is%3Apr&per_page=10&sort=updated&order=desc",
-        { items: [dup] },
-      ],
-      [
-        "https://api.github.com/search/issues?q=author%3Abot-b+is%3Apr&per_page=10&sort=updated&order=desc",
-        { items: [] },
-      ],
-      [
-        "https://api.github.com/search/issues?q=commenter%3Abot-a+is%3Apr+-author%3Abot-a&per_page=10&sort=updated&order=desc",
-        { items: [] },
-      ],
-      [
-        "https://api.github.com/search/issues?q=commenter%3Abot-b+is%3Apr+-author%3Abot-b&per_page=10&sort=updated&order=desc",
-        { items: [dup] },
-      ],
-      [
-        "https://api.github.com/search/issues?q=commenter%3Abot-a+is%3Aissue&per_page=10&sort=updated&order=desc",
-        {
-          items: [
-            {
-              html_url: "https://github.com/o/r/issues/5",
-              title: "bug report",
-              updated_at: "2026-05-10T01:00:00Z",
-              repository_url: "https://api.github.com/repos/o/r",
+        "https://api.github.com/users/bot-a/events/public?per_page=100",
+        [
+          {
+            type: "PullRequestReviewEvent",
+            created_at: "2026-05-10T01:00:00Z",
+            repo: { name: "o/r" },
+            payload: {
+              action: "created",
+              review: { state: "approved" },
+              pull_request: { html_url: "https://github.com/o/r/pull/5", title: "feat: shared" },
             },
-          ],
-        },
+          },
+          {
+            type: "IssuesEvent",
+            created_at: "2026-05-10T03:00:00Z",
+            repo: { name: "o/r" },
+            payload: {
+              action: "closed",
+              issue: { html_url: "https://github.com/o/r/issues/9", title: "old bug" },
+            },
+          },
+          // foreign repo — dropped
+          {
+            type: "IssuesEvent",
+            created_at: "2026-05-10T05:00:00Z",
+            repo: { name: "o/other" },
+            payload: {
+              action: "closed",
+              issue: { html_url: "https://github.com/o/other/issues/1", title: "nope" },
+            },
+          },
+        ],
       ],
       [
-        "https://api.github.com/search/issues?q=commenter%3Abot-b+is%3Aissue&per_page=10&sort=updated&order=desc",
+        "https://api.github.com/users/bot-b/events/public?per_page=100",
+        [
+          // same PR as bot-a's review, newer timestamp → dedup keeps this one
+          {
+            type: "PullRequestReviewEvent",
+            created_at: "2026-05-10T02:00:00Z",
+            repo: { name: "o/r" },
+            payload: {
+              action: "created",
+              review: { state: "approved" },
+              pull_request: { html_url: "https://github.com/o/r/pull/5", title: "feat: shared" },
+            },
+          },
+          {
+            type: "PullRequestEvent",
+            created_at: "2026-05-10T00:00:00Z",
+            repo: { name: "o/r" },
+            payload: {
+              action: "opened",
+              pull_request: {
+                html_url: "https://github.com/o/r/pull/6",
+                title: "chore: cache audit",
+                head: { ref: "tend/cache-audit" },
+              },
+            },
+          },
+        ],
+      ],
+      [
+        "https://api.github.com/search/issues?q=author%3Abot-a+is%3Apr+is%3Amerged&per_page=10&sort=updated&order=desc",
+        { items: [] },
+      ],
+      [
+        "https://api.github.com/search/issues?q=author%3Abot-b+is%3Apr+is%3Amerged&per_page=10&sort=updated&order=desc",
         { items: [] },
       ],
     ]);
@@ -227,20 +544,28 @@ describe("refreshActivity", () => {
     expect(out.events).toEqual([
       {
         repo: "o/r",
-        kind: "triage",
-        title: "bug report",
-        url: "https://github.com/o/r/issues/5",
-        at: "2026-05-10T01:00:00Z",
+        kind: "issue-closed",
+        title: "old bug",
+        url: "https://github.com/o/r/issues/9",
+        at: "2026-05-10T03:00:00Z",
       },
       {
         repo: "o/r",
-        kind: "ci-fix",
-        title: "fix: x",
-        url: "https://github.com/o/r/pull/100",
-        at: "2026-05-09T12:00:00Z",
+        kind: "pr-reviewed",
+        title: "feat: shared",
+        url: "https://github.com/o/r/pull/5",
+        at: "2026-05-10T02:00:00Z",
+        detail: { verdict: "approved" },
+      },
+      {
+        repo: "o/r",
+        kind: "pr-opened",
+        title: "chore: cache audit",
+        url: "https://github.com/o/r/pull/6",
+        at: "2026-05-10T00:00:00Z",
+        detail: { category: "maintenance" },
       },
     ]);
-    expect(out.generated_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
   });
 
   it("returns empty when no consumers", async () => {

--- a/worker/test/worker.test.ts
+++ b/worker/test/worker.test.ts
@@ -159,258 +159,51 @@ describe("refreshCurrentlyTending", () => {
   });
 });
 
-function byAtDesc(a: { at: string }, b: { at: string }) {
-  return a.at < b.at ? 1 : a.at > b.at ? -1 : 0;
-}
-
-describe("eventsToActivity", () => {
-  it("maps each event type, filters foreign repos, collapses comments and pushes", async () => {
-    const { __test } = await import("../src/index");
-    const repos = new Set(["o/r"]);
-    const ev = <P>(type: string, created_at: string, payload: P) => ({
-      type,
-      created_at,
-      repo: { name: "o/r" },
-      payload,
-    });
-    const out = __test
-      .eventsToActivity(
-        [
-          // foreign repo — dropped entirely
-          {
-            type: "PullRequestEvent",
-            created_at: "2026-05-10T00:00:00Z",
-            repo: { name: "someone/else" },
-            payload: {
-              action: "opened",
-              pull_request: { html_url: "https://github.com/someone/else/pull/1", title: "nope" },
-            },
-          },
-          ev("PullRequestEvent", "2026-05-10T09:00:00Z", {
-            action: "opened",
-            pull_request: {
-              html_url: "https://github.com/o/r/pull/10",
-              title: "fix: flaky test",
-              head: { ref: "fix/ci-12345" },
-            },
-          }),
-          ev("PullRequestReviewEvent", "2026-05-10T08:00:00Z", {
-            action: "created",
-            review: { state: "approved" },
-            pull_request: { html_url: "https://github.com/o/r/pull/11", title: "feat: x" },
-          }),
-          // dependabot PR review → dep-approved, not pr-reviewed
-          ev("PullRequestReviewEvent", "2026-05-10T07:30:00Z", {
-            action: "created",
-            review: { state: "approved" },
-            pull_request: {
-              html_url: "https://github.com/o/r/pull/12",
-              title: "Bump serde 1.0.1 to 1.0.2",
-              user: { login: "dependabot[bot]" },
-            },
-          }),
-          // a "commented" review + an inline comment + a conversation comment, all on #11 → collapse to count 3
-          ev("PullRequestReviewEvent", "2026-05-10T08:05:00Z", {
-            action: "created",
-            review: { state: "commented" },
-            pull_request: { html_url: "https://github.com/o/r/pull/11", title: "feat: x" },
-          }),
-          ev("PullRequestReviewCommentEvent", "2026-05-10T08:10:00Z", {
-            action: "created",
-            pull_request: { html_url: "https://github.com/o/r/pull/11", title: "feat: x" },
-          }),
-          ev("IssueCommentEvent", "2026-05-10T08:20:00Z", {
-            action: "created",
-            issue: {
-              html_url: "https://github.com/o/r/pull/11",
-              title: "feat: x",
-              pull_request: { url: "..." },
-            },
-          }),
-          // triage comment on a real issue
-          ev("IssueCommentEvent", "2026-05-10T06:00:00Z", {
-            action: "created",
-            issue: { html_url: "https://github.com/o/r/issues/20", title: "bug report" },
-          }),
-          ev("IssuesEvent", "2026-05-10T05:00:00Z", {
-            action: "closed",
-            issue: { html_url: "https://github.com/o/r/issues/21", title: "resolved bug" },
-          }),
-          // two pushes to the same PR branch → collapse, count 1+2=3, newest at/url wins
-          ev("PushEvent", "2026-05-10T04:00:00Z", {
-            ref: "refs/heads/fix/ci-12345",
-            head: "aaa",
-            size: 1,
-            commits: [{ sha: "aaa", message: "first\n\nbody" }],
-          }),
-          ev("PushEvent", "2026-05-10T04:30:00Z", {
-            ref: "refs/heads/fix/ci-12345",
-            head: "bbb",
-            size: 2,
-            commits: [{ sha: "ccc", message: "mid" }, { sha: "bbb", message: "second commit" }],
-          }),
-          // push to the default branch → ignored
-          ev("PushEvent", "2026-05-10T03:00:00Z", {
-            ref: "refs/heads/main",
-            head: "ddd",
-            size: 1,
-            commits: [{ sha: "ddd", message: "direct to main" }],
-          }),
-        ],
-        repos,
-      )
-      .sort(byAtDesc);
-
-    expect(out).toEqual([
-      {
-        repo: "o/r",
-        kind: "pr-opened",
-        title: "fix: flaky test",
-        url: "https://github.com/o/r/pull/10",
-        at: "2026-05-10T09:00:00Z",
-        detail: { category: "ci-fix" },
-      },
-      {
-        repo: "o/r",
-        kind: "pr-commented",
-        title: "feat: x",
-        url: "https://github.com/o/r/pull/11",
-        at: "2026-05-10T08:20:00Z",
-        detail: { count: 3 },
-      },
-      {
-        repo: "o/r",
-        kind: "pr-reviewed",
-        title: "feat: x",
-        url: "https://github.com/o/r/pull/11",
-        at: "2026-05-10T08:00:00Z",
-        detail: { verdict: "approved" },
-      },
-      {
-        repo: "o/r",
-        kind: "dep-approved",
-        title: "Bump serde 1.0.1 to 1.0.2",
-        url: "https://github.com/o/r/pull/12",
-        at: "2026-05-10T07:30:00Z",
-      },
-      {
-        repo: "o/r",
-        kind: "issue-commented",
-        title: "bug report",
-        url: "https://github.com/o/r/issues/20",
-        at: "2026-05-10T06:00:00Z",
-        detail: { count: 1 },
-      },
-      {
-        repo: "o/r",
-        kind: "issue-closed",
-        title: "resolved bug",
-        url: "https://github.com/o/r/issues/21",
-        at: "2026-05-10T05:00:00Z",
-      },
-      {
-        repo: "o/r",
-        kind: "pr-commits",
-        title: "second commit",
-        url: "https://github.com/o/r/commit/bbb",
-        at: "2026-05-10T04:30:00Z",
-        detail: { count: 3 },
-      },
-    ]);
-  });
-});
-
-describe("prCategory", () => {
-  it("infers PR category from the head-branch name", async () => {
-    const { __test } = await import("../src/index");
-    expect(__test.prCategory("fix/ci-99887")).toBe("ci-fix");
-    expect(__test.prCategory("tend/update-workflows")).toBe("workflow");
-    expect(__test.prCategory("tend/msrv-bump")).toBe("maintenance");
-    expect(__test.prCategory("dependabot/cargo/serde-1.2")).toBe("other");
-    expect(__test.prCategory(undefined)).toBe("other");
-  });
-});
-
-describe("fetchBotEvents", () => {
-  it("returns the event array on success", async () => {
-    const { __test } = await import("../src/index");
-    globalThis.fetch = makeFetch(
-      new Map<string, unknown>([
-        [
-          "https://api.github.com/users/bot-a/events/public?per_page=100",
-          [{ type: "PushEvent", created_at: "2026-05-10T00:00:00Z" }],
-        ],
-      ]),
-    ) as unknown as typeof fetch;
-    expect(await __test.fetchBotEvents("bot-a", "tok")).toEqual([
-      { type: "PushEvent", created_at: "2026-05-10T00:00:00Z" },
-    ]);
-  });
-
-  it("returns empty on 404; throws on 401/403", async () => {
-    const { __test } = await import("../src/index");
-    globalThis.fetch = vi.fn(
-      async () => new Response("not found", { status: 404 }),
-    ) as unknown as typeof fetch;
-    expect(await __test.fetchBotEvents("bot-a", "tok")).toEqual([]);
-
-    globalThis.fetch = vi.fn(
-      async () => new Response("bad credentials", { status: 401 }),
-    ) as unknown as typeof fetch;
-    await expect(__test.fetchBotEvents("bot-a", "tok")).rejects.toThrow(
-      /auth failure/,
-    );
-  });
-});
-
 describe("refreshActivity", () => {
-  it("fans out events + merged-PR search per bot, sorts newest first, keeps a PR that both opened and merged", async () => {
+  // Build a Search URL the way searchRaw does: q + per_page, then sort/order
+  // appended (perPage > 1).
+  const searchUrl = (q: string) =>
+    `https://api.github.com/search/issues?${new URLSearchParams({
+      q,
+      per_page: "100",
+    })}&sort=updated&order=desc`;
+
+  it("fans out one Search query per bucket per bot — sums counts, merges + sorts recent, counts this week", async () => {
     const { __test } = await import("../src/index");
+    const nowMs = Date.now();
+    const daysAgo = (n: number) => new Date(nowMs - n * 86_400_000).toISOString();
+    const recentA = daysAgo(1); // within the last 7 days
+    const recentB = daysAgo(2);
+    const oldA = daysAgo(30); // not
+    const oldB = daysAgo(60);
+
+    const item = (
+      repo: string,
+      n: number,
+      kind: "pull" | "issues",
+      at: string,
+    ) => ({
+      html_url: `https://github.com/${repo}/${kind}/${n}`,
+      title: `${repo}#${n}`,
+      updated_at: at,
+      repository_url: `https://api.github.com/repos/${repo}`,
+    });
+
     const responses = new Map<string, unknown>([
       [
         "https://raw.githubusercontent.com/max-sixty/tend/main/data/consumers.json",
-        [{ repo: "o/r", bot_name: "bot-a" }],
-      ],
-      [
-        "https://api.github.com/users/bot-a/events/public?per_page=100",
         [
-          {
-            type: "PullRequestEvent",
-            created_at: "2026-05-09T10:00:00Z",
-            repo: { name: "o/r" },
-            payload: {
-              action: "opened",
-              pull_request: {
-                html_url: "https://github.com/o/r/pull/30",
-                title: "fix: thing",
-                head: { ref: "fix/ci-7" },
-              },
-            },
-          },
-          {
-            type: "IssuesEvent",
-            created_at: "2026-05-11T10:00:00Z",
-            repo: { name: "o/r" },
-            payload: {
-              action: "closed",
-              issue: { html_url: "https://github.com/o/r/issues/31", title: "stale issue" },
-            },
-          },
+          { repo: "o/a", bot_name: "bot-a" },
+          { repo: "o/b", bot_name: "bot-b" },
         ],
       ],
-      [
-        "https://api.github.com/search/issues?q=author%3Abot-a+is%3Apr+is%3Amerged&per_page=10&sort=updated&order=desc",
-        {
-          items: [
-            {
-              html_url: "https://github.com/o/r/pull/30",
-              title: "fix: thing",
-              updated_at: "2026-05-10T12:00:00Z",
-              repository_url: "https://api.github.com/repos/o/r",
-            },
-          ],
-        },
-      ],
+      // bots sorted → bot-a, bot-b. Buckets in declared order: prs, issues, comments.
+      [searchUrl("author:bot-a is:pr"), { total_count: 7, items: [item("o/a", 1, "pull", recentA), item("o/a", 2, "pull", oldA)] }],
+      [searchUrl("author:bot-b is:pr"), { total_count: 3, items: [item("o/b", 9, "pull", oldB)] }],
+      [searchUrl("author:bot-a is:issue"), { total_count: 2, items: [item("o/a", 5, "issues", recentB)] }],
+      [searchUrl("author:bot-b is:issue"), { total_count: 0, items: [] }],
+      [searchUrl("commenter:bot-a -author:bot-a"), { total_count: 12, items: [item("o/a", 3, "pull", recentA)] }],
+      [searchUrl("commenter:bot-b -author:bot-b"), { total_count: 4, items: [item("o/b", 8, "issues", recentB)] }],
     ]);
     globalThis.fetch = makeFetch(responses) as unknown as typeof fetch;
 
@@ -422,116 +215,51 @@ describe("refreshActivity", () => {
         "https://raw.githubusercontent.com/max-sixty/tend/main/data/consumers.json",
     };
     const out = await __test.refreshActivity(env);
-    expect(out.events).toEqual([
-      {
-        repo: "o/r",
-        kind: "issue-closed",
-        title: "stale issue",
-        url: "https://github.com/o/r/issues/31",
-        at: "2026-05-11T10:00:00Z",
-      },
-      {
-        repo: "o/r",
-        kind: "pr-merged",
-        title: "fix: thing",
-        url: "https://github.com/o/r/pull/30",
-        at: "2026-05-10T12:00:00Z",
-      },
-      {
-        repo: "o/r",
-        kind: "pr-opened",
-        title: "fix: thing",
-        url: "https://github.com/o/r/pull/30",
-        at: "2026-05-09T10:00:00Z",
-        detail: { category: "ci-fix" },
-      },
-    ]);
+
+    expect(out.prs).toEqual({
+      count: 10, // 7 + 3
+      count_this_week: 1, // o/a#1 recent; o/a#2 and o/b#9 old
+      recent: [
+        { repo: "o/a", title: "o/a#1", url: "https://github.com/o/a/pull/1", at: recentA },
+        { repo: "o/a", title: "o/a#2", url: "https://github.com/o/a/pull/2", at: oldA },
+        { repo: "o/b", title: "o/b#9", url: "https://github.com/o/b/pull/9", at: oldB },
+      ],
+    });
+    expect(out.issues).toEqual({
+      count: 2,
+      count_this_week: 1,
+      recent: [
+        { repo: "o/a", title: "o/a#5", url: "https://github.com/o/a/issues/5", at: recentB },
+      ],
+    });
+    expect(out.comments).toEqual({
+      count: 16, // 12 + 4
+      count_this_week: 2,
+      recent: [
+        { repo: "o/a", title: "o/a#3", url: "https://github.com/o/a/pull/3", at: recentA },
+        { repo: "o/b", title: "o/b#8", url: "https://github.com/o/b/issues/8", at: recentB },
+      ],
+    });
     expect(out.generated_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
   });
 
-  it("merges two bots' streams, dedups same-kind/url rows (newest wins), drops foreign repos", async () => {
+  it("degrades a failed bucket query to an empty bucket without sinking the refresh", async () => {
     const { __test } = await import("../src/index");
-    const responses = new Map<string, unknown>([
-      [
-        "https://raw.githubusercontent.com/max-sixty/tend/main/data/consumers.json",
-        [
-          { repo: "o/r", bot_name: "bot-a" },
-          { repo: "o/r", bot_name: "bot-b" },
-        ],
-      ],
-      [
-        "https://api.github.com/users/bot-a/events/public?per_page=100",
-        [
-          {
-            type: "PullRequestReviewEvent",
-            created_at: "2026-05-10T01:00:00Z",
-            repo: { name: "o/r" },
-            payload: {
-              action: "created",
-              review: { state: "approved" },
-              pull_request: { html_url: "https://github.com/o/r/pull/5", title: "feat: shared" },
-            },
-          },
-          {
-            type: "IssuesEvent",
-            created_at: "2026-05-10T03:00:00Z",
-            repo: { name: "o/r" },
-            payload: {
-              action: "closed",
-              issue: { html_url: "https://github.com/o/r/issues/9", title: "old bug" },
-            },
-          },
-          // foreign repo — dropped
-          {
-            type: "IssuesEvent",
-            created_at: "2026-05-10T05:00:00Z",
-            repo: { name: "o/other" },
-            payload: {
-              action: "closed",
-              issue: { html_url: "https://github.com/o/other/issues/1", title: "nope" },
-            },
-          },
-        ],
-      ],
-      [
-        "https://api.github.com/users/bot-b/events/public?per_page=100",
-        [
-          // same PR as bot-a's review, newer timestamp → dedup keeps this one
-          {
-            type: "PullRequestReviewEvent",
-            created_at: "2026-05-10T02:00:00Z",
-            repo: { name: "o/r" },
-            payload: {
-              action: "created",
-              review: { state: "approved" },
-              pull_request: { html_url: "https://github.com/o/r/pull/5", title: "feat: shared" },
-            },
-          },
-          {
-            type: "PullRequestEvent",
-            created_at: "2026-05-10T00:00:00Z",
-            repo: { name: "o/r" },
-            payload: {
-              action: "opened",
-              pull_request: {
-                html_url: "https://github.com/o/r/pull/6",
-                title: "chore: cache audit",
-                head: { ref: "tend/cache-audit" },
-              },
-            },
-          },
-        ],
-      ],
-      [
-        "https://api.github.com/search/issues?q=author%3Abot-a+is%3Apr+is%3Amerged&per_page=10&sort=updated&order=desc",
-        { items: [] },
-      ],
-      [
-        "https://api.github.com/search/issues?q=author%3Abot-b+is%3Apr+is%3Amerged&per_page=10&sort=updated&order=desc",
-        { items: [] },
-      ],
-    ]);
-    globalThis.fetch = makeFetch(responses) as unknown as typeof fetch;
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.endsWith("/data/consumers.json")) {
+        return new Response(
+          JSON.stringify([{ repo: "o/r", bot_name: "bot-a" }]),
+          { status: 200 },
+        );
+      }
+      if (url.includes("commenter")) {
+        return new Response("Validation Failed", { status: 422 });
+      }
+      return new Response(JSON.stringify({ total_count: 1, items: [] }), {
+        status: 200,
+      });
+    }) as unknown as typeof fetch;
 
     const env = {
       GITHUB_TOKEN: "tok",
@@ -541,34 +269,12 @@ describe("refreshActivity", () => {
         "https://raw.githubusercontent.com/max-sixty/tend/main/data/consumers.json",
     };
     const out = await __test.refreshActivity(env);
-    expect(out.events).toEqual([
-      {
-        repo: "o/r",
-        kind: "issue-closed",
-        title: "old bug",
-        url: "https://github.com/o/r/issues/9",
-        at: "2026-05-10T03:00:00Z",
-      },
-      {
-        repo: "o/r",
-        kind: "pr-reviewed",
-        title: "feat: shared",
-        url: "https://github.com/o/r/pull/5",
-        at: "2026-05-10T02:00:00Z",
-        detail: { verdict: "approved" },
-      },
-      {
-        repo: "o/r",
-        kind: "pr-opened",
-        title: "chore: cache audit",
-        url: "https://github.com/o/r/pull/6",
-        at: "2026-05-10T00:00:00Z",
-        detail: { category: "maintenance" },
-      },
-    ]);
+    expect(out.comments).toEqual({ count: 0, count_this_week: 0, recent: [] });
+    expect(out.prs.count).toBe(1);
+    expect(out.issues.count).toBe(1);
   });
 
-  it("returns empty when no consumers", async () => {
+  it("returns empty buckets when there are no consumers", async () => {
     const { __test } = await import("../src/index");
     globalThis.fetch = makeFetch(
       new Map([[
@@ -585,46 +291,22 @@ describe("refreshActivity", () => {
         "https://raw.githubusercontent.com/max-sixty/tend/main/data/consumers.json",
     };
     const out = await __test.refreshActivity(env);
-    expect(out.events).toEqual([]);
+    expect(out.prs).toEqual({ count: 0, count_this_week: 0, recent: [] });
+    expect(out.issues).toEqual({ count: 0, count_this_week: 0, recent: [] });
+    expect(out.comments).toEqual({ count: 0, count_this_week: 0, recent: [] });
   });
-});
 
-describe("refreshStats", () => {
-  it("sums total_count across bots for each counter", async () => {
+  it("throws on a 401 from Search — surfaces so the refresh falls back", async () => {
     const { __test } = await import("../src/index");
-    // Match by URL prefix — week-windowed queries embed today's date.
-    const fixedTotals: Record<string, number> = {
-      "author%3Abot-a+is%3Apr": 10,
-      "author%3Abot-b+is%3Apr": 4,
-      "commenter%3Abot-a+is%3Apr+-author%3Abot-a": 7,
-      "commenter%3Abot-b+is%3Apr+-author%3Abot-b": 3,
-      "commenter%3Abot-a+is%3Aissue": 2,
-      "commenter%3Abot-b+is%3Aissue": 1,
-    };
     globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
       const url = typeof input === "string" ? input : input.toString();
       if (url.endsWith("/data/consumers.json")) {
         return new Response(
-          JSON.stringify([
-            { repo: "o/r", bot_name: "bot-a" },
-            { repo: "o/r", bot_name: "bot-b" },
-          ]),
+          JSON.stringify([{ repo: "o/r", bot_name: "bot-a" }]),
           { status: 200 },
         );
       }
-      // Pull total_count by matching the substring of the query body.
-      for (const [needle, total] of Object.entries(fixedTotals)) {
-        if (url.includes(needle)) {
-          // "this_week" queries also contain the needle but additionally
-          // include `updated:>=`. Treat them as 0 to make the assertion
-          // distinguishable.
-          if (url.includes("updated%3A%3E%3D")) {
-            return new Response(JSON.stringify({ total_count: 0 }), { status: 200 });
-          }
-          return new Response(JSON.stringify({ total_count: total }), { status: 200 });
-        }
-      }
-      throw new Error(`unexpected fetch ${url}`);
+      return new Response("bad credentials", { status: 401 });
     }) as unknown as typeof fetch;
 
     const env = {
@@ -634,13 +316,43 @@ describe("refreshStats", () => {
       REPOS_URL:
         "https://raw.githubusercontent.com/max-sixty/tend/main/data/consumers.json",
     };
-    const out = await __test.refreshStats(env);
-    expect(out.ci_fixes_total).toBe(14); // 10 + 4
-    expect(out.ci_fixes_this_week).toBe(0);
-    expect(out.reviews_total).toBe(10); // 7 + 3
-    expect(out.reviews_this_week).toBe(0);
-    expect(out.triage_comments_total).toBe(3); // 2 + 1
-    expect(out.generated_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+    await expect(__test.refreshActivity(env)).rejects.toThrow(/auth failure/);
+  });
+
+  it("keeps only the newest RECENT_PER_BUCKET items per bucket", async () => {
+    const { __test } = await import("../src/index");
+    const items = Array.from({ length: 15 }, (_, i) => ({
+      html_url: `https://github.com/o/r/pull/${i}`,
+      title: `#${i}`,
+      // i=0 is newest (largest timestamp), i=14 is oldest
+      updated_at: new Date(2026, 0, 1, 0, 15 - i).toISOString(),
+      repository_url: "https://api.github.com/repos/o/r",
+    }));
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.endsWith("/data/consumers.json")) {
+        return new Response(
+          JSON.stringify([{ repo: "o/r", bot_name: "bot-a" }]),
+          { status: 200 },
+        );
+      }
+      const body = url.includes("is%3Apr") ? { total_count: 15, items } : { total_count: 0, items: [] };
+      return new Response(JSON.stringify(body), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const env = {
+      GITHUB_TOKEN: "tok",
+      CACHE: makeFakeKv(),
+      ALLOWED_ORIGIN: "*",
+      REPOS_URL:
+        "https://raw.githubusercontent.com/max-sixty/tend/main/data/consumers.json",
+    };
+    const out = await __test.refreshActivity(env);
+    expect(out.prs.count).toBe(15);
+    expect(out.prs.recent).toHaveLength(10);
+    expect(out.prs.recent.map((r) => r.title)).toEqual(
+      ["#0", "#1", "#2", "#3", "#4", "#5", "#6", "#7", "#8", "#9"], // newest first
+    );
   });
 });
 


### PR DESCRIPTION
Reworks the live-data Worker's `/activity` route and folds `/stats` into it.

`/activity` now reports three **primitive buckets** rather than an editorialized event taxonomy:

| bucket | Search query | "the bot…" |
| --- | --- | --- |
| `prs` | `author:<bot> is:pr` | opened these PRs (any state) |
| `issues` | `author:<bot> is:issue` | opened these issues — mostly tend's own trackers (missing PAT scopes, "nightly tests failed", `tend-outage`), so this leans "tend flagged a problem" |
| `comments` | `commenter:<bot> -author:<bot>` | chimed in on these PRs/issues (not its own) |

Each bucket is `{ count, count_this_week, recent: [{repo, title, url, at}] }`. One Search query per bucket per bot (`sort=updated&per_page=100`): the page yields both the `recent` items (newest 10, merged across bots) and the lifetime `count` (`total_count`, summed); `count_this_week` is counted off the page, so it saturates around one page per bot per bucket — fine for a headline number. The fanout is 3·N concurrent Search requests, under the 30 req/min cap up to ~10 bots.

This replaces the per-event `kind` taxonomy (`ci-fix`/`review`/`triage`, and a richer events-API version) — the mapping from GitHub's mechanical events to tend's *jobs* was lossy and heuristic (a PR on `fix/ci-*` vs `tend/update-workflows` is the same event type; a nightly survey that finds nothing leaves no trace). Report the mechanical buckets honestly; defer the "here's what tend's been up to" narrative to a later layer. There's a `// TODO — Phase 2` in `docs/website-data.md`: a consumer (a scheduled job, or the Worker calling Claude) reads `/activity` and writes a prose summary into KV; that becomes what the site renders.

`/stats` is gone — its counts are now `/activity`'s `count` / `count_this_week`, so the site makes two Worker fetches instead of three. `/currently-tending` is unchanged.

Site: `Stats.astro` renders a 3-cell strip (PRs / comments / issues) from the bucket counts; `Activity.astro` merges the three `recent` lists into one newest-first feed (≤12 rows, each tagged `PR`/`issue`/`comment`); `CurrentlyTending.astro`'s "last tended N min ago" fallback picks the newest item across the buckets.

Docs: `docs/website-data.md` documents the new shape, queries, and Phase-2 TODO; `docs/activity-stream-design.md` is trimmed to the rationale (why primitive, not a taxonomy) and what was considered/dropped.

Net: −1073/+354 lines. `worker/` typecheck clean, 16 worker tests, `site` builds, `pre-commit` clean.
