### PR TITLE
docs: note auto-started dev server, warn off `npm run dev`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,11 +6,19 @@ completely — old formats should fail with a clear error, not silently parse.
 ## Commands
 
 ```bash
-wt test                                # run pytest in generator/
-uvx tend@latest init                   # regenerate workflows from .config/tend.yaml
-uvx tend@latest init --dry-run         # preview without writing
-uvx tend@latest check                  # verify branch protection, secrets, bot access
+wt test                                               # run pytest in generator/
+wt list statusline --format json | jq -r '.[].url'    # this worktree's dev server URL
+uvx tend@latest init                                  # regenerate workflows from .config/tend.yaml
+uvx tend@latest init --dry-run                        # preview without writing
+uvx tend@latest check                                 # verify branch protection, secrets, bot access
 ```
+
+The Astro dev server starts automatically per worktree via a `wt`
+post-start hook (`.config/wt.toml`) on a deterministic port derived from
+the branch name. Get the URL from
+`wt list statusline --format json | jq -r '.[].url'`; logs land in
+`.git/wt/logs/`. Do not run `npm run dev` — it duplicates the existing
+server on a different port.
 
 ## Architecture
 


### PR DESCRIPTION
The `wt` post-start hook in `.config/wt.toml` already runs the Astro dev server on a per-worktree port derived from the branch name. Running `npm run dev` on top of that duplicates the server on a different port — and a fresh Claude session has no way to know the existing one is there. CLAUDE.md now points at `wt list statusline --format json | jq -r '.[].url'` for the URL and warns off `npm run dev`.
