### PR TITLE
worker: anchor /activity review rows on the latest inline comment

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -91,13 +91,9 @@ interface SearchResponse {
   items?: SearchItem[];
 }
 
-// GitHub review / issue-comment objects — fields we actually use.
-interface ReviewObject {
-  user?: { login?: string } | null;
-  html_url?: string;
-  submitted_at?: string;
-}
-
+// GitHub comment objects — fields we actually use. Same shape for inline
+// PR review comments (`/pulls/{n}/comments`) and conversation comments
+// (`/issues/{n}/comments`).
 interface IssueCommentObject {
   user?: { login?: string } | null;
   html_url?: string;
@@ -466,30 +462,35 @@ async function toRecentItem(
   return { ...base, url: it.html_url };
 }
 
-// Latest review on a PR authored by `bot` — `submitted_at` desc. Returns null
-// if the fetch fails or no review by the bot is present (caller falls back).
+// Latest inline review comment on a PR authored by `bot` — `created_at` desc.
+// We deliberately don't anchor on the review summary (`#pullrequestreview-…`):
+// tend's reviews are typically `COMMENTED` with an empty body wrapping inline
+// comments, so the review anchor scrolls nowhere on the conversation page.
+// `#discussion_r…` anchors land on the actual comment thread. Returns null if
+// the fetch fails or the bot left no inline comments (caller falls back to
+// the parent PR URL).
 async function findBotReviewUrl(
   repo: string,
   n: number,
   bot: string,
   token: string,
 ): Promise<string | null> {
-  const url = `${GITHUB_API}/repos/${repo}/pulls/${n}/reviews?per_page=100`;
+  const url = `${GITHUB_API}/repos/${repo}/pulls/${n}/comments?per_page=100`;
   try {
     const resp = await fetchWithTimeout(url, { headers: githubHeaders(token) });
     if (!resp.ok) {
-      console.error(`review lookup failed (${resp.status}): ${repo}#${n}`);
+      console.error(`review-comment lookup failed (${resp.status}): ${repo}#${n}`);
       return null;
     }
-    const reviews = (await resp.json()) as ReviewObject[];
+    const comments = (await resp.json()) as IssueCommentObject[];
     return latestByBot(
-      reviews,
+      comments,
       bot,
-      (r) => r.submitted_at,
-      (r) => r.html_url,
+      (c) => c.created_at,
+      (c) => c.html_url,
     );
   } catch (e) {
-    console.error(`review lookup error: ${repo}#${n}`, e);
+    console.error(`review-comment lookup error: ${repo}#${n}`, e);
     return null;
   }
 }

--- a/worker/test/worker.test.ts
+++ b/worker/test/worker.test.ts
@@ -196,15 +196,17 @@ describe("refreshActivity", () => {
     });
 
     // For reviews/comments rows, the worker issues one follow-up per recent
-    // item to resolve the bot's specific review/comment anchor. Mock those.
-    const reviewUrl = (repo: string, n: number) =>
-      `https://api.github.com/repos/${repo}/pulls/${n}/reviews?per_page=100`;
+    // item to resolve the bot's specific comment anchor. Mock those.
+    // Reviews → inline PR review comments (`#discussion_r…`); the review
+    // summary anchor is skipped because tend's reviews are typically body-empty.
+    const reviewCommentUrl = (repo: string, n: number) =>
+      `https://api.github.com/repos/${repo}/pulls/${n}/comments?per_page=100`;
     const commentUrl = (repo: string, n: number) =>
       `https://api.github.com/repos/${repo}/issues/${n}/comments?per_page=100`;
-    const review = (repo: string, n: number, bot: string, id: number, at: string) => ({
+    const reviewComment = (repo: string, n: number, bot: string, id: number, at: string) => ({
       user: { login: bot },
-      html_url: `https://github.com/${repo}/pull/${n}#pullrequestreview-${id}`,
-      submitted_at: at,
+      html_url: `https://github.com/${repo}/pull/${n}#discussion_r${id}`,
+      created_at: at,
     });
     const comment = (
       repo: string,
@@ -237,11 +239,11 @@ describe("refreshActivity", () => {
       [searchUrl("commenter:bot-a -author:bot-a -reviewed-by:bot-a"), { total_count: 12, items: [item("o/a", 3, "pull", recentA)] }],
       [searchUrl("commenter:bot-b -author:bot-b -reviewed-by:bot-b"), { total_count: 4, items: [item("o/b", 8, "issues", recentB)] }],
       // Follow-ups: pick the latest entry by the bot; the worker should land on the deepest URL.
-      [reviewUrl("o/a", 4), [
-        review("o/a", 4, "someone-else", 100, recentB),
-        review("o/a", 4, "bot-a", 101, recentA),
+      [reviewCommentUrl("o/a", 4), [
+        reviewComment("o/a", 4, "someone-else", 100, recentB),
+        reviewComment("o/a", 4, "bot-a", 101, recentA),
       ]],
-      [reviewUrl("o/b", 7), [review("o/b", 7, "bot-b", 202, oldB)]],
+      [reviewCommentUrl("o/b", 7), [reviewComment("o/b", 7, "bot-b", 202, oldB)]],
       [commentUrl("o/a", 3), [
         comment("o/a", 3, "pull", "bot-a", 301, recentB),
         comment("o/a", 3, "pull", "bot-a", 302, recentA), // newest by created_at
@@ -279,9 +281,9 @@ describe("refreshActivity", () => {
       count: 14, // 9 + 5
       count_this_week: 1, // o/a#4 recent; o/b#7 old
       recent: [
-        // url resolved to the bot's actual review anchor, not the PR top.
-        { repo: "o/a", title: "o/a#4", url: "https://github.com/o/a/pull/4#pullrequestreview-101", at: recentA },
-        { repo: "o/b", title: "o/b#7", url: "https://github.com/o/b/pull/7#pullrequestreview-202", at: oldB },
+        // url resolved to the bot's most recent inline comment, not the PR top.
+        { repo: "o/a", title: "o/a#4", url: "https://github.com/o/a/pull/4#discussion_r101", at: recentA },
+        { repo: "o/b", title: "o/b#7", url: "https://github.com/o/b/pull/7#discussion_r202", at: oldB },
       ],
     });
     expect(out.comments).toEqual({
@@ -345,8 +347,8 @@ describe("refreshActivity", () => {
         }
         return new Response(JSON.stringify({ total_count: 0, items: [] }), { status: 200 });
       }
-      // Follow-up review lookup 404s; follow-up comment lookup returns no bot match.
-      if (url.includes("/pulls/5/reviews")) {
+      // Follow-up review-comment lookup 404s; follow-up comment lookup returns no bot match.
+      if (url.includes("/pulls/5/comments")) {
         return new Response("not found", { status: 404 });
       }
       if (url.includes("/issues/6/comments")) {


### PR DESCRIPTION
## Summary

`/activity` review rows were linking to `#pullrequestreview-<id>`, which scrolls to the review's summary block. tend's reviews are almost always `COMMENTED` with an empty body — so the anchor has nothing to scroll to and clicks land at the top of the PR.

Example: [PR #463's tend review](https://github.com/max-sixty/tend/pull/463#pullrequestreview-4285852730) — empty body, one inline comment on `site/src/components/CurrentlyTending.astro`. The link as served was effectively a no-op.

Switch the reviews bucket to `/pulls/{n}/comments` (inline PR review comments) and pick the bot's latest by `created_at`. The resulting `#discussion_r…` anchor lands on the actual comment thread.

Body-only reviews (no inline comments) now fall back to the parent PR URL rather than the review anchor; in practice tend rarely posts those, and the parent URL is the same fallback already used on lookup failure.

## Test plan

- [x] `npm test` in `worker/` — 19 tests pass, including updated `refreshActivity` assertions
- [x] Verified against PR #463 via `gh api`: the bot's latest inline comment is `#discussion_r3237865298`, which the new code will pick
- [ ] After deploy, confirm `/activity` rows in the review bucket point at `#discussion_r…` (≤5 min cache refresh after first request)
