### PR TITLE
site: align activity rows via CSS subgrid

### DIFF
--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -471,12 +471,15 @@ hr::after {
   list-style: none;
   margin: 0;
   padding: 0;
+  display: grid;
+  grid-template-columns: auto minmax(0, 11rem) minmax(0, 1fr) auto;
+  column-gap: 1rem;
 }
 
 .activity-row {
   display: grid;
-  grid-template-columns: auto minmax(0, 11rem) minmax(0, 1fr) auto;
-  gap: 1rem;
+  grid-column: 1 / -1;
+  grid-template-columns: subgrid;
   align-items: baseline;
   padding: 0.6rem 0;
   border-bottom: 1px solid var(--paper-deep);
@@ -526,7 +529,11 @@ hr::after {
 }
 
 @media (max-width: 720px) {
+  .activity-rows {
+    display: block;
+  }
   .activity-row {
+    grid-column: auto;
     grid-template-columns: auto 1fr;
     grid-template-areas:
       "kind repo"


### PR DESCRIPTION
## What

The "recent ground" homepage section had rows whose columns visually jittered — repo names and titles shifted left/right depending on whether the kind badge in that row was `PR` (2 chars) or `comment` (7 chars). Only the right-anchored timestamp aligned.

## Why

Each `<li class="activity-row">` was its own grid container with `grid-template-columns: auto minmax(0, 11rem) minmax(0, 1fr) auto`. The leading `auto` column sized to that row's badge text, so column tracks were independent per row.

## Fix

Promote the grid to `.activity-rows` (the `<ul>`) and make each `<li>` a subgrid spanning all four columns. Every row now shares one set of column tracks, so all column edges line up — including for the `review` badge coming in #446. Mobile (`max-width: 720px`) drops the parent grid and resets the row to its own grid-template-areas layout, same as before.

## Verification

- Measured all four column edges across 12 live rows post-fix: identical x for every row.
- Injected a synthetic `review` badge — still aligned.
- Long titles still ellipsize cleanly.
- Mobile layout (kind+repo stacked over title, then timestamp) still works.
- `astro build` and `pre-commit run --all-files` pass.
