### PR TITLE
docs: align CODEX_AUTH_JSON references with the device-code mint flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To use Tend, a project needs:
 - A GitHub account for the agent (for example this project's is **[@tend-agent](https://www.github.com/tend-agent))**
 - One of:
   - A Claude Max subscription (harness = "claude")
-  - An OpenAI API key, or a ChatGPT subscription via `~/.codex/auth.json` (harness = "codex")
+  - An OpenAI API key, or a ChatGPT subscription via a Codex `auth.json` (harness = "codex")
 
 Tend offers the default code & guidance for the agent. Specifically that means:
 
@@ -161,8 +161,8 @@ Repo secrets depend on the harness:
 `BOT_TOKEN` is the bot account's PAT — see
 [example config](docs/tend.example.yaml) for scopes.
 `CLAUDE_CODE_OAUTH_TOKEN` is from `claude setup-token`;
-`CODEX_AUTH_JSON` is the contents of `~/.codex/auth.json` after
-`codex login`. The other two are standard API keys from
+`CODEX_AUTH_JSON` is the contents of the `auth.json` Codex writes after
+`codex login --device-auth`. The other two are standard API keys from
 console.anthropic.com and platform.openai.com. See
 [Codex (alternative)](#codex-alternative) for the Codex trade-off and
 public-repo gate; [docs/security-model.md](docs/security-model.md) has
@@ -220,7 +220,7 @@ Installs `@openai/codex` on the runner and invokes `codex exec` against a
 bundled `AGENTS.md` that teaches it to resolve tend's slash commands to
 skill markdown. Two auth modes:
 
-- **`CODEX_AUTH_JSON`** (recommended) — `~/.codex/auth.json` shipped
+- **`CODEX_AUTH_JSON`** (recommended) — Codex `auth.json` shipped
   as a secret, billed at the Plus/Pro/Business subscription's flat
   rate. On public repos the token must come from a ChatGPT account
   dedicated to the bot; recommended on private. See

--- a/codex/action.yaml
+++ b/codex/action.yaml
@@ -2,7 +2,7 @@ name: Tend (Codex)
 description: >-
   Tend's Codex harness: an autonomous junior maintainer for GitHub repos
   powered by OpenAI Codex. Authenticates via OPENAI_API_KEY or a
-  subscription-funded ~/.codex/auth.json (the latter is officially
+  subscription-funded Codex auth.json (the latter is officially
   discouraged by OpenAI for public repos — see docs/security-model.md).
 
 inputs:
@@ -20,10 +20,11 @@ inputs:
     required: false
     default: ""
     description: >-
-      Contents of ~/.codex/auth.json — funds the run from a flat-rate
-      Plus/Pro/Business subscription. Takes precedence over openai_api_key
-      when set. Carries read+write access to the minting ChatGPT account;
-      on public repos mint from a dedicated bot account
+      Contents of the auth.json Codex writes after `codex login
+      --device-auth` — funds the run from a flat-rate Plus/Pro/Business
+      subscription. Takes precedence over openai_api_key when set.
+      Carries read+write access to the minting ChatGPT account; on
+      public repos mint from a dedicated bot account
       (see docs/security-model.md).
   bot_name:
     required: true

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -170,7 +170,7 @@ credential whose exact form depends on `harness` in `.config/tend.yaml`.
 | Bot token (PAT or App) | GitHub API and git operations. Consistent bot identity. |
 | Harness auth (one of, per harness) | Authenticates the agent runtime. |
 | ↳ Claude OAuth token | `harness: claude`: authenticates Claude Code to the Anthropic API. |
-| ↳ `CODEX_AUTH_JSON` | `harness: codex`, subscription-funded: the contents of `~/.codex/auth.json` after `codex login`. Default recommendation; on public repos mint it from a ChatGPT account dedicated to the bot (see below). |
+| ↳ `CODEX_AUTH_JSON` | `harness: codex`, subscription-funded: the contents of the `auth.json` Codex writes after `codex login --device-auth`. Default recommendation; on public repos mint it from a ChatGPT account dedicated to the bot (see below). |
 | ↳ `OPENAI_API_KEY` | `harness: codex`, API-billed: standard OpenAI API key, billed per token. Alternative for users who'd rather not mint a separate ChatGPT account. |
 
 **Why one bot token.** The bot token is equally safe in any workflow because
@@ -188,7 +188,7 @@ consistent identity for reviews and comments and avoids the
 | `OPENAI_API_KEY` | Until revoked | Run Codex/OpenAI API calls billed to the account | Access GitHub |
 | `CODEX_AUTH_JSON` | ~8-day refresh window | Run any ChatGPT API call as the account the token was minted from. **Personal-account leak**: read chat history, access custom GPTs, exhaust plan quota. **Dedicated-account leak (recommended)**: burn subscription quota until rotation. | Access GitHub |
 
-**The `CODEX_AUTH_JSON` caveat.** `~/.codex/auth.json` is an OAuth
+**The `CODEX_AUTH_JSON` caveat.** Codex's `auth.json` is an OAuth
 refresh token bound to a ChatGPT account; a leak gives an attacker
 that account's plan resources. OpenAI's
 [CI/CD auth guide](https://developers.openai.com/codex/auth/ci-cd-auth)

--- a/docs/tend.example.yaml
+++ b/docs/tend.example.yaml
@@ -56,8 +56,8 @@ bot_name: my-project-bot
 # `BOT_TOKEN` is the bot account's PAT (scopes below).
 # `CLAUDE_CODE_OAUTH_TOKEN` is from `claude setup-token` (PKCE).
 # `ANTHROPIC_API_KEY` is a console.anthropic.com API key.
-# `CODEX_AUTH_JSON` is the contents of `~/.codex/auth.json` after
-# `codex login` — the install skill's default; see
+# `CODEX_AUTH_JSON` is the contents of the `auth.json` Codex writes
+# after `codex login --device-auth` — the install skill's default; see
 # docs/security-model.md for the trade-off and public-repo gate.
 # `OPENAI_API_KEY` is a standard OpenAI API key.
 #

--- a/generator/src/tend/config.py
+++ b/generator/src/tend/config.py
@@ -36,9 +36,9 @@ KNOWN_TOP_LEVEL = {
 KNOWN_HARNESSES = {"claude", "codex"}
 # Claude harness reads claude_token (OAuth) and anthropic_api_key (console.
 # anthropic.com) — adopters set one. Codex harness reads openai_key and
-# codex_auth_json; the latter is the subscription-funded path
-# (~/.codex/auth.json contents stored as a repo secret), officially
-# discouraged for public repos but supported.
+# codex_auth_json; the latter is the subscription-funded path (the auth.json
+# Codex writes after `codex login --device-auth`, stored as a repo secret),
+# officially discouraged for public repos but supported.
 KNOWN_SECRETS_KEYS = {
     "bot_token",
     "claude_token",


### PR DESCRIPTION
Follow-up to #490, which switched the install-tend skill to mint Codex's `auth.json` into `/tmp/codex-tend` via `codex login --device-auth`. The README, security-model doc, and example config still described `CODEX_AUTH_JSON` as "the contents of `~/.codex/auth.json` after `codex login`". Cross-referencing skill + docs gave readers mismatched paths. Rephrased generically so the docs describe the secret value (the `auth.json` Codex writes after `codex login --device-auth`) without naming a specific home path. The runtime side — `codex/action.yaml` writing the secret to `$HOME/.codex/auth.json` on the GHA runner — is unchanged.
