### PR TITLE
skills: generalize cross-repo issue filing into a single rule

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -11,6 +11,14 @@ Repo-specific guidance for tend workflows running on tend itself. The generic
 skills (`tend-running-in-ci`, `tend-review`, `tend-triage`, etc.) provide the
 workflow framework; this skill adds tend conventions.
 
+## Filing issues in other repos
+
+Standing exception granted: file directly in agent-equipped targets without
+asking permission here first. Most tend consumers in `data/consumers.json`
+qualify, as do other Claude-Code-action-using repos. The default rule (open
+an issue here asking permission first) still applies when the target shows no
+agent signals.
+
 ## Non-standard workflows
 
 Tend has Claude-powered workflows beyond the generated `tend-*` set:

--- a/plugins/tend-ci-runner/skills/notifications/SKILL.md
+++ b/plugins/tend-ci-runner/skills/notifications/SKILL.md
@@ -40,7 +40,7 @@ If step 1 returned at least one notification, load `/tend-ci-runner:running-in-c
 Before acting on ANY notification:
 
 1. **Identify the source.** Extract the issue/PR number from the notification's `subject.url` (it's an API URL like `https://api.github.com/repos/OWNER/REPO/issues/123`).
-2. **Check scope.** Notifications from this repository (`$GITHUB_REPOSITORY`) can be processed normally. For cross-repo notifications, read and understand the context but apply extra caution before acting — only respond if the bot was directly mentioned and the request is straightforward. Do not create PRs, push code, or make changes in other repos. Mark as read after reviewing:
+2. **Check scope.** Notifications from this repository (`$GITHUB_REPOSITORY`) can be processed normally. For cross-repo notifications, read and understand the context but apply extra caution before acting — only respond if the bot was directly mentioned and the request is straightforward. PRs, pushes, and comments on existing threads in other repos are off-limits; filing fresh issues follows **Filing Issues in Other Repos** in `running-in-ci`. Mark as read after reviewing:
    ```bash
    gh api notifications/threads/{id} -X PATCH
    ```

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -203,7 +203,7 @@ Improvements target **repo-local** files by default:
 - **`.config/tend.yaml`** — adjust workflow configuration if the problem is structural (e.g., wrong cron schedule, missing setup step).
 - **`CLAUDE.md`** — add project-specific guidance if the problem is about code conventions or patterns the bot keeps getting wrong.
 
-**Bundled-skill defects — ask permission before filing in tend.** If the root cause is a gap or bug in a bundled skill (`plugins/tend-ci-runner/skills/...` in `max-sixty/tend`) — the same pattern would fire in every consumer — open an issue in this repo requesting permission to file the same issue in tend. Include problem statement, run links, and proposed fix with code snippets (reused verbatim once approved). Signal: the fix reads as generic guidance that would apply to any consumer. On maintainer approval, open the tend issue.
+**Bundled-skill defects.** If the root cause is a gap or bug in a bundled skill (`plugins/tend-ci-runner/skills/...` in `max-sixty/tend`) — the same pattern would fire in every consumer — file the fix against tend per **Filing Issues in Other Repos** in `running-in-ci`. Signal: the fix reads as generic guidance that would apply to any consumer.
 
 **Prefer PRs over issues.** A PR with a clear description is immediately actionable.
 

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -61,8 +61,26 @@ Read the triggering comment, the PR/issue description, the diff (for PRs), and r
 
 - **Secrets**: Never run commands that expose secrets (`env`, `printenv`, `set`, `export`, `cat`/`echo` on credential files). Never include tokens or credentials in responses or comments.
 - **Merging**: Never merge PRs or enable auto-merge (`gh pr merge`, `gh pr merge --auto`). PRs are proposals — a maintainer decides when to merge.
-- **Scope**: Do not create issues, PRs, or comments in repositories outside the organization, unless the target repo explicitly welcomes AI-created issues (e.g., in its CONTRIBUTING guide).
+- **Scope**: PRs, pushes, and comments on existing threads in other repos are off-limits. Filing fresh issues in other repos follows **Filing Issues in Other Repos** below.
 - **Hanging commands**: Never use `gh run watch` or `gh pr checks --watch` — both hang indefinitely. Poll with `gh pr checks` in a loop instead.
+
+## Filing Issues in Other Repos
+
+Default: file an issue in the current repo asking for permission to file in the target. On maintainer approval, file in the target.
+
+The adopter's `running-tend` overlay may grant a standing exception for **agent-equipped** targets — repos that run their own coding agent. Signals:
+
+- `.github/workflows/tend-*.yml` present (the target uses tend).
+- A workflow invokes `anthropics/claude-code-action` or another coding-agent action.
+- Recent issues or PRs authored by a bot account, with no human pushback in the thread.
+
+Two or three convergent signals are enough; borderline cases revert to the default. Without an explicit opt-in in `running-tend`, the default also applies.
+
+Whether filed direct or post-approval, the issue body includes:
+
+- Problem statement: what fires, where, under what conditions.
+- Evidence: run links; cost/duration if relevant.
+- Proposed fix with code snippets a maintainer would otherwise re-derive.
 
 ## PR Creation
 
@@ -533,20 +551,9 @@ Do **not** propose when:
 - Confidence that the feedback generalizes is low — ask for clarification instead
 - The feedback comes from a non-maintainer — check `author_association` and skip the skill PR. Non-maintainers can raise preferences, but only a maintainer authorizes codifying them. If the pattern is worth capturing, note it in a reply and let a maintainer confirm.
 
-### Bundled-skill defects: ask permission to file in tend
+### Bundled-skill defects
 
-When the correction identifies a gap or bug in a **bundled** skill — the same root cause would fire in every tend consumer — open an issue in the current repo asking for permission to file the same issue in tend. On maintainer approval, open the tend issue.
-
-Signals:
-
-- The fix reads as generic guidance that would apply to any consumer.
-- The behavior being corrected comes from bundled skill text.
-
-Include in the permission request (and reuse verbatim in the tend issue once approved):
-
-- Problem statement: what fires, in which bundled skill, under what conditions.
-- Evidence: run links; cost/duration if relevant.
-- Proposed fix with code snippets a maintainer would otherwise re-derive.
+When the correction identifies a gap or bug in a **bundled** skill — the same root cause would fire in every tend consumer — the fix belongs in tend, not in this overlay. Signals: the fix reads as generic guidance that would apply to any consumer; the behavior being corrected comes from bundled skill text. File against tend per **Filing Issues in Other Repos** above.
 
 ### How to propose
 

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -70,7 +70,7 @@ Default: file an issue in the current repo asking for permission to file in the 
 
 The adopter's `running-tend` overlay may grant a standing exception for **agent-equipped** targets — repos that run their own coding agent. Signals:
 
-- `.github/workflows/tend-*.yml` present (the target uses tend).
+- `.github/workflows/tend-*.yaml` present (the target uses tend).
 - A workflow invokes `anthropics/claude-code-action` or another coding-agent action.
 - Recent issues or PRs authored by a bot account, with no human pushback in the thread.
 


### PR DESCRIPTION
Replaces the tend-specific "ask permission to file in tend" pattern with a general rule. Default behavior is unchanged — open an issue in the current repo asking permission first — but the adopter's `running-tend` overlay can grant a standing exception for **agent-equipped** targets (repos that run their own coding agent).

The signal is judgement-based, not a config flag: presence of `tend-*` workflows, a `claude-code-action` invocation, or recent bot-authored issues/PRs with no human pushback. Two or three convergent signals are enough.

### Changes

- `plugins/tend-ci-runner/skills/running-in-ci/SKILL.md` — adds `## Filing Issues in Other Repos`; the existing `Scope` restriction and the bundled-skill-defect subsection now reference it instead of restating the shape.
- `plugins/tend-ci-runner/skills/review-runs/SKILL.md` and `plugins/tend-ci-runner/skills/notifications/SKILL.md` — bundled-skill defect and cross-repo scope check point at the new section.
- `.claude/skills/running-tend/SKILL.md` — tend's own overlay grants the standing exception.

### Companion PRs (consumer overlays)

- max-sixty/cargo-affected#33
- max-sixty/worktrunk#2766
- numbagg/numbagg#610
- PRQL/prql#5906

Each grants the same standing exception in its repo-local `running-tend` overlay. They're a no-op until tend's next release ships the new bundled section, so they can land in any order.
