### PR TITLE
docs(worker): align /activity README with actual deep-link anchors

### DIFF
--- a/worker/README.md
+++ b/worker/README.md
@@ -75,11 +75,13 @@ need staggering or a scheduled refresh (see the Phase-2 note).
 `updated_at`, and `title` is the parent's title — Search returns the item, not
 the comment or review body. Newest-first, ≤10 per bucket.
 
-For `reviews` and `comments`, `url` deep-links to the bot's specific
-review (`…#pullrequestreview-<id>`) or comment (`…#issuecomment-<id>`), so
-clicking lands on tend's actual action rather than the top of the thread.
-The Worker does one extra GitHub REST call per recent item to resolve the
-anchor (`/repos/{repo}/pulls/{n}/reviews` for reviews,
+For `reviews` and `comments`, `url` deep-links to the bot's latest inline
+review comment (`…#discussion_r<id>`) or conversation comment
+(`…#issuecomment-<id>`), so clicking lands on tend's actual action rather
+than the top of the thread. The Worker does one extra GitHub REST call per
+recent item to resolve the anchor (`/repos/{repo}/pulls/{n}/comments` for
+reviews — the inline-comment endpoint, since tend's reviews are
+`COMMENTED` with empty bodies and the review anchor scrolls nowhere;
 `/repos/{repo}/issues/{n}/comments` for comments) and falls back to the
 parent URL if the follow-up fails. For `prs` and `issues`, `url` is the
 parent issue/PR — that is what the bot created.


### PR DESCRIPTION
The `/activity` description on `worker/README.md` lines 78-85 doesn't match what the Worker actually does:

- README claims reviews deep-link to `#pullrequestreview-<id>`. Code (`worker/src/index.ts:465-496`) uses `#discussion_r…` anchors instead, because tend's reviews are `COMMENTED` with empty bodies wrapping inline comments and the review anchor scrolls nowhere.
- README claims the follow-up call hits `/repos/{repo}/pulls/{n}/reviews`. Code calls `/repos/{repo}/pulls/{n}/comments` (the inline-comment endpoint).

Brought the README in line with the code and added the one-line rationale that the inline comment in `index.ts` already documents.

No behavior change.
