### PR TITLE
site: unify right and left margins around one rail-plus-measure column

### DIFF
--- a/site/src/components/CurrentlyTending.astro
+++ b/site/src/components/CurrentlyTending.astro
@@ -51,8 +51,8 @@
         const buildText = () => {
           const elapsed = elapsedTime(r.started_at);
           return elapsed
-            ? `tending ${r.repo} · ${workflow} · ${elapsed}${more}`
-            : `tending ${r.repo} · ${workflow}${more}`;
+            ? `currently tending ${r.repo} · ${workflow} · ${elapsed}${more}`
+            : `currently tending ${r.repo} · ${workflow}${more}`;
         };
         const label = paint(el, "live", buildText());
         if (!Number.isNaN(startedMs)) {

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -35,12 +35,6 @@ const {
         <Logo size={28} static />
         <span>tend</span>
       </a>
-      <nav>
-        <a href="#what-tend-tends">What it tends</a>
-        <a href="#quick-start">Quick start</a>
-        <a href="#security">Security</a>
-        <a href="https://github.com/max-sixty/tend">GitHub</a>
-      </nav>
     </header>
     <main class="page">
       <slot />

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -61,7 +61,7 @@ const areas = [
       <h1>tend</h1>
       <p class="tagline">An agent that tends your repo — reviewing PRs, triaging issues, and responding to whatever comes up, so you can focus on building beautiful things.</p>
 
-      <pre class="install"><code>claude plugin marketplace add max-sixty/tend
+      <pre><code>claude plugin marketplace add max-sixty/tend
 claude plugin install install-tend@tend
 claude /install-tend</code></pre>
     </div>
@@ -77,8 +77,6 @@ claude /install-tend</code></pre>
       <CurrentlyTending />
     </div>
   </div>
-
-  <hr />
 
   <!-- ===== WHAT TEND TENDS ===== -->
   <section id="what-tend-tends">
@@ -96,11 +94,7 @@ claude /install-tend</code></pre>
     ))}
   </section>
 
-  <hr />
-
   <Activity />
-
-  <hr />
 
   <!-- ===== HOW IT WORKS ===== -->
   <section id="how-it-works">
@@ -129,8 +123,6 @@ claude /install-tend</code></pre>
     </div>
   </section>
 
-  <hr />
-
   <!-- ===== QUICK START ===== -->
   <section id="quick-start">
     <p class="section-eyebrow">getting started</p>
@@ -148,8 +140,6 @@ claude /install-tend</code></pre>
       </div>
     </div>
   </section>
-
-  <hr />
 
   <!-- ===== SECURITY ===== -->
   <section id="security">

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -23,10 +23,11 @@
   --font-mono:    "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace;
 
   /* Layout */
-  --measure:      62ch;
-  --gutter:       3rem;
-  --rail:         7rem;                                  /* margin-note column + gap */
-  --page-width:   calc(var(--rail) + var(--measure) + 4rem);    /* one right edge for prose, tables, and rails — small headroom past measure so the activity table can breathe */
+  --measure:        62ch;                                  /* prose readability cap — resolves against the element's own font */
+  --measure-narrow: 48ch;                                  /* taglines, section leads — one cap for short serif intros */
+  --gutter:         3rem;
+  --rail:           7rem;                                  /* margin-note column + gap */
+  --page-width:     50rem;                                 /* rail + measure-in-Inter + 4rem headroom; rem keeps this stable across child font-sizes */
 }
 
 @media (prefers-color-scheme: dark) {
@@ -126,29 +127,21 @@ code {
 }
 
 pre {
-  background: var(--paper-soft);
-  border: 1px solid var(--paper-deep);
-  border-left: 2px solid var(--oak);
-  border-radius: 3px;
-  padding: 1rem 1.2rem;
+  background: transparent;
+  border: none;
+  border-left: 1px solid var(--oak);
+  padding: 0.2rem 0 0.2rem 1rem;
   overflow-x: auto;
-  line-height: 1.55;
+  line-height: 1.7;
   width: fit-content;
   max-width: 100%;
+  margin: 0 0 1rem;
 }
 pre code {
   background: none;
   border: none;
   padding: 0;
   color: var(--ink);
-}
-
-hr {
-  border: none;
-  height: 1px;
-  margin: 4rem auto 3rem;
-  width: 50%;
-  background: var(--paper-deep);
 }
 
 /* ---------- Page shell ---------- */
@@ -158,6 +151,10 @@ hr {
   margin: 0 auto;
   padding: 0.5rem var(--gutter) 6rem;
 }
+
+/* Sections are separated by whitespace rather than visible dividers — the
+   section-eyebrow's leading tick already marks each new block. */
+.page > section:not(.hero) { margin-top: 5rem; }
 
 @media (max-width: 720px) {
   :root { --gutter: 1.5rem; }
@@ -237,27 +234,11 @@ hr {
   align-items: center;
   gap: 0.55rem;
   line-height: 1;
+  margin-left: var(--rail);                              /* align to the body rail */
 }
 .site-header .wordmark .logo {
   color: var(--oak);
 }
-.site-header nav {
-  display: flex;
-  gap: 1.8rem;
-}
-
-@media (max-width: 620px) {
-  .site-header {
-    flex-wrap: wrap;
-    gap: 0.5rem 1.2rem;
-  }
-  .site-header nav {
-    flex-wrap: wrap;
-    gap: 0.4rem 1.2rem;
-    font-size: 0.82rem;
-  }
-}
-
 /* ---------- Hero ---------- */
 
 .hero {
@@ -287,22 +268,9 @@ hr {
   font-size: 1.35rem;
   line-height: 1.45;
   color: var(--ink-soft);
-  max-width: 32ch;
+  max-width: var(--measure-narrow);
   margin: 0.5rem 0 1.8rem;
   font-style: italic;
-}
-
-.hero .install {
-  display: inline-block;
-  background: transparent;
-  border: none;
-  border-left: 1px solid var(--oak);
-  padding: 0.2rem 0 0.2rem 1rem;
-  font-family: var(--font-mono);
-  font-size: 0.85rem;
-  color: var(--loam);
-  margin-bottom: 1rem;
-  line-height: 1.7;
 }
 
 .logo-frame {
@@ -390,7 +358,7 @@ hr {
   line-height: 1.3;
   color: var(--ink);
   margin: 0 0 1rem var(--rail);
-  max-width: 48ch;
+  max-width: var(--measure-narrow);
 }
 
 @media (max-width: 760px) {
@@ -590,6 +558,7 @@ hr {
 .site-footer .credit {
   font-family: var(--font-serif);
   font-style: italic;
+  margin-left: var(--rail);                              /* align to the body rail, matching the header */
 }
 
 /* ---------- Misc ---------- */

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -365,6 +365,8 @@ pre code {
   .section-eyebrow { margin-left: 0; }
   .section-eyebrow::before { left: -1.5rem; }
   .section-lead { margin-left: 0; }
+  .site-header .wordmark,
+  .site-footer .credit { margin-left: 0; }
 }
 
 /* ---------- Stat strip ---------- */

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -25,6 +25,8 @@
   /* Layout */
   --measure:      62ch;
   --gutter:       3rem;
+  --rail:         7rem;                                  /* margin-note column + gap */
+  --page-width:   calc(var(--rail) + var(--measure) + 4rem);    /* one right edge for prose, tables, and rails — small headroom past measure so the activity table can breathe */
 }
 
 @media (prefers-color-scheme: dark) {
@@ -152,7 +154,7 @@ hr {
 /* ---------- Page shell ---------- */
 
 .page {
-  max-width: 1080px;
+  max-width: calc(var(--page-width) + var(--gutter) * 2);
   margin: 0 auto;
   padding: 0.5rem var(--gutter) 6rem;
 }
@@ -212,7 +214,7 @@ hr {
 
 .site-header {
   padding: 1.6rem var(--gutter);
-  max-width: 1080px;
+  max-width: calc(var(--page-width) + var(--gutter) * 2);
   margin: 0 auto;
   display: flex;
   align-items: center;
@@ -259,7 +261,7 @@ hr {
 /* ---------- Hero ---------- */
 
 .hero {
-  padding: 2rem 0 1.5rem 7rem;
+  padding: 2rem 0 1.5rem var(--rail);
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   column-gap: clamp(1.5rem, 3vw, 2.5rem);
@@ -304,7 +306,7 @@ hr {
 }
 
 .logo-frame {
-  width: clamp(210px, 26vw, 330px);
+  width: clamp(170px, 18vw, 230px);
   display: flex;
   justify-content: center;
   justify-self: center;
@@ -367,7 +369,7 @@ hr {
   letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--oak-deep);
-  margin: 0 0 0.6rem 7rem;
+  margin: 0 0 0.6rem var(--rail);
   position: relative;
 }
 .section-eyebrow::before {
@@ -387,7 +389,7 @@ hr {
   font-style: italic;
   line-height: 1.3;
   color: var(--ink);
-  margin: 0 0 1rem 7rem;
+  margin: 0 0 1rem var(--rail);
   max-width: 48ch;
 }
 
@@ -567,7 +569,7 @@ hr {
   border-top: 1px solid var(--paper-deep);
   margin-top: 5rem;
   padding: 2rem var(--gutter);
-  max-width: 1080px;
+  max-width: calc(var(--page-width) + var(--gutter) * 2);
   margin-left: auto;
   margin-right: auto;
   display: flex;


### PR DESCRIPTION
Several passes to give the marketing site a single visual column instead of five competing edges.

## What changed

- **Right edge.** Page width was `1080px` with body paragraphs ending at 62ch, the activity table extending to the full page, the install snippet at `fit-content`, and the tagline at 32ch — five right edges. Page width is now `calc(--rail + --measure + 4rem) = 50rem`, so prose, the activity feed, stats, and the footer all share one right edge.
- **Left edge.** The header wordmark and footer credit now `margin-left: var(--rail)`, sitting at the same left position as every section eyebrow and paragraph. The "tend" wordmark in the header sits directly above the "tend" H1 in the hero.
- **Horizontal dividers.** Dropped all `<hr />` between sections; spacing now comes from `.page > section:not(.hero) { margin-top: 5rem }`. The section-eyebrow's leading tick still marks each new block, so the change reads as cleaner rather than less structured.
- **Header nav.** Removed the four anchor links. The page is short enough that scrolling beats clicking, the footer carries the same destinations, and the nav was already incomplete (missing "Recent ground" and "How it works").
- **Install snippet.** The two install pres (hero teaser + quick-start instruction) are unified on the quieter style — left ochre rule, no box. Dropped the `.install` override.

## Variables

- `--rail: 7rem` (margin-note column + gap) replaces magic `7rem` values in 4 places.
- `--measure-narrow: 48ch` replaces the one-off `32ch` tagline cap and `48ch` section-lead cap.
- `--page-width: 50rem` is now rem-based. It used to be `calc(--rail + 62ch + 4rem)`, but `ch` resolves at the consuming element; the header sets `font-size: 0.9rem` so its `ch` was smaller, making the header 4rem narrower than the page. rem keeps the layout stable regardless of child font-sizes.

## Other

- Renamed the "currently tending" indicator to lead with the word "currently".

## Notes for review

The footer still has its full-width `border-top` separator. With every other divider gone, it's now the only horizontal line on the page. I'd argue it reads as edge/chrome rather than a section break (it's full-width, not centered), but worth a glance.
