### PR TITLE
chore: release 0.0.18

### DIFF
--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tend"
-version = "0.0.17"
+version = "0.0.18"
 description = "An autonomous junior maintainer for GitHub repos, powered by Claude — reviews PRs, triages issues, fixes CI"
 license = "MIT"
 requires-python = ">=3.11"

--- a/generator/uv.lock
+++ b/generator/uv.lock
@@ -144,7 +144,7 @@ wheels = [
 
 [[package]]
 name = "tend"
-version = "0.0.17"
+version = "0.0.18"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Bumps generator to 0.0.18.

## Headline

Expose the `__TEND_DELETE__` sentinel so TOML overrides can reach RFC 7396 delete-key semantics — useful for dropping a generator-injected key (e.g. `on.schedule` from a scheduled workflow) while keeping the rest. Closes #439, thanks @jrdncstr for reporting.

## Other changes since 0.0.17

- fix(action): sum usage and num_turns across all result entries (#437)
- diag(action): upload execution-output.json (#408)
- fix(mention): run setup before PR checkout so stale PRs don't drop mentions (#391)
- fix(running-in-ci): base skill worktree on default branch (#401)
- install-tend: fix oauth-token.sh returning an invalid token on macOS (#398)
- oauth-token.sh: don't tee the OAuth token to stderr (#421)
- Skill hardening: bang-escape guidance, review-reviewers corruption scans, dedup rules, $GITHUB_RUN_ID requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)