### PR TITLE
worker: document required Browser Cache TTL setting

### DIFF
--- a/worker/README.md
+++ b/worker/README.md
@@ -224,3 +224,10 @@ A cold cache miss costs the route's full fanout (N actions/runs calls for
 `/currently-tending`, 4·N Search calls for `/activity`). The freshness
 budget bounds how often that happens: at most one cold refresh per budget
 per colo, under any traffic level.
+
+The zone's **Browser Cache TTL** must be set to "Respect Existing Headers"
+(value `0`). Any positive value is treated as a floor on outgoing
+`max-age` — the Free plan's 4 h default silently rewrites the response on
+the way out, pinning browsers to the first snapshot they fetched and
+defeating the per-route `max-age` chosen here. `s-maxage` is left alone,
+so the colo cache stays correct; only the browser view is affected.

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -670,9 +670,10 @@ function jsonResponse(data: unknown, env: Env, ttlSeconds: number): Response {
         // Browsers revalidate after the freshness budget (`max-age`); the
         // colo cache, a shared cache, keeps the entry for STALE_SERVE_FACTOR
         // budgets (`s-maxage`) so it stays warm for stale-while-revalidate.
-        // Assumes Cloudflare's zone cache isn't also storing this route — it
-        // isn't on a vanilla Workers custom domain, but adding a Cache Rule
-        // here would honor `s-maxage` and break SWR by shadowing the Worker.
+        // Requires the zone's Browser Cache TTL to be "Respect Existing
+        // Headers" — any positive value there acts as a floor on outgoing
+        // `max-age`, so a 4 h default silently inflates this header and
+        // pins browsers to whichever snapshot they fetched first.
         "Cache-Control":
           `public, max-age=${ttlSeconds}, ` +
           `s-maxage=${ttlSeconds * STALE_SERVE_FACTOR}`,


### PR DESCRIPTION
The zone-level Browser Cache TTL silently rewrites outgoing `max-age` upward — the Free plan's 4 h default was pinning browsers to whichever `/activity` snapshot they fetched first, so multiple bot comments on one issue collapsed to a deep-link of whichever the browser happened to cache. The zone setting itself has been changed to "Respect Existing Headers"; this commit replaces the wrong source comment ("zone cache isn't storing this route") and adds a paragraph to `worker/README.md` so the requirement is visible to anyone setting up a new zone.

`s-maxage` is untouched by the override, so the colo cache stayed correct throughout; only the browser view was affected.
