### PR TITLE
site: live tending timer, merge in-flight runs into activity feed

### DIFF
--- a/site/src/components/Activity.astro
+++ b/site/src/components/Activity.astro
@@ -1,7 +1,8 @@
 ---
-// Recent activity feed — runtime-fetched from api.tend-src.com/activity.
-// Stays hidden until the fetch returns a non-empty list, so a Worker outage
-// or empty data degrades to no section at all rather than a broken state.
+// Recent activity feed — runtime-fetched from api.tend-src.com/activity, merged
+// with in-flight runs from /currently-tending so an idle-but-actively-tending
+// state still shows the section. Stays hidden until the merged list is
+// non-empty, so a Worker outage or empty data degrades to no section at all.
 ---
 
 <section id="recent-activity" class="recent-activity" hidden>
@@ -17,8 +18,8 @@
 </section>
 
 <script>
-  import { liveData } from "../lib/api";
-  import { relativeTime } from "../lib/time";
+  import { fetchJson, liveData } from "../lib/api";
+  import { elapsedTime, relativeTime } from "../lib/time";
 
   const MAX_ROWS = 12; // the buckets hold up to ~10 each; this section shows a merged slice
 
@@ -37,12 +38,47 @@
     reviews?: Bucket;
     comments?: Bucket;
   }
+  interface Run {
+    repo: string;
+    workflow: string;
+    started_at: string;
+    run_url: string;
+  }
 
-  type Kind = "pr" | "issue" | "review" | "comment";
-  const KIND_LABELS: Record<Kind, string> = { pr: "PR", issue: "issue", review: "review", comment: "comment" };
+  type Kind = "pr" | "issue" | "review" | "comment" | "tending";
+  const KIND_LABELS: Record<Kind, string> = {
+    pr: "PR",
+    issue: "issue",
+    review: "review",
+    comment: "comment",
+    tending: "tending",
+  };
 
-  liveData<Activity>("/activity", "recent-activity", (data) => {
+  function updateTendingTimes(): void {
+    const cells = document.querySelectorAll<HTMLTimeElement>(
+      ".activity-row .at[data-started-at]",
+    );
+    for (const cell of cells) {
+      const startedAt = cell.dataset.startedAt;
+      if (!startedAt) continue;
+      cell.textContent = elapsedTime(startedAt);
+    }
+  }
+
+  liveData<Activity>("/activity", "recent-activity", async (data) => {
+    const tending = await fetchJson<{ currently_tending?: Run[] }>("/currently-tending");
+    const tendingRows: Array<RecentItem & { kind: Kind }> = (tending?.currently_tending ?? []).map(
+      (r) => ({
+        kind: "tending" as const,
+        repo: r.repo,
+        title: r.workflow.replace(/^tend-/, ""),
+        url: r.run_url,
+        at: r.started_at,
+      }),
+    );
+
     const rows: Array<RecentItem & { kind: Kind }> = [
+      ...tendingRows,
       ...(data?.prs?.recent ?? []).map((r) => ({ ...r, kind: "pr" as const })),
       ...(data?.issues?.recent ?? []).map((r) => ({ ...r, kind: "issue" as const })),
       ...(data?.reviews?.recent ?? []).map((r) => ({ ...r, kind: "review" as const })),
@@ -75,10 +111,19 @@
       const time = document.createElement("time");
       time.className = "at";
       time.dateTime = e.at;
-      time.textContent = relativeTime(e.at);
+      if (e.kind === "tending") {
+        time.dataset.startedAt = e.at;
+        time.textContent = elapsedTime(e.at);
+      } else {
+        time.textContent = relativeTime(e.at);
+      }
 
       li.append(kind, repo, link, time);
       ul.appendChild(li);
+    }
+
+    if (top.some((r) => r.kind === "tending")) {
+      setInterval(updateTendingTimes, 1000);
     }
     return true;
   });

--- a/site/src/components/CurrentlyTending.astro
+++ b/site/src/components/CurrentlyTending.astro
@@ -26,12 +26,13 @@
     comments?: Bucket;
   }
 
-  function paint(el: HTMLElement, state: "live" | "idle", text: string): void {
+  function paint(el: HTMLElement, state: "live" | "idle", text: string): HTMLSpanElement {
     const dot = document.createElement("span");
     dot.className = `now-dot now-dot-${state}`;
     const label = document.createElement("span");
     label.textContent = text;
     el.replaceChildren(dot, label);
+    return label;
   }
 
   liveData<{ currently_tending?: Run[] }>(
@@ -44,16 +45,16 @@
         const workflow = r.workflow.replace(/^tend-/, "");
         const more = runs.length > 1 ? ` (+${runs.length - 1} more)` : "";
         const startedMs = Date.parse(r.started_at);
-        const render = () => {
+        const buildText = () => {
           const elapsed = elapsedTime(r.started_at);
-          if (!elapsed) {
-            paint(el, "live", `tending ${r.repo} · ${workflow}${more}`);
-            return;
-          }
-          paint(el, "live", `tending ${r.repo} · ${workflow} · ${elapsed}${more}`);
+          return elapsed
+            ? `tending ${r.repo} · ${workflow} · ${elapsed}${more}`
+            : `tending ${r.repo} · ${workflow}${more}`;
         };
-        render();
-        if (!Number.isNaN(startedMs)) setInterval(render, 1000);
+        const label = paint(el, "live", buildText());
+        if (!Number.isNaN(startedMs)) {
+          setInterval(() => { label.textContent = buildText(); }, 1000);
+        }
         return true;
       }
 

--- a/site/src/components/CurrentlyTending.astro
+++ b/site/src/components/CurrentlyTending.astro
@@ -5,15 +5,16 @@
 // runs. Hidden only when both requests fail.
 ---
 
-<p id="now-tending" class="now-tending" hidden></p>
+<a id="now-tending" class="now-tending" href="#recent-activity" hidden></a>
 
 <script>
   import { fetchJson, liveData } from "../lib/api";
-  import { relativeTime } from "../lib/time";
+  import { elapsedTime, relativeTime } from "../lib/time";
 
   interface Run {
     repo: string;
     workflow: string;
+    started_at: string;
   }
   interface Bucket {
     recent?: Array<{ at: string }>;
@@ -42,7 +43,17 @@
         const r = runs[0];
         const workflow = r.workflow.replace(/^tend-/, "");
         const more = runs.length > 1 ? ` (+${runs.length - 1} more)` : "";
-        paint(el, "live", `tending ${r.repo} · ${workflow}${more}`);
+        const startedMs = Date.parse(r.started_at);
+        const render = () => {
+          const elapsed = elapsedTime(r.started_at);
+          if (!elapsed) {
+            paint(el, "live", `tending ${r.repo} · ${workflow}${more}`);
+            return;
+          }
+          paint(el, "live", `tending ${r.repo} · ${workflow} · ${elapsed}${more}`);
+        };
+        render();
+        if (!Number.isNaN(startedMs)) setInterval(render, 1000);
         return true;
       }
 

--- a/site/src/lib/time.ts
+++ b/site/src/lib/time.ts
@@ -11,3 +11,17 @@ export function relativeTime(iso: string): string {
   if (hours < 36) return `${hours} h ago`;
   return `${days} d ago`;
 }
+
+// Live elapsed timer for in-flight runs — "m:ss", or "h:mm:ss" past an hour.
+// Returns "" when startedAt isn't a parseable timestamp.
+export function elapsedTime(startedAt: string): string {
+  const startedMs = Date.parse(startedAt);
+  if (Number.isNaN(startedMs)) return "";
+  const s = Math.max(0, Math.floor((Date.now() - startedMs) / 1000));
+  const hh = Math.floor(s / 3600);
+  const mm = Math.floor((s % 3600) / 60);
+  const ss = s % 60;
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  if (hh > 0) return `${hh}:${pad(mm)}:${pad(ss)}`;
+  return `${mm}:${pad(ss)}`;
+}

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -368,7 +368,10 @@ hr::after {
   font-size: 0.78rem;
   letter-spacing: 0.03em;
   color: var(--ink-soft);
+  text-decoration: none;
+  border-bottom: none;
 }
+.now-tending:hover { color: var(--moss-deep); }
 
 .now-dot {
   flex: none;
@@ -521,12 +524,32 @@ hr::after {
   border-bottom-color: var(--moss);
 }
 
+.activity-row .kind-tending {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: var(--paper);
+  background: var(--moss-deep);
+  border-color: var(--moss-deep);
+}
+.activity-row .kind-tending::before {
+  content: "";
+  width: 0.4rem;
+  height: 0.4rem;
+  border-radius: 50%;
+  background: var(--paper);
+}
+@media (prefers-reduced-motion: no-preference) {
+  .activity-row .kind-tending::before { animation: now-pulse 2.6s ease-in-out infinite; }
+}
+
 .activity-row .at {
   font-family: var(--font-mono);
   font-size: 0.75rem;
   color: var(--ink-fade);
   white-space: nowrap;
 }
+.activity-row .at[data-started-at] { color: var(--moss-deep); }
 
 @media (max-width: 720px) {
   .activity-rows {


### PR DESCRIPTION
Two changes that make the "currently tending" pulse provably real:

- The hero line ticks elapsed time each second (`tending repo · workflow · 0:42`), driven by `started_at`. Live digits beat decorative text.
- The hero is now an `<a href="#recent-activity">`, and the activity feed merges in-flight runs (`kind: "tending"`) into the same time-ordered list — title links to the GitHub Actions run, time cell shows live elapsed, kind chip is a filled moss pulse. Click the pulse, land on the unified feed.

The shared `m:ss` / `h:mm:ss` formatter lives in `site/src/lib/time.ts` as `elapsedTime(iso)`. A single `setInterval` updates every tending row.

Caveats:

- One additional fetch (`/currently-tending`) from the activity section. The Worker caches both endpoints, so it's effectively free.
- Anchor scroll only works once `/activity` has resolved and the section is no longer `hidden`. Sub-second normally; not papered over.
