### PR TITLE
docs: align CLAUDE.md and codex action comments with two-harness model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,12 +56,18 @@ and rendered into each workflow.
 ```
 tend/
 ├── .claude-plugin/
-│   └── marketplace.json  # Lists both plugins
+│   └── marketplace.json  # Claude Code marketplace — lists both plugins
+├── .agents/plugins/
+│   └── marketplace.json  # Codex marketplace — lists tend-ci-runner
 ├── plugins/
 │   ├── install-tend/     # User-facing plugin (setup skill)
 │   └── tend-ci-runner/   # CI plugin (review, triage, ci-fix, etc.)
+│       ├── .codex-plugin/  # Codex plugin manifest
 │       └── scripts/      # Helper scripts (survey, run listing)
-├── action.yaml           # Composite action — the stable interface
+├── action.yaml           # Claude harness composite action
+├── codex/
+│   ├── action.yaml       # Codex harness composite action
+│   └── agents-tail.md    # AGENTS.md appendix for Codex
 ├── generator/            # Python package (uvx tend@latest), hatchling build
 │   ├── src/tend/
 │   │   ├── config.py     # Reads .config/tend.yaml
@@ -256,8 +262,9 @@ When adding to or editing files in `plugins/tend-ci-runner/skills/` or
 
 ## Agent-driven vs deterministic steps
 
-Tend's workflows invoke Claude through `max-sixty/tend@v1`. When adding new
-capability, split work along this line:
+Tend's workflows invoke the agent through the harness-specific composite
+action (`max-sixty/tend@v1` for Claude, `max-sixty/tend/codex@v1` for
+Codex). When adding new capability, split work along this line:
 
 - **The agent drives diagnostics and remediation.** Once the action is
   running, put logic into the relevant skill (or a script the skill calls —

--- a/codex/action.yaml
+++ b/codex/action.yaml
@@ -242,7 +242,7 @@ runs:
         codex plugin add tend-ci-runner@tend
         codex plugin list 2>/dev/null || true
 
-    # Stage AGENTS.md into $CODEX_HOME so it loads alongside any AGENTS.md
+    # Stage AGENTS.md into ~/.codex so it loads alongside any AGENTS.md
     # the adopter already has in their repo. Adopters' files are not
     # touched. The bulk of the prompt comes from shared/system-prompt.md
     # (harness-neutral; the Claude action consumes the same file via
@@ -364,7 +364,7 @@ runs:
         fi
         exit $EXIT
 
-    # Codex writes rollouts to $CODEX_HOME/sessions/YYYY/MM/DD/rollout-*.jsonl.
+    # Codex writes rollouts to ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl.
     # Each event includes a token_count field (input/output/cached). Sum
     # them. Cost is left at 0 — Codex CLI doesn't surface API list prices
     # and computing them ourselves would require maintaining a price table.


### PR DESCRIPTION
## Summary

Nightly survey found three small doc/comment drifts left over from the Claude → Claude+Codex split:

- `CLAUDE.md` § Structure: tree showed only `.claude-plugin/` and a single `action.yaml`. Adds `.agents/plugins/`, `plugins/tend-ci-runner/.codex-plugin/`, and `codex/{action.yaml,agents-tail.md}` so the two-harness layout is discoverable.
- `CLAUDE.md` § Agent-driven vs deterministic steps: opened with "Tend's workflows invoke Claude through `max-sixty/tend@v1`." Now names both `max-sixty/tend@v1` (Claude) and `max-sixty/tend/codex@v1` (Codex), matching the architecture section above.
- `codex/action.yaml` (lines 245, 367): two comments referenced `$CODEX_HOME` but the action hard-codes `$HOME/.codex` everywhere — no `CODEX_HOME` env is exported. Updated the comments to say `~/.codex` so they match behavior.

Documentation-only — no behavior change. No regression test feasible.

## Test plan

- [ ] CI green