### PR TITLE
site: align browser title and meta description with current tagline

### DIFF
--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -8,8 +8,8 @@ interface Props {
 }
 
 const {
-  title = "Tend — a dutiful junior maintainer for your repo",
-  description = "Tend gives a repo an autonomous junior maintainer — PR reviews, issue triage, CI fixes, and the day-to-day upkeep, with a human on every merge.",
+  title = "Tend — an agent that tends your repo",
+  description = "An agent that tends your repo — reviewing PRs, triaging issues, and responding to whatever comes up, so you can focus on building beautiful things.",
 } = Astro.props;
 ---
 


### PR DESCRIPTION
Title and meta description in `Base.astro` were still the old framing ("a dutiful junior maintainer", "the day-to-day upkeep"). Bring them in line with the hero tagline so social previews, search results, and the browser tab match the page itself.