### PR TITLE
install-tend: Claude installs codex and runs the device-code login

### DIFF
--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -426,22 +426,25 @@ If not set:
 1. Install codex if missing (`npm i -g @openai/codex`) and create
    the mint dir: `mkdir -p /tmp/codex-tend`.
 
-2. Run the device-code login:
+2. Have the user run, in their own terminal:
 
    ```bash
    CODEX_HOME=/tmp/codex-tend codex login --device-auth
    ```
 
-   The dedicated `CODEX_HOME` isolates the bot's `auth.json` from
-   the user's personal `~/.codex/` — both coexist, no need to log
-   out of personal Codex. `--device-auth` prints a URL and a
-   one-time code; relay both to the user so they open the URL in
-   any browser and sign in as the dedicated bot ChatGPT account
-   chosen above (device-code is how they sign in as the bot without
-   juggling browser sessions). After they sign in, codex completes
-   and writes `/tmp/codex-tend/auth.json`.
+   (Don't drive this from Claude's `Bash` tool — codex blocks until
+   sign-in and only flushes stdout on exit, so Claude wouldn't be
+   able to surface the URL+code in time.) `--device-auth` prints a
+   URL and a one-time code; the user opens the URL in any browser
+   and signs in as the dedicated bot ChatGPT account chosen above
+   (device-code is how they sign in as the bot without juggling
+   browser sessions). The dedicated `CODEX_HOME` isolates the bot's
+   `auth.json` from the user's personal `~/.codex/` — both coexist,
+   no need to log out of personal Codex. Codex writes
+   `/tmp/codex-tend/auth.json` once they sign in.
 
-3. Set the secret and clean up:
+3. After the user confirms they've signed in, read the file and
+   set the secret:
 
    ```bash
    gh secret set CODEX_AUTH_JSON --repo "$REPO" < /tmp/codex-tend/auth.json

--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -423,30 +423,32 @@ gh secret list --repo "$REPO" --json name --jq '.[].name' | grep -q CODEX_AUTH_J
 
 If not set:
 
-1. On a trusted local machine, the user installs codex
-   (`npm i -g @openai/codex`) and runs:
+1. Install codex if missing (`npm i -g @openai/codex`) and create
+   the mint dir: `mkdir -p /tmp/codex-tend`.
+
+2. Run the device-code login:
 
    ```bash
-   mkdir -p /tmp/codex-tend
    CODEX_HOME=/tmp/codex-tend codex login --device-auth
    ```
 
    The dedicated `CODEX_HOME` isolates the bot's `auth.json` from
    the user's personal `~/.codex/` — both coexist, no need to log
    out of personal Codex. `--device-auth` prints a URL and a
-   one-time code; the user opens the URL in any browser and signs
-   in as the dedicated bot ChatGPT account chosen above (device-code
-   is how the user authenticates as the bot without juggling browser
-   sessions). Codex writes `/tmp/codex-tend/auth.json` with the
-   refresh-tokened OAuth payload.
-2. Wait for the user to confirm they've signed in. Then read the
-   file directly and set the secret:
+   one-time code; relay both to the user so they open the URL in
+   any browser and sign in as the dedicated bot ChatGPT account
+   chosen above (device-code is how they sign in as the bot without
+   juggling browser sessions). After they sign in, codex completes
+   and writes `/tmp/codex-tend/auth.json`.
+
+3. Set the secret and clean up:
 
    ```bash
    gh secret set CODEX_AUTH_JSON --repo "$REPO" < /tmp/codex-tend/auth.json
    rm -rf /tmp/codex-tend
    ```
-3. Add a TODO in the repo's tracking system: rotate auth.json every
+
+4. Add a TODO in the repo's tracking system: rotate auth.json every
    ~7 days (the refresh window closes around 8 days). Codex refreshes
    on use, but a long-idle bot can expire — re-run the device-code
    mint and re-set the secret if the bot starts failing 401.


### PR DESCRIPTION
Follow-up to #490 and #493. The Codex mint flow in section 7b previously had "have the user install codex (`npm i -g @openai/codex`) and run `codex login --device-auth`" — but Claude is already executing in the user's shell during install-tend, so it can do both. The user's only required action is the browser sign-in: Claude relays the URL + one-time code from codex's stdout and waits for the user to sign in as the dedicated bot ChatGPT account. Steps 1–3 are now Claude actions (install if missing, mkdir, run login, set secret, clean up); the inline narrative in step 2 spells out the relay.
