### PR TITLE
worker: coalesce concurrent stale-hits so one background refresh fires per stale window

### DIFF
--- a/docs/website-data.md
+++ b/docs/website-data.md
@@ -63,6 +63,14 @@ fresh. An entry stays serveable for 10 freshness budgets — 5 min on
 a viewer never sees data older than that and an ordinarily-trafficked site
 never goes cold.
 
+Concurrent stale-hits are coalesced. The first stale-hit pushes the
+cached entry's stale-at forward by a short grace window (30 s) before
+starting its background refresh; viewers arriving within that window
+read the bumped entry as fresh and skip starting their own refresh. The
+real refresh's put overwrites the bumped entry with fresh data when it
+completes. One refresh per stale window per colo, not one per viewer —
+keeps the Search fanout under the 30 req/min cap during bursts.
+
 When a refresh throws (GitHub outage), the empty payload is cached with a
 short **fallback budget** (5 s / 30 s) so the next request retries soon
 rather than locking in an empty response.

--- a/worker/README.md
+++ b/worker/README.md
@@ -108,6 +108,13 @@ GITHUB_TOKEN=ghp_...
   is appropriate here because the 1 h TTL is above KV's 60 s minimum and we
   want cross-isolate sharing.
 
+Concurrent stale-hits are coalesced: the first request pushes the
+cached entry's `x-tend-stale-at` forward by a short grace window
+(`REFRESH_GRACE_MS`, currently 30 s) and starts the background refresh;
+viewers arriving within that window read the bumped entry as fresh and
+skip starting their own refresh. One refresh per stale window per colo,
+not one per viewer — keeps the Search-API fanout bounded under bursts.
+
 A cold cache miss costs the route's full fanout (N actions/runs calls for
 `/currently-tending`, 4·N Search calls for `/activity`). The freshness
 budget bounds how often that happens: at most one cold refresh per budget

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -147,6 +147,14 @@ const STALE_SERVE_FACTOR = 10;
 // which a hit should trigger a background refresh.
 const STALE_AT_HEADER = "x-tend-stale-at";
 
+// How far forward a stale-hit pushes its cached entry's stale-at before
+// firing the background refresh. Concurrent stale-hits within this window
+// read the bumped entry as fresh and skip starting their own refresh, so
+// the colo runs one refresh per stale window instead of one per viewer.
+// Comfortably above the FETCH_TIMEOUT_MS=10s worst-case refresh time; the
+// real refresh's put overwrites the bumped entry as soon as it completes.
+const REFRESH_GRACE_MS = 30_000;
+
 // owner/name — alphanumerics + `_-.`, no leading `.`/`-`, no `..` anywhere,
 // exactly one slash.
 const REPO_PART = /^[A-Za-z0-9_][A-Za-z0-9._-]*$/;
@@ -222,13 +230,15 @@ async function serveCached<T>(
 
   if (cached) {
     // Stale-while-revalidate: answer from cache immediately — never make a
-    // viewer wait on the GitHub fanout. Past its freshness budget, refresh
-    // in the background so the next request gets fresher data. A burst of
-    // concurrent stale-hits can fan out several refreshes at once; the
-    // short fallback budget caps the fallout if that trips a rate limit.
+    // viewer wait on the GitHub fanout. Past its freshness budget, kick
+    // off a background refresh so the next request gets fresher data.
+    // coalesceAndRefresh first pushes the entry's stale-at forward by
+    // REFRESH_GRACE_MS so concurrent stale-hits within that window read
+    // the entry as fresh and skip starting their own refresh — one refresh
+    // per stale window per colo instead of one per viewer.
     if (isStale(cached.headers.get(STALE_AT_HEADER), Date.now())) {
       ctx.waitUntil(
-        refreshAndCache(cacheKey, env, ctx, opts).catch((e) =>
+        coalesceAndRefresh(cacheKey, cached, env, opts).catch((e) =>
           console.error(
             `background refresh failed for ${opts.cacheKeyPath}:`,
             e,
@@ -245,16 +255,11 @@ async function serveCached<T>(
   return refreshAndCache(cacheKey, env, ctx, opts);
 }
 
-// Run the refresh, store the result in the colo cache stamped with its
-// freshness budget, and return the response. On any unexpected failure,
-// cache the empty payload with the shorter fallback budget so a transient
-// outage doesn't break the page or wedge the cache.
-async function refreshAndCache<T>(
-  cacheKey: Request,
-  env: Env,
-  ctx: ExecutionContext,
-  opts: CacheOpts<T>,
-): Promise<Response> {
+// Run the configured refresh and shape it into a Response stamped with
+// its freshness budget. On any unexpected failure return the empty
+// payload tagged with the shorter fallback budget so a transient outage
+// clears quickly instead of wedging the cache.
+async function freshResponse<T>(env: Env, opts: CacheOpts<T>): Promise<Response> {
   let fresh: T;
   let ttlSeconds = opts.ttl.ok;
   try {
@@ -264,9 +269,40 @@ async function refreshAndCache<T>(
     fresh = opts.empty();
     ttlSeconds = opts.ttl.fallback;
   }
-  const response = jsonResponse(fresh, env, ttlSeconds);
+  return jsonResponse(fresh, env, ttlSeconds);
+}
+
+// Cold-cache path: the caller is waiting on this, so we return the fresh
+// Response and let the cache put run via ctx.waitUntil.
+async function refreshAndCache<T>(
+  cacheKey: Request,
+  env: Env,
+  ctx: ExecutionContext,
+  opts: CacheOpts<T>,
+): Promise<Response> {
+  const response = await freshResponse(env, opts);
   ctx.waitUntil(caches.default.put(cacheKey, response.clone()));
   return response;
+}
+
+// Stale-hit path: coalesce concurrent refreshes by bumping the cached
+// entry's stale-at forward before running the refresh. Concurrent
+// stale-hits arriving within REFRESH_GRACE_MS read the bumped entry as
+// fresh and skip starting their own refresh. The puts are sequenced —
+// bumped first, then the fresh result — so the fresh result always wins.
+async function coalesceAndRefresh<T>(
+  cacheKey: Request,
+  cached: Response,
+  env: Env,
+  opts: CacheOpts<T>,
+): Promise<void> {
+  const bumped = new Response(cached.clone().body, {
+    status: cached.status,
+    headers: new Headers(cached.headers),
+  });
+  bumped.headers.set(STALE_AT_HEADER, String(Date.now() + REFRESH_GRACE_MS));
+  await caches.default.put(cacheKey, bumped);
+  await caches.default.put(cacheKey, await freshResponse(env, opts));
 }
 
 // A cached entry past this instant (epoch ms, from STALE_AT_HEADER) is


### PR DESCRIPTION
PR #445 (stale-while-revalidate) called out an open trade-off: a burst of concurrent stale-hits could each fan out their own background refresh, so K viewers landing on a stale `/activity` entry triggered K Search fanouts — 4·N·K Search calls against GitHub's 30/min cap. The short fallback budget capped the fallout but the burst was wasteful.

This coalesces the burst. Before firing the real refresh in the stale-hit branch, the worker pushes the cached entry's `x-tend-stale-at` forward by `REFRESH_GRACE_MS` (30 s) and writes it back to the colo cache; concurrent stale-hits arriving within that window read the bumped entry as `isStale → false` and skip starting their own refresh. The real refresh's put overwrites the bumped entry with fresh data when it completes. One refresh per stale window per colo, instead of one per viewer.

### Mechanism

`coalesceAndRefresh` (new) sequences two puts: a bump-put that copies the cached body and overrides only `x-tend-stale-at`, then a fresh-put with the refresh result (or fallback payload on throw — fallback budget semantics preserved, since the bump only extends staleness up to the moment the real put lands). `refreshAndCache` (cold path) is unchanged in behavior; the refresh-or-fallback logic is extracted into `freshResponse` and shared.

### Trade-offs left in

Not perfectly one refresh per stale window. K viewers reading the stale entry within the colo's cache-propagation window (a few ms in practice) all still enter `coalesceAndRefresh` and fire a refresh — once a bump-put propagates colo-wide, subsequent viewers skip. So K drops from "all viewers in the stale window" to "viewers in the propagation window", a meaningful improvement without needing Durable Objects. Decision-time jitter (xfetch) would tighten this further; deferred until traffic actually surfaces it.
