### PR TITLE
chore(wt): add test alias for pytest

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -9,7 +9,7 @@ metadata:
 
 ## Steps
 
-1. **Run tests and lints**: `cd generator && uv run pytest` and `pre-commit run --all-files`
+1. **Run tests and lints**: `wt test` and `pre-commit run --all-files`
 2. **Check current version**: Read `version` in `generator/pyproject.toml`
 3. **Review commits**: `git log <last-version>..HEAD --oneline` to understand scope
 4. **Confirm version with user**: Present changes summary and proposed version

--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -31,3 +31,7 @@ url = "http://localhost:{{ branch | hash_port }}"
 # Stop the dev server when the worktree is removed.
 [[pre-remove]]
 server = "lsof -ti :{{ branch | hash_port }} -sTCP:LISTEN | xargs kill 2>/dev/null || true"
+
+# The Python package lives under generator/; this alias runs pytest from the right cwd.
+[aliases]
+test = "cd generator && uv run pytest {{ args }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ completely — old formats should fail with a clear error, not silently parse.
 ## Commands
 
 ```bash
-cd generator && uv run pytest          # run tests
+wt test                                # run pytest in generator/
 uvx tend@latest init                   # regenerate workflows from .config/tend.toml
 uvx tend@latest init --dry-run         # preview without writing
 uvx tend@latest check                  # verify branch protection, secrets, bot access


### PR DESCRIPTION
Replaces `cd generator && uv run pytest` in docs with `wt test`. Avoids the broken `uv run pytest` from worktree root — without a root pyproject.toml, system pytest gets invoked, finds `generator/tests/conftest.py`, and fails on the `pytest_regtest` import.