### PR TITLE
install-tend: drop per-scope justifications from §8

### DIFF
--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -456,11 +456,8 @@ gh secret set OPENAI_API_KEY --repo "$REPO" --body "$KEY"
 ## 8. Bot token and secret
 
 The bot's token needs scopes `repo`, `workflow`, `notifications`,
-`write:discussion`, `gist`, and `user`. (`workflow` pushes commits that
-modify `.github/workflows/` files; `notifications` reads/dismisses the
-bot's own threads; `write:discussion` posts on GitHub Discussions; `gist`
-lets skills like `review-reviewers` store evidence in the bot's secret
-gists; `user` lets step 10 set the bio via `PATCH /user`.)
+`write:discussion`, `gist`, and `user` (per-scope justifications in
+`docs/tend.example.yaml`).
 
 Have the user run, in any terminal:
 


### PR DESCRIPTION
## Summary

Small follow-up to #491. The bot-token scope list in `install-tend/SKILL.md` step 8 carried the same per-scope justifications already in `docs/tend.example.yaml` — drop the explanations from the skill, keep the literal scope list (the `gh auth login --scopes …` command immediately below uses it verbatim), and link out for the why.

Net: −3 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)