### PR TITLE
site: lift recent activity above how-it-works; quiet dividers; rework security lead

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -98,6 +98,10 @@ claude /install-tend</code></pre>
 
   <hr />
 
+  <Activity />
+
+  <hr />
+
   <!-- ===== HOW IT WORKS ===== -->
   <section id="how-it-works">
     <p class="section-eyebrow">how it works</p>
@@ -127,10 +131,6 @@ claude /install-tend</code></pre>
 
   <hr />
 
-  <Activity />
-
-  <hr />
-
   <!-- ===== QUICK START ===== -->
   <section id="quick-start">
     <p class="section-eyebrow">getting started</p>
@@ -154,12 +154,12 @@ claude /install-tend</code></pre>
   <!-- ===== SECURITY ===== -->
   <section id="security">
     <p class="section-eyebrow">security</p>
-    <p class="section-lead">Where the bot can and can't go.</p>
+    <p class="section-lead">You remain in control.</p>
 
     <div class="marginalia">
       <div class="margin-note">model</div>
       <div class="body">
-        <p>Tend gives Claude write access to a repository. The primary boundary is a GitHub ruleset that blocks the bot from merging to protected branches — whoever opened the PR, however it's been reviewed — so every change lands through a human merge; tend's setup script verifies and (if you ask) creates that ruleset for you. On top of that sit config-pinning, burst-and-spike rate limiting, and a fixed prompt and Skill set: an attacker who controls a PR diff or an issue body can shape what Claude reads, never the instructions it follows.</p>
+        <p>Tend gives Claude write access to your repo, but not the merge. A GitHub ruleset blocks the bot from merging to protected branches — whoever opened the PR, however it's been reviewed — so every change lands through a human; tend's setup verifies the ruleset and (if you ask) creates it for you. Around that sit config-pinning, rate limits, and a fixed prompt and Skill set.</p>
         <p><a href="https://github.com/max-sixty/tend/blob/main/docs/security-model.md">Read the full threat model →</a></p>
       </div>
     </div>

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -143,30 +143,10 @@ pre code {
 
 hr {
   border: none;
-  height: 1.5rem;
-  margin: 4rem 0 3rem;
-  text-align: center;
-  position: relative;
-}
-hr::before {
-  content: "❦";
-  font-family: var(--font-serif);
-  font-size: 1.2rem;
-  color: var(--oak);
-  background: var(--paper);
-  padding: 0 0.8rem;
-  position: relative;
-  top: -0.1rem;
-}
-hr::after {
-  content: "";
-  position: absolute;
-  top: 50%;
-  left: 25%;
-  right: 25%;
   height: 1px;
+  margin: 4rem auto 3rem;
+  width: 50%;
   background: var(--paper-deep);
-  z-index: -1;
 }
 
 /* ---------- Page shell ---------- */


### PR DESCRIPTION
Three small landing-page edits:

- **Section order**: the live recent-activity feed now sits right after the field guide, with "how it works" and "getting started" below. Activity is the most dynamic thing on the page; keeping it near the top means returning visitors see fresh signal without scrolling past static prose.
- **Dividers**: swap the ❦ fleuron `hr::before` for a plain centered hairline (`width: 50%`, `height: 1px`). Less ornament, less competition with the section eyebrows.
- **Security section**: lead is now "You remain in control." (from "Where the bot can and can't go."). Model paragraph tightened — `not the merge` instead of the full "primary boundary" framing, `rate limits` instead of `burst-and-spike rate limiting`, and trailing prompt-injection clause dropped per follow-up.