### PR TITLE
action+skills: workaround Linux bwrap shell-quote bang bug, drop now-unneeded guidance

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -216,6 +216,17 @@ runs:
     - name: Run Claude Code
       id: claude
       uses: anthropics/claude-code-action@v1
+      env:
+        # Disable the bubblewrap-backed subprocess sandbox. The Linux bwrap
+        # wrapping path inside Claude Code v2.1.142 still uses the legacy
+        # shell-quote `quote()` (`/(["\\$`!])/g`), which escapes `!` to `\!`
+        # in any command whose argv tokens contain both `'` and whitespace —
+        # corrupting jq `!=`, code references like `assert!()`, conventional-
+        # commits `feat!:` titles, and so on. macOS uses sandbox-exec on a
+        # different code path that's already fixed; the bug is Linux-only.
+        # Setting this to 0 routes bash through the fixed `'\''`-wrap path
+        # at the cost of subprocess env isolation. See anthropics/claude-code#35701.
+        CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "0"
       with:
         show_full_output: ${{ inputs.show_full_output }}
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}

--- a/plugins/tend-ci-runner/skills/notifications/SKILL.md
+++ b/plugins/tend-ci-runner/skills/notifications/SKILL.md
@@ -77,7 +77,7 @@ IN_PROGRESS=$(gh api \
 
 If `IN_PROGRESS > 0`, **skip without marking read** — the next poll will see the completed response via the dedup check below. Match on `display_title` because the `workflow_run` payload does not expose the triggering issue number for `issue_comment` / `pull_request_review` events.
 
-`gh api --jq` does not accept `--arg`/`--argjson` — pipe to standalone `jq`. Avoid jq's not-equal operator in filters authored via the Bash tool (a bare bang can get rewritten outside heredocs); use `(X) | not`.
+`gh api --jq` does not accept `--arg`/`--argjson` — pipe to standalone `jq`.
 
 **Dedup check:** For same-repo notifications older than 10 minutes with no in-flight dedicated run, check whether the bot already responded:
 

--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -113,11 +113,12 @@ if [ -z "$GIST_ID" ]; then
   # The gist file takes its name from the local file's basename; later reads
   # and PATCHes target `findings.md`, so the seed must live at that basename.
   mkdir -p /tmp/gist-seed
-  cat > /tmp/gist-seed/findings.md << EOF
-# review-reviewers evidence — $TARGET — $MONTH
-
-Secret gist. Append-only log of below-threshold findings used for gate evaluation.
-EOF
+  # Use the Write tool to author /tmp/gist-seed/findings.md (substituting
+  # $TARGET and $MONTH from the environment). Content:
+  #
+  #   # review-reviewers evidence — <target> — <YYYY-MM>
+  #
+  #   Secret gist. Append-only log of below-threshold findings used for gate evaluation.
   GIST_URL=$(gh gist create --desc "$GIST_DESC" /tmp/gist-seed/findings.md)
   if [ -z "$GIST_URL" ]; then
     echo "ERROR: gh gist create failed — BOT_TOKEN likely lacks 'gist' scope (see install-tend)" >&2
@@ -162,7 +163,6 @@ After applying the gates, write each run's new findings (format in `@review-gate
 ```bash
 # Verify the run heading references this run's $GITHUB_RUN_ID literally —
 # fabricated round numbers produce dead Workflow links, see @review-gates.md.
-# Use `||` not `if ! cmd` — the Bash-tool preprocessor rewrites bangs.
 grep -qF "$GITHUB_RUN_ID" /tmp/findings.md || {
   echo "ERROR: /tmp/findings.md does not contain \$GITHUB_RUN_ID=$GITHUB_RUN_ID — refusing to PATCH gist" >&2
   exit 1
@@ -238,9 +238,9 @@ Use `Agent` with `model: "haiku"` and a prompt like:
 > - Bot-closed issue was reopened
 > - Fix commit was reverted or CI still failing after bot pushed
 > - Human replied to bot with correction or complaint
-> - Bot comment contains corruption (literal `${`, unescaped bangs, broken heredoc markers)
+> - Bot comment contains corruption (literal `${`, unescaped bangs, backslash-backticks, broken heredoc markers)
 >
-> **Corruption-scan recipe.** Inline `jq` filters or `grep` regexes whose pattern is a literal backslash-bang are mangled by the Bash-tool preprocessor (every literal exclamation mark in the command string gets rewritten to backslash-bang, including inside the regex), so a `jq` filter aborts with `Invalid escape` and the scan silently passes zero matches. Save bot bodies to a file first, then scan the file with `grep -F` for fixed strings and `grep -P` for backslash-bang:
+> **Corruption-scan recipe.** Save bot bodies to a file, then scan with `grep`:
 >
 > ```bash
 > mkdir -p /tmp/bot-output && : > /tmp/bot-output/all.txt
@@ -280,7 +280,7 @@ Use `Agent` with `model: "haiku"` and a prompt like:
 > grep -nF 'anthropics/' /tmp/bot-output/all.txt         # wrong-owner URL
 > ```
 >
-> Cover all four bot-output surfaces: issue comments, issue bodies, PR bodies, and reviews/inline review comments. Comments-only scans miss corruption that ships in a survey-issue or PR body — those are composed via `gh issue create --body` / `gh pr create --body`, exactly the surface the Bash-tool preprocessor hits.
+> Cover all four bot-output surfaces: issue comments, issue bodies, PR bodies, and reviews/inline review comments. Comments-only scans miss corruption that ships in a survey-issue or PR body.
 >
 > **Report format** — return a structured summary:
 > ```
@@ -358,17 +358,17 @@ PR/issue bodies should link to the evidence gist (`$GIST_URL`) so reviewers can 
 
 ## Step 6: Summary
 
-Report results in the conversation log and save a markdown summary to `/tmp/claude/step-summary.md` (a post-Claude step copies this into the GitHub Actions step summary). Include `$GIST_URL` at the top so maintainers viewing the run page can click through to the full evidence log:
+Report results in the conversation log and save a markdown summary to `/tmp/claude/step-summary.md` (a post-Claude step copies this into the GitHub Actions step summary). Use the Write tool. Include `$GIST_URL` at the top so maintainers viewing the run page can click through to the full evidence log:
 
 ```bash
 mkdir -p /tmp/claude
-cat > /tmp/claude/step-summary.md << EOF
-## Review-reviewers summary
-
-Evidence: $GIST_URL
-
-...
-EOF
+# Then use the Write tool to author /tmp/claude/step-summary.md, starting:
+#
+#   ## Review-reviewers summary
+#
+#   Evidence: <value of $GIST_URL>
+#
+#   ...
 ```
 
 If no problems found (or none passed the gates), report "all clear" with: runs analyzed, outcomes checked, brief quality assessment, and a link to the evidence gist for any below-threshold findings recorded this run.

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -97,7 +97,6 @@ If `EXISTING_COMMENT` is non-empty, check its size before appending. GitHub reje
 ```bash
 # Verify the run heading references this run's $GITHUB_RUN_ID literally —
 # fabricated round numbers produce dead Workflow links, see @review-gates.md.
-# Use `||` not `if ! cmd` — the Bash-tool preprocessor rewrites bangs.
 grep -qF "$GITHUB_RUN_ID" /tmp/findings.md || {
   echo "ERROR: /tmp/findings.md does not contain \$GITHUB_RUN_ID=$GITHUB_RUN_ID — refusing to post" >&2
   exit 1

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -207,12 +207,9 @@ gh run rerun <run-id> --failed --repo "$REPO"
 # the next query can see only the prior `failure` rows and exit immediately.
 sleep 10
 
-# `?filter=latest` returns each job's most recent attempt. Avoid the
-# `!=` operator in --jq filters — the Bash tool rewrites the exclamation
-# mark to a backslash-escape, which jq rejects. Use
-# `== "completed" | not` instead.
+# `?filter=latest` returns each job's most recent attempt.
 JOB_IDS=$(gh api "repos/$REPO/actions/runs/<run-id>/jobs?filter=latest" \
-  --jq '.jobs[] | select((.status == "completed") | not) | .id')
+  --jq '.jobs[] | select(.status != "completed") | .id')
 
 # Rollup poll: one pass checks all reran jobs together and exits when the
 # last one is terminal.
@@ -310,28 +307,33 @@ If `EXISTING` is greater than 0, **do not post** — another run already handled
 
 ## Comment Formatting
 
-**Line wrapping:** GitHub renders newlines literally in issue bodies, PR descriptions, and comments — a line break in the source becomes a `<br>` in the output. Write each paragraph as a single long line and let the browser reflow. This applies to every delivery path — heredoc, `--body "…"`, `--body-file`, and what the Write tool puts in a file.
-
-<example>
-<bad reason="Paragraph hard-wrapped at ~72 chars inside the heredoc; GitHub renders each newline as `<br>`, producing mid-sentence breaks">
+**Compose bodies with the Write tool, then post with `--body-file`.** The composed file is reviewable before it ships, quoting and escaping are non-issues, and line wrapping is just file content. The bot writes to `/tmp/` constantly — one more file is cheap. For one-line bodies, `--body "…"` is fine.
 
 ```bash
-gh pr create --body "$(cat <<'EOF'
-Extend the bang-escape workaround in `running-in-ci` to cover PR and issue
-titles. The existing guidance covers comment bodies via `--body-file`;
-titles are still uncovered because `gh pr create` has no `--title-file` flag.
-EOF
-)"
+# After writing /tmp/comment-body.md with the Write tool:
+gh issue comment "$ISSUE" --body-file /tmp/comment-body.md
+```
+
+**Line wrapping:** GitHub renders newlines literally in issue bodies, PR descriptions, and comments — a line break in the source becomes a `<br>` in the output. Write each paragraph as a single long line and let the browser reflow.
+
+<example>
+<bad reason="Paragraph hard-wrapped at ~72 chars; GitHub renders each newline as `<br>`, producing mid-sentence breaks">
+
+Content of `/tmp/pr-body.md`:
+
+```
+This PR refactors the `poll_jobs` helper to take a list of job IDs and
+return only those still pending. The previous version queried the run
+endpoint, which lagged behind the per-job endpoint after a rerun.
 ```
 
 </bad>
-<good reason="Each paragraph is one long line inside the heredoc; GitHub reflows to the reader's window width">
+<good reason="Each paragraph is one long line; GitHub reflows to the reader's window width">
 
-```bash
-gh pr create --body "$(cat <<'EOF'
-Extend the bang-escape workaround in `running-in-ci` to cover PR and issue titles. The existing guidance covers comment bodies via `--body-file`; titles are still uncovered because `gh pr create` has no `--title-file` flag.
-EOF
-)"
+Content of `/tmp/pr-body.md`:
+
+```
+This PR refactors the `poll_jobs` helper to take a list of job IDs and return only those still pending. The previous version queried the run endpoint, which lagged behind the per-job endpoint after a rerun.
 ```
 
 </good>
@@ -351,25 +353,7 @@ Keep comments concise. Put supporting detail inside `<details>` tags — the rea
 
 Always use markdown links for files, issues, PRs, and docs. **Any link containing `#L` must use a commit SHA, never `blob/main/...#L42`** — line numbers shift silently, so the link stays valid but starts pointing at different code than the comment describes. Get the SHA with `git rev-parse HEAD` before composing the link.
 
-**GitHub URLs — always embed `$GITHUB_REPOSITORY`.** Construct links as `https://github.com/${GITHUB_REPOSITORY}/...`; never hand-type the owner. The model reliably guesses wrong — past comments have shipped with the wrong owner (e.g. `anthropics/<repo>` on a repo not owned by Anthropic). Before posting a comment, scan it for `github.com/` and confirm every owner matches `$GITHUB_REPOSITORY`. **Also check that the variable actually expanded** — if you see a literal `${GITHUB_REPOSITORY}` in the rendered comment, you used a single-quoted heredoc (`<< 'EOF'`) which disables expansion. Rewrite using an unquoted `<<EOF` (so `${GITHUB_REPOSITORY}` interpolates) or compose the body with the Write tool. **If the body also contains an exclamation mark (so the rule below makes Write mandatory), the Write tool does not interpolate either** — write an `OWNER_REPO` placeholder into the file and substitute before posting: `sed -i "s|OWNER_REPO|$GITHUB_REPOSITORY|g" /tmp/body.md && gh ... --body-file /tmp/body.md`. A single-quoted `<<'EOF'` body containing both an exclamation mark and `${GITHUB_REPOSITORY}` fails on both counts: the preprocessor rewrite still fires *and* the variable stays literal.
-
-**If a Bash-tool command string contains a literal exclamation mark — issue body, PR body, comment body, jq script, markdown heredoc, anything — use the Write tool. Heredocs and quoting do not save you.** The Bash tool rewrites every exclamation mark to a literal backslash-bang before bash parses the command, so a greeting like "Thanks for the suggestion!" renders as "Thanks for the suggestion\!" in the posted comment. Quoting and heredoc form don't matter: `<< 'EOF'`, `<<EOF`, plain single-quoted, and double-quoted arguments all lose the character. Use the Write tool for any issue body, PR body, or comment body containing an exclamation mark, then pass the file to `gh issue create` / `gh issue edit` / `gh pr create` / `gh pr edit` / `gh issue comment` / `gh pr comment` via `--body-file`. Code references in survey or triage bodies are a common trap — a body that quotes `eprintln!(...)`, `assert!(...)`, `<!-- ... -->`, or `!=` and is composed via `gh issue create --body "$(cat <<EOF ... EOF)"` ships visibly corrupted backslash-bang sequences. The same trap applies to `jq` and `--jq` filters with `!=` — either avoid the `!=` operator (rephrase as `== "x" | not`), filter client-side after fetching, or load the jq script from a file written with the Write tool via `jq -f`.
-
-**Inside `<<'EOF' ... EOF` heredocs, leave backticks bare — do not escape them.** Single-quoted heredocs disable command substitution, so `\`` is wrong: the backslash survives as data and renders as a literal backslash in front of every backtick in the posted body (`` \`foo\` `` instead of `` `foo` ``). This is a model habit, not a Bash-tool preprocessor rewrite — the corruption is authored, not injected. If a body contains many code spans, use the Write tool with `--body-file` rather than relying on careful unescaping.
-
-`gh pr create` / `gh pr edit` / `gh issue create` / `gh issue edit` have no `--title-file` flag, so a title containing an exclamation mark (e.g. the conventional-commits breaking-change marker in a title like "feat(hooks)!: rename …") hits the same rewrite and ships a visibly corrupted title. Write the title with the Write tool and pass it via command substitution — `$(cat …)` is evaluated by bash after the preprocessor's string scan, so the exclamation mark stays literal:
-
-```bash
-gh pr create --title "$(cat /tmp/pr-title.txt)" --body-file /tmp/pr-body.md ...
-```
-
-`git commit -m "..."` is the same trap: the message is a literal string argument, so any exclamation mark in it (Rust's `assert!(...)`, `format!(...)`, `panic!(...)`; a conventional-commits breaking-change marker like `feat(api)!:`) ships into permanent git history as backslash-bang. Write the message with the Write tool and pass it via `-F` — `git commit` reads the file directly, so the Bash-tool preprocessor never sees the bang:
-
-```bash
-git commit -F /tmp/commit-msg.txt
-```
-
-This applies to every git commit path the bot uses (fix PRs, skill PRs, conflict-resolution merges). A title without an exclamation mark may still ship a corrupted *body* if the body contains one, so prefer `-F` whenever the message contains code references.
+**GitHub URLs — read `$GITHUB_REPOSITORY` from the environment, don't hand-type the owner.** The model reliably guesses wrong — past comments have shipped with the wrong owner (e.g. `anthropics/<repo>` on a repo not owned by Anthropic). Before posting, scan the composed body for `github.com/` and confirm every owner matches `$GITHUB_REPOSITORY`.
 
 - **File-level link (no `#L` anchor)**: `blob/main/src/foo.rs` is fine
 - **Line reference**: `blob/<sha>/src/foo.rs#L42` — commit SHA required, never `blob/main/...#L42`

--- a/plugins/tend-ci-runner/skills/triage/SKILL.md
+++ b/plugins/tend-ci-runner/skills/triage/SKILL.md
@@ -171,10 +171,6 @@ gh issue view $ARGUMENTS --json author,authorAssociation --jq '.authorAssociatio
 
 **Stay within what you verified.** State facts you found in the codebase — don't characterize something as "known" unless you find prior issues or documentation about it. Don't speculate beyond the code you read.
 
-Use the heredoc pattern from `/tend-ci-runner:running-in-ci` for `--body` arguments to avoid shell quoting issues.
-
-**Do not introduce exclamation marks into the comment body.** The Bash tool rewrites every exclamation mark to a literal backslash-bang before bash parses the command, so a greeting like "Thanks for reporting this!" lands in the posted comment as "Thanks for reporting this\!" — quoting and heredoc form do not save you. The templates below intentionally end greetings with periods. If you must include an exclamation mark (e.g. quoting a user), author the comment with the Write tool and pass it via `gh issue comment --body-file`.
-
 Choose the appropriate template:
 
 ### Fix PR created


### PR DESCRIPTION
## Bug

Linux Claude Code v2.1.142's bubblewrap-backed subprocess sandbox wraps bash commands using the legacy `shell-quote` quote function with the regex `/(["\\$`!])/g`, which escapes `!` to `\!` in any argv token that mixes `'` with whitespace. That landed `\!=` in `jq` filters, `assert\!()` in code references, `feat(api)\!:` in conventional-commit titles, etc. The same binary contains a **fixed** `'\''`-wrap quoting path for the macOS `sandbox-exec` route — both paths coexist, only the Linux-bwrap path still uses the buggy quoter. See [anthropics/claude-code#35701](https://github.com/anthropics/claude-code/issues/35701) (closed as stale; multiple duplicates closed since).

## Fix

1. **`action.yaml`**: set `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=0` on the `claude-code-action` invocation. This disables the bwrap sandbox and routes bash through the fixed `'\''`-wrap path. Trade-off: loses subprocess env isolation. Applied at the composite-action level, so all `max-sixty/tend@v1` consumers pick it up automatically once tagged.

2. **Skills**: with the bug worked around, the bang-trap guidance can go. Removed across `triage`, `notifications`, `review-runs`, `review-reviewers`, and `running-in-ci`:
   - "Don't use `!` in comment body" / "use Write tool for bodies with `!`"
   - `!=` rewrite warnings in `jq` recipes (and the awkward `(.status == "completed") | not` rephrase)
   - `--title-file` and `git commit -F` workarounds
   - `||` not `if !` rationale comments
   - `<<'EOF'`/`<<EOF` interpolation footgun warning

3. **Body composition**: standardized on Write tool + `--body-file` for substantial PR/comment/gist bodies. Removed the inline `gh ... --body "$(cat <<'EOF' ...)"` heredoc patterns from `review-reviewers`'s gist seed and step summary and the line-wrap example in `running-in-ci`. Write-tool composition is reviewable, sandbox-independent, and bypasses the shell-quoting layer entirely.

## Kept on purpose

- **Backtick-in-heredoc paragraph** (extended via origin/main merge with [#495](https://github.com/max-sixty/tend/pull/495)'s nested-fence guidance). This is a model authoring habit, *not* the shell-quote bug — the workaround doesn't help. The paragraph now covers inline spans AND nested fences, recommending longer outer fences for nesting and bare backticks throughout.
- **Corruption-scan tripwires in `review-reviewers`** (`grep -nP '\\!'` and `` grep -nP '\\\`' ``). If the workaround stops working — bug returns upstream, env var override, the sandbox surface changes — the scans catch it in the bot's own output.
- **`no-preprocessor-poison-in-skills` pre-commit hook**. Different bug (slash-command preprocessor crashes on literal `` !` `` in plugin skill `.md` files, regressed twice per #234/#243/#244), unrelated to the Bash-tool rewrite.

## Validation posture

Workaround is empirically targeted: the bug reproduces in CI (bwrap sandbox active), does not reproduce locally (`sandbox-exec` on the fixed path), and the env-var docstring inside the binary explicitly documents the opt-out. If a regression slips, `review-reviewers`'s `grep -nP '\\!'` / `` grep -nP '\\\`' `` scans against the bot's own output fire on the next run. Easy revert via `git revert <commit>` if anything misbehaves.
