### PR TITLE
site: widen marginalia label column so "structure" fits

### DIFF
--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -185,7 +185,7 @@ hr::after {
 /* Marginalia layout — small numeral marker in left column, body in right */
 .marginalia {
   display: grid;
-  grid-template-columns: 4.5rem minmax(0, 1fr);
+  grid-template-columns: 5.5rem minmax(0, 1fr);
   gap: 1.5rem;
   margin: 2.5rem 0;
 }

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -279,7 +279,7 @@ hr::after {
 /* ---------- Hero ---------- */
 
 .hero {
-  padding: 2rem 0 1.5rem 6rem;
+  padding: 2rem 0 1.5rem 7rem;
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   column-gap: clamp(1.5rem, 3vw, 2.5rem);
@@ -377,8 +377,8 @@ hr::after {
 }
 
 /* ---------- Section headers (eyebrow + lead) ----------
-   Indented to align with the marginalia body column (4.5rem rail + 1.5rem
-   gap = 6rem), so the page's left margin reads as a single rail running
+   Indented to align with the marginalia body column (5.5rem rail + 1.5rem
+   gap = 7rem), so the page's left margin reads as a single rail running
    through hero → stats → field guide → quick-start → security. */
 
 .section-eyebrow {
@@ -387,7 +387,7 @@ hr::after {
   letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--oak-deep);
-  margin: 0 0 0.6rem 6rem;
+  margin: 0 0 0.6rem 7rem;
   position: relative;
 }
 .section-eyebrow::before {
@@ -407,7 +407,7 @@ hr::after {
   font-style: italic;
   line-height: 1.3;
   color: var(--ink);
-  margin: 0 0 1rem 6rem;
+  margin: 0 0 1rem 7rem;
   max-width: 48ch;
 }
 


### PR DESCRIPTION
The 4.5rem (72px) column clipped "structure" (renders at ~81px), so the text overflowed past the hairline rule and visually appeared left-aligned compared to the other labels. Bumping to 5.5rem (88px) lets every margin label — `structure`, `activity`, `runtime`, `overlay`, `install`, `model`, `to date`, plus the roman numerals — right-align cleanly to the column edge.

The marginalia body column shifts right by the same 1rem, so this PR also bumps the three section indents (`.hero` left padding, `.section-eyebrow` left margin, `.section-lead` left margin) from `6rem` to `7rem` and updates the rail-math comment from `4.5rem rail + 1.5rem gap = 6rem` to `5.5rem rail + 1.5rem gap = 7rem`. The vertical rail through hero → stats → field guide → quick-start → security stays unbroken.
