### PR TITLE
site: widen prose measure, tighten activity repo column

### DIFF
--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -23,7 +23,7 @@
   --font-mono:    "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace;
 
   /* Layout */
-  --measure:        62ch;                                  /* prose readability cap — resolves against the element's own font */
+  --measure:        68ch;                                  /* prose readability cap — resolves against the element's own font */
   --measure-narrow: 48ch;                                  /* taglines, section leads — one cap for short serif intros */
   --gutter:         3rem;
   --rail:           7rem;                                  /* margin-note column + gap */
@@ -436,7 +436,7 @@ pre code {
   margin: 0;
   padding: 0;
   display: grid;
-  grid-template-columns: auto minmax(0, 11rem) minmax(0, 1fr) auto;
+  grid-template-columns: auto minmax(0, 7.5rem) minmax(0, 1fr) auto;
   column-gap: 1rem;
   /* Space is reserved by the 12 skeleton rows in the markup; the script
      replaces them with real rows when the fetch resolves. */


### PR DESCRIPTION
Two tweaks to the activity list and surrounding prose on the marketing site:

- Bump `--measure` from `62ch` to `68ch` so prose paragraphs fill the section body width (~688px) instead of capping at ~626px. Prose now lines up with the H2 headings and the activity list's right edge, eliminating a ~62px ragged right margin in `what-tend-tends` and other prose sections.
- Tighten the activity list's repo column from `11rem` (176px) to `7.5rem` (120px). The longest repo name currently rendered ("worktrunk") is 71px; 120px leaves room for ~15-character names ("cargo-affected" measures 110px) while handing the reclaimed ~56px to the title column.
