### PR TITLE
site: fix Currently-tending wrap and Firefox selection

### DIFF
--- a/site/src/components/CurrentlyTending.astro
+++ b/site/src/components/CurrentlyTending.astro
@@ -5,10 +5,7 @@
 // runs. Hidden only when both requests fail.
 ---
 
-<a id="now-tending" class="now-tending" href="#recent-activity" data-state="loading">
-  <span class="now-dot now-dot-idle" aria-hidden="true"></span>
-  <span>&nbsp;</span>
-</a>
+<a id="now-tending" class="now-tending" href="#recent-activity" data-state="loading" data-pulse="idle">&nbsp;</a>
 
 <script>
   import { fetchJson, liveData } from "../lib/api";
@@ -37,13 +34,10 @@
     return i === -1 ? repo : repo.slice(i + 1);
   }
 
-  function paint(el: HTMLElement, state: "live" | "idle", text: string): HTMLSpanElement {
-    const dot = document.createElement("span");
-    dot.className = `now-dot now-dot-${state}`;
-    const label = document.createElement("span");
-    label.textContent = text;
-    el.replaceChildren(dot, label);
-    return label;
+  function paint(el: HTMLElement, state: "live" | "idle", text: string): HTMLElement {
+    el.dataset.pulse = state;
+    el.textContent = text;
+    return el;
   }
 
   liveData<{ currently_tending?: Run[] }>(

--- a/site/src/components/CurrentlyTending.astro
+++ b/site/src/components/CurrentlyTending.astro
@@ -5,7 +5,7 @@
 // runs. Hidden only when both requests fail.
 ---
 
-<a id="now-tending" class="now-tending" href="#recent-activity" data-state="loading" data-pulse="idle">&nbsp;</a>
+<a id="currently-tending" class="currently-tending" href="#recent-activity" data-state="loading" data-pulse="idle">&nbsp;</a>
 
 <script>
   import { fetchJson, liveData } from "../lib/api";
@@ -42,7 +42,7 @@
 
   liveData<{ currently_tending?: Run[] }>(
     "/currently-tending",
-    "now-tending",
+    "currently-tending",
     async (data, el) => {
       const runs = data?.currently_tending ?? [];
       if (runs.length > 0) {

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -287,9 +287,7 @@ pre code {
 /* ---------- "Currently tending" indicator ---------- */
 
 .now-tending {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
+  display: block;
   margin: 1.4rem 0 0;
   font-family: var(--font-mono);
   font-size: 0.78rem;
@@ -297,29 +295,35 @@ pre code {
   color: var(--ink-soft);
   text-decoration: none;
   border-bottom: none;
-  /* Space is reserved by the skeleton dot + nbsp label in the markup; we
-     just fade in once the fetch resolves so the hero doesn't redraw. */
+  /* Hanging indent: dot sits in a 1rem gutter on line 1; wrapped lines
+     align flush with the text, not under the dot. */
+  padding-left: 1rem;
+  text-indent: -1rem;
+  /* Space is reserved by the nbsp placeholder in the markup; we just
+     fade in once the fetch resolves so the hero doesn't redraw. */
   opacity: 0;
   transition: opacity 250ms ease;
+}
+.now-tending::before {
+  content: "";
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  margin-right: 0.5rem;
+  border-radius: 50%;
+  vertical-align: 0.1em;
+}
+.now-tending[data-pulse="live"]::before { background: var(--moss); }
+.now-tending[data-pulse="idle"]::before {
+  background: transparent;
+  border: 1px solid var(--oak-deep);
 }
 .now-tending:hover { color: var(--moss-deep); }
 .now-tending[data-state="loaded"] { opacity: 1; }
 .now-tending[data-state="hidden"] { display: none; }
 
-.now-dot {
-  flex: none;
-  width: 0.5rem;
-  height: 0.5rem;
-  border-radius: 50%;
-}
-.now-dot-live { background: var(--moss); }
-.now-dot-idle {
-  background: transparent;
-  border: 1px solid var(--oak-deep);
-}
-
 @media (prefers-reduced-motion: no-preference) {
-  .now-dot-live { animation: now-pulse 2.6s ease-in-out infinite; }
+  .now-tending[data-pulse="live"]::before { animation: now-pulse 2.6s ease-in-out infinite; }
 }
 @keyframes now-pulse {
   0%, 100% { opacity: 1; }

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -249,7 +249,7 @@ pre code {
   align-items: start;
 }
 .hero-body { min-width: 0; }
-.stats-rail .now-tending {
+.stats-rail .currently-tending {
   margin: 0.8rem 0 0;
 }
 @media (max-width: 760px) {
@@ -286,7 +286,7 @@ pre code {
 
 /* ---------- "Currently tending" indicator ---------- */
 
-.now-tending {
+.currently-tending {
   display: block;
   margin: 1.4rem 0 0;
   font-family: var(--font-mono);
@@ -304,7 +304,7 @@ pre code {
   opacity: 0;
   transition: opacity 250ms ease;
 }
-.now-tending::before {
+.currently-tending::before {
   content: "";
   display: inline-block;
   width: 0.5rem;
@@ -313,17 +313,17 @@ pre code {
   border-radius: 50%;
   vertical-align: 0.1em;
 }
-.now-tending[data-pulse="live"]::before { background: var(--moss); }
-.now-tending[data-pulse="idle"]::before {
+.currently-tending[data-pulse="live"]::before { background: var(--moss); }
+.currently-tending[data-pulse="idle"]::before {
   background: transparent;
   border: 1px solid var(--oak-deep);
 }
-.now-tending:hover { color: var(--moss-deep); }
-.now-tending[data-state="loaded"] { opacity: 1; }
-.now-tending[data-state="hidden"] { display: none; }
+.currently-tending:hover { color: var(--moss-deep); }
+.currently-tending[data-state="loaded"] { opacity: 1; }
+.currently-tending[data-state="hidden"] { display: none; }
 
 @media (prefers-reduced-motion: no-preference) {
-  .now-tending[data-pulse="live"]::before { animation: now-pulse 2.6s ease-in-out infinite; }
+  .currently-tending[data-pulse="live"]::before { animation: now-pulse 2.6s ease-in-out infinite; }
 }
 @keyframes now-pulse {
   0%, 100% { opacity: 1; }


### PR DESCRIPTION
The "Currently tending" pulse wrapped badly on long titles — the dot was a flex sibling vertically centered with the wrapped text, so it floated in the white space between the two lines instead of sitting on the first line.

The empty `<span class="now-dot">` child also made selection awkward in Firefox: triple-click could grab the dot's empty box and confuse the copy.

Move the dot to a `::before` pseudo-element on the link, drop flex, and use a hanging indent (`padding-left: 1rem; text-indent: -1rem`). On line 1 the dot sits in the gutter; wrapped lines align flush with the text column. The `<a>` now has a single text node, so selection captures exactly the visible string.

State (live/idle) is driven by `data-pulse` on the link instead of classes on the (now-removed) dot child.

Also renames the CSS class/id from `now-tending` to `currently-tending` to match the visible label and the component file name.
