### PR TITLE
site: stop page-load redraw with hero realign + skeleton placeholders

### DIFF
--- a/site/src/components/Activity.astro
+++ b/site/src/components/Activity.astro
@@ -3,16 +3,31 @@
 // with in-flight runs from /currently-tending so an idle-but-actively-tending
 // state still shows the section. Stays hidden until the merged list is
 // non-empty, so a Worker outage or empty data degrades to no section at all.
+//
+// The list ships with placeholder rows of the same shape as the real data so
+// the section reserves its natural height before the fetch resolves (no
+// min-height hack in CSS). The script clears them before appending real rows.
+
+const MAX_ROWS = 12;
 ---
 
-<section id="recent-activity" class="recent-activity" hidden>
+<section id="recent-activity" class="recent-activity" data-state="loading">
   <p class="section-eyebrow">recent ground</p>
   <p class="section-lead">A few of the last things the bots have touched.</p>
 
   <div class="marginalia">
     <div class="margin-note">activity</div>
     <div class="body">
-      <ul class="activity-rows" data-activity-rows></ul>
+      <ul class="activity-rows" data-activity-rows>
+        {Array.from({ length: MAX_ROWS }).map(() => (
+          <li class="activity-row" aria-hidden="true">
+            <span class="kind">&nbsp;</span>
+            <span class="repo">&nbsp;</span>
+            <a class="title">&nbsp;</a>
+            <time class="at">&nbsp;</time>
+          </li>
+        ))}
+      </ul>
     </div>
   </div>
 </section>
@@ -21,7 +36,7 @@
   import { fetchJson, liveData } from "../lib/api";
   import { elapsedTime, relativeTime } from "../lib/time";
 
-  const MAX_ROWS = 12; // the buckets hold up to ~10 each; this section shows a merged slice
+  const MAX_ROWS = 12; // matches the placeholder count in the markup above
 
   interface RecentItem {
     repo: string;
@@ -90,6 +105,7 @@
 
     const ul = document.querySelector("[data-activity-rows]");
     if (!ul) return false;
+    ul.replaceChildren(); // drop the skeleton rows
     for (const e of top) {
       const li = document.createElement("li");
       li.className = "activity-row";

--- a/site/src/components/CurrentlyTending.astro
+++ b/site/src/components/CurrentlyTending.astro
@@ -5,7 +5,10 @@
 // runs. Hidden only when both requests fail.
 ---
 
-<a id="now-tending" class="now-tending" href="#recent-activity" hidden></a>
+<a id="now-tending" class="now-tending" href="#recent-activity" data-state="loading">
+  <span class="now-dot now-dot-idle" aria-hidden="true"></span>
+  <span>&nbsp;</span>
+</a>
 
 <script>
   import { fetchJson, liveData } from "../lib/api";

--- a/site/src/components/Stats.astro
+++ b/site/src/components/Stats.astro
@@ -2,10 +2,23 @@
 // Stat strip — runtime-fetched from api.tend-src.com/activity (the bucket
 // counts). Hidden until the fetch returns non-zero values, so a cold deploy
 // with empty data doesn't render a row of zeros.
+//
+// The strip ships with four placeholder cells of the same shape as the real
+// data so the section reserves its natural height before the fetch resolves
+// (no min-height hack in CSS). The script clears the placeholders before
+// appending real cells.
 ---
 
-<section id="stats" class="stats" hidden>
-  <div class="stat-strip" data-stat-strip></div>
+<section id="stats" class="stats" data-state="loading">
+  <div class="stat-strip" data-stat-strip>
+    {Array.from({ length: 4 }).map(() => (
+      <div class="stat-cell" aria-hidden="true">
+        <div class="stat-num">&nbsp;</div>
+        <div class="stat-label">&nbsp;</div>
+        <div class="stat-week">&nbsp;</div>
+      </div>
+    ))}
+  </div>
 </section>
 
 <script>
@@ -38,6 +51,7 @@
 
     const strip = document.querySelector("[data-stat-strip]");
     if (!strip) return false;
+    strip.replaceChildren(); // drop the skeleton cells
     for (const cell of cells) {
       const div = document.createElement("div");
       div.className = "stat-cell";
@@ -50,15 +64,13 @@
       label.className = "stat-label";
       label.textContent = cell.label;
 
-      div.append(num, label);
+      const week = document.createElement("div");
+      week.className = "stat-week";
+      // Render the week line unconditionally so every cell is the same height
+      // as the skeleton — a non-breaking space when there's nothing to report.
+      week.textContent = cell.week > 0 ? `+${format(cell.week)} this week` : " ";
 
-      if (cell.week > 0) {
-        const week = document.createElement("div");
-        week.className = "stat-week";
-        week.textContent = `+${format(cell.week)} this week`;
-        div.appendChild(week);
-      }
-
+      div.append(num, label, week);
       strip.appendChild(div);
     }
     return true;

--- a/site/src/lib/api.ts
+++ b/site/src/lib/api.ts
@@ -19,9 +19,11 @@ export async function fetchJson<T>(path: string): Promise<T | null> {
 }
 
 // Drives a runtime-fetched section: fetch `path`, hand the parsed body (or
-// null on failure) to `render`, and reveal the element with id `sectionId`
-// only if `render` returns true. `render` owns the DOM and the "is this worth
-// showing" decision, and may issue further fetches (e.g. a fallback endpoint).
+// null on failure) to `render`, and transition the element with id `sectionId`
+// from its initial `data-state="loading"` to either `"loaded"` (render returned
+// true) or `"hidden"` (false). CSS uses these states to reserve layout space
+// during loading, fade content in on success, and collapse on failure — so
+// the page doesn't shift when the fetch resolves.
 export async function liveData<T>(
   path: string,
   sectionId: string,
@@ -30,5 +32,5 @@ export async function liveData<T>(
   const el = document.getElementById(sectionId);
   if (!el) return;
   const shown = await render(await fetchJson<T>(path), el);
-  if (shown) el.hidden = false;
+  el.dataset.state = shown ? "loaded" : "hidden";
 }

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -283,7 +283,10 @@ hr::after {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
   gap: clamp(1.5rem, 3vw, 2.5rem);
-  align-items: center;
+  /* `start` instead of `center` so the left column growing (e.g. when the
+     runtime-fetched #now-tending indicator appears) doesn't re-center the
+     row and visibly shift the heading. */
+  align-items: start;
 }
 @media (max-width: 760px) {
   .hero {
@@ -357,9 +360,7 @@ hr::after {
 
 /* ---------- "Currently tending" indicator ---------- */
 
-/* Scoped to :not([hidden]) so the layout rules don't defeat the UA
-   [hidden] { display: none } default before the fetch resolves. */
-.now-tending:not([hidden]) {
+.now-tending {
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -370,8 +371,14 @@ hr::after {
   color: var(--ink-soft);
   text-decoration: none;
   border-bottom: none;
+  /* Space is reserved by the skeleton dot + nbsp label in the markup; we
+     just fade in once the fetch resolves so the hero doesn't redraw. */
+  opacity: 0;
+  transition: opacity 250ms ease;
 }
 .now-tending:hover { color: var(--moss-deep); }
+.now-tending[data-state="loaded"] { opacity: 1; }
+.now-tending[data-state="hidden"] { display: none; }
 
 .now-dot {
   flex: none;
@@ -428,7 +435,15 @@ hr::after {
 
 /* ---------- Stat strip ---------- */
 
-.stats { margin: 2rem 0 1rem; }
+.stats {
+  margin: 2rem 0 1rem;
+  /* Space is reserved by the four skeleton cells in the markup; we just
+     fade in once the fetch resolves. */
+  opacity: 0;
+  transition: opacity 250ms ease;
+}
+.stats[data-state="loaded"] { opacity: 1; }
+.stats[data-state="hidden"] { display: none; }
 
 .stat-strip {
   display: flex;
@@ -470,6 +485,13 @@ hr::after {
 
 /* ---------- Activity feed ---------- */
 
+.recent-activity {
+  opacity: 0;
+  transition: opacity 250ms ease;
+}
+.recent-activity[data-state="loaded"] { opacity: 1; }
+.recent-activity[data-state="hidden"] { display: none; }
+
 .activity-rows {
   list-style: none;
   margin: 0;
@@ -477,6 +499,8 @@ hr::after {
   display: grid;
   grid-template-columns: auto minmax(0, 11rem) minmax(0, 1fr) auto;
   column-gap: 1rem;
+  /* Space is reserved by the 12 skeleton rows in the markup; the script
+     replaces them with real rows when the fetch resolves. */
 }
 
 .activity-row {


### PR DESCRIPTION
## Summary

Two sources of layout shift on every page load.

1. **Hero re-center.** `.hero` used `align-items: center`, so when the runtime-fetched `#now-tending` indicator appeared at the bottom of the left column, the row re-centered and the heading visibly shifted upward. Switched to `align-items: start`.

2. **Sections popping in.** `#now-tending`, `#stats`, and `#recent-activity` flipped from the HTML `hidden` attribute (`display: none`) to visible once each fetch resolved, pushing the page down each time. Replaced the `hidden` attribute with a tri-state `data-state` attribute driven by `liveData`:
   - `loading` — laid out, `opacity: 0`
   - `loaded` — fades to `opacity: 1`
   - `hidden` — collapsed via `display: none` (preserves today's worker-outage behaviour)

To reserve the right amount of space during `loading` without hardcoding heights in CSS, each component ships skeleton placeholders of the same DOM shape as its real content (4 stat cells, 12 activity rows, a dot + nbsp for now-tending). The renderers call `replaceChildren()` before appending real data. Stats now always renders the "this week" line (nbsp when zero) so cell heights stay constant whether or not there's week-over-week activity.

## Test plan

- [ ] Skeleton and loaded heights match within sub-pixel rounding (verified locally: now-tending 19.96px, stats 83.36px, activity-rows 557.4px both before and after fetch)
- [ ] CLS = 0 on fresh load (verified locally via PerformanceObserver)
- [ ] Worker-outage fallback still collapses each section (data-state="hidden" → display: none)
- [ ] Visual smoke test on production deploy