### PR TITLE
site: show the PR/issue being tended in activity rows and pulse

### DIFF
--- a/site/src/components/Activity.astro
+++ b/site/src/components/Activity.astro
@@ -56,6 +56,8 @@ const MAX_ROWS = 12;
   interface Run {
     repo: string;
     workflow: string;
+    display_title?: string;
+    pr_number?: number;
     started_at: string;
     run_url: string;
   }
@@ -83,13 +85,26 @@ const MAX_ROWS = 12;
   liveData<Activity>("/activity", "recent-activity", async (data) => {
     const tending = await fetchJson<{ currently_tending?: Run[] }>("/currently-tending");
     const tendingRows: Array<RecentItem & { kind: Kind }> = (tending?.currently_tending ?? []).map(
-      (r) => ({
-        kind: "tending" as const,
-        repo: r.repo,
-        title: r.workflow.replace(/^tend-/, ""),
-        url: r.run_url,
-        at: r.started_at,
-      }),
+      (r) => {
+        const workflow = r.workflow.replace(/^tend-/, "");
+        // Show what the bot is working on, not just the job kind. PR-triggered
+        // runs (review/mention on a PR) get "review · #N PR title"; issue-
+        // triggered runs (triage, mention on an issue) get "triage · issue
+        // title". Scheduled runs (nightly/weekly) have no target — fall back
+        // to the job kind alone.
+        const detail = r.pr_number != null && r.display_title
+          ? `${workflow} · #${r.pr_number} ${r.display_title}`
+          : r.display_title
+            ? `${workflow} · ${r.display_title}`
+            : workflow;
+        return {
+          kind: "tending" as const,
+          repo: r.repo,
+          title: detail,
+          url: r.run_url,
+          at: r.started_at,
+        };
+      },
     );
 
     const rows: Array<RecentItem & { kind: Kind }> = [

--- a/site/src/components/CurrentlyTending.astro
+++ b/site/src/components/CurrentlyTending.astro
@@ -17,6 +17,8 @@
   interface Run {
     repo: string;
     workflow: string;
+    display_title?: string;
+    pr_number?: number;
     started_at: string;
   }
   interface Bucket {
@@ -46,13 +48,18 @@
       if (runs.length > 0) {
         const r = runs[0];
         const workflow = r.workflow.replace(/^tend-/, "");
+        const detail = r.pr_number != null && r.display_title
+          ? `${workflow} · #${r.pr_number} ${r.display_title}`
+          : r.display_title
+            ? `${workflow} · ${r.display_title}`
+            : workflow;
         const more = runs.length > 1 ? ` (+${runs.length - 1} more)` : "";
         const startedMs = Date.parse(r.started_at);
         const buildText = () => {
           const elapsed = elapsedTime(r.started_at);
           return elapsed
-            ? `currently tending ${r.repo} · ${workflow} · ${elapsed}${more}`
-            : `currently tending ${r.repo} · ${workflow}${more}`;
+            ? `currently tending ${r.repo} · ${detail} · ${elapsed}${more}`
+            : `currently tending ${r.repo} · ${detail}${more}`;
         };
         const label = paint(el, "live", buildText());
         if (!Number.isNaN(startedMs)) {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -38,8 +38,10 @@ interface Consumer {
 
 interface WorkflowRun {
   name?: string;
+  display_title?: string;
   run_started_at?: string;
   html_url?: string;
+  pull_requests?: Array<{ number?: number } | null> | null;
 }
 
 interface RunsResponse {
@@ -49,6 +51,14 @@ interface RunsResponse {
 interface CurrentlyTendingEntry {
   repo: string;
   workflow: string;
+  // PR/issue title for PR-/issue-triggered runs. Omitted when GitHub's
+  // `display_title` is just the workflow name (scheduled runs like
+  // nightly/weekly add nothing extra there).
+  display_title?: string;
+  // PR number when the trigger is a pull_request_* event. Issues events
+  // don't populate `pull_requests`, so triage rows carry display_title
+  // without a number.
+  pr_number?: number;
   started_at: string;
   run_url: string;
 }
@@ -386,12 +396,25 @@ async function fetchRepoRuns(
         typeof run.run_started_at === "string" &&
         typeof run.html_url === "string",
     )
-    .map((run) => ({
-      repo,
-      workflow: run.name,
-      started_at: run.run_started_at,
-      run_url: run.html_url,
-    }));
+    .map((run) => {
+      const entry: CurrentlyTendingEntry = {
+        repo,
+        workflow: run.name,
+        started_at: run.run_started_at,
+        run_url: run.html_url,
+      };
+      // GitHub falls `display_title` back to the workflow name for events
+      // with no event-specific title (schedule, workflow_dispatch). Drop
+      // those — they'd render as "nightly · nightly".
+      if (typeof run.display_title === "string" && run.display_title !== run.name) {
+        entry.display_title = run.display_title;
+      }
+      const prNumber = run.pull_requests?.[0]?.number;
+      if (typeof prNumber === "number") {
+        entry.pr_number = prNumber;
+      }
+      return entry;
+    });
 }
 
 // ---------------------------------------------------------------------------

--- a/worker/test/worker.test.ts
+++ b/worker/test/worker.test.ts
@@ -5,8 +5,10 @@ const originalFetch = globalThis.fetch;
 interface RunsResponse {
   workflow_runs: Array<{
     name: string;
+    display_title?: string;
     run_started_at: string;
     html_url: string;
+    pull_requests?: Array<{ number: number }>;
   }>;
 }
 
@@ -37,8 +39,10 @@ describe("fetchRepoRuns", () => {
           workflow_runs: [
             {
               name: "tend-review",
+              display_title: "Fix the bug",
               run_started_at: "2026-05-10T17:00:00Z",
               html_url: "https://github.com/o/r/actions/runs/1",
+              pull_requests: [{ number: 42 }],
             },
             {
               name: "ci",
@@ -47,8 +51,18 @@ describe("fetchRepoRuns", () => {
             },
             {
               name: "tend-triage",
+              display_title: "Bug: thing is broken",
               run_started_at: "2026-05-10T17:02:00Z",
               html_url: "https://github.com/o/r/actions/runs/3",
+              pull_requests: [],
+            },
+            {
+              name: "tend-nightly",
+              // schedule runs have display_title === name; should drop it.
+              display_title: "tend-nightly",
+              run_started_at: "2026-05-10T17:03:00Z",
+              html_url: "https://github.com/o/r/actions/runs/4",
+              pull_requests: [],
             },
           ],
         } satisfies RunsResponse,
@@ -61,14 +75,23 @@ describe("fetchRepoRuns", () => {
       {
         repo: "o/r",
         workflow: "tend-review",
+        display_title: "Fix the bug",
+        pr_number: 42,
         started_at: "2026-05-10T17:00:00Z",
         run_url: "https://github.com/o/r/actions/runs/1",
       },
       {
         repo: "o/r",
         workflow: "tend-triage",
+        display_title: "Bug: thing is broken",
         started_at: "2026-05-10T17:02:00Z",
         run_url: "https://github.com/o/r/actions/runs/3",
+      },
+      {
+        repo: "o/r",
+        workflow: "tend-nightly",
+        started_at: "2026-05-10T17:03:00Z",
+        run_url: "https://github.com/o/r/actions/runs/4",
       },
     ]);
   });


### PR DESCRIPTION
## Summary

- Activity rows and the currently-tending pulse used to show only the workflow kind (`review`, `triage`). Now they show the target the bot is acting on:
  - `review · #493 PR title` (PR-triggered runs)
  - `triage · Issue title` (issue-triggered runs)
  - `nightly` (scheduled runs, no target)
- Worker propagates `display_title` and `pr_number` from GitHub's workflow_runs API; the site renders both. Scheduled runs whose `display_title` equals the workflow name are dropped server-side so they don't render as "nightly · nightly".

## Test plan

- [x] `npm test` in worker/ — covers PR-, issue-, and scheduled-run shapes in `fetchRepoRuns`
- [x] `npm run build` in site/ — Astro build clean
- [x] `tsc --noEmit` in both worker/ and site/ — clean
- [x] `pre-commit run --all-files` — clean
- [ ] After deploy: visually confirm `currently tending max-sixty/tend · review · #N PR title · 2m` and the matching activity row format

🤖 Generated with [Claude Code](https://claude.com/claude-code)