### PR TITLE
feat(generator): expose `__TEND_DELETE__` sentinel for RFC 7396 deletes

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -157,6 +157,16 @@ packages = "read"
 # Result: packages added, contents/pull-requests/id-token/actions/issues preserved
 ```
 
+RFC 7396 also uses `null` to delete a key, but TOML has no `null` literal.
+The string sentinel `"__TEND_DELETE__"` substitutes — a pre-pass converts
+it to `None` before merging. Example: drop the cron from a scheduled
+workflow while keeping `workflow_dispatch`:
+
+```toml
+[workflows.nightly.workflow_extra.on]
+schedule = "__TEND_DELETE__"
+```
+
 When overrides are present, the generator renders the base template, parses it,
 merges the overrides, and re-serializes. The output YAML formatting differs
 slightly from the base template (block-style lists, quoted `'on':` key) but is

--- a/docs/tend.example.toml
+++ b/docs/tend.example.toml
@@ -243,3 +243,21 @@ bot_name = "my-project-bot"
 #
 # [workflows.review.workflow_extra.env]
 # MY_VAR = "hello"
+#
+# ### Example: delete a generated key
+#
+# TOML has no `null` literal, so the RFC 7396 delete semantic (set a key to
+# null to remove it) is reached via the string sentinel `"__TEND_DELETE__"`.
+# The generator swaps the sentinel for None before merging. Use this to drop
+# a generator-injected key entirely — useful when list-replace or `if:`
+# filters can't express what you want.
+#
+# Drop the cron from a scheduled workflow (keep `workflow_dispatch`):
+#
+# [workflows.nightly.workflow_extra.on]
+# schedule = "__TEND_DELETE__"
+#
+# Drop one trigger from `tend-mention` (keep the rest of `on:`):
+#
+# [workflows.mention.workflow_extra.on]
+# issues = "__TEND_DELETE__"

--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -805,6 +805,24 @@ def generate_review_runs(cfg: Config) -> GeneratedWorkflow:
 # Extras (workflow_extra / jobs pass-through)
 # ---------------------------------------------------------------------------
 
+# TOML has no `null` literal, so the RFC 7396 delete branch in `_deep_merge`
+# (None pops the key) is unreachable from `.config/tend.toml`. This sentinel
+# string stands in for null: a pre-pass converts it to None before merging.
+DELETE_SENTINEL = "__TEND_DELETE__"
+
+
+def _resolve_sentinels(value: object) -> object:
+    """Recursively replace DELETE_SENTINEL strings with None in mappings.
+
+    JSON Merge Patch doesn't support array element deletion, so lists are
+    passed through unchanged.
+    """
+    if value == DELETE_SENTINEL:
+        return None
+    if isinstance(value, dict):
+        return {k: _resolve_sentinels(v) for k, v in value.items()}
+    return value
+
 
 def _deep_merge(base: dict, override: dict) -> dict:
     """RFC 7396 JSON Merge Patch: mappings deep-merge, scalars/lists replace."""
@@ -831,13 +849,15 @@ def _apply_extras(wf: GeneratedWorkflow, wf_cfg: WorkflowConfig) -> GeneratedWor
         data["on"] = data.pop(True)
 
     if wf_cfg.workflow_extra:
-        data = _deep_merge(data, wf_cfg.workflow_extra)
+        data = _deep_merge(data, _resolve_sentinels(wf_cfg.workflow_extra))
 
     if wf_cfg.jobs:
         jobs = data.get("jobs", {})
         for job_name, job_extra in wf_cfg.jobs.items():
             if job_name in jobs:
-                jobs[job_name] = _deep_merge(jobs[job_name], job_extra)
+                jobs[job_name] = _deep_merge(
+                    jobs[job_name], _resolve_sentinels(job_extra)
+                )
             else:
                 click.echo(
                     f"Warning: job '{job_name}' not found in {wf.filename} "

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -815,6 +815,50 @@ def test_job_extras_replace_if_for_skip_review_label(tmp_path: Path) -> None:
     assert "steps" in data["jobs"]["review"]
 
 
+def test_delete_sentinel_drops_top_level_key(tmp_path: Path) -> None:
+    """`"__TEND_DELETE__"` in workflow_extra removes the targeted key.
+
+    TOML has no `null` literal, so this sentinel string substitutes for None
+    to reach RFC 7396's delete branch.
+    """
+    extra = dedent("""\
+        [workflows.nightly.workflow_extra.on]
+        schedule = "__TEND_DELETE__"
+    """)
+    cfg = Config.load(_minimal_config(tmp_path, extra))
+    workflows = {wf.filename: wf for wf in generate_all(cfg)}
+    data = yaml.safe_load(workflows["tend-nightly.yaml"].content)
+    assert "schedule" not in data["on"]
+    assert "workflow_dispatch" in data["on"]
+
+
+def test_delete_sentinel_drops_nested_key(tmp_path: Path) -> None:
+    """Sentinel works at any depth inside a job override."""
+    extra = dedent("""\
+        [workflows.review.jobs.review.permissions]
+        issues = "__TEND_DELETE__"
+    """)
+    cfg = Config.load(_minimal_config(tmp_path, extra))
+    workflows = {wf.filename: wf for wf in generate_all(cfg)}
+    perms = yaml.safe_load(workflows["tend-review.yaml"].content)["jobs"]["review"][
+        "permissions"
+    ]
+    assert "issues" not in perms
+    assert perms["contents"] == "write"
+
+
+def test_delete_sentinel_drops_missing_key_is_noop(tmp_path: Path) -> None:
+    """Deleting a key that doesn't exist is silently a no-op (RFC 7396)."""
+    extra = dedent("""\
+        [workflows.review.workflow_extra]
+        nonexistent = "__TEND_DELETE__"
+    """)
+    cfg = Config.load(_minimal_config(tmp_path, extra))
+    workflows = {wf.filename: wf for wf in generate_all(cfg)}
+    data = yaml.safe_load(workflows["tend-review.yaml"].content)
+    assert "nonexistent" not in data
+
+
 def test_unknown_job_warns(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     extra = dedent("""\
         [workflows.review.jobs.nonexistent]


### PR DESCRIPTION
Adds `"__TEND_DELETE__"` as a sentinel for RFC 7396's null-deletes-key semantic, which was unreachable from TOML before. A pre-pass in `_apply_extras` walks `workflow_extra` and per-job overrides, swapping the sentinel for `None` before the existing `_deep_merge` runs — the delete branch then does the work.

Motivating case: a scheduled workflow that should be `workflow_dispatch`-only. The user can now drop just `on.schedule` instead of replacing the whole `on:` block:

```toml
[workflows.nightly.workflow_extra.on]
schedule = "__TEND_DELETE__"
```

Same shape covers the issue author's case (narrowing `on.issues` on `tend-mention`) and any other generator-injected key.

Lists are passed through unchanged — JSON Merge Patch doesn't define array element deletion, and the sentinel inherits that limitation.

A parallel PR exploring the alternative (switch the config format to YAML so `null` is native) will appear as a separate PR; #439 has both for comparison.

Closes #439

Thanks to @jrdncstr for reporting in #439.
