### PR TITLE
mention: remove the eyes reaction after the agent responds

### DIFF
--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -586,6 +586,25 @@ jobs:
           EVENT_TS: ${{{{ github.event.comment.created_at || github.event.review.submitted_at || github.event.issue.updated_at }}}}
 
 {agent}
+
+      - name: Remove eyes reaction
+        if: |
+          always()
+          && github.event.comment
+          && contains(github.event.comment.body, '@{bn}')
+        run: |
+          for KIND in issues pulls; do
+            REACTION_ID=$(gh api "repos/$REPO/$KIND/comments/$COMMENT_ID/reactions?content=eyes" \\
+              --jq ".[] | select(.user.login == \\"$BOT_NAME\\") | .id" 2>/dev/null | head -n1)
+            if [ -n "$REACTION_ID" ]; then
+              gh api -X DELETE "repos/$REPO/$KIND/comments/$COMMENT_ID/reactions/$REACTION_ID" 2>/dev/null && break
+            fi
+          done
+        env:
+          REPO: ${{{{ github.repository }}}}
+          COMMENT_ID: ${{{{ github.event.comment.id }}}}
+          BOT_NAME: {bn}
+          GITHUB_TOKEN: {bt}
 """
     return GeneratedWorkflow(filename="tend-mention.yaml", content=content)
 

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
@@ -221,3 +221,22 @@ jobs:
                 && format('You were mentioned in a comment ({0}). Read the full context and respond. If changes are requested, make them, commit, and push.', github.event.comment.html_url))
               || format('A user commented on an issue/PR where you previously participated ({0}). Read the full context. Only respond if the comment is directed at you, asks a question you can help with, or requests changes you can make. If the conversation is between other participants, exit silently.', github.event.comment.html_url)
             }}
+
+      - name: Remove eyes reaction
+        if: |
+          always()
+          && github.event.comment
+          && contains(github.event.comment.body, '@test-bot')
+        run: |
+          for KIND in issues pulls; do
+            REACTION_ID=$(gh api "repos/$REPO/$KIND/comments/$COMMENT_ID/reactions?content=eyes" \
+              --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" 2>/dev/null | head -n1)
+            if [ -n "$REACTION_ID" ]; then
+              gh api -X DELETE "repos/$REPO/$KIND/comments/$COMMENT_ID/reactions/$REACTION_ID" 2>/dev/null && break
+            fi
+          done
+        env:
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          BOT_NAME: test-bot
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
@@ -221,3 +221,22 @@ jobs:
                 && format('You were mentioned in a comment ({0}). Read the full context and respond. If changes are requested, make them, commit, and push.', github.event.comment.html_url))
               || format('A user commented on an issue/PR where you previously participated ({0}). Read the full context. Only respond if the comment is directed at you, asks a question you can help with, or requests changes you can make. If the conversation is between other participants, exit silently.', github.event.comment.html_url)
             }}
+
+      - name: Remove eyes reaction
+        if: |
+          always()
+          && github.event.comment
+          && contains(github.event.comment.body, '@test-bot')
+        run: |
+          for KIND in issues pulls; do
+            REACTION_ID=$(gh api "repos/$REPO/$KIND/comments/$COMMENT_ID/reactions?content=eyes" \
+              --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" 2>/dev/null | head -n1)
+            if [ -n "$REACTION_ID" ]; then
+              gh api -X DELETE "repos/$REPO/$KIND/comments/$COMMENT_ID/reactions/$REACTION_ID" 2>/dev/null && break
+            fi
+          done
+        env:
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          BOT_NAME: test-bot
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
@@ -223,3 +223,22 @@ jobs:
                 && format('You were mentioned in a comment ({0}). Read the full context and respond. If changes are requested, make them, commit, and push.', github.event.comment.html_url))
               || format('A user commented on an issue/PR where you previously participated ({0}). Read the full context. Only respond if the comment is directed at you, asks a question you can help with, or requests changes you can make. If the conversation is between other participants, exit silently.', github.event.comment.html_url)
             }}
+
+      - name: Remove eyes reaction
+        if: |
+          always()
+          && github.event.comment
+          && contains(github.event.comment.body, '@test-bot')
+        run: |
+          for KIND in issues pulls; do
+            REACTION_ID=$(gh api "repos/$REPO/$KIND/comments/$COMMENT_ID/reactions?content=eyes" \
+              --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" 2>/dev/null | head -n1)
+            if [ -n "$REACTION_ID" ]; then
+              gh api -X DELETE "repos/$REPO/$KIND/comments/$COMMENT_ID/reactions/$REACTION_ID" 2>/dev/null && break
+            fi
+          done
+        env:
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          BOT_NAME: test-bot
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}


### PR DESCRIPTION
The verify job in `tend-mention` reacts with 👀 to acknowledge a mention. Add a cleanup step at the end of `handle` (with `if: always()`) that looks up the bot's eyes reaction on the triggering comment and deletes it, so the reaction signals "in flight" rather than sticking around after the run completes. The cleanup gates on the same condition as the React step (comment present and body contains the mention), tries the `issues` and `pulls` comment endpoints in turn to match how the reaction is added, and uses the bot's own token so it removes only the bot's reaction.

Tend's checked-in `.github/workflows/tend-mention.yaml` lags the in-tree generator until the next release, which is expected per CLAUDE.md.
