### PR TITLE
worker+site: split /activity reviews from comments; filter bookkeeping issues

### DIFF
--- a/docs/website-data.md
+++ b/docs/website-data.md
@@ -94,27 +94,30 @@ Recent things tend has done, in primitive buckets — one Search query per bucke
 per bot (`sort=updated`): the page yields both the `recent` items and the
 lifetime `count` (`total_count`); `count_this_week` is counted off the page, so
 it saturates around one page (~100) per bot per bucket — fine for a headline
-number. The fanout is 3·N concurrent Search requests, which stays under the
-30 req/min cap up to ~10 bots; past that, the per-bot calls would need
+number. The fanout is 4·N concurrent Search requests, which stays under the
+30 req/min cap up to ~7 bots; past that, the per-bot calls would need
 staggering or a scheduled refresh (see the Phase-2 note).
 
 ```jsonc
 {
   "generated_at": "2026-05-10T17:30:00Z",
-  "prs":      { "count": 980,  "count_this_week": 12, "recent": [ /* RecentItem */ ] },
-  "issues":   { "count": 41,   "count_this_week": 1,  "recent": [ ... ] },
-  "comments": { "count": 1530, "count_this_week": 36, "recent": [ ... ] }
+  "prs":      { "count": 485,  "count_this_week": 6,  "recent": [ /* RecentItem */ ] },
+  "issues":   { "count": 82,   "count_this_week": 2,  "recent": [ ... ] },
+  "reviews":  { "count": 1102, "count_this_week": 28, "recent": [ ... ] },
+  "comments": { "count": 206,  "count_this_week": 4,  "recent": [ ... ] }
 }
 ```
 
-`RecentItem` = `{ repo, title, url, at }` (`at` is the issue/PR `updated_at`),
-newest-first, ≤10 per bucket.
+`RecentItem` = `{ repo, title, url, at }`. `at` is the parent issue/PR's
+`updated_at`, and `title` is the parent's title — Search returns the item, not
+the comment or review body. Newest-first, ≤10 per bucket.
 
 | bucket | Search query | "the bot …" |
 | --- | --- | --- |
 | `prs` | `author:<bot> is:pr` | opened these PRs (any state) |
-| `issues` | `author:<bot> is:issue` | opened these issues — mostly tend's own trackers (missing PAT scopes, "nightly tests failed", `tend-outage`), so this bucket leans "tend flagged a problem" |
-| `comments` | `commenter:<bot> -author:<bot>` | chimed in on these PRs/issues (not its own) |
+| `issues` | `author:<bot> is:issue` minus four bookkeeping labels (`tend-outage`, `review-runs-tracking`, `review-reviewers-tracking`, `nightly-cleanup`) | opened these issues, filed against the repo — tend's own outage and tracking issues are excluded |
+| `reviews` | `reviewed-by:<bot>` | reviewed these PRs (approve / request-changes / review comment) — by volume, tend's main action |
+| `comments` | `commenter:<bot> -author:<bot> -reviewed-by:<bot>` | commented on these PRs/issues — excludes its own threads and items already in `reviews` |
 
 > **TODO — Phase 2:** a consumer (a scheduled job, or the Worker calling Claude)
 > reads `/activity` and writes a short prose summary of what tend's been up to;

--- a/site/src/components/Activity.astro
+++ b/site/src/components/Activity.astro
@@ -34,16 +34,18 @@
   interface Activity {
     prs?: Bucket;
     issues?: Bucket;
+    reviews?: Bucket;
     comments?: Bucket;
   }
 
-  type Kind = "pr" | "issue" | "comment";
-  const KIND_LABELS: Record<Kind, string> = { pr: "PR", issue: "issue", comment: "comment" };
+  type Kind = "pr" | "issue" | "review" | "comment";
+  const KIND_LABELS: Record<Kind, string> = { pr: "PR", issue: "issue", review: "review", comment: "comment" };
 
   liveData<Activity>("/activity", "recent-activity", (data) => {
     const rows: Array<RecentItem & { kind: Kind }> = [
       ...(data?.prs?.recent ?? []).map((r) => ({ ...r, kind: "pr" as const })),
       ...(data?.issues?.recent ?? []).map((r) => ({ ...r, kind: "issue" as const })),
+      ...(data?.reviews?.recent ?? []).map((r) => ({ ...r, kind: "review" as const })),
       ...(data?.comments?.recent ?? []).map((r) => ({ ...r, kind: "comment" as const })),
     ];
     rows.sort((a, b) => (a.at < b.at ? 1 : a.at > b.at ? -1 : 0));

--- a/site/src/components/CurrentlyTending.astro
+++ b/site/src/components/CurrentlyTending.astro
@@ -21,6 +21,7 @@
   interface Activity {
     prs?: Bucket;
     issues?: Bucket;
+    reviews?: Bucket;
     comments?: Bucket;
   }
 
@@ -46,7 +47,7 @@
       }
 
       const activity = await fetchJson<Activity>("/activity");
-      const newest = [activity?.prs, activity?.issues, activity?.comments]
+      const newest = [activity?.prs, activity?.issues, activity?.reviews, activity?.comments]
         .map((b) => b?.recent?.[0]?.at)
         .filter((at): at is string => !!at)
         .sort()

--- a/site/src/components/Stats.astro
+++ b/site/src/components/Stats.astro
@@ -18,6 +18,7 @@
   interface Activity {
     prs: Bucket;
     issues: Bucket;
+    reviews: Bucket;
     comments: Bucket;
   }
 
@@ -29,6 +30,7 @@
     if (!data) return false;
     const cells = [
       { n: data.prs?.count ?? 0, week: data.prs?.count_this_week ?? 0, label: "PRs" },
+      { n: data.reviews?.count ?? 0, week: data.reviews?.count_this_week ?? 0, label: "reviews" },
       { n: data.comments?.count ?? 0, week: data.comments?.count_this_week ?? 0, label: "comments" },
       { n: data.issues?.count ?? 0, week: data.issues?.count_this_week ?? 0, label: "issues" },
     ];

--- a/worker/README.md
+++ b/worker/README.md
@@ -2,9 +2,9 @@
 
 Cloudflare Worker that serves the data the tend marketing site renders —
 `/currently-tending` (in-progress tend-* runs) and `/activity` (recent PRs /
-issues / comments + lifetime counts) — each at its own route with its own edge
-TTL. See [`../docs/website-data.md`](../docs/website-data.md) for the route
-table, shapes, and the rate-limit reasoning.
+issues / reviews / comments + lifetime counts) — each at its own route with its
+own edge TTL. See [`../docs/website-data.md`](../docs/website-data.md) for the
+route table, shapes, and the rate-limit reasoning.
 
 ## Endpoint
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -4,8 +4,8 @@
 // matched to the freshness budget:
 //
 //   /currently-tending   30 s   in-progress tend-* workflow runs
-//   /activity            5 min  recent PRs / issues / comments + lifetime
-//                               counts, per primitive bucket
+//   /activity            5 min  recent PRs / issues / reviews / comments +
+//                               lifetime counts, per primitive bucket
 //
 // Both read the consumer list (`consumers.json`) from the repo, KV-cached
 // for an hour, and fan out to GitHub. The edge cache coalesces concurrent
@@ -14,8 +14,8 @@
 // `/activity` is one Search query per bucket per bot (`sort=updated`): the
 // page yields both the recent items and the lifetime `total_count`; "this
 // week" is counted off the page, so it saturates around one page (~100) per
-// bot per bucket — fine for a headline number. The fanout is 3·N concurrent
-// Search requests, under the 30/min cap up to ~10 bots.
+// bot per bucket — fine for a headline number. The fanout is 4·N concurrent
+// Search requests, under the 30/min cap up to ~7 bots.
 //
 // See docs/website-data.md for architecture and the rate-limit reasoning
 // behind the TTLs.
@@ -55,7 +55,7 @@ interface CurrentlyTendingResponse {
 }
 
 // /activity: one bucket per primitive Search query, named off the query.
-type ActivityBucketName = "prs" | "issues" | "comments";
+type ActivityBucketName = "prs" | "issues" | "reviews" | "comments";
 
 interface RecentItem {
   repo: string; // "owner/name"
@@ -103,11 +103,25 @@ const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 const GITHUB_API = "https://api.github.com";
 const USER_AGENT = "tend-website-worker";
 
+// tend's own bookkeeping issues — "Bot temporarily unavailable" outage
+// trackers, the monthly review-runs / review-reviewers trackers, nightly
+// drift-cleanup notes — carry these labels. The `issues` bucket excludes
+// them so its count reflects issues filed about the repo, not tend's
+// internal record-keeping. A repo without a label just matches nothing.
+const BOOKKEEPING_LABELS = [
+  "tend-outage",
+  "review-runs-tracking",
+  "review-reviewers-tracking",
+  "nightly-cleanup",
+];
+const ISSUE_LABEL_FILTER = BOOKKEEPING_LABELS.map((l) => `-label:${l}`).join(" ");
+
 // `q` for each /activity bucket — "the bot …":
 const BUCKET_QUERIES: Record<ActivityBucketName, (bot: string) => string> = {
   prs: (b) => `author:${b} is:pr`, // …opened these PRs
-  issues: (b) => `author:${b} is:issue`, // …opened these issues
-  comments: (b) => `commenter:${b} -author:${b}`, // …chimed in on these PRs/issues
+  issues: (b) => `author:${b} is:issue ${ISSUE_LABEL_FILTER}`, // …opened these issues (minus its own bookkeeping)
+  reviews: (b) => `reviewed-by:${b}`, // …reviewed these PRs (approve / request-changes / review comment)
+  comments: (b) => `commenter:${b} -author:${b} -reviewed-by:${b}`, // …commented on these PRs/issues (not its own, not folded in from a review)
 };
 
 // Per-route TTLs. The fallback TTL (used when refresh throws) is shorter
@@ -318,6 +332,7 @@ function emptyActivity(): ActivityResponse {
     generated_at: nowIso(),
     prs: { count: 0, count_this_week: 0, recent: [] },
     issues: { count: 0, count_this_week: 0, recent: [] },
+    reviews: { count: 0, count_this_week: 0, recent: [] },
     comments: { count: 0, count_this_week: 0, recent: [] },
   };
 }

--- a/worker/test/worker.test.ts
+++ b/worker/test/worker.test.ts
@@ -160,13 +160,18 @@ describe("refreshCurrentlyTending", () => {
 });
 
 describe("refreshActivity", () => {
-  // Build a Search URL the way searchRaw does: q + per_page, then sort/order
-  // appended (perPage > 1).
+  // Build a Search URL the way searchIssues does: q + per_page + sort + order.
   const searchUrl = (q: string) =>
     `https://api.github.com/search/issues?${new URLSearchParams({
       q,
       per_page: "100",
     })}&sort=updated&order=desc`;
+
+  // The label filter the worker appends to the `issues` bucket query —
+  // mirrors BOOKKEEPING_LABELS in src/index.ts. Coupling is deliberate: a
+  // change to that list is a behaviour change and should break this test.
+  const ISSUE_FILTER =
+    "-label:tend-outage -label:review-runs-tracking -label:review-reviewers-tracking -label:nightly-cleanup";
 
   it("fans out one Search query per bucket per bot — sums counts, merges + sorts recent, counts this week", async () => {
     const { __test } = await import("../src/index");
@@ -197,13 +202,15 @@ describe("refreshActivity", () => {
           { repo: "o/b", bot_name: "bot-b" },
         ],
       ],
-      // bots sorted → bot-a, bot-b. Buckets in declared order: prs, issues, comments.
+      // bots sorted → bot-a, bot-b. Buckets in declared order: prs, issues, reviews, comments.
       [searchUrl("author:bot-a is:pr"), { total_count: 7, items: [item("o/a", 1, "pull", recentA), item("o/a", 2, "pull", oldA)] }],
       [searchUrl("author:bot-b is:pr"), { total_count: 3, items: [item("o/b", 9, "pull", oldB)] }],
-      [searchUrl("author:bot-a is:issue"), { total_count: 2, items: [item("o/a", 5, "issues", recentB)] }],
-      [searchUrl("author:bot-b is:issue"), { total_count: 0, items: [] }],
-      [searchUrl("commenter:bot-a -author:bot-a"), { total_count: 12, items: [item("o/a", 3, "pull", recentA)] }],
-      [searchUrl("commenter:bot-b -author:bot-b"), { total_count: 4, items: [item("o/b", 8, "issues", recentB)] }],
+      [searchUrl(`author:bot-a is:issue ${ISSUE_FILTER}`), { total_count: 2, items: [item("o/a", 5, "issues", recentB)] }],
+      [searchUrl(`author:bot-b is:issue ${ISSUE_FILTER}`), { total_count: 0, items: [] }],
+      [searchUrl("reviewed-by:bot-a"), { total_count: 9, items: [item("o/a", 4, "pull", recentA)] }],
+      [searchUrl("reviewed-by:bot-b"), { total_count: 5, items: [item("o/b", 7, "pull", oldB)] }],
+      [searchUrl("commenter:bot-a -author:bot-a -reviewed-by:bot-a"), { total_count: 12, items: [item("o/a", 3, "pull", recentA)] }],
+      [searchUrl("commenter:bot-b -author:bot-b -reviewed-by:bot-b"), { total_count: 4, items: [item("o/b", 8, "issues", recentB)] }],
     ]);
     globalThis.fetch = makeFetch(responses) as unknown as typeof fetch;
 
@@ -230,6 +237,14 @@ describe("refreshActivity", () => {
       count_this_week: 1,
       recent: [
         { repo: "o/a", title: "o/a#5", url: "https://github.com/o/a/issues/5", at: recentB },
+      ],
+    });
+    expect(out.reviews).toEqual({
+      count: 14, // 9 + 5
+      count_this_week: 1, // o/a#4 recent; o/b#7 old
+      recent: [
+        { repo: "o/a", title: "o/a#4", url: "https://github.com/o/a/pull/4", at: recentA },
+        { repo: "o/b", title: "o/b#7", url: "https://github.com/o/b/pull/7", at: oldB },
       ],
     });
     expect(out.comments).toEqual({
@@ -272,6 +287,7 @@ describe("refreshActivity", () => {
     expect(out.comments).toEqual({ count: 0, count_this_week: 0, recent: [] });
     expect(out.prs.count).toBe(1);
     expect(out.issues.count).toBe(1);
+    expect(out.reviews.count).toBe(1);
   });
 
   it("returns empty buckets when there are no consumers", async () => {
@@ -293,6 +309,7 @@ describe("refreshActivity", () => {
     const out = await __test.refreshActivity(env);
     expect(out.prs).toEqual({ count: 0, count_this_week: 0, recent: [] });
     expect(out.issues).toEqual({ count: 0, count_this_week: 0, recent: [] });
+    expect(out.reviews).toEqual({ count: 0, count_this_week: 0, recent: [] });
     expect(out.comments).toEqual({ count: 0, count_this_week: 0, recent: [] });
   });
 


### PR DESCRIPTION
The `comments` bucket on `/activity` was matching PR review submissions — including body-less "Approved" reviews — because GitHub's `commenter:` Search qualifier covers reviews, not just discussion comments. The activity feed rendered them with a `comment` badge next to the parent PR's title, so a routine dependabot-bump approval looked like tend had commented on (or authored) the bump.

Split `/activity` into four primitive buckets so reviews tag as reviews:

| bucket | Search query |
| --- | --- |
| `prs` | `author:<bot> is:pr` |
| `issues` | `author:<bot> is:issue` minus four bookkeeping labels |
| `reviews` | `reviewed-by:<bot>` |
| `comments` | `commenter:<bot> -author:<bot> -reviewed-by:<bot>` |

The `-reviewed-by:` exclusion on `comments` is what cleanly separates the two — a PR the bot reviewed (with or without a body) lands in `reviews`, not `comments`.

The `issues` bucket also drops tend's own outage and tracking issues (`tend-outage`, `review-runs-tracking`, `review-reviewers-tracking`, `nightly-cleanup`) so its count reflects issues filed *about* the repo, not tend's internal record-keeping.

Stat strip gains a `reviews` cell (now PRs / reviews / comments / issues); the recent-activity feed picks up a `review` kind alongside `pr`/`issue`/`comment`; `CurrentlyTending`'s "last tended N min ago" fallback considers the new bucket.

Worker fanout goes 3·N → 4·N concurrent Search requests per refresh; doc and header comments updated (~10 → ~7 bots before the 30/min cap).
