### PR TITLE
install-tend: mint Codex auth.json via device-code into isolated CODEX_HOME

### DIFF
--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -433,19 +433,19 @@ If not set:
    (`npm i -g @openai/codex`) and runs:
 
    ```bash
-   TEND_CODEX_HOME=$(mktemp -d)
-   CODEX_HOME=$TEND_CODEX_HOME codex login --device-auth
+   mkdir -p /tmp/codex-tend
+   CODEX_HOME=/tmp/codex-tend codex login --device-auth
    ```
 
-   The tempdir isolates the bot's `auth.json` from the user's
-   personal `~/.codex/` — both coexist, no need to log out of
-   personal Codex. `--device-auth` prints a URL and a one-time code;
-   the user opens the URL in any browser and signs in as the
-   dedicated bot ChatGPT account chosen above (device-code is how
-   the user authenticates as the bot without juggling browser
-   sessions). Codex writes `$TEND_CODEX_HOME/auth.json` with the
+   The dedicated `CODEX_HOME` isolates the bot's `auth.json` from
+   the user's personal `~/.codex/` — both coexist, no need to log
+   out of personal Codex. `--device-auth` prints a URL and a
+   one-time code; the user opens the URL in any browser and signs
+   in as the dedicated bot ChatGPT account chosen above (device-code
+   is how the user authenticates as the bot without juggling browser
+   sessions). Codex writes `/tmp/codex-tend/auth.json` with the
    refresh-tokened OAuth payload.
-2. Have the user run `cat $TEND_CODEX_HOME/auth.json` and paste the
+2. Have the user run `cat /tmp/codex-tend/auth.json` and paste the
    full JSON back. Then:
 
    ```bash
@@ -455,7 +455,7 @@ If not set:
    )"
    ```
 
-   After the secret is set, `rm -rf $TEND_CODEX_HOME` to clear the
+   After the secret is set, `rm -rf /tmp/codex-tend` to clear the
    on-disk copy of the refresh token.
 3. Add a TODO in the repo's tracking system: rotate auth.json every
    ~7 days (the refresh window closes around 8 days). Codex refreshes

--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -445,18 +445,13 @@ If not set:
    is how the user authenticates as the bot without juggling browser
    sessions). Codex writes `/tmp/codex-tend/auth.json` with the
    refresh-tokened OAuth payload.
-2. Have the user run `cat /tmp/codex-tend/auth.json` and paste the
-   full JSON back. Then:
+2. Wait for the user to confirm they've signed in. Then read the
+   file directly and set the secret:
 
    ```bash
-   gh secret set CODEX_AUTH_JSON --repo "$REPO" --body "$(cat <<'EOF'
-   <pasted-json>
-   EOF
-   )"
+   gh secret set CODEX_AUTH_JSON --repo "$REPO" < /tmp/codex-tend/auth.json
+   rm -rf /tmp/codex-tend
    ```
-
-   After the secret is set, `rm -rf /tmp/codex-tend` to clear the
-   on-disk copy of the refresh token.
 3. Add a TODO in the repo's tracking system: rotate auth.json every
    ~7 days (the refresh window closes around 8 days). Codex refreshes
    on use, but a long-idle bot can expire — re-run the device-code

--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -430,10 +430,21 @@ gh secret list --repo "$REPO" --json name --jq '.[].name' | grep -q CODEX_AUTH_J
 If not set:
 
 1. On a trusted local machine, the user installs codex
-   (`npm i -g @openai/codex`) and runs `codex login`, signing in as
-   the account chosen above. Codex writes `~/.codex/auth.json` with
-   the refresh-tokened OAuth payload.
-2. Have the user run `cat ~/.codex/auth.json` and paste the
+   (`npm i -g @openai/codex`) and runs:
+
+   ```bash
+   CODEX_HOME=~/.codex-tend codex login --device-auth
+   ```
+
+   `CODEX_HOME=~/.codex-tend` isolates the bot's `auth.json` from the
+   user's personal `~/.codex/` — both coexist, no need to log out of
+   personal Codex. `--device-auth` prints a URL and a one-time code;
+   the user opens the URL in any browser and signs in as the
+   dedicated bot ChatGPT account chosen above (device-code is how the
+   user authenticates as the bot without juggling browser sessions).
+   Codex writes `~/.codex-tend/auth.json` with the refresh-tokened
+   OAuth payload.
+2. Have the user run `cat ~/.codex-tend/auth.json` and paste the
    full JSON back. Then:
 
    ```bash
@@ -444,8 +455,9 @@ If not set:
    ```
 3. Add a TODO in the repo's tracking system: rotate auth.json every
    ~7 days (the refresh window closes around 8 days). Codex refreshes
-   on use, but a long-idle bot can expire — re-run `codex login` and
-   re-set the secret if the bot starts failing 401.
+   on use, but a long-idle bot can expire — re-run
+   `CODEX_HOME=~/.codex-tend codex login --device-auth` and re-set
+   the secret if the bot starts failing 401.
 
 For **API key**:
 

--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -433,18 +433,19 @@ If not set:
    (`npm i -g @openai/codex`) and runs:
 
    ```bash
-   CODEX_HOME=~/.codex-tend codex login --device-auth
+   TEND_CODEX_HOME=$(mktemp -d)
+   CODEX_HOME=$TEND_CODEX_HOME codex login --device-auth
    ```
 
-   `CODEX_HOME=~/.codex-tend` isolates the bot's `auth.json` from the
-   user's personal `~/.codex/` — both coexist, no need to log out of
+   The tempdir isolates the bot's `auth.json` from the user's
+   personal `~/.codex/` — both coexist, no need to log out of
    personal Codex. `--device-auth` prints a URL and a one-time code;
    the user opens the URL in any browser and signs in as the
-   dedicated bot ChatGPT account chosen above (device-code is how the
-   user authenticates as the bot without juggling browser sessions).
-   Codex writes `~/.codex-tend/auth.json` with the refresh-tokened
-   OAuth payload.
-2. Have the user run `cat ~/.codex-tend/auth.json` and paste the
+   dedicated bot ChatGPT account chosen above (device-code is how
+   the user authenticates as the bot without juggling browser
+   sessions). Codex writes `$TEND_CODEX_HOME/auth.json` with the
+   refresh-tokened OAuth payload.
+2. Have the user run `cat $TEND_CODEX_HOME/auth.json` and paste the
    full JSON back. Then:
 
    ```bash
@@ -453,11 +454,13 @@ If not set:
    EOF
    )"
    ```
+
+   After the secret is set, `rm -rf $TEND_CODEX_HOME` to clear the
+   on-disk copy of the refresh token.
 3. Add a TODO in the repo's tracking system: rotate auth.json every
    ~7 days (the refresh window closes around 8 days). Codex refreshes
-   on use, but a long-idle bot can expire — re-run
-   `CODEX_HOME=~/.codex-tend codex login --device-auth` and re-set
-   the secret if the bot starts failing 401.
+   on use, but a long-idle bot can expire — re-run the device-code
+   mint and re-set the secret if the bot starts failing 401.
 
 For **API key**:
 


### PR DESCRIPTION
Switches section 7b's `auth.json` mint step to a device-code flow that writes into an isolated `CODEX_HOME=/tmp/codex-tend`, so the bot's `auth.json` doesn't clobber the user's personal `~/.codex/auth.json` — both coexist, no logout required. `--device-auth` prints a URL and one-time code; the user signs in as the dedicated bot ChatGPT account in any browser without juggling sessions. Step 2 no longer asks the user to `cat` and paste the JSON — the agent reads `/tmp/codex-tend/auth.json` directly, pipes it to `gh secret set CODEX_AUTH_JSON` via stdin, then `rm -rf`s the dir. The rest of 7b — the dedicated-vs-personal `AskUserQuestion` gate, the public-repo refusal, the rotation TODO — is unchanged.
