### PR TITLE
install-tend: recommend subscription auth.json over OpenAI API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,15 +156,16 @@ Repo secrets depend on the harness:
 | Harness   | Required secrets                                                                                                |
 | -------- | --------------------------------------------------------------------------------------------------------------- |
 | `claude` | `BOT_TOKEN` + `CLAUDE_CODE_OAUTH_TOKEN`                                                                          |
-| `codex`  | `BOT_TOKEN` + one of `OPENAI_API_KEY` (recommended) or `CODEX_AUTH_JSON` (subscription, discouraged on public repos) |
+| `codex`  | `BOT_TOKEN` + one of `CODEX_AUTH_JSON` (subscription, recommended) or `OPENAI_API_KEY` (pay-per-token) |
 
 `BOT_TOKEN` is the bot account's PAT — classic or fine-grained (see
 [example config](docs/tend.example.yaml) for scopes). `CLAUDE_CODE_OAUTH_TOKEN`
 is a Claude Code OAuth token via PKCE flow (not an API key from
-console.anthropic.com). `OPENAI_API_KEY` is a standard OpenAI API key.
-`CODEX_AUTH_JSON` is the literal contents of `~/.codex/auth.json` after
-running `codex login` locally — OpenAI's docs explicitly discourage this
-path for public repos.
+console.anthropic.com). `CODEX_AUTH_JSON` is the contents of
+`~/.codex/auth.json` after `codex login` — funds the runs from a
+flat-rate ChatGPT subscription. `OPENAI_API_KEY` is a standard OpenAI
+API key — pay-per-token. See [Codex (alternative)](#codex-alternative)
+below for the trade-off and the public-repo gate.
 
 All other options — secret name overrides, setup steps, protected branches,
 workflow overrides, schedules — are documented in
@@ -209,13 +210,15 @@ Installs `@openai/codex` on the runner and invokes `codex exec` against a
 bundled `AGENTS.md` that teaches it to resolve tend's slash commands to
 skill markdown. Two auth modes:
 
-- **`OPENAI_API_KEY`** — standard API billing; works for any repo.
-  Recommended.
-- **`CODEX_AUTH_JSON`** — `~/.codex/auth.json` shipped as a secret, billed
-  to a ChatGPT Plus/Pro/Business subscription. OpenAI explicitly
-  discourages this on public repos because the token has read+write access
-  to the entire ChatGPT account; only use on private repos and rotate
-  often (the refresh window closes around 8 days of inactivity).
+- **`CODEX_AUTH_JSON`** (recommended) — `~/.codex/auth.json` shipped
+  as a secret, billed at the Plus/Pro/Business subscription's flat
+  rate (capped by the plan's limits). The token has read+write access
+  to the ChatGPT account that minted it; on public repos it must
+  come from a dedicated bot account, recommended on private. Rotate
+  by re-running `codex login` and re-setting the secret — the refresh
+  window closes around 8 days of inactivity.
+- **`OPENAI_API_KEY`** — pay-per-token API billing. Works for any
+  repo; pick this to avoid a separate ChatGPT account.
 
 ## Badge
 

--- a/TODO.md
+++ b/TODO.md
@@ -13,7 +13,7 @@ needs the release sequence:
 3. Edit `.config/tend.yaml`: add `harness: codex` (and optionally
    `effort: medium`). Set `model: gpt-5.5` explicitly or let the
    default win.
-4. Set `OPENAI_API_KEY` secret on `max-sixty/tend` (or `CODEX_AUTH_JSON`).
+4. Set `CODEX_AUTH_JSON` secret on `max-sixty/tend` (or `OPENAI_API_KEY`).
    Drop `CLAUDE_CODE_OAUTH_TOKEN` from `secrets.allowed` once unused.
 5. `uvx tend@latest init` to regenerate workflows. Commit both the config
    and the regenerated `tend-*.yaml` files in one commit.

--- a/codex/action.yaml
+++ b/codex/action.yaml
@@ -13,16 +13,18 @@ inputs:
     required: false
     default: ""
     description: >-
-      OpenAI API key for the Responses API. One of openai_api_key or
-      codex_auth_json must be set; codex_auth_json takes precedence when both
-      are present.
+      OpenAI API key for the Responses API, billed per token. One of
+      openai_api_key or codex_auth_json must be set; codex_auth_json takes
+      precedence when both are present.
   codex_auth_json:
     required: false
     default: ""
     description: >-
-      Contents of ~/.codex/auth.json — funds the run from a ChatGPT
-      Plus/Pro/Business subscription. OpenAI's docs explicitly discourage
-      this for public repos. Takes precedence over openai_api_key when set.
+      Contents of ~/.codex/auth.json — funds the run from a flat-rate
+      Plus/Pro/Business subscription. Takes precedence over openai_api_key
+      when set. Carries read+write access to the minting ChatGPT account;
+      on public repos mint from a dedicated bot account
+      (see docs/security-model.md).
   bot_name:
     required: true
     description: GitHub username of the bot account

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -170,8 +170,8 @@ credential whose exact form depends on `harness` in `.config/tend.yaml`.
 | Bot token (PAT or App) | GitHub API and git operations. Consistent bot identity. |
 | Harness auth (one of, per harness) | Authenticates the agent runtime. |
 | ↳ Claude OAuth token | `harness: claude`: authenticates Claude Code to the Anthropic API. |
-| ↳ `OPENAI_API_KEY` | `harness: codex`, API-billed: standard OpenAI API key, billed per token. |
-| ↳ `CODEX_AUTH_JSON` | `harness: codex`, subscription-funded: the contents of `~/.codex/auth.json` after `codex login` — **discouraged for public repos** (see below). |
+| ↳ `CODEX_AUTH_JSON` | `harness: codex`, subscription-funded: the contents of `~/.codex/auth.json` after `codex login`. Default recommendation; on public repos mint it from a ChatGPT account dedicated to the bot (see below). |
+| ↳ `OPENAI_API_KEY` | `harness: codex`, API-billed: standard OpenAI API key, billed per token. Alternative for users who'd rather not mint a separate ChatGPT account. |
 
 **Why one bot token.** The bot token is equally safe in any workflow because
 the merge restriction caps the blast radius. Using a single token gives
@@ -186,24 +186,27 @@ consistent identity for reviews and comments and avoids the
 | Bot token (App) | ~1 hour | Same as PAT, but only until token expires | Same + token auto-expires |
 | Claude OAuth | Long-lived | Run Claude sessions billed to the account | Access GitHub |
 | `OPENAI_API_KEY` | Until revoked | Run Codex/OpenAI API calls billed to the account | Access GitHub |
-| `CODEX_AUTH_JSON` | ~8-day refresh window | Run any ChatGPT API call as the user — including reading their entire chat history, accessing their custom GPTs, and exhausting their plan quota | Access GitHub |
+| `CODEX_AUTH_JSON` | ~8-day refresh window | Run any ChatGPT API call as the account the token was minted from. **Personal-account leak**: read chat history, access custom GPTs, exhaust plan quota. **Dedicated-account leak (recommended)**: burn subscription quota until rotation. | Access GitHub |
 
-**The `CODEX_AUTH_JSON` caveat.** `~/.codex/auth.json` contains an OAuth
-refresh token bound to the whole ChatGPT account. Leaking it gives an
-attacker the user's chats, custom GPTs, and any usage-billed quota — not
-just the Codex API quota. OpenAI's own
+**The `CODEX_AUTH_JSON` caveat.** `~/.codex/auth.json` is an OAuth
+refresh token bound to a ChatGPT account; a leak gives an attacker
+that account's plan resources. OpenAI's
 [CI/CD auth guide](https://developers.openai.com/codex/auth/ci-cd-auth)
-says:
+discourages this path for public or open-source repos:
 
 > The right way to authenticate automation is with an API key. Use this
 > guide only if you specifically need to run the workflow as your Codex
 > account... Do not use this workflow for public or open-source repositories.
 
-Tend's Codex action accepts `CODEX_AUTH_JSON` so subscription-funded
-private-repo workflows are possible, but the install skill refuses to
-configure it on a public repo and the secrets allowlist warning fires
-if it's set without explicit allowlisting. Rotate every ~7 days; revoke
-via `https://chatgpt.com/#settings/Personalization` if leaked.
+That guidance assumes the token comes from the user's personal account.
+Tend recommends a **ChatGPT account dedicated to the bot** instead —
+required on public repos, recommended on private — which narrows a
+leak to subscription-quota burn until the next rotation, similar in
+scope to an `OPENAI_API_KEY` leak (agent-runtime access only, no
+GitHub). Flat-rate subscription billing also typically beats per-token
+API billing on a busy repo, so the dedicated-account `auth.json` is
+the install skill's default. Rotate every ~7 days; revoke via
+`https://chatgpt.com/#settings/Personalization` if leaked.
 
 `GITHUB_TOKEN` is ephemeral (single job) and automatically scoped by each
 workflow's `permissions:` block. Not a meaningful leak target.

--- a/docs/tend.example.yaml
+++ b/docs/tend.example.yaml
@@ -51,20 +51,22 @@ bot_name: my-project-bot
 # | Harness   | Required                                                              |
 # |----------|------------------------------------------------------------------------|
 # | `claude` | `BOT_TOKEN` + `CLAUDE_CODE_OAUTH_TOKEN`                                |
-# | `codex`  | `BOT_TOKEN` + one of `OPENAI_API_KEY` or `CODEX_AUTH_JSON`             |
+# | `codex`  | `BOT_TOKEN` + one of `CODEX_AUTH_JSON` or `OPENAI_API_KEY`             |
 #
 # `BOT_TOKEN` is the bot account's PAT (see scopes below).
 #
 # `CLAUDE_CODE_OAUTH_TOKEN` is a Claude Code OAuth token via PKCE flow
 # (not an API key from console.anthropic.com).
 #
-# `OPENAI_API_KEY` is a standard OpenAI API key — billed per token.
-#
 # `CODEX_AUTH_JSON` is the literal contents of `~/.codex/auth.json` after
-# `codex login`. Bills a ChatGPT Plus/Pro/Business subscription. OpenAI
-# explicitly discourages this for public repos because the token has
-# read+write access to the entire ChatGPT account. The codex action prefers
-# `CODEX_AUTH_JSON` over `OPENAI_API_KEY` when both are set.
+# `codex login`. Bills a Plus/Pro/Business subscription at its flat rate
+# — the install skill's default. On public repos it must come from a
+# ChatGPT account dedicated to the bot, since the token has read+write
+# access to that account; see docs/security-model.md for the trade-off.
+# The codex action prefers `CODEX_AUTH_JSON` over `OPENAI_API_KEY` when
+# both are set.
+#
+# `OPENAI_API_KEY` is a standard OpenAI API key, billed per token.
 #
 # Classic PAT scopes: `repo`, `workflow`, `notifications`, `write:discussion`,
 # `gist`, `user`. `workflow` is required to push commits that modify

--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: install-tend
-description: Sets up tend — an autonomous junior maintainer for a GitHub repo, powered by Claude or OpenAI Codex — that reviews PRs, triages issues, and fixes CI. Creates config, generates workflows, configures secrets and branch protection via API, creates the bot account, and provisions the harness auth token (Claude OAuth or OpenAI API/Codex auth.json). Use when setting up tend on a new repo or when asked to install/configure tend.
+description: Sets up tend — an autonomous junior maintainer for a GitHub repo, powered by Claude or OpenAI Codex — that reviews PRs, triages issues, and fixes CI. Creates config, generates workflows, configures secrets and branch protection via API, creates the bot account, and provisions the harness auth token (Claude OAuth or OpenAI Codex auth.json/API key). Use when setting up tend on a new repo or when asked to install/configure tend.
 ---
 
 # Install Tend
@@ -32,10 +32,12 @@ Before running step 1, choose the harness and lay out the plan:
     to Claude Code and claude.ai only — `claude-code-action` is a
     third-party harness, so subscription auth may be blocked depending
     on enforcement. Confirm the user understands this before picking.
-  - **Codex (OpenAI)** — uses an OpenAI API key (billed per token) or
-    a ChatGPT Plus/Pro `auth.json` (subscription-funded but officially
-    discouraged for public repos). Don't recommend the `auth.json`
-    path for an open-source repo.
+  - **Codex (OpenAI)** — uses a ChatGPT Plus/Pro/Business `auth.json`
+    (flat subscription rate, capped by the plan's limits; recommended)
+    or an OpenAI API key (billed per token). On public repos the
+    `auth.json` must come from a ChatGPT account dedicated to the bot,
+    since the token has read+write access to the account that minted
+    it.
 - List the steps you'll be running (the section headings below: Create
   config → Generate workflows → Branch protection → Skill overlay →
   Badge → Bot account → Harness auth → Bot token → Grant access →
@@ -373,34 +375,43 @@ Codex supports two auth modes. The `tend/codex` action prefers
 
 Ask via `AskUserQuestion`:
 
-- **OpenAI API key (recommended)** — billed per token via the user's
-  OpenAI account. Works for any repo, public or private. The user
-  generates the key at `https://platform.openai.com/api-keys`.
-- **ChatGPT subscription (auth.json)** — funds the run from a
-  ChatGPT Plus/Pro/Business plan. OpenAI explicitly discourages this
-  for public repos (the token has read+write access to the user's
-  whole ChatGPT account, and CI runs print it in the proxy logs).
-  Only offer this option when the repo is private; refuse and
-  recommend API key for public repos.
+- **ChatGPT subscription (auth.json, recommended)** — billed at the
+  Plus/Pro/Business subscription's flat rate, capped by the plan's
+  limits. API billing scales per token instead, which on a busy repo
+  adds up fast. The token carries read+write access to the ChatGPT
+  account that minted it, so **mint `auth.json` from a dedicated bot
+  account that has no personal chat history** — required for public
+  repos, recommended for private. With a clean account the worst-case
+  leak is subscription-quota burn until the next rotation, similar in
+  scope to an `OPENAI_API_KEY` leak (agent-runtime access only, no
+  GitHub).
+- **OpenAI API key** — billed per token. Works for any repo. Pick
+  this if the user doesn't want to mint a separate ChatGPT account.
+  Key from `https://platform.openai.com/api-keys`.
 
-For **API key**:
+For **auth.json** (recommended):
+
+Ask via `AskUserQuestion` which account the user will sign in as:
+
+- **Dedicated bot account (recommended)** — no personal data behind
+  the token; a leak narrows to subscription-quota burn.
+- **Personal account** — exposes the user's full ChatGPT account if
+  leaked.
+
+Refuse the personal option on public repos; if the user won't mint a
+dedicated account, skip to **API key** below. On private repos
+accept either, and honor the answer in step 1.
 
 ```bash
-gh secret list --repo "$REPO" --json name --jq '.[].name' | grep -q OPENAI_API_KEY && echo "SET" || echo "NOT SET"
+gh secret list --repo "$REPO" --json name --jq '.[].name' | grep -q CODEX_AUTH_JSON && echo "SET" || echo "NOT SET"
 ```
 
-If not set, have the user paste the `sk-…` key. Store it:
-
-```bash
-gh secret set OPENAI_API_KEY --repo "$REPO" --body "$KEY"
-```
-
-For **auth.json** (private repos only, after confirming the user
-understands the trade-off):
+If not set:
 
 1. On a trusted local machine, the user installs codex
-   (`npm i -g @openai/codex`) and runs `codex login`. Codex writes
-   `~/.codex/auth.json` with the refresh-tokened OAuth payload.
+   (`npm i -g @openai/codex`) and runs `codex login`, signing in as
+   the account chosen above. Codex writes `~/.codex/auth.json` with
+   the refresh-tokened OAuth payload.
 2. Have the user run `cat ~/.codex/auth.json` and paste the
    full JSON back. Then:
 
@@ -414,6 +425,18 @@ understands the trade-off):
    ~7 days (the refresh window closes around 8 days). Codex refreshes
    on use, but a long-idle bot can expire — re-run `codex login` and
    re-set the secret if the bot starts failing 401.
+
+For **API key**:
+
+```bash
+gh secret list --repo "$REPO" --json name --jq '.[].name' | grep -q OPENAI_API_KEY && echo "SET" || echo "NOT SET"
+```
+
+If not set, have the user paste the `sk-…` key. Store it:
+
+```bash
+gh secret set OPENAI_API_KEY --repo "$REPO" --body "$KEY"
+```
 
 ## 8. Bot token and secret
 
@@ -531,7 +554,7 @@ line picks the row that matches the chosen harness):
 - [ ] Badge: offered to add to README (optional)
 - [ ] Bot account: `<bot-name>` exists on GitHub
 - [ ] Harness auth (claude): `CLAUDE_CODE_OAUTH_TOKEN` secret set
-- [ ] Harness auth (codex): `OPENAI_API_KEY` or `CODEX_AUTH_JSON` secret set
+- [ ] Harness auth (codex): `CODEX_AUTH_JSON` (subscription, recommended) or `OPENAI_API_KEY` secret set
 - [ ] Bot token: `BOT_TOKEN` secret set with `repo`+`workflow`+`notifications`+`write:discussion`+`gist`+`user` scopes
 - [ ] Bot access: repo collaborator with write access, invitation accepted
 - [ ] Bot bio: profile bio reflects the authorization stance


### PR DESCRIPTION
## Summary

Flip the recommended Codex auth in tend's install flow: prefer subscription-funded `CODEX_AUTH_JSON` over `OPENAI_API_KEY`. Cost is the driver — API billing scales per token; a Plus/Pro/Business subscription bills flat-rate (capped by the plan's limits).

The public-repo concern with `auth.json` (read+write access to whatever ChatGPT account minted it) is now mitigated rather than refused: the install skill requires the user to mint `auth.json` from a **ChatGPT account dedicated to the bot** on public repos, recommended on private. With a clean dedicated account a leak narrows to subscription-quota burn until rotation — similar in scope to an `OPENAI_API_KEY` leak (agent-runtime access only, no GitHub).

## Changes

- `plugins/install-tend/skills/install-tend/SKILL.md` — section 7b rewritten; dedicated/personal `AskUserQuestion` added with public/private branching; Kickoff blurb and install checklist re-balanced
- `README.md`, `docs/security-model.md`, `docs/tend.example.yaml` — re-balanced framing, table row order, leak-case enumeration
- `codex/action.yaml` — per-input descriptions updated (top-level upstream-stance language preserved deliberately)
- `TODO.md` — cutover step's parenthetical reordered for consistency

No behavior changes in `codex/action.yaml` — it already prefers `auth.json` over `OPENAI_API_KEY` when both are set; that precedence is now coherent with the recommendation.

Tend's own CI auth and a release bump are intentionally out of scope.

## Test plan

- [x] `pre-commit run --all-files` passes
- [x] Three review iterations (`/reviewing-code` + `/writing-prose`) converged to "no issues — ship it"
- [ ] Watch a Codex CI run after merge to confirm the recommendation framing reads cleanly to a fresh user
