### PR TITLE
docs(CLAUDE): list activity-stream-design.md, correct worker stream count

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,9 +31,10 @@ tend/
 │   │   └── cli.py        # Click CLI (init, check)
 │   └── tests/
 ├── site/                 # Astro marketing site (tend-src.com)
-├── worker/               # Cloudflare Worker — serves all 3 site data streams
+├── worker/               # Cloudflare Worker — serves the 2 site data streams
 ├── data/                 # consumers.json — Worker's input (refreshed weekly)
 └── docs/
+    ├── activity-stream-design.md
     ├── security-model.md
     └── website-data.md
 ```


### PR DESCRIPTION
## Summary

Two small CLAUDE.md drift fixes spotted during the nightly survey:

- `docs/activity-stream-design.md` (added in #441) was not listed in the structure tree under `docs/`.
- The `worker/` line in the same tree still said "serves all 3 site data streams"; `/stats` was folded into `/activity` in #441, so the worker now serves 2 routes (`/currently-tending` and `/activity`).

Keeping CLAUDE.md's tree in sync with the on-disk layout matters because it's loaded into every Claude Code session in this repo.

## Test plan

- [x] Diff matches intent (two-line change, both touching the structure tree)
- [ ] Lint passes
