### PR TITLE
site: hero on shared left rail, live indicator under stats

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -57,38 +57,26 @@ const areas = [
 <Base>
   <!-- ===== HERO ===== -->
   <section class="hero">
-    <div>
-      <h1>Tend</h1>
-      <p class="tagline">An agent that tends your repo — reviewing PRs, triaging issues, and responding to whatever comes up, so you can focus on building beautiful things.</p>
+    <div class="hero-body">
+      <h1>tend</h1>
+      <p class="tagline">An agent that tends your repo — reviewing PRs, triaging issues, and responding to whatever comes up so you can focus on building beautiful things.</p>
 
       <pre class="install"><code>claude plugin marketplace add max-sixty/tend
 claude plugin install install-tend@tend
 claude /install-tend</code></pre>
-
-      <div class="badges">
-        <a class="meta-link" href="https://github.com/max-sixty/tend">
-          <svg class="inline-icon" viewBox="0 0 16 16" aria-hidden="true">
-            <path fill="currentColor" d="M8 .2a8 8 0 0 0-2.5 15.6c.4.1.5-.2.5-.4v-1.4c-2.2.5-2.7-1-2.7-1-.4-1-.9-1.3-.9-1.3-.7-.5.1-.5.1-.5.8.1 1.2.8 1.2.8.7 1.2 1.9.9 2.4.7 0-.5.3-.9.5-1.1-1.8-.2-3.6-.9-3.6-3.9 0-.9.3-1.6.8-2.2 0-.2-.4-1 .1-2.1 0 0 .7-.2 2.2.8a7.7 7.7 0 0 1 4 0c1.5-1 2.2-.8 2.2-.8.4 1.1.1 1.9.1 2.1.5.6.8 1.3.8 2.2 0 3.1-1.9 3.7-3.7 3.9.3.3.6.8.6 1.5v2.2c0 .2.1.5.5.4A8 8 0 0 0 8 .2z"/>
-          </svg>
-          github
-        </a>
-        <a class="meta-link" href="https://pypi.org/project/tend/">
-          <span class="meta-glyph">π</span> pypi
-        </a>
-        <a class="meta-link" href="https://github.com/max-sixty/tend/blob/main/LICENSE">
-          MIT
-        </a>
-        <span class="note">already in production, albeit early days</span>
-      </div>
-
-      <CurrentlyTending />
     </div>
     <div class="logo-frame">
-      <Logo size={260} />
+      <Logo size={220} />
     </div>
   </section>
 
-  <Stats />
+  <div class="marginalia stats-rail">
+    <div class="margin-note">to date</div>
+    <div class="body">
+      <Stats />
+      <CurrentlyTending />
+    </div>
+  </div>
 
   <hr />
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -113,7 +113,7 @@ claude /install-tend</code></pre>
     <div class="marginalia">
       <div class="margin-note">structure</div>
       <div class="body">
-        <p>A handful of GitHub Actions workflows, each running a Skill. They're generated into your repo from a single config.</p>
+        <p>In your repo, Tend is a handful of GitHub Actions workflows, each running a Skill, generated from a single config.</p>
       </div>
     </div>
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -59,7 +59,7 @@ const areas = [
   <section class="hero">
     <div class="hero-body">
       <h1>tend</h1>
-      <p class="tagline">An agent that tends your repo — reviewing PRs, triaging issues, and responding to whatever comes up so you can focus on building beautiful things.</p>
+      <p class="tagline">An agent that tends your repo — reviewing PRs, triaging issues, and responding to whatever comes up, so you can focus on building beautiful things.</p>
 
       <pre class="install"><code>claude plugin marketplace add max-sixty/tend
 claude plugin install install-tend@tend

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -279,20 +279,23 @@ hr::after {
 /* ---------- Hero ---------- */
 
 .hero {
-  padding: 2rem 0 3rem;
+  padding: 2rem 0 1.5rem 6rem;
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: clamp(1.5rem, 3vw, 2.5rem);
-  /* `start` instead of `center` so the left column growing (e.g. when the
-     runtime-fetched #now-tending indicator appears) doesn't re-center the
-     row and visibly shift the heading. */
+  grid-template-columns: minmax(0, 1fr) auto;
+  column-gap: clamp(1.5rem, 3vw, 2.5rem);
   align-items: start;
+}
+.hero-body { min-width: 0; }
+.stats-rail .now-tending {
+  margin: 0.8rem 0 0;
 }
 @media (max-width: 760px) {
   .hero {
     grid-template-columns: 1fr;
     text-align: left;
-    padding: 2rem 0 2.5rem;
+    padding: 2rem 0 2rem;
+    column-gap: 0;
+    row-gap: 0.5rem;
   }
   .hero .logo-frame { order: -1; max-width: 150px; justify-self: start; }
 }
@@ -316,35 +319,8 @@ hr::after {
   font-family: var(--font-mono);
   font-size: 0.85rem;
   color: var(--loam);
-  margin-bottom: 1.5rem;
+  margin-bottom: 1rem;
   line-height: 1.7;
-}
-
-.hero .badges {
-  display: flex;
-  gap: 1.4rem;
-  align-items: center;
-  flex-wrap: wrap;
-  font-family: var(--font-sans);
-  font-size: 0.85rem;
-  color: var(--ink-soft);
-  line-height: 1;
-}
-.meta-link {
-  color: var(--ink-soft);
-  border: none;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  font-variant-numeric: tabular-nums;
-}
-.meta-link:hover { color: var(--moss); }
-.meta-glyph {
-  font-family: var(--font-serif);
-  font-style: italic;
-  color: var(--oak-deep);
-  font-size: 1em;
-  line-height: 0;
 }
 
 .logo-frame {
@@ -400,7 +376,10 @@ hr::after {
   50%      { opacity: 0.35; }
 }
 
-/* ---------- "What tend tends" ---------- */
+/* ---------- Section headers (eyebrow + lead) ----------
+   Indented to align with the marginalia body column (4.5rem rail + 1.5rem
+   gap = 6rem), so the page's left margin reads as a single rail running
+   through hero → stats → field guide → quick-start → security. */
 
 .section-eyebrow {
   font-family: var(--font-mono);
@@ -408,14 +387,13 @@ hr::after {
   letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--oak-deep);
-  margin: 0 0 0.6rem;
+  margin: 0 0 0.6rem 6rem;
   position: relative;
-  padding-left: 1.6rem;
 }
 .section-eyebrow::before {
   content: "";
   position: absolute;
-  left: 0;
+  left: -1.5rem;
   top: 50%;
   width: 1rem;
   height: 1px;
@@ -429,11 +407,20 @@ hr::after {
   font-style: italic;
   line-height: 1.3;
   color: var(--ink);
-  margin: 0 0 1rem;
+  margin: 0 0 1rem 6rem;
   max-width: 48ch;
 }
 
+@media (max-width: 760px) {
+  .section-eyebrow { margin-left: 0; }
+  .section-eyebrow::before { left: -1.5rem; }
+  .section-lead { margin-left: 0; }
+}
+
 /* ---------- Stat strip ---------- */
+
+.stats-rail { margin: 0.5rem 0 2rem; }
+.stats-rail .stats { margin: 0; }
 
 .stats {
   margin: 2rem 0 1rem;
@@ -630,11 +617,4 @@ hr::after {
   font-style: italic;
   color: var(--ink-fade);
   font-size: 0.95rem;
-}
-
-.inline-icon {
-  width: 1em;
-  height: 1em;
-  vertical-align: -0.1em;
-  fill: currentColor;
 }


### PR DESCRIPTION
## Summary

- Hero, stats, and section headers now share a single 6rem left rail. The hero loses its inline marker but its body aligns with the marginalia body column below, so the page reads as one document with one rhythm.
- Stats get a `to date` margin note. The live "tending …" indicator moves from under the H1 to sit beneath the stats — past + present in one band.
- Hero h1 is lowercase ("tend") to match the wordmark.
- Maturity note and the inline `github / pypi / MIT` badges drop (footer already covers them); cleans up the unused `.hero-note`, `.meta-glyph`, `.meta-link`, `.inline-icon`, and `.hero .badges` rules.
- Rewrites the "structure" marginalia from a two-sentence fragment into one clause with a subject, scoped with "In your repo" so it doesn't claim Tend *is* only those workflows.

## Test plan
- [ ] Visual: hero, stats, and field-guide sections all left-anchored at the same x; live indicator pulses below the stats.
- [ ] Mobile (≤760px): hero collapses to single column, logo above text.
- [ ] Footer still has GitHub / PyPI / MIT links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)