### PR TITLE
site: prioritize activity list by per-repo cap

### DIFF
--- a/site/src/components/Activity.astro
+++ b/site/src/components/Activity.astro
@@ -99,8 +99,40 @@ const MAX_ROWS = 12;
       ...(data?.reviews?.recent ?? []).map((r) => ({ ...r, kind: "review" as const })),
       ...(data?.comments?.recent ?? []).map((r) => ({ ...r, kind: "comment" as const })),
     ];
-    rows.sort((a, b) => (a.at < b.at ? 1 : a.at > b.at ? -1 : 0));
-    const top = rows.slice(0, MAX_ROWS);
+
+    // Drop stale items first — we'd rather show a shorter list than pad
+    // with week-old work as if it's recent. Then cap each repo to PER_REPO_CAP
+    // in a first pass (age-ordered), so a single-repo burst can't crowd out
+    // the list. If slots remain, fill from the over-cap surplus, still
+    // age-ordered. The cap is the only diversification mechanism; soft
+    // weighting (sqrt etc.) is too weak to dent a fresh burst against
+    // day-old alternatives.
+    const PER_REPO_CAP = 3;
+    const FRESH_MS = 7 * 24 * 3600 * 1000;
+    const now = Date.now();
+    const fresh = rows
+      .filter((r) => now - new Date(r.at).getTime() <= FRESH_MS)
+      .sort((a, b) => (a.at < b.at ? 1 : a.at > b.at ? -1 : 0));
+
+    const counts = new Map<string, number>();
+    const picked: Array<RecentItem & { kind: Kind }> = [];
+    const overflow: Array<RecentItem & { kind: Kind }> = [];
+    for (const r of fresh) {
+      if (picked.length >= MAX_ROWS) break;
+      const c = counts.get(r.repo) ?? 0;
+      if (c < PER_REPO_CAP) {
+        picked.push(r);
+        counts.set(r.repo, c + 1);
+      } else {
+        overflow.push(r);
+      }
+    }
+    for (const r of overflow) {
+      if (picked.length >= MAX_ROWS) break;
+      picked.push(r);
+    }
+    picked.sort((a, b) => (a.at < b.at ? 1 : a.at > b.at ? -1 : 0));
+    const top = picked;
     if (top.length === 0) return false;
 
     const ul = document.querySelector("[data-activity-rows]");


### PR DESCRIPTION
A burst of work in one repo would fill the whole 12-row Activity list and make tend look like only one repo was active. Now: drop items older than 7 days first (a short list beats stale work shown as recent), then take at most 3 per repo in age order, then fill remaining slots from the over-cap surplus, still age-ordered.

The cap is the only diversification mechanism. I tried `age × (1 + √count)` soft weighting first, but for a typical burst (e.g. 12 items in 2h vs another repo's day-old item) the penalty is too gentle — A's 10th item still scores 1.5h effective against B's 24h, so A wins every slot. A hard per-repo cap is what actually moves the needle.

Scenarios:

- **Burst with diverse alternatives**: 12 items in A, 1-day-old item in B, 3-day-old in C → A×3 + B + C in pass 1, A×7 in overflow → A×10, B, C. Other repos visible.
- **Burst with only stale alternatives**: 12 items in A, B and C 8 days old → B/C dropped at the freshness gate → A×12, no stale items dragged in.
- **Thin week**: 3 fresh items in A, nothing else → list is 3 items, short but honest.
