### PR TITLE
site: rewrite hero tagline, drop eyebrow

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -58,9 +58,8 @@ const areas = [
   <!-- ===== HERO ===== -->
   <section class="hero">
     <div>
-      <p class="section-eyebrow">an agent · tending your repo</p>
       <h1>Tend</h1>
-      <p class="tagline">A dutiful junior maintainer for your repo — quietly reviewing PRs, triaging issues, fixing CI, and keeping up with the day-to-day so the queue is never waiting on you.</p>
+      <p class="tagline">An agent that tends your repo — reviewing PRs, triaging issues, and keeping up with the day-to-day so you can focus on building beautiful things.</p>
 
       <pre class="install"><code>claude plugin marketplace add max-sixty/tend
 claude plugin install install-tend@tend


### PR DESCRIPTION
Tightens the hero copy: the tagline now leads with what tend is (`An agent that tends your repo`) and earns the product name. Drops "fixing CI" from the verb list and replaces "so the queue is never waiting on you" with "so you can focus on building beautiful things." The eyebrow above the H1 now duplicated the tagline, so it's gone.