### PR TITLE
chore: release 0.0.19

### DIFF
--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tend"
-version = "0.0.18"
+version = "0.0.19"
 description = "An autonomous junior maintainer for GitHub repos, powered by Claude — reviews PRs, triages issues, fixes CI"
 license = "MIT"
 requires-python = ">=3.11"

--- a/generator/uv.lock
+++ b/generator/uv.lock
@@ -98,7 +98,7 @@ wheels = [
 
 [[package]]
 name = "tend"
-version = "0.0.18"
+version = "0.0.19"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Release 0.0.19. Headline change: **Codex harness support alongside Claude** (#480).

- New `codex/action.yaml` composite action — invokable as `max-sixty/tend/codex@v1`.
- `harness: claude | codex` field in `.config/tend.yaml` (default `claude`); the generator picks the matching action ref and secret names per harness.
- `shared/system-prompt.md` consumed by both actions.
- Codex plugin manifest at `plugins/tend-ci-runner/.codex-plugin/plugin.json` and marketplace at `.agents/plugins/marketplace.json`.

Tend's own config stays on `harness: claude` for now — flipping to Codex is a separate follow-up PR after this release publishes.

Site polish + minor fixes round out the rest (#456, #462–#464, #468–#472, #475, #476, #478, #481, #457, #459, #466, #482).

## Test plan

- [x] `wt test` passes
- [x] `pre-commit run --all-files` passes
- [ ] CI green on this PR
- [ ] After merge: `uvx tend@0.0.19 --help` resolves once PyPI release workflow completes
- [ ] v1 branch auto-updated by `update-action-branch.yaml`
- [ ] Follow-up PR regenerates tend's own workflows with `uvx tend@latest init`

🤖 Generated with [Claude Code](https://claude.com/claude-code)