### PR TITLE
ci(review-reviewers): cap job at 30 min so setup hangs don't waste 6 hours

### DIFF
--- a/.github/workflows/review-reviewers.yaml
+++ b/.github/workflows/review-reviewers.yaml
@@ -22,6 +22,11 @@ jobs:
           - max-sixty/tend
           - PRQL/prql
     runs-on: ubuntu-24.04
+    # Successful legs run 3–13 min (30-day p99 ≈ 10 min). Without a cap, an
+    # `apt-get`/`curl` hang in the upstream `claude-code-action` setup step
+    # burns the full 360-min GHA default — observed twice: 75 leg-min during
+    # the 2026-05-02 azure-mirror DNS outage and 360 leg-min on 2026-05-13.
+    timeout-minutes: 30
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary

Cap `review-reviewers` job duration at 30 min so action-setup hangs no longer burn the full 360-min GHA default.

## Evidence

Two occurrences in the past 12 days where the upstream `anthropics/claude-code-action` setup steps (`apt-get install bubblewrap socat`, `curl` Claude install) hung past their internal retries:

- **2026-05-02** ([run 25238521038](https://github.com/max-sixty/tend/actions/runs/25238521038)): `azure.archive.ubuntu.com` DNS outage during the apt-get retry loop ate ~25 min per leg across all 3 matrix legs (~75 leg-min total). Recorded in [#365](https://github.com/max-sixty/tend/issues/365).
- **2026-05-13** ([run 25806418135](https://github.com/max-sixty/tend/actions/runs/25806418135), PRQL/prql leg [job 75810320212](https://github.com/max-sixty/tend/actions/runs/25806418135/job/75810320212)): apt-get step hung silently for **6 hours** between `14:43:27Z` (bun install completes) and `20:43:14Z` (GHA cancel at the 360-min default). No session log was uploaded — the job never reached the Claude session.

## Why 30 min

30-day distribution of successful leg durations:

| Minutes | Count |
|---|---|
| 1–4   | 185 |
| 5–7   |  83 |
| 8–10  |  25 |
| 11–13 |   5 |

p99 ≈ 10 min, max successful = 13 min. 30 min is 3× p99 — plenty of headroom for the long worktrunk legs that occasionally hit 16 min during deep investigation, while killing structural hangs early. The root cause sits in upstream `claude-code-action`'s setup steps (not in tend's `action.yaml`); a cap here is the per-workflow mitigation that doesn't depend on upstream fixes.

## Scope

This PR only caps `review-reviewers.yaml` (the immediate-cost workflow). The generated `tend-*` workflows share the same risk profile — any consumer's tend run can hang at the same setup step. Adding a `timeout-minutes` default to the generator templates is a larger, separate concern worth landing once this targeted fix is validated.

## Test plan

- [ ] Workflow file parses (validated by actionlint pre-commit)
- [ ] Next scheduled `review-reviewers` cron tick completes within the 30-min cap
