### PR TITLE
Add ANTHROPIC_API_KEY auth path for the Claude harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,13 +155,14 @@ Repo secrets depend on the harness:
 
 | Harness   | Required secrets                                                                                                |
 | -------- | --------------------------------------------------------------------------------------------------------------- |
-| `claude` | `BOT_TOKEN` + `CLAUDE_CODE_OAUTH_TOKEN`                                                                          |
+| `claude` | `BOT_TOKEN` + one of `CLAUDE_CODE_OAUTH_TOKEN` (subscription, see caveat below) or `ANTHROPIC_API_KEY` (API-billed) |
 | `codex`  | `BOT_TOKEN` + one of `OPENAI_API_KEY` (recommended) or `CODEX_AUTH_JSON` (subscription, discouraged on public repos) |
 
 `BOT_TOKEN` is the bot account's PAT — classic or fine-grained (see
 [example config](docs/tend.example.yaml) for scopes). `CLAUDE_CODE_OAUTH_TOKEN`
-is a Claude Code OAuth token via PKCE flow (not an API key from
-console.anthropic.com). `OPENAI_API_KEY` is a standard OpenAI API key.
+is a Claude Code OAuth token via PKCE flow (`claude setup-token`).
+`ANTHROPIC_API_KEY` is a standard API key from console.anthropic.com.
+`OPENAI_API_KEY` is a standard OpenAI API key.
 `CODEX_AUTH_JSON` is the literal contents of `~/.codex/auth.json` after
 running `codex login` locally — OpenAI's docs explicitly discourage this
 path for public repos.
@@ -188,8 +189,17 @@ already have; both run with the same workflows and skills.
 
 Wraps
 [`claude-code-action`](https://github.com/anthropics/claude-code-action),
-Anthropic's official GitHub Action for running Claude Code in CI. Your
-`CLAUDE_CODE_OAUTH_TOKEN` is used exactly as it would be in any
+Anthropic's official GitHub Action for running Claude Code in CI. Two
+auth modes:
+
+- **`CLAUDE_CODE_OAUTH_TOKEN`** — Claude Code OAuth token from
+  `claude setup-token`. Funded by a Max/Team subscription before
+  2026-06-16; see caveat below.
+- **`ANTHROPIC_API_KEY`** — standard API key from console.anthropic.com,
+  billed per token. Works for any repo and is the recommended path for
+  open-source.
+
+Whichever you set is used exactly as it would be in any
 claude-code-action workflow — tend adds the framework (workflows, skills,
 prompts) around it but never sees the token itself.
 
@@ -198,8 +208,8 @@ Code runs (CI, headless, batch) at API rates rather than against
 Max/Pro/Team plan allowances. `anthropics/claude-code-action` in
 GitHub Actions is non-interactive — a Max subscription will not fund
 runs after that date. Adopters needing subscription-funded CI should
-plan to move to the Codex harness, or accept API billing on the Claude
-harness. See Anthropic's
+plan to move to the Codex harness, or switch to `ANTHROPIC_API_KEY`. See
+Anthropic's
 [authentication policy](https://code.claude.com/docs/en/authentication)
 for the canonical statement.
 

--- a/action.yaml
+++ b/action.yaml
@@ -9,8 +9,19 @@ inputs:
     required: true
     description: GitHub token for API access and pushing commits
   claude_code_oauth_token:
-    required: true
-    description: Claude Code OAuth token for Anthropic API
+    required: false
+    default: ""
+    description: >-
+      Claude Code OAuth token (Max/Team subscription, obtained via
+      `claude setup-token`). One of claude_code_oauth_token or
+      anthropic_api_key must be set.
+  anthropic_api_key:
+    required: false
+    default: ""
+    description: >-
+      Anthropic API key from console.anthropic.com (billed per token).
+      One of claude_code_oauth_token or anthropic_api_key must be set;
+      claude_code_oauth_token takes precedence when both are present.
   bot_name:
     required: true
     description: GitHub username of the bot account
@@ -126,6 +137,14 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
 
+    - name: Validate auth configured
+      shell: bash
+      run: |
+        if [ -z "${{ inputs.claude_code_oauth_token }}" ] && [ -z "${{ inputs.anthropic_api_key }}" ]; then
+          echo "::error::No Claude auth configured. Set either the CLAUDE_CODE_OAUTH_TOKEN secret (subscription-funded, via \`claude setup-token\`) or the ANTHROPIC_API_KEY secret (billed per token via console.anthropic.com)."
+          exit 1
+        fi
+
     # Ensure uv/uvx is on PATH for Claude sessions. The nightly skill runs
     # `uvx tend@latest init` to regenerate workflow files, and mention/review
     # skills may invoke tend as well. Adopters can override the workflow
@@ -200,6 +219,7 @@ runs:
       with:
         show_full_output: ${{ inputs.show_full_output }}
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
+        anthropic_api_key: ${{ inputs.anthropic_api_key }}
         github_token: ${{ inputs.github_token }}
         bot_id: ${{ steps.bot.outputs.id }}
         bot_name: ${{ inputs.bot_name }}

--- a/docs/tend.example.yaml
+++ b/docs/tend.example.yaml
@@ -48,15 +48,19 @@ bot_name: my-project-bot
 #
 # Repo secrets, by harness:
 #
-# | Harness   | Required                                                              |
-# |----------|------------------------------------------------------------------------|
-# | `claude` | `BOT_TOKEN` + `CLAUDE_CODE_OAUTH_TOKEN`                                |
-# | `codex`  | `BOT_TOKEN` + one of `OPENAI_API_KEY` or `CODEX_AUTH_JSON`             |
+# | Harness   | Required                                                                |
+# |----------|--------------------------------------------------------------------------|
+# | `claude` | `BOT_TOKEN` + one of `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`    |
+# | `codex`  | `BOT_TOKEN` + one of `OPENAI_API_KEY` or `CODEX_AUTH_JSON`               |
 #
 # `BOT_TOKEN` is the bot account's PAT (see scopes below).
 #
 # `CLAUDE_CODE_OAUTH_TOKEN` is a Claude Code OAuth token via PKCE flow
-# (not an API key from console.anthropic.com).
+# (`claude setup-token`). The Claude action prefers this over
+# `ANTHROPIC_API_KEY` when both are set.
+#
+# `ANTHROPIC_API_KEY` is a standard API key from console.anthropic.com,
+# billed per token.
 #
 # `OPENAI_API_KEY` is a standard OpenAI API key — billed per token.
 #
@@ -82,7 +86,8 @@ bot_name: my-project-bot
 #
 # secrets:
 #   bot_token: MY_BOT_PAT
-#   claude_token: MY_CLAUDE_TOKEN      # harness: claude
+#   claude_token: MY_CLAUDE_TOKEN      # harness: claude (OAuth)
+#   anthropic_api_key: MY_ANTHROPIC_KEY  # harness: claude (API key)
 #   openai_key: MY_OPENAI_KEY          # harness: codex
 #   codex_auth_json: MY_CODEX_AUTH     # harness: codex
 #

--- a/generator/src/tend/checks.py
+++ b/generator/src/tend/checks.py
@@ -444,17 +444,15 @@ def run_all_checks(cfg: Config, repo: str | None = None) -> list[CheckResult]:
             )
         ]
 
-    # Engine-specific auth secret(s). Claude needs the OAuth token; Codex
-    # needs at least one of (api key, auth.json) — verified in a separate
-    # check below so the message can name both candidates.
+    # Engine-specific auth secret(s). Both harnesses accept one of two
+    # candidates (Claude: OAuth token or API key; Codex: API key or auth.json),
+    # verified in a separate check below so the message can name both.
     engine_auth_secrets = (
-        [cfg.claude_token_secret]
+        [cfg.claude_token_secret, cfg.anthropic_api_key_secret]
         if cfg.harness == "claude"
         else [cfg.openai_key_secret, cfg.codex_auth_json_secret]
     )
     required_secrets = [cfg.bot_token_secret]
-    if cfg.harness == "claude":
-        required_secrets.append(cfg.claude_token_secret)
 
     allowed = {cfg.bot_token_secret, *engine_auth_secrets} | set(
         cfg.allowed_repo_secrets
@@ -466,10 +464,47 @@ def run_all_checks(cfg: Config, repo: str | None = None) -> list[CheckResult]:
             results.append(check_branch_protection(repo, branch))
     results.append(check_bot_permission(repo, cfg.bot_name))
     results.append(check_secrets(repo, required_secrets))
-    if cfg.harness == "codex":
+    if cfg.harness == "claude":
+        results.append(check_claude_auth(repo, cfg))
+    else:
         results.append(check_codex_auth(repo, cfg))
     results.append(check_repo_secret_allowlist(repo, allowed))
     return results
+
+
+def check_claude_auth(repo: str, cfg: Config) -> CheckResult:
+    """Claude needs either CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY —
+    both being absent is the failure mode. Both being set is fine; the
+    action prefers the OAuth token.
+    """
+    result = _gh("api", f"repos/{repo}/actions/secrets", "--jq", "[.secrets[].name]")
+    if result is None:
+        return CheckResult("claude-auth", None, "gh CLI not found")
+    if result.returncode != 0:
+        return CheckResult(
+            "claude-auth", None, "Could not list secrets (may require admin access)"
+        )
+    try:
+        names = set(json.loads(result.stdout))
+    except json.JSONDecodeError:
+        return CheckResult("claude-auth", None, "Could not parse secrets response")
+    has_oauth = cfg.claude_token_secret in names
+    has_key = cfg.anthropic_api_key_secret in names
+    if has_oauth or has_key:
+        which = []
+        if has_oauth:
+            which.append(cfg.claude_token_secret)
+        if has_key:
+            which.append(cfg.anthropic_api_key_secret)
+        return CheckResult(
+            "claude-auth", True, f"Claude auth secret present: {', '.join(which)}"
+        )
+    return CheckResult(
+        "claude-auth",
+        False,
+        f"Claude harness selected but neither {cfg.claude_token_secret} nor "
+        f"{cfg.anthropic_api_key_secret} is set as a repo secret.",
+    )
 
 
 def check_codex_auth(repo: str, cfg: Config) -> CheckResult:

--- a/generator/src/tend/config.py
+++ b/generator/src/tend/config.py
@@ -34,12 +34,15 @@ KNOWN_TOP_LEVEL = {
     "workflows",
 }
 KNOWN_HARNESSES = {"claude", "codex"}
-# claude_token and openai_key are read; we accept either/both. codex_auth_json
-# is the subscription-funded path (~/.codex/auth.json contents stored as a
-# repo secret); officially discouraged for public repos but supported.
+# Claude harness reads claude_token (OAuth) and anthropic_api_key (console.
+# anthropic.com) — adopters set one. Codex harness reads openai_key and
+# codex_auth_json; the latter is the subscription-funded path
+# (~/.codex/auth.json contents stored as a repo secret), officially
+# discouraged for public repos but supported.
 KNOWN_SECRETS_KEYS = {
     "bot_token",
     "claude_token",
+    "anthropic_api_key",
     "openai_key",
     "codex_auth_json",
     "allowed",
@@ -116,6 +119,7 @@ class Config:
     protected_branches: list[str]
     bot_token_secret: str
     claude_token_secret: str
+    anthropic_api_key_secret: str
     openai_key_secret: str
     codex_auth_json_secret: str
     harness: str
@@ -295,6 +299,9 @@ class Config:
             protected_branches=protected_branches,
             bot_token_secret=secrets.get("bot_token", "BOT_TOKEN"),
             claude_token_secret=secrets.get("claude_token", "CLAUDE_CODE_OAUTH_TOKEN"),
+            anthropic_api_key_secret=secrets.get(
+                "anthropic_api_key", "ANTHROPIC_API_KEY"
+            ),
             openai_key_secret=secrets.get("openai_key", "OPENAI_API_KEY"),
             codex_auth_json_secret=secrets.get("codex_auth_json", "CODEX_AUTH_JSON"),
             harness=harness,

--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -60,6 +60,10 @@ def _claude_token(cfg: Config) -> str:
     return f"${{{{ secrets.{cfg.claude_token_secret} }}}}"
 
 
+def _anthropic_api_key(cfg: Config) -> str:
+    return f"${{{{ secrets.{cfg.anthropic_api_key_secret} }}}}"
+
+
 def _openai_key(cfg: Config) -> str:
     return f"${{{{ secrets.{cfg.openai_key_secret} }}}}"
 
@@ -118,12 +122,14 @@ def _agent_step(
     lines.append(f"{pad}    github_token: {bt}")
 
     if cfg.harness == "claude":
-        ct = _claude_token(cfg)
-        lines.append(f"{pad}    claude_code_oauth_token: {ct}")
+        # Emit both Claude auth inputs unconditionally; the action validates
+        # exactly one is set and forwards both to claude-code-action, which
+        # treats empty as absent. Adopters set just the one they want.
+        lines.append(f"{pad}    claude_code_oauth_token: {_claude_token(cfg)}")
+        lines.append(f"{pad}    anthropic_api_key: {_anthropic_api_key(cfg)}")
     else:
-        # Emit both Codex auth inputs unconditionally; the codex action picks
-        # auth.json over api-key when both are configured. Adopters set just
-        # the one they want — the other renders as an empty string.
+        # Same pattern for Codex: the codex action picks auth.json over api-key
+        # when both are configured.
         lines.append(f"{pad}    openai_api_key: {_openai_key(cfg)}")
         lines.append(f"{pad}    codex_auth_json: {_codex_auth_json(cfg)}")
         if cfg.effort:

--- a/generator/tests/_regtest_outputs/test_generate.test_extras_apply_path_regtest.out
+++ b/generator/tests/_regtest_outputs/test_generate.test_extras_apply_path_regtest.out
@@ -53,6 +53,7 @@ jobs:
         with:
           github_token: ${{ secrets.BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
           use_sticky_comment: true

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-ci-fix.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-ci-fix.yaml].out
@@ -34,6 +34,7 @@ jobs:
         with:
           github_token: ${{ secrets.BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
           prompt: |

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-nightly.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-nightly.yaml].out
@@ -34,6 +34,7 @@ jobs:
         with:
           github_token: ${{ secrets.BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
           prompt: |

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
@@ -101,6 +101,7 @@ jobs:
         with:
           github_token: ${{ secrets.BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
           prompt: |

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-review-runs.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-review-runs.yaml].out
@@ -34,6 +34,7 @@ jobs:
         with:
           github_token: ${{ secrets.BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
           prompt: |

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-triage.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-triage.yaml].out
@@ -37,6 +37,7 @@ jobs:
         with:
           github_token: ${{ secrets.BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
           prompt: |

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-weekly.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-weekly.yaml].out
@@ -34,6 +34,7 @@ jobs:
         with:
           github_token: ${{ secrets.BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
           prompt: |

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[ci-fix].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[ci-fix].out
@@ -34,6 +34,7 @@ jobs:
         with:
           github_token: ${{ secrets.BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
           prompt: |

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
@@ -197,6 +197,7 @@ jobs:
         with:
           github_token: ${{ secrets.BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
           prompt: >-

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[nightly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[nightly].out
@@ -33,6 +33,7 @@ jobs:
         with:
           github_token: ${{ secrets.BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
           prompt: |

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
@@ -100,6 +100,7 @@ jobs:
         with:
           github_token: ${{ secrets.BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
           prompt: |

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review-runs].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review-runs].out
@@ -33,6 +33,7 @@ jobs:
         with:
           github_token: ${{ secrets.BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
           prompt: |

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review].out
@@ -52,6 +52,7 @@ jobs:
         with:
           github_token: ${{ secrets.BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
           use_sticky_comment: true

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[triage].out
@@ -36,6 +36,7 @@ jobs:
         with:
           github_token: ${{ secrets.BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
           prompt: |

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[weekly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[weekly].out
@@ -33,6 +33,7 @@ jobs:
         with:
           github_token: ${{ secrets.BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
           prompt: |

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[ci-fix].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[ci-fix].out
@@ -36,6 +36,7 @@ jobs:
         with:
           github_token: ${{ secrets.BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
           prompt: |

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
@@ -199,6 +199,7 @@ jobs:
         with:
           github_token: ${{ secrets.BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
           prompt: >-

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[nightly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[nightly].out
@@ -35,6 +35,7 @@ jobs:
         with:
           github_token: ${{ secrets.BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
           prompt: |

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
@@ -103,6 +103,7 @@ jobs:
         with:
           github_token: ${{ secrets.BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
           prompt: |

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review-runs].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review-runs].out
@@ -35,6 +35,7 @@ jobs:
         with:
           github_token: ${{ secrets.BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
           prompt: |

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review].out
@@ -54,6 +54,7 @@ jobs:
         with:
           github_token: ${{ secrets.BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
           use_sticky_comment: true

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[triage].out
@@ -38,6 +38,7 @@ jobs:
         with:
           github_token: ${{ secrets.BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
           prompt: |

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[weekly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[weekly].out
@@ -35,6 +35,7 @@ jobs:
         with:
           github_token: ${{ secrets.BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
           prompt: |

--- a/generator/tests/test_checks.py
+++ b/generator/tests/test_checks.py
@@ -43,6 +43,7 @@ def _config(
         protected_branches=protected_branches or [],
         bot_token_secret=bot_token_secret,
         claude_token_secret=claude_token_secret,
+        anthropic_api_key_secret="ANTHROPIC_API_KEY",
         openai_key_secret="OPENAI_API_KEY",
         codex_auth_json_secret="CODEX_AUTH_JSON",
         harness=harness,
@@ -661,8 +662,8 @@ def test_run_all_checks_with_protected_branches() -> None:
             _config(protected_branches=["v1", "v2"]),
             repo="owner/repo",
         )
-    # default + v1 + v2 + bot-permission + secrets + allowlist = 6
-    assert len(results) == 6
+    # default + v1 + v2 + bot-permission + secrets + claude-auth + allowlist = 7
+    assert len(results) == 7
     bp_results = [r for r in results if r.name.startswith("branch-protection:")]
     assert len(bp_results) == 3
     assert {r.name for r in bp_results} == {
@@ -772,6 +773,79 @@ def test_claude_engine_omits_codex_auth_check() -> None:
     assert not any(r.name == "codex-auth" for r in results)
 
 
+def test_claude_engine_passes_with_oauth_token() -> None:
+    """Engine=claude with the OAuth token secret set passes claude-auth."""
+    # _fake_gh_all_pass returns ["T1","T2"] — T2 is claude_token_secret.
+    with (
+        patch("shutil.which", return_value="/usr/bin/gh"),
+        patch("tend.checks._gh", side_effect=_fake_gh_all_pass),
+    ):
+        results = run_all_checks(_config(), repo="owner/repo")
+    claude_check = [r for r in results if r.name == "claude-auth"]
+    assert len(claude_check) == 1
+    assert claude_check[0].passed is True
+    assert "T2" in claude_check[0].message
+
+
+def test_claude_engine_passes_with_api_key() -> None:
+    """Engine=claude with only ANTHROPIC_API_KEY set passes claude-auth."""
+
+    def fake_gh(*args, **kwargs):
+        url = args[1]
+        if url == "repos/owner/repo" and "--jq" in args and ".default_branch" in args:
+            return _make_completed("main\n")
+        if "rules/branches" in url:
+            return _make_completed(_BRANCH_HAS_UPDATE_RULE)
+        if "branches" in url:
+            return _make_completed("true\n")
+        if "collaborators" in url:
+            return _make_completed("write\n")
+        if "secrets" in url:
+            if "--json" in args:
+                return _make_completed('[{"name":"T1"},{"name":"ANTHROPIC_API_KEY"}]\n')
+            return _make_completed('["T1","ANTHROPIC_API_KEY"]\n')
+        return _make_completed(returncode=1)
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/gh"),
+        patch("tend.checks._gh", side_effect=fake_gh),
+    ):
+        results = run_all_checks(_config(), repo="owner/repo")
+    claude_check = [r for r in results if r.name == "claude-auth"]
+    assert claude_check[0].passed is True
+    assert "ANTHROPIC_API_KEY" in claude_check[0].message
+
+
+def test_claude_engine_fails_when_no_auth() -> None:
+    """Engine=claude with neither secret set is a hard failure."""
+
+    def fake_gh(*args, **kwargs):
+        url = args[1]
+        if url == "repos/owner/repo" and "--jq" in args and ".default_branch" in args:
+            return _make_completed("main\n")
+        if "rules/branches" in url:
+            return _make_completed(_BRANCH_HAS_UPDATE_RULE)
+        if "branches" in url:
+            return _make_completed("true\n")
+        if "collaborators" in url:
+            return _make_completed("write\n")
+        if "secrets" in url:
+            if "--json" in args:
+                return _make_completed('[{"name":"T1"}]\n')
+            return _make_completed('["T1"]\n')
+        return _make_completed(returncode=1)
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/gh"),
+        patch("tend.checks._gh", side_effect=fake_gh),
+    ):
+        results = run_all_checks(_config(), repo="owner/repo")
+    claude_check = [r for r in results if r.name == "claude-auth"]
+    assert claude_check[0].passed is False
+    assert "T2" in claude_check[0].message
+    assert "ANTHROPIC_API_KEY" in claude_check[0].message
+
+
 def test_run_all_checks_deduplicates_default_branch() -> None:
     """If protected_branches includes the default branch, it's not checked twice."""
     with (
@@ -782,8 +856,8 @@ def test_run_all_checks_deduplicates_default_branch() -> None:
             _config(protected_branches=["main", "v1"]),
             repo="owner/repo",
         )
-    # main (deduped) + v1 + bot-permission + secrets + allowlist = 5
-    assert len(results) == 5
+    # main (deduped) + v1 + bot-permission + secrets + claude-auth + allowlist = 6
+    assert len(results) == 6
     bp_results = [r for r in results if r.name.startswith("branch-protection:")]
     assert len(bp_results) == 2
     assert {r.name for r in bp_results} == {

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -203,11 +203,31 @@ def test_custom_secrets(tmp_path: Path) -> None:
         secrets:
           bot_token: MY_BOT_PAT
           claude_token: MY_CLAUDE
+          anthropic_api_key: MY_API_KEY
     """)
     cfg = Config.load(_minimal_config(tmp_path, extra))
     for wf in generate_all(cfg):
         assert "MY_BOT_PAT" in wf.content, f"{wf.filename} missing custom bot token"
         assert "MY_CLAUDE" in wf.content, f"{wf.filename} missing custom claude token"
+        assert "MY_API_KEY" in wf.content, (
+            f"{wf.filename} missing custom anthropic_api_key secret"
+        )
+
+
+def test_claude_workflows_emit_both_auth_inputs(tmp_path: Path) -> None:
+    """Claude agent step references both OAuth token and API key secrets."""
+    cfg = Config.load(_minimal_config(tmp_path))
+    for wf in generate_all(cfg):
+        assert (
+            "claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}"
+            in wf.content
+        ), f"{wf.filename} missing claude_code_oauth_token input"
+        assert "anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}" in wf.content, (
+            f"{wf.filename} missing anthropic_api_key input"
+        )
+        assert "openai_api_key" not in wf.content, (
+            f"{wf.filename} should not reference openai_api_key under claude"
+        )
 
 
 def test_custom_prompt(tmp_path: Path) -> None:

--- a/generator/tests/test_integration.py
+++ b/generator/tests/test_integration.py
@@ -322,8 +322,8 @@ def test_check_full_pipeline_with_mocked_gh(
 
     assert result.exit_code == 0
     assert "FAIL" not in result.output
-    # All four check types should report PASS
-    assert result.output.count("PASS") == 4
+    # branch-protection + bot-permission + secrets + claude-auth + allowlist = 5
+    assert result.output.count("PASS") == 5
 
 
 def test_check_full_pipeline_branch_not_protected(

--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -27,11 +27,12 @@ Before running step 1, choose the harness and lay out the plan:
 
 - Ask via `AskUserQuestion` which harness to use:
   - **Claude (Anthropic)** — uses a Claude Code OAuth token (Max/Team
-    subscription) or a console.anthropic.com API key. Note: as of
-    2026-02, Anthropic restricts OAuth tokens from Free/Pro/Max plans
-    to Claude Code and claude.ai only — `claude-code-action` is a
-    third-party harness, so subscription auth may be blocked depending
-    on enforcement. Confirm the user understands this before picking.
+    subscription) or a console.anthropic.com API key. Note: starting
+    2026-06-16, Anthropic bills non-interactive Claude Code runs (CI,
+    headless, batch) at API rates rather than against Max/Pro/Team
+    subscriptions. After that date, the OAuth path no longer funds CI
+    runs; the API key path is the only Claude option. Confirm the user
+    understands before picking.
   - **Codex (OpenAI)** — uses an OpenAI API key (billed per token) or
     a ChatGPT Plus/Pro `auth.json` (subscription-funded but officially
     discouraged for public repos). Don't recommend the `auth.json`
@@ -331,15 +332,35 @@ Branch on the harness chosen in Kickoff.
 
 ### 7a. Harness = claude
 
-An OAuth access token from Claude's auth service — uses the user's Claude
-subscription (Max/Team) for billing. Not an API key from console.anthropic.com.
+The Claude action accepts two auth modes; pick whichever the user has.
+The action prefers `CLAUDE_CODE_OAUTH_TOKEN` when both are set.
 
 ```bash
-gh secret list --repo "$REPO" --json name --jq '.[].name' | grep -q CLAUDE_CODE_OAUTH_TOKEN && echo "SET" || echo "NOT SET"
+gh secret list --repo "$REPO" --json name --jq '.[].name' \
+  | grep -E -q '^(CLAUDE_CODE_OAUTH_TOKEN|ANTHROPIC_API_KEY)$' \
+  && echo "SET" || echo "NOT SET"
 ```
 
-If not set, ask the user via `AskUserQuestion` how to obtain it. Token is
-valid for 1 year. Before offering the CLI option, check:
+If not set, ask via `AskUserQuestion` which auth mode to use:
+
+- **API key (recommended after 2026-06-16)** — `sk-ant-…` from
+  `https://console.anthropic.com/settings/keys`. Billed per token. Works
+  for any repo and is the only Claude path that funds non-interactive
+  CI runs after Anthropic's 2026-06-16 policy change.
+- **OAuth token (subscription)** — `sk-ant-oat01-…` from
+  `claude setup-token`. Funded by a Max/Team subscription before
+  2026-06-16; after that date Anthropic bills these CI runs at API
+  rates regardless. Token is valid for 1 year.
+
+For **API key**:
+
+Have the user paste the `sk-ant-…` key, then store it:
+
+```bash
+gh secret set ANTHROPIC_API_KEY --repo "$REPO" --body "$KEY"
+```
+
+For **OAuth token**: before offering the CLI option, check:
 
 - `command -v claude` — if missing, only offer Manual (point them at
   `https://claude.com/claude-code` to install).
@@ -530,7 +551,7 @@ line picks the row that matches the chosen harness):
 - [ ] Skill overlay: `.claude/skills/running-tend/SKILL.md` (tend-specific only)
 - [ ] Badge: offered to add to README (optional)
 - [ ] Bot account: `<bot-name>` exists on GitHub
-- [ ] Harness auth (claude): `CLAUDE_CODE_OAUTH_TOKEN` secret set
+- [ ] Harness auth (claude): `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` secret set
 - [ ] Harness auth (codex): `OPENAI_API_KEY` or `CODEX_AUTH_JSON` secret set
 - [ ] Bot token: `BOT_TOKEN` secret set with `repo`+`workflow`+`notifications`+`write:discussion`+`gist`+`user` scopes
 - [ ] Bot access: repo collaborator with write access, invitation accepted


### PR DESCRIPTION
The Claude harness previously required a Claude Code OAuth token even though install-tend's text claimed a console.anthropic.com API key was an option. This PR wires the API-key path through end-to-end so adopters can pick either credential type — and lines the install skill up for Anthropic's 2026-06-16 cutoff, after which OAuth tokens no longer fund non-interactive CI runs.

## Changes

**Action interface** (`action.yaml`)
- `claude_code_oauth_token` is now optional (`required: false`, default `""`).
- New `anthropic_api_key` input forwarded to `claude-code-action@v1`, which natively accepts both inputs.
- New "Validate auth configured" preflight requires at least one to be set, mirroring the codex action.

**Generator** (`config.py`, `workflows.py`, `checks.py`)
- New `secrets.anthropic_api_key` config key (default secret name `ANTHROPIC_API_KEY`).
- The Claude agent step emits both `claude_code_oauth_token` and `anthropic_api_key` lines (mirrors the existing codex two-secrets pattern; empty string for the unset one is a no-op in claude-code-action).
- `tend check` adds a `claude-auth` either-or check (mirrors `codex-auth`) and drops the hard `check_secrets` requirement on `CLAUDE_CODE_OAUTH_TOKEN`.

**Install skill** (`plugins/install-tend/.../SKILL.md`)
- Step 7a now branches on an `AskUserQuestion` between API-key (recommended after 2026-06-16) and OAuth, with the right `gh secret set` for each.
- Kickoff text updated to mention the 2026-06-16 billing change instead of the older 2026-02 OAuth-restriction caveat.
- Summary checklist accepts either secret.

**Docs** (`README.md`, `docs/tend.example.yaml`)
- Required-secrets table shows either-or for both harnesses.
- Claude harness section explains both modes and the 2026-06-16 caveat.

## Test coverage

- `test_claude_workflows_emit_both_auth_inputs` mirrors the existing codex assertion.
- `test_custom_secrets` extended to cover `anthropic_api_key`.
- New `test_claude_engine_passes_with_oauth_token`, `test_claude_engine_passes_with_api_key`, `test_claude_engine_fails_when_no_auth`.
- Result-count assertions in `test_run_all_checks_with_protected_branches`, `test_run_all_checks_deduplicates_default_branch`, and `test_check_full_pipeline_with_mocked_gh` updated for the new `claude-auth` row.
- 23 regtest snapshots refreshed (each adds exactly one `anthropic_api_key:` line under the agent step).

230 tests pass; pre-commit clean.
