### PR TITLE
site: tweak Work delegation list, widen section-lead

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -33,7 +33,7 @@ const areas = [
     eyebrow: "iv.",
     title: "Work delegation",
     body: [
-      "Mention the bot in a PR or issue and it takes a pass at what you asked — resolve a merge conflict, read the diff, run a check, draft a change, answer the question.",
+      "Mention the bot in a PR or issue and it takes a pass at what you asked — resolve a merge conflict, draft a change, research a question, fix the tests.",
     ],
   },
   {

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -420,7 +420,7 @@ hr::after {
   line-height: 1.3;
   color: var(--ink);
   margin: 0 0 1rem;
-  max-width: 32ch;
+  max-width: 48ch;
 }
 
 /* ---------- Stat strip ---------- */


### PR DESCRIPTION
## Summary

- **Work delegation examples**: dropped "read the diff", "run a check", and "answer the question"; added "research a question" and "fix the tests". Four heavier examples, lead unchanged.
- **`.section-lead` max-width**: bumped from `32ch` to `48ch`. The new getting-started lead ("Claude Code sets Tend up in about ten minutes.") wrapped at an awkward spot ("in / about"); 48ch fits the longest current lead on one line.

## Test plan
- [x] `cd site && npx astro build` passes
- [x] `pre-commit run --all-files` passes
