### PR TITLE
chore(wt): exclude .venv/ from copy-ignored

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -7,6 +7,12 @@
 [[post-start]]
 copy = "wt step copy-ignored"
 
+# Virtual envs contain absolute paths in their entry-point shebangs; copying
+# them across worktrees leaves `uv run pytest` (etc.) launching the source
+# worktree's interpreter. `uv sync` recreates the venv with correct shebangs.
+[step.copy-ignored]
+exclude = [".venv/"]
+
 # Restore anything copy-ignored didn't bring over. --prefer-offline keeps it
 # off the network once the shared npm cache is warm; --no-audit/--no-fund
 # skip the slow, noisy bits of an otherwise-empty run.


### PR DESCRIPTION
## Problem

`wt step copy-ignored` (run as a post-start hook in `.config/wt.toml`) copies every gitignored file from the primary worktree into the new one — including `generator/.venv/`.

Most files in a uv-managed venv are fine after copy: `.venv/bin/python3` is a symlink to the absolute path of the uv-managed interpreter, `pyvenv.cfg` uses absolute paths, etc. But the **entry-point scripts** (`pytest`, `py.test`, `pygmentize`, `tend`, …) are regular files with hard-coded shebangs that still point at the *source* worktree:

```
$ head -1 .venv/bin/pytest
#!/Users/maximilian/workspace/tend/generator/.venv/bin/python3   # ← wrong worktree
```

So `uv run pytest` in the new worktree `exec`s the original worktree's interpreter, which has a different site-packages. Symptom observed during the 0.0.18 release: `ModuleNotFoundError: No module named 'pytest_regtest'` even though the package was clearly installed in the local venv.

Worktrunk's own docs (`wt step copy-ignored --help`) call this out explicitly:

> **Python**: Virtual environments contain absolute paths and can't be copied. Use `uv sync` instead — it's fast enough that copying isn't worth it.

## Fix

Add a `.venv/` exclude to `[step.copy-ignored]`. uv recreates the venv on first use with correct shebangs.

```toml
[step.copy-ignored]
exclude = [".venv/"]
```

## Verified

After deleting the poisoned `.venv` in this worktree and letting `uv run pytest` recreate it, all 191 tests pass — confirming the rebuild fixes the shebangs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)