### PR TITLE
site: comma before "so" in tagline

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -59,7 +59,7 @@ const areas = [
   <section class="hero">
     <div>
       <h1>Tend</h1>
-      <p class="tagline">An agent that tends your repo — reviewing PRs, triaging issues, and responding to whatever comes up so you can focus on building beautiful things.</p>
+      <p class="tagline">An agent that tends your repo — reviewing PRs, triaging issues, and responding to whatever comes up, so you can focus on building beautiful things.</p>
 
       <pre class="install"><code>claude plugin marketplace add max-sixty/tend
 claude plugin install install-tend@tend


### PR DESCRIPTION
Helps the long sentence breathe and marks the pivot from what tend does to what you get.