### PR TITLE
skills(review-reviewers,review-runs): refuse to publish findings missing $GITHUB_RUN_ID

### DIFF
--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -160,6 +160,12 @@ LAST_GIST_ID=$(gh api /gists --paginate \
 After applying the gates, write each run's new findings (format in `@review-gates.md`) to `/tmp/findings.md`, then append them to the gist's `findings.md`. Reuse the current content already fetched into `/tmp/current.md` in "Reading historical evidence", concatenate, and PATCH via the API (`--rawfile` preserves trailing newlines that command substitution would strip):
 
 ```bash
+# Verify the run heading references this run's $GITHUB_RUN_ID literally —
+# fabricated round numbers produce dead Workflow links, see @review-gates.md.
+if ! grep -qF "$GITHUB_RUN_ID" /tmp/findings.md; then
+  echo "ERROR: /tmp/findings.md does not contain \$GITHUB_RUN_ID=$GITHUB_RUN_ID — refusing to PATCH gist" >&2
+  exit 1
+fi
 cat /tmp/current.md /tmp/findings.md > /tmp/combined.md
 jq -n --rawfile content /tmp/combined.md \
   '{files: {"findings.md": {content: $content}}}' \

--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -162,8 +162,7 @@ After applying the gates, write each run's new findings (format in `@review-gate
 ```bash
 # Verify the run heading references this run's $GITHUB_RUN_ID literally —
 # fabricated round numbers produce dead Workflow links, see @review-gates.md.
-# `|| { …; exit 1; }` rather than `if ! grep …`: the Bash-tool preprocessor
-# rewrites `!` to backslash-bang and silently inverts the if-condition.
+# Use `||` not `if ! cmd` — the Bash-tool preprocessor rewrites bangs.
 grep -qF "$GITHUB_RUN_ID" /tmp/findings.md || {
   echo "ERROR: /tmp/findings.md does not contain \$GITHUB_RUN_ID=$GITHUB_RUN_ID — refusing to PATCH gist" >&2
   exit 1

--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -162,10 +162,12 @@ After applying the gates, write each run's new findings (format in `@review-gate
 ```bash
 # Verify the run heading references this run's $GITHUB_RUN_ID literally —
 # fabricated round numbers produce dead Workflow links, see @review-gates.md.
-if ! grep -qF "$GITHUB_RUN_ID" /tmp/findings.md; then
+# `|| { …; exit 1; }` rather than `if ! grep …`: the Bash-tool preprocessor
+# rewrites `!` to backslash-bang and silently inverts the if-condition.
+grep -qF "$GITHUB_RUN_ID" /tmp/findings.md || {
   echo "ERROR: /tmp/findings.md does not contain \$GITHUB_RUN_ID=$GITHUB_RUN_ID — refusing to PATCH gist" >&2
   exit 1
-fi
+}
 cat /tmp/current.md /tmp/findings.md > /tmp/combined.md
 jq -n --rawfile content /tmp/combined.md \
   '{files: {"findings.md": {content: $content}}}' \

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -97,10 +97,12 @@ If `EXISTING_COMMENT` is non-empty, check its size before appending. GitHub reje
 ```bash
 # Verify the run heading references this run's $GITHUB_RUN_ID literally —
 # fabricated round numbers produce dead Workflow links, see @review-gates.md.
-if ! grep -qF "$GITHUB_RUN_ID" /tmp/findings.md; then
+# `|| { …; exit 1; }` rather than `if ! grep …`: the Bash-tool preprocessor
+# rewrites `!` to backslash-bang and silently inverts the if-condition.
+grep -qF "$GITHUB_RUN_ID" /tmp/findings.md || {
   echo "ERROR: /tmp/findings.md does not contain \$GITHUB_RUN_ID=$GITHUB_RUN_ID — refusing to post" >&2
   exit 1
-fi
+}
 gh api "repos/$REPO/issues/comments/$EXISTING_COMMENT" --jq '.body' > /tmp/existing.md
 EXISTING_SIZE=$(wc -c < /tmp/existing.md)
 if [ "$EXISTING_SIZE" -lt 50000 ]; then

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -95,6 +95,12 @@ EXISTING_COMMENT=$(gh api "repos/$REPO/issues/$TRACKING_NUMBER/comments" \
 If `EXISTING_COMMENT` is non-empty, check its size before appending. GitHub rejects comment bodies over 65536 characters — start a new comment when the existing one is too large.
 
 ```bash
+# Verify the run heading references this run's $GITHUB_RUN_ID literally —
+# fabricated round numbers produce dead Workflow links, see @review-gates.md.
+if ! grep -qF "$GITHUB_RUN_ID" /tmp/findings.md; then
+  echo "ERROR: /tmp/findings.md does not contain \$GITHUB_RUN_ID=$GITHUB_RUN_ID — refusing to post" >&2
+  exit 1
+fi
 gh api "repos/$REPO/issues/comments/$EXISTING_COMMENT" --jq '.body' > /tmp/existing.md
 EXISTING_SIZE=$(wc -c < /tmp/existing.md)
 if [ "$EXISTING_SIZE" -lt 50000 ]; then

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -97,8 +97,7 @@ If `EXISTING_COMMENT` is non-empty, check its size before appending. GitHub reje
 ```bash
 # Verify the run heading references this run's $GITHUB_RUN_ID literally —
 # fabricated round numbers produce dead Workflow links, see @review-gates.md.
-# `|| { …; exit 1; }` rather than `if ! grep …`: the Bash-tool preprocessor
-# rewrites `!` to backslash-bang and silently inverts the if-condition.
+# Use `||` not `if ! cmd` — the Bash-tool preprocessor rewrites bangs.
 grep -qF "$GITHUB_RUN_ID" /tmp/findings.md || {
   echo "ERROR: /tmp/findings.md does not contain \$GITHUB_RUN_ID=$GITHUB_RUN_ID — refusing to post" >&2
   exit 1


### PR DESCRIPTION
## Problem

Two entries in this month's `review-reviewers` evidence gist for `max-sixty/worktrunk` reference run IDs that don't exist:

- `## Run 25770110018 — 2026-05-13T00:13:00Z` — actual review-reviewers run at that time was [25769810463](https://github.com/max-sixty/tend/actions/runs/25769810463) (00:10:30Z). ID `25770110018` 404s.
- `## Run 25776847094 — 2026-05-13T03:54:00Z` — actual review-reviewers run was [25777733746](https://github.com/max-sixty/tend/actions/runs/25777733746) (04:10:22Z). ID `25776847094` 404s on both `max-sixty/tend` and `max-sixty/worktrunk`.

The `## Workflow` URLs in those headings point at the fabricated IDs and dead-end, breaking the audit trail the skill relies on for cumulative occurrence counts. Verified the 04:10Z session's JSONL: the agent never invoked `$GITHUB_RUN_ID` in any `Bash` tool call and hand-typed the heading values.

`review-gates.md` already warns about this exact failure mode (`Past sessions have filled the <run-id> placeholder with fabricated round numbers (e.g. 24294000000)`), but the textual warning hasn't been enough — the recurrence shows the same pattern still produces broken headings.

## Fix

Add a pre-publish grep in both `review-reviewers/SKILL.md` and `review-runs/SKILL.md` recording recipes. Right before the gist PATCH (review-reviewers) or tracking-comment update (review-runs), verify `/tmp/findings.md` contains `$GITHUB_RUN_ID` verbatim; abort with a clear error otherwise.

This is a structural failure (the textual recipe can be skipped) so one occurrence is sufficient evidence per `review-gates.md`. Two confirmed cases this month plus the historical `24294000000` case the existing warning cites.

## Gates

- **Confidence**: High (2 confirmed fabrications this month + historical case behind the existing warning).
- **Failure type**: Structural — same conditions consistently produce hand-typed IDs.
- **Magnitude**: Targeted fix — adds 6 lines per skill, no behavior change when the agent followed the recipe correctly.
- **Both gates**: pass.

Evidence: https://gist.github.com/9675d1510da32c68a68c1d45137b21e0
