### PR TITLE
site: keep tending rows visible in the activity list

### DIFF
--- a/site/src/components/Activity.astro
+++ b/site/src/components/Activity.astro
@@ -106,7 +106,9 @@ const MAX_ROWS = 12;
     // the list. If slots remain, fill from the over-cap surplus, still
     // age-ordered. The cap is the only diversification mechanism; soft
     // weighting (sqrt etc.) is too weak to dent a fresh burst against
-    // day-old alternatives.
+    // day-old alternatives. Tending rows bypass the cap — they represent
+    // work happening *right now*, so a busy repo shouldn't displace its own
+    // live run from the list.
     const PER_REPO_CAP = 3;
     const FRESH_MS = 7 * 24 * 3600 * 1000;
     const now = Date.now();
@@ -119,6 +121,10 @@ const MAX_ROWS = 12;
     const overflow: Array<RecentItem & { kind: Kind }> = [];
     for (const r of fresh) {
       if (picked.length >= MAX_ROWS) break;
+      if (r.kind === "tending") {
+        picked.push(r);
+        continue;
+      }
       const c = counts.get(r.repo) ?? 0;
       if (c < PER_REPO_CAP) {
         picked.push(r);


### PR DESCRIPTION
A repo with 3+ newer activity items would push its own currently-running tend-* workflow into the overflow bucket, and the picked-list would fill before overflow had a chance to contribute — so the activity feed could be silent about live work that `CurrentlyTending` was happily displaying. Tending entries now short-circuit the cap and don't count toward their repo's quota, so a live run is always represented in the merged list.

Caught while verifying the earlier Cloudflare Browser-Cache-TTL fix: a PRQL `ci-fix` workflow had been running for 3:30 but no `tending` row appeared in the activity list.
