### PR TITLE
site: flip relative time to hours at 60 min, not 90

### DIFF
--- a/site/src/lib/time.ts
+++ b/site/src/lib/time.ts
@@ -7,7 +7,7 @@ export function relativeTime(iso: string): string {
   const hours = Math.round(minutes / 60);
   const days = Math.round(hours / 24);
   if (seconds < 90) return "just now";
-  if (minutes < 90) return `${minutes} min ago`;
+  if (minutes < 60) return `${minutes} min ago`;
   if (hours < 36) return `${hours} h ago`;
   return `${days} d ago`;
 }


### PR DESCRIPTION
Avoids awkward strings like "81 min ago" — once a timestamp crosses an hour, switch to "1 h ago" rather than continuing to count minutes up to 89.