### PR TITLE
worker: stale-while-revalidate so cache hits never wait on the GitHub fanout

### DIFF
--- a/docs/website-data.md
+++ b/docs/website-data.md
@@ -4,7 +4,7 @@ Both data streams the tend site renders are served by one Cloudflare Worker.
 The Worker reads a small input file (`data/consumers.json`) from this repo, fans
 out to GitHub, and serves CORS-enabled JSON to the site.
 
-| Stream | Endpoint | Edge TTL | Fallback TTL |
+| Stream | Endpoint | Freshness budget | Fallback budget |
 | --- | --- | --- | --- |
 | Currently tending | `/currently-tending` (also `/`) | 30 s | 5 s |
 | Activity | `/activity` | 5 min | 30 s |
@@ -18,8 +18,9 @@ req/min/IP — both shared across everyone behind a NAT. A single
 currently-tending poll fans out one `actions/runs` call per consumer repo every
 30 s; `/activity` fans out one Search query per bucket per bot. One browser tab
 would exhaust those quotas in minutes. The Worker holds an authenticated token
-(5,000 req/hour, 30 Search req/min) and edge-caches each route, so origin load
-is bounded by the TTL, not by viewer count. Static nightly JSON would cover
+(5,000 req/hour, 30 Search req/min) and caches each route at the colo, so
+origin load is bounded by the freshness budget, not by viewer count. Static
+nightly JSON would cover
 `/activity` but can't meet currently-tending's sub-minute freshness budget, so
 both live on the one Worker.
 
@@ -52,14 +53,26 @@ practice.
 
 ## Caching
 
-Each Worker route has two TTLs: the normal cache window, and a short
-fallback window applied when the refresh throws. The fallback window
-ensures a transient GitHub outage clears within seconds rather than locking
-in an empty response for the full normal TTL.
+Stale-while-revalidate, in the Worker's colo cache. Every request is
+answered from cache — no waiting on the GitHub fanout. Each route has a
+**freshness budget** (`/currently-tending` 30 s, `/activity` 5 min); once a
+cached entry is older than that, the next request still gets the cached
+copy *and* triggers a background refresh, so the entry following it is
+fresh. An entry stays serveable for 10 freshness budgets — 5 min on
+`/currently-tending`, 50 min on `/activity` — before the cache drops it, so
+a viewer never sees data older than that and an ordinarily-trafficked site
+never goes cold.
 
-Cache is demand-driven — nothing runs on a schedule. The first request in
-a TTL window pays the full origin cost; subsequent requests inside that
-window hit the edge cache. A no-traffic day costs zero GitHub calls.
+When a refresh throws (GitHub outage), the empty payload is cached with a
+short **fallback budget** (5 s / 30 s) so the next request retries soon
+rather than locking in an empty response.
+
+Still demand-driven: a background refresh only fires when a request comes
+in, so a no-traffic day costs zero GitHub calls. The cost is one cold
+start — a fresh deploy, or a gap longer than 10 freshness budgets, makes
+that one request wait on the fanout. A cron-triggered prewarm would close
+even that gap but would trade away the zero-when-idle property; not worth
+it at this scale.
 
 ## Endpoint shapes
 
@@ -139,7 +152,7 @@ Cloudflare Worker (tend-website)
   ├─ reads data/consumers.json via raw URL (KV-cached 1 h)
   ├─ /currently-tending: fans out actions/runs per repo (in-progress, tend-*)
   ├─ /activity:          fans out one Search query per bucket per bot
-  └─ each route edge-cached at its own TTL, served at api.tend-src.com
+  └─ each route stale-while-revalidate from the colo cache, served at api.tend-src.com
 ```
 
 ## Local development

--- a/worker/README.md
+++ b/worker/README.md
@@ -2,9 +2,9 @@
 
 Cloudflare Worker that serves the data the tend marketing site renders —
 `/currently-tending` (in-progress tend-* runs) and `/activity` (recent PRs /
-issues / comments + lifetime counts) — each at its own route with its own edge
-TTL. See [`../docs/website-data.md`](../docs/website-data.md) for the route
-table, shapes, and the rate-limit reasoning.
+issues / comments + lifetime counts) — each at its own route with its own
+freshness budget. See [`../docs/website-data.md`](../docs/website-data.md)
+for the route table, shapes, and the rate-limit reasoning.
 
 ## Endpoint
 
@@ -28,22 +28,32 @@ Example (`/currently-tending`) returns:
 }
 ```
 
-`Access-Control-Allow-Origin: *` (public read-only data). Browser and
-Cloudflare edge cache both honor `Cache-Control: public, max-age=30`.
+`Access-Control-Allow-Origin: *` (public read-only data).
 
 ## How it works
 
 The Worker reads `data/consumers.json` from `main` via
-`raw.githubusercontent.com` (KV-cached for 1 h), fans out parallel
-`GET /repos/{r}/actions/runs?status=in_progress&per_page=30` calls
-authenticated with a read-only PAT, filters to `tend-*` workflows, and
-returns the compact JSON above. The rendered response is edge-cached
-(`caches.default`) for 30 s, which both bounds GitHub fanout and dedupes
-concurrent cache misses at the edge. Fallback responses (when refresh
-fails) are cached for 5 s so a transient outage clears fast.
+`raw.githubusercontent.com` (KV-cached for 1 h) and fans out parallel
+authenticated calls to GitHub:
 
-With N=5 consumers and a 30 s TTL, that's at most ~10 GitHub API calls/min
-regardless of viewer count — well below the 5,000/hour limit on the PAT.
+- `/currently-tending` — one `GET /repos/{r}/actions/runs?status=in_progress`
+  per consumer, filtered to `tend-*` workflows.
+- `/activity` — one Search query per primitive bucket (`prs` / `issues` /
+  `comments`) per bot.
+
+Responses are served **stale-while-revalidate** from the colo cache
+(`caches.default`). A request is always answered from cache — no waiting on
+the GitHub fanout. When the cached entry is past its freshness budget
+(`/currently-tending` 30 s, `/activity` 5 min), the hit also kicks off a
+background refresh via `ctx.waitUntil` so the next viewer sees fresher data.
+Only a cold cache — a fresh deploy, or a quiet stretch longer than ten
+freshness budgets — makes one request synchronously refresh. Fallback
+responses (when refresh throws) are cached with a short fallback budget so a
+transient outage clears fast.
+
+Origin load is bounded by the freshness budget, not viewer count. The
+authenticated PAT's 5,000 req/hour and 30 Search req/min ceilings leave
+plenty of headroom for the documented fanout shapes.
 
 ## One-time setup (already done)
 
@@ -85,15 +95,20 @@ GITHUB_TOKEN=ghp_...
 
 ## Cache strategy
 
-- `caches.default` (Cloudflare HTTP edge cache), keyed by the normalized
-  request URL, TTL = `Cache-Control: max-age` — the rendered response.
-  Edge dedupes concurrent misses, so a viral spike fans out at most once
-  per 30 s per edge node.
+- `caches.default` (Cloudflare's colo cache), keyed by the normalized request
+  URL — stores the rendered response. The browser revalidates after the
+  freshness budget (`Cache-Control: max-age`); the colo cache, a shared
+  cache, retains the entry for ten freshness budgets (`s-maxage`) so SWR
+  keeps working between viewers. A `x-tend-stale-at` header on the cached
+  response tells `serveCached` when to background-refresh a hit. A missing
+  or garbled stamp counts as stale, so the first hit self-heals an entry
+  written by code predating this scheme.
 - `CACHE` KV namespace, key `repos:v1`, TTL 1 h — the `consumers.json`
-  content. Decouples `running-tend`'s weekly refresh from Worker deploys.
-  KV is appropriate here because the 1 h TTL is above KV's 60 s minimum
-  and we want cross-isolate sharing.
+  content. Decouples `running-tend`'s weekly refresh from Worker deploys. KV
+  is appropriate here because the 1 h TTL is above KV's 60 s minimum and we
+  want cross-isolate sharing.
 
-A cold cache miss costs N parallel GitHub API calls (one per consumer repo).
-The 30 s TTL keeps the worst case to ~2 GitHub calls/sec for any traffic
-level.
+A cold cache miss costs the route's full fanout (N actions/runs calls for
+`/currently-tending`, 3·N Search calls for `/activity`). The freshness
+budget bounds how often that happens: at most one cold refresh per budget
+per colo, under any traffic level.

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,15 +1,19 @@
 // Cloudflare Worker that serves the tend website's live data streams.
 //
-// Two routes, both CORS-enabled JSON, each with its own edge-cache TTL
-// matched to the freshness budget:
+// Two routes, both CORS-enabled JSON, each with its own freshness budget:
 //
 //   /currently-tending   30 s   in-progress tend-* workflow runs
 //   /activity            5 min  recent PRs / issues / comments + lifetime
 //                               counts, per primitive bucket
 //
 // Both read the consumer list (`consumers.json`) from the repo, KV-cached
-// for an hour, and fan out to GitHub. The edge cache coalesces concurrent
-// misses — origin load is bounded by TTL, not viewer count.
+// for an hour, and fan out to GitHub. Responses are stale-while-revalidate:
+// a request is always answered from the colo cache (no waiting on the
+// fanout) and, when the cached entry is past its budget, also kicks off a
+// background refresh so the next request sees fresher data. Only a cold
+// cache — a fresh deploy, or a quiet stretch long enough for the entry to
+// be evicted — makes a viewer wait. A background refresh only fires on a
+// request, so idle days still cost zero GitHub calls.
 //
 // `/activity` is one Search query per bucket per bot (`sort=updated`): the
 // page yields both the recent items and the lifetime `total_count`; "this
@@ -18,7 +22,7 @@
 // Search requests, under the 30/min cap up to ~10 bots.
 //
 // See docs/website-data.md for architecture and the rate-limit reasoning
-// behind the TTLs.
+// behind the budgets.
 
 interface Env {
   GITHUB_TOKEN: string;
@@ -110,12 +114,24 @@ const BUCKET_QUERIES: Record<ActivityBucketName, (bot: string) => string> = {
   comments: (b) => `commenter:${b} -author:${b}`, // …chimed in on these PRs/issues
 };
 
-// Per-route TTLs. The fallback TTL (used when refresh throws) is shorter
-// so a transient outage clears quickly.
+// Per-route freshness budgets, in seconds. `ok` applies to a good refresh;
+// `fallback` (used when the refresh throws) is shorter so a transient
+// outage clears quickly. Past its budget a cached entry is still served —
+// see serveCached's stale-while-revalidate — until it's STALE_SERVE_FACTOR
+// budgets old, at which point the colo cache drops it.
 const TTL = {
   "currently-tending": { ok: 30, fallback: 5 },
   activity: { ok: 300, fallback: 30 },
 } as const;
+
+// Multiple of the freshness budget that a cached entry stays serveable
+// before the colo cache evicts it. Bounds how stale a viewer can see; the
+// larger it is, the longer a quiet site stays warm between refreshes.
+const STALE_SERVE_FACTOR = 10;
+
+// serveCached stamps each cached response with the instant (epoch ms) past
+// which a hit should trigger a background refresh.
+const STALE_AT_HEADER = "x-tend-stale-at";
 
 // owner/name — alphanumerics + `_-.`, no leading `.`/`-`, no `..` anywhere,
 // exactly one slash.
@@ -182,33 +198,70 @@ async function serveCached<T>(
   ctx: ExecutionContext,
   opts: CacheOpts<T>,
 ): Promise<Response> {
-  // Normalize the cache key so query strings don't fork the cache. The
-  // HTTP edge cache coalesces concurrent misses, which bounds origin
-  // fanout AND dodges KV's 60s minimum expirationTtl.
+  // Normalize the cache key so query strings don't fork the cache. Using
+  // the colo cache (not KV) for the response also dodges KV's 60s minimum
+  // expirationTtl — currently-tending's budget is shorter than that.
   const cacheKey = new Request(`${url.origin}${opts.cacheKeyPath}`, {
     method: "GET",
   });
   const cached = await caches.default.match(cacheKey).catch(() => undefined);
+
   if (cached) {
+    // Stale-while-revalidate: answer from cache immediately — never make a
+    // viewer wait on the GitHub fanout. Past its freshness budget, refresh
+    // in the background so the next request gets fresher data. A burst of
+    // concurrent stale-hits can fan out several refreshes at once; the
+    // short fallback budget caps the fallout if that trips a rate limit.
+    if (isStale(cached.headers.get(STALE_AT_HEADER), Date.now())) {
+      ctx.waitUntil(
+        refreshAndCache(cacheKey, env, ctx, opts).catch((e) =>
+          console.error(
+            `background refresh failed for ${opts.cacheKeyPath}:`,
+            e,
+          ),
+        ),
+      );
+    }
     return cached;
   }
 
-  // On any unexpected failure return the empty payload (with a short TTL)
-  // so a transient outage doesn't break the page or wedge the cache.
+  // Cold cache — a fresh deploy, or no traffic for STALE_SERVE_FACTOR
+  // budgets. This request pays the fanout; everyone after it is served
+  // from cache until the next cold start.
+  return refreshAndCache(cacheKey, env, ctx, opts);
+}
+
+// Run the refresh, store the result in the colo cache stamped with its
+// freshness budget, and return the response. On any unexpected failure,
+// cache the empty payload with the shorter fallback budget so a transient
+// outage doesn't break the page or wedge the cache.
+async function refreshAndCache<T>(
+  cacheKey: Request,
+  env: Env,
+  ctx: ExecutionContext,
+  opts: CacheOpts<T>,
+): Promise<Response> {
   let fresh: T;
-  let isFallback = false;
+  let ttlSeconds = opts.ttl.ok;
   try {
     fresh = await opts.refresh();
   } catch (e) {
     console.error(`refresh failed for ${opts.cacheKeyPath}:`, e);
     fresh = opts.empty();
-    isFallback = true;
+    ttlSeconds = opts.ttl.fallback;
   }
-
-  const ttl = isFallback ? opts.ttl.fallback : opts.ttl.ok;
-  const response = jsonResponse(fresh, env, ttl);
+  const response = jsonResponse(fresh, env, ttlSeconds);
   ctx.waitUntil(caches.default.put(cacheKey, response.clone()));
   return response;
+}
+
+// A cached entry past this instant (epoch ms, from STALE_AT_HEADER) is
+// still served but triggers a background refresh. A missing or garbled
+// stamp counts as stale, so an entry written before this scheme — or any
+// the cache mangles — gets refreshed promptly.
+function isStale(staleAtHeader: string | null, nowMs: number): boolean {
+  const staleAt = Number(staleAtHeader);
+  return !Number.isFinite(staleAt) || nowMs >= staleAt;
 }
 
 // ---------------------------------------------------------------------------
@@ -428,10 +481,20 @@ function withCors(resp: Response, env: Env): Response {
 }
 
 function jsonResponse(data: unknown, env: Env, ttlSeconds: number): Response {
+  const staleAtMs = Date.now() + ttlSeconds * 1000;
   return new Response(JSON.stringify(data), {
     headers: {
       "Content-Type": "application/json",
-      "Cache-Control": `public, max-age=${ttlSeconds}`,
+      // Browsers revalidate after the freshness budget (`max-age`); the
+      // colo cache, a shared cache, keeps the entry for STALE_SERVE_FACTOR
+      // budgets (`s-maxage`) so it stays warm for stale-while-revalidate.
+      // Assumes Cloudflare's zone cache isn't also storing this route — it
+      // isn't on a vanilla Workers custom domain, but adding a Cache Rule
+      // here would honor `s-maxage` and break SWR by shadowing the Worker.
+      "Cache-Control":
+        `public, max-age=${ttlSeconds}, ` +
+        `s-maxage=${ttlSeconds * STALE_SERVE_FACTOR}`,
+      [STALE_AT_HEADER]: String(staleAtMs),
       "Access-Control-Allow-Origin": env.ALLOWED_ORIGIN,
     },
   });
@@ -458,4 +521,5 @@ export const __test = {
   isConsumerArray,
   isValidRepo,
   isValidBotName,
+  isStale,
 };

--- a/worker/test/worker.test.ts
+++ b/worker/test/worker.test.ts
@@ -455,6 +455,24 @@ describe("getConsumers", () => {
   });
 });
 
+describe("isStale (stale-while-revalidate decision)", () => {
+  const now = 1_700_000_000_000;
+
+  it("treats a future stamp as fresh and past/at as stale", async () => {
+    const { __test } = await import("../src/index");
+    expect(__test.isStale(String(now + 1000), now)).toBe(false);
+    expect(__test.isStale(String(now - 1000), now)).toBe(true);
+    expect(__test.isStale(String(now), now)).toBe(true); // boundary refreshes
+  });
+
+  it("treats a missing or garbled stamp as stale", async () => {
+    const { __test } = await import("../src/index");
+    expect(__test.isStale(null, now)).toBe(true);
+    expect(__test.isStale("", now)).toBe(true);
+    expect(__test.isStale("not-a-number", now)).toBe(true);
+  });
+});
+
 function makeFakeKv(): KVNamespace {
   const store = new Map<string, string>();
   return {


### PR DESCRIPTION
The `/activity` stat strip — `964 PRs / 1,512 comments / 186 issues` — took a couple of seconds to load on every visit that landed inside a fresh 5-minute window: the first request fanned out 12 concurrent GitHub Search calls and the viewer waited for them.

This is stale-while-revalidate. A request always returns from the colo cache immediately; when the cached entry is past its freshness budget, the hit *also* kicks off a `ctx.waitUntil(refreshAndCache(...))` so the next viewer gets fresher data. Only a cold cache — a fresh deploy, or a quiet stretch longer than ten freshness budgets — makes one request synchronously refresh.

### Mechanism

Each cached response carries `x-tend-stale-at` (epoch ms = put time + ttl) and `Cache-Control: public, max-age=<ttl>, s-maxage=<10·ttl>`. The colo cache honors `s-maxage`, keeping the entry serveable for 10 budgets (5 min on `/currently-tending`, 50 min on `/activity`). Browsers ignore `s-maxage` and use `max-age`. `serveCached` reads the stamp on each hit to decide whether to background-refresh; a missing or garbled stamp counts as stale, so the first hit after this deploys self-heals any entry written by the old code.

Fallback budget semantics are preserved: a refresh that throws still writes the empty payload with `opts.ttl.fallback`, so the next visitor retries quickly.

### Verified

`curl -sD- https://api.tend-src.com/activity` against the current production deploy returns no `cf-cache-status` and no `Age` header, confirming Cloudflare's zone CDN isn't caching this Worker route — so `s-maxage` only affects `caches.default` retention, exactly as the design assumes. A note next to the `Cache-Control` line flags the assumption so a future Cache Rule on this host would prompt a revisit.

Tests, typecheck, and `pre-commit` all green; added 2 unit cases for the pure `isStale` helper (boundary, missing, garbled stamps).

### Trade-offs left in

A burst of concurrent stale-hits can fan out several refreshes at once; the short fallback budget caps the damage if that ever trips a rate limit. `STALE_SERVE_FACTOR = 10` is one knob across both routes; per-route values would be straightforward but add a knob without a current pain point. A cron prewarm would close the cold-start gap entirely but trade away the "zero GitHub calls when idle" property — documented as a deliberate non-choice in `docs/website-data.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
