### PR TITLE
skills(review): cite code outside the diff by semantic anchor

### DIFF
--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -138,6 +138,10 @@ Check the project's CLAUDE.md for language-specific review criteria and conventi
 
 When a PR fixes a bug or changes a pattern, search for the same pattern in other files. If found in the diff, add inline suggestions; if found outside the diff, offer to push a fix commit.
 
+**Citing code outside the diff:**
+
+The checkout uses `refs/pull/N/merge`, so you read the merged tree (PR head + current base branch). When a finding involves code outside `gh pr diff` — code the PR didn't touch but now interacts with — identify the interacting code by semantic anchor (selector, function name, declaration text) and quote enough of the relevant property/value that the reader can grep for it. Don't lead with the line number: the author's local branch may be behind main, so line numbers from the merged tree won't match their checkout, and a line-number-first citation reads as a hallucination when they check the line on their stale branch. Same principle as the `blob/main/...#L42` link rule in `running-in-ci` — line numbers are fragile across diverging refs.
+
 **Duplication check (for new functions/types):**
 
 For every new public or module-level function added in the diff, search the codebase for existing functions that do the same thing. LLM-generated code frequently reinvents internal APIs — this is the highest-value check for externally contributed PRs.


### PR DESCRIPTION
Adds a step-4 rule in the review skill: when a finding involves code outside `gh pr diff` (i.e. code the PR didn't touch but now interacts with), identify it by semantic anchor (selector, function name, declaration text) rather than raw line number, and quote enough property/value that the reader can grep for it.

**Why:** `tend-review` checks out `refs/pull/N/merge`, so it reads the merged tree. The contributor's local branch may be behind main, so line numbers from the merged tree won't match their local checkout. A line-number-first citation of code that only exists at that line in main reads as a hallucination — the contributor checks the cited line, sees different content, and dismisses the review. Happened in #475, where the reviewer correctly flagged that the new `5.5rem` rail desynchronized three `6rem` indents in `.hero`, `.section-eyebrow`, and `.section-lead`; I posted a (wrong, since-deleted) rebuttal based on a stale local checkout before realizing my branch was significantly behind main.

**Why this framing, not a blanket caveat:** every review can't open with "your branch may be behind main." The trigger is specific — the citation is outside the diff — so the rule fires narrowly. Findings inside the diff don't need it.

**Cross-reference:** `running-in-ci:352` already says outbound `blob/main/...#L42` links must use a commit SHA because line numbers shift. This is the inbound dual: don't lead with a line number when citing code that may have moved.
