### PR TITLE
site: tagline catch-all → "responding to whatever comes up"

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -59,7 +59,7 @@ const areas = [
   <section class="hero">
     <div>
       <h1>Tend</h1>
-      <p class="tagline">An agent that tends your repo — reviewing PRs, triaging issues, and keeping up with the day-to-day so you can focus on building beautiful things.</p>
+      <p class="tagline">An agent that tends your repo — reviewing PRs, triaging issues, and responding to whatever comes up so you can focus on building beautiful things.</p>
 
       <pre class="install"><code>claude plugin marketplace add max-sixty/tend
 claude plugin install install-tend@tend


### PR DESCRIPTION
Tightens the third item in the hero verb list. "keeping up with the day-to-day" read as small-stuff filler; tend's actual shape is event- and schedule-driven across a half-dozen workflows (review, triage, ci-fix, mention, nightly, weekly, notifications, self-review). The new phrase reflects that breadth without overclaiming.