### PR TITLE
site: drop the org prefix from activity rows and the pulse

### DIFF
--- a/site/src/components/Activity.astro
+++ b/site/src/components/Activity.astro
@@ -71,6 +71,13 @@ const MAX_ROWS = 12;
     tending: "tending",
   };
 
+  // Drop the org — current consumers have distinct repo names, and the
+  // owner just eats space.
+  function shortRepo(repo: string): string {
+    const i = repo.indexOf("/");
+    return i === -1 ? repo : repo.slice(i + 1);
+  }
+
   function updateTendingTimes(): void {
     const cells = document.querySelectorAll<HTMLTimeElement>(
       ".activity-row .at[data-started-at]",
@@ -169,7 +176,7 @@ const MAX_ROWS = 12;
 
       const repo = document.createElement("span");
       repo.className = "repo";
-      repo.textContent = e.repo;
+      repo.textContent = shortRepo(e.repo);
 
       const link = document.createElement("a");
       link.className = "title";

--- a/site/src/components/CurrentlyTending.astro
+++ b/site/src/components/CurrentlyTending.astro
@@ -31,6 +31,12 @@
     comments?: Bucket;
   }
 
+  // Drop the org — the pulse already has plenty to say. Mirrors Activity.astro.
+  function shortRepo(repo: string): string {
+    const i = repo.indexOf("/");
+    return i === -1 ? repo : repo.slice(i + 1);
+  }
+
   function paint(el: HTMLElement, state: "live" | "idle", text: string): HTMLSpanElement {
     const dot = document.createElement("span");
     dot.className = `now-dot now-dot-${state}`;
@@ -57,9 +63,10 @@
         const startedMs = Date.parse(r.started_at);
         const buildText = () => {
           const elapsed = elapsedTime(r.started_at);
+          const repo = shortRepo(r.repo);
           return elapsed
-            ? `currently tending ${r.repo} · ${detail} · ${elapsed}${more}`
-            : `currently tending ${r.repo} · ${detail}${more}`;
+            ? `currently tending ${repo} · ${detail} · ${elapsed}${more}`
+            : `currently tending ${repo} · ${detail}${more}`;
         };
         const label = paint(el, "live", buildText());
         if (!Number.isNaN(startedMs)) {


### PR DESCRIPTION
## Summary

- `max-sixty/` repeats on most activity rows; the column was already narrow. Strip the org everywhere so the repo column reads as `tend` / `worktrunk` / `cargo-affected` / `prql` / `numbagg`. Names stay distinct across the current consumer set.
- Same treatment in the currently-tending pulse for consistency.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npm run build` clean
- [x] Verified live on the dev server — rows and pulse render with the prefix stripped

🤖 Generated with [Claude Code](https://claude.com/claude-code)