### PR TITLE
codex: add nightly refresh workflow and document rotation hazard

### DIFF
--- a/.github/workflows/codex-auth-refresh.yaml
+++ b/.github/workflows/codex-auth-refresh.yaml
@@ -1,0 +1,102 @@
+name: codex-auth-refresh
+
+# Refresh the CODEX_AUTH_JSON secret nightly by hitting OpenAI's OAuth
+# token endpoint directly with the current refresh_token. Decouples
+# refresh from consumer workflows so they never trigger a rotation —
+# they read a always-fresh secret and codex sees last_refresh < 8 days,
+# so no proactive refresh fires inside the consumer runs.
+#
+# Without this, the static secret breaks after ~8 days when the first
+# consumer workflow triggers a refresh, ephemeral runner discards the
+# new tokens, and the GitHub secret still holds the rotated-out value.
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  refresh:
+    if: github.repository_owner == 'max-sixty'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Refresh CODEX_AUTH_JSON
+        env:
+          CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+          GH_TOKEN: ${{ secrets.CODEX_REFRESH_PAT }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$CODEX_AUTH_JSON" ]; then
+            echo "::error::CODEX_AUTH_JSON secret is unset"
+            exit 1
+          fi
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::CODEX_REFRESH_PAT secret is unset — needs a PAT with secrets:write"
+            exit 1
+          fi
+
+          REFRESH_TOKEN=$(printf '%s' "$CODEX_AUTH_JSON" | jq -r '.tokens.refresh_token')
+          ACCOUNT_ID=$(printf '%s' "$CODEX_AUTH_JSON" | jq -r '.tokens.account_id')
+          PRIOR_API_KEY=$(printf '%s' "$CODEX_AUTH_JSON" | jq -r '.OPENAI_API_KEY // empty')
+
+          if [ -z "$REFRESH_TOKEN" ] || [ "$REFRESH_TOKEN" = "null" ]; then
+            echo "::error::CODEX_AUTH_JSON is missing tokens.refresh_token"
+            exit 1
+          fi
+
+          # Hit OpenAI's OAuth token endpoint. client_id is fixed for codex:
+          # see https://github.com/openai/codex/blob/main/codex-rs/login/src/auth/manager.rs
+          RESPONSE=$(curl -fsS -X POST https://auth.openai.com/oauth/token \
+            -H "Content-Type: application/x-www-form-urlencoded" \
+            --data-urlencode "grant_type=refresh_token" \
+            --data-urlencode "refresh_token=$REFRESH_TOKEN" \
+            --data-urlencode "client_id=app_EMoamEEZ73f0CkXaXp7hrann")
+
+          if printf '%s' "$RESPONSE" | jq -e '.error' >/dev/null; then
+            ERR=$(printf '%s' "$RESPONSE" | jq -r '.error_description // .error')
+            echo "::error::OAuth refresh failed: $ERR"
+            exit 1
+          fi
+
+          NOW=$(date -u +%Y-%m-%dT%H:%M:%S.%6NZ)
+
+          NEW_AUTH=$(printf '%s' "$RESPONSE" | jq \
+            --arg now "$NOW" \
+            --arg account_id "$ACCOUNT_ID" \
+            --arg api_key "$PRIOR_API_KEY" \
+            '{
+              OPENAI_API_KEY: (if $api_key == "" then null else $api_key end),
+              auth_mode: "chatgpt",
+              tokens: {
+                access_token: .access_token,
+                refresh_token: .refresh_token,
+                id_token: .id_token,
+                account_id: $account_id
+              },
+              last_refresh: $now
+            }')
+
+          # Sanity-check the new payload has the three rotated tokens
+          for field in access_token refresh_token id_token; do
+            VAL=$(printf '%s' "$NEW_AUTH" | jq -r ".tokens.$field")
+            if [ -z "$VAL" ] || [ "$VAL" = "null" ]; then
+              echo "::error::refreshed auth.json is missing tokens.$field"
+              exit 1
+            fi
+          done
+
+          printf '%s' "$NEW_AUTH" | gh secret set CODEX_AUTH_JSON --repo "$REPO"
+
+          EXP=$(printf '%s' "$NEW_AUTH" | jq -r '.tokens.access_token' \
+            | awk -F. '{print $2}' \
+            | { read -r t; pad=$(( (4 - ${#t} % 4) % 4 )); printf "%s%*s" "$t" "$pad" "" | tr ' ' '='; } \
+            | base64 -d 2>/dev/null \
+            | jq -r '.exp | todate' 2>/dev/null || echo "unknown")
+
+          echo "Refresh complete."
+          echo "  last_refresh: $NOW"
+          echo "  access_token.exp: $EXP"

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -205,8 +205,36 @@ leak to subscription-quota burn until the next rotation, similar in
 scope to an `OPENAI_API_KEY` leak (agent-runtime access only, no
 GitHub). Flat-rate subscription billing also typically beats per-token
 API billing on a busy repo, so the dedicated-account `auth.json` is
-the install skill's default. Rotate every ~7 days; revoke via
+the install skill's default. Revoke via
 `https://chatgpt.com/#settings/Personalization` if leaked.
+
+**Static-secret CI requires active rotation, not just hygiene.** Codex
+rotates the refresh token on use with a ~1-hour grace window for the
+old token. In CI the rotated tokens land in an ephemeral runner and
+the GitHub secret holds the invalidated value. After ~8 days Codex's
+proactive refresh fires in the next consumer workflow to run, and
+within ~1 hour every subsequent run 401s permanently. The same OpenAI
+guide adds: "Use one `auth.json` per runner or per serialized workflow
+stream. Do not share the same file across concurrent jobs or multiple
+machines." — which rules out the naive single-secret pattern for any
+repo with overlapping workflows.
+
+Two paths to safe operation:
+
+- **Manual rotation.** Re-run `CODEX_HOME=/tmp/codex-tend codex login
+  --device-auth` every ~6 days and re-set the secret. Fails on a
+  missed week. Acceptable when consumer workflows are rare enough
+  that the day-8 rotation race is unlikely.
+- **Automated refresher workflow.** A scheduled workflow POSTs the
+  current refresh token to `https://auth.openai.com/oauth/token`,
+  reconstructs auth.json with the rotated tokens, and updates
+  `CODEX_AUTH_JSON` via a dedicated PAT (`CODEX_REFRESH_PAT`,
+  fine-grained, `secrets: read and write` on the repo). The refresher
+  updates the secret before any consumer workflow can trigger a
+  rotation, so `last_refresh` stays under 8 days from the consumer's
+  perspective and no refresh fires inside concurrent consumer runs.
+  See `.github/workflows/codex-auth-refresh.yaml` for the
+  implementation.
 
 `GITHUB_TOKEN` is ephemeral (single job) and automatically scoped by each
 workflow's `permissions:` block. Not a meaningful leak target.

--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -446,10 +446,20 @@ If not set:
    gh secret set CODEX_AUTH_JSON --repo "$REPO" < /tmp/codex-tend/auth.json
    rm -rf /tmp/codex-tend
    ```
-3. Add a TODO in the repo's tracking system: rotate auth.json every
-   ~7 days (the refresh window closes around 8 days). Codex refreshes
-   on use, but a long-idle bot can expire — re-run the device-code
-   mint and re-set the secret if the bot starts failing 401.
+3. Set up rotation. The static secret breaks ~8 days after mint —
+   the first consumer workflow to run after that triggers a Codex
+   refresh, rotates the tokens in an ephemeral runner, and the
+   GitHub secret holds the invalidated value. Two paths:
+
+   - **Manual** (low-volume bots): re-run the device-code mint every
+     ~6 days and re-set the secret.
+   - **Automated refresher workflow** (concurrent CI): a scheduled
+     workflow updates the secret before any consumer can trigger a
+     rotation. Requires a `CODEX_REFRESH_PAT` secret (fine-grained
+     PAT, `secrets: read and write` on the repo). See
+     `docs/security-model.md` for the pattern and
+     `.github/workflows/codex-auth-refresh.yaml` for a reference
+     implementation.
 
 For **API key**:
 


### PR DESCRIPTION
## Summary

Two related changes that improve Codex CI support without flipping the harness for tend itself:

1. **`codex-auth-refresh.yaml`** — a scheduled workflow that POSTs the current refresh token to `https://auth.openai.com/oauth/token` and updates the `CODEX_AUTH_JSON` secret nightly. Decouples refresh from consumer workflows so concurrent `mention`/`review`/`triage`/`ci-fix` runs never trigger a rotation. Requires a `CODEX_REFRESH_PAT` secret (fine-grained PAT, `secrets: read and write`).
2. **Doc updates** — `plugins/install-tend/skills/install-tend/SKILL.md` and `docs/security-model.md` previously framed rotation as a calendar task ("rotate every ~7 days"). The real failure mode is more subtle: Codex rotates the refresh token on use, the rotated value lands in an ephemeral runner, the GitHub secret holds the invalidated value, and after ~8 days concurrent consumer workflows 401 permanently. OpenAI's [CI/CD auth guide](https://developers.openai.com/codex/auth/ci-cd-auth) warns explicitly against sharing `auth.json` across concurrent jobs. Both docs now spell out the failure mode and offer two paths (manual rotation, automated refresher).

Cutover of tend's own CI to `harness: codex` is parked on a separate branch (`cutover-to-codex`) until the refresher proves out.

## Test plan

- [ ] Pre-commit + actionlint pass locally (verified before push)
- [ ] After merge: mint `CODEX_REFRESH_PAT` (fine-grained PAT on `max-sixty/tend`, `secrets: read and write`), store as repo secret
- [ ] Trigger `codex-auth-refresh.yaml` via `workflow_dispatch` and verify `last_refresh` updates on the `CODEX_AUTH_JSON` secret
- [ ] Watch the nightly cron firing for a few days; confirm the refresher self-sustains
