### PR TITLE
skills(nightly): base update-workflows worktree on existing remote PR

### DIFF
--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -117,7 +117,13 @@ Used by both Step 3 (applied to recent diffs) and Step 5 (applied to full files)
 Regenerate the tend workflow files and open a PR if anything changed. The checkout's `.github/` directory may be mounted read-only under the sandbox (protecting bots from modifying their own workflows in place), so do the regeneration in a git worktree under `$TMPDIR`, which is writable:
 
 ```bash
-git worktree add "$TMPDIR/tend-update-workflows" -b tend/update-workflows HEAD
+# Base the worktree on the open update-workflows PR if one exists, so the
+# regen produces only the incremental delta. Falls back to HEAD when no PR
+# is open (first regen, or after the prior PR merged). `-B` resets a stale
+# local branch from a prior failed attempt rather than rejecting it.
+git fetch origin tend/update-workflows 2>/dev/null || true
+BASE=$(git rev-parse --verify origin/tend/update-workflows 2>/dev/null || git rev-parse HEAD)
+git worktree add "$TMPDIR/tend-update-workflows" -B tend/update-workflows "$BASE"
 cd "$TMPDIR/tend-update-workflows"
 
 # Capture the stamped tend version before regenerating, so the next bash


### PR DESCRIPTION
## Problem

The bundled `tend-ci-runner:nightly` skill's Step 6 worktree recipe uses `git worktree add ... -b tend/update-workflows HEAD`. The `-b NAME BASE` form always creates a fresh local branch from `BASE` (here `HEAD`, i.e. `main`), ignoring any existing `origin/tend/update-workflows`. When a tend-update PR is already open from a prior nightly, the first regen diffs against `main`, the bot detects the existing PR, resets to `origin/tend/update-workflows`, and re-runs `uvx tend@latest init` — one wasted pass per nightly run while the PR is open.

Reported in #496 with two consecutive nightly run citations and maintainer approval to file in tend.

## Solution

Fetch the remote update-workflows branch and base the worktree on its tip when present, else fall back to `HEAD`. Use `-B` instead of `-b` so a stale local branch (from a prior failed attempt) is reset rather than rejected:

```bash
git fetch origin tend/update-workflows 2>/dev/null || true
BASE=$(git rev-parse --verify origin/tend/update-workflows 2>/dev/null || git rev-parse HEAD)
git worktree add "$TMPDIR/tend-update-workflows" -B tend/update-workflows "$BASE"
```

Limited to the one recipe in `plugins/tend-ci-runner/skills/nightly/SKILL.md`. The two other `git worktree add ... -b` recipes in the bundled skills (`review-runs`, `running-in-ci`) use `$GITHUB_RUN_ID`-scoped branch names that can't collide across runs, so they don't need the same treatment.

## Testing

No automated test added — skill recipe content (markdown-embedded shell) isn't exercised by the generator test suite, and there is no pre-existing harness to extend. The change is verifiable by inspection against `git worktree add` semantics: `-b NAME BASE` ignores `origin/NAME`, while the new form explicitly resolves the remote ref before passing it as `BASE`.

`pre-commit run --files plugins/tend-ci-runner/skills/nightly/SKILL.md` passes (trim trailing whitespace, fix end of files, typos, forbid bang-backtick).

---
Closes #496 — automated triage
