### PR TITLE
site: tighten leads, add paragraph-formatting policy

### DIFF
--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -1,0 +1,21 @@
+# Site
+
+Astro marketing site for tend-src.com.
+
+## Paragraph formatting
+
+Put each prose element's text on a single line with its tags:
+
+```astro
+<p>The content goes here.</p>
+```
+
+Not:
+
+```astro
+<p>
+  The content goes here.
+</p>
+```
+
+Firefox grabs the leading whitespace as part of the selection when a reader triple-clicks the paragraph, polluting copy-paste. Applies to any prose block element — `<p>`, `<li>`, `<blockquote>`. Long paragraphs stay on one long line; let the editor soft-wrap.

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -119,11 +119,7 @@ claude /install-tend</code></pre>
     <div class="marginalia">
       <div class="margin-note">overlay</div>
       <div class="body">
-        <p>
-          Tend's bundled skills supply the defaults; skills and docs in your
-          repo override them. Set what it auto-approves, have it close some
-          category of PR on sight, or give it a new chore to run each night.
-        </p>
+        <p>Tend's bundled skills supply the defaults; skills and docs in your repo override them. Set what it auto-approves, calibrate what it flags in reviews, have it close some category of PR on sight, or give it a new chore to run each night.</p>
       </div>
     </div>
   </section>
@@ -137,7 +133,7 @@ claude /install-tend</code></pre>
   <!-- ===== QUICK START ===== -->
   <section id="quick-start">
     <p class="section-eyebrow">getting started</p>
-    <p class="section-lead">Three commands and five to ten minutes.</p>
+    <p class="section-lead">Claude Code sets Tend up in about ten minutes.</p>
 
     <div class="marginalia">
       <div class="margin-note">install</div>
@@ -146,19 +142,8 @@ claude /install-tend</code></pre>
 claude plugin install install-tend@tend
 claude /install-tend</code></pre>
 
-        <p>
-          The <code>/install-tend</code> skill walks the rest of the way:
-          config file, workflow generation, bot account, secrets, branch
-          protection. It'll ask before each step that touches your repo.
-        </p>
-        <p class="note">
-          You'll need a GitHub account for the bot (something like
-          <code>@your-project-bot</code>) and a Claude Max subscription.
-          Maintainers of sizeable OSS projects can{" "}
-          <a href="https://claude.com/contact-sales/claude-for-oss">
-            get a Max subscription free from Anthropic
-          </a>.
-        </p>
+        <p>The <code>/install-tend</code> skill walks the rest of the way: config file, workflow generation, bot account, secrets, branch protection. It'll ask before each step that touches your repo.</p>
+        <p class="note">You'll need a GitHub account for the bot (something like <code>@your-project-bot</code>) and a Claude Max subscription. Maintainers of sizeable OSS projects can <a href="https://claude.com/contact-sales/claude-for-oss">get a Max subscription free from Anthropic</a>.</p>
       </div>
     </div>
   </section>
@@ -167,27 +152,14 @@ claude /install-tend</code></pre>
 
   <!-- ===== SECURITY ===== -->
   <section id="security">
-    <p class="section-eyebrow">a question every adopter asks</p>
+    <p class="section-eyebrow">security</p>
     <p class="section-lead">Where the bot can and can't go.</p>
 
     <div class="marginalia">
       <div class="margin-note">model</div>
       <div class="body">
-        <p>
-          Tend gives Claude write access to a repository. The primary boundary
-          is a GitHub ruleset that blocks the bot from merging to protected
-          branches — whoever opened the PR, however it's been reviewed — so
-          every change lands through a human merge; tend's setup script verifies
-          and (if you ask) creates that ruleset for you. On top of that sit
-          config-pinning, burst-and-spike rate limiting, and a fixed prompt and
-          skill set: an attacker who controls a PR diff or an issue body can
-          shape what Claude reads, never the instructions it follows.
-        </p>
-        <p>
-          <a href="https://github.com/max-sixty/tend/blob/main/docs/security-model.md">
-            Read the full threat model →
-          </a>
-        </p>
+        <p>Tend gives Claude write access to a repository. The primary boundary is a GitHub ruleset that blocks the bot from merging to protected branches — whoever opened the PR, however it's been reviewed — so every change lands through a human merge; tend's setup script verifies and (if you ask) creates that ruleset for you. On top of that sit config-pinning, burst-and-spike rate limiting, and a fixed prompt and skill set: an attacker who controls a PR diff or an issue body can shape what Claude reads, never the instructions it follows.</p>
+        <p><a href="https://github.com/max-sixty/tend/blob/main/docs/security-model.md">Read the full threat model →</a></p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary

- **Security section eyebrow**: "a question every adopter asks" → "security".
- **Getting-started lead**: "Three commands and five to ten minutes." → "Claude Code sets Tend up in about ten minutes." The command count is irrelevant; lead with the agent doing the work.
- **Customize sentence**: added "calibrate what it flags in reviews" as a second handle. The `review` skill is the most-touched surface in adopter repos and didn't have an example in the original list.
- **Single-line `<p>` blocks**: flattened five multi-line paragraphs in `index.astro`. Firefox's triple-click selection grabs leading whitespace inside a multi-line `<p>`, polluting copy-paste.
- **`site/CLAUDE.md`** (new): documents the single-line rule and its rationale, scoped to `<p>` / `<li>` / `<blockquote>`.

## Test plan
- [x] `cd site && npx astro build` passes
- [x] `pre-commit run --all-files` passes
