### PR TITLE
codex: scope refresher PAT to a main-only environment

### DIFF
--- a/.github/workflows/codex-auth-refresh.yaml
+++ b/.github/workflows/codex-auth-refresh.yaml
@@ -19,6 +19,7 @@ jobs:
   refresh:
     if: github.repository_owner == 'max-sixty'
     runs-on: ubuntu-24.04
+    environment: codex-auth-refresh
     permissions:
       contents: read
     steps:

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -233,8 +233,17 @@ Two paths to safe operation:
   updates the secret before any consumer workflow can trigger a
   rotation, so `last_refresh` stays under 8 days from the consumer's
   perspective and no refresh fires inside concurrent consumer runs.
-  See `.github/workflows/codex-auth-refresh.yaml` for the
-  implementation.
+
+  The PAT must not live as a plain repo secret — the bot has
+  `workflow` scope and can push workflow files to feature branches
+  that read repo secrets, which would escalate the bot from "write
+  collaborator" to "rewrite every repo secret." Store it in an
+  Environment (e.g. `codex-auth-refresh`) pinned to `main` only;
+  GitHub gates secret injection on the workflow's ref before the job
+  starts, so bot-pushed feature-branch workflows can't read it. See
+  `.github/workflows/codex-auth-refresh.yaml` for the implementation
+  and `plugins/install-tend/skills/install-tend/SKILL.md` §7b step 4
+  for the setup walkthrough.
 
 `GITHUB_TOKEN` is ephemeral (single job) and automatically scoped by each
 workflow's `permissions:` block. Not a meaningful leak target.

--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -499,7 +499,8 @@ If not set:
      this repo. No expiry because the env's `main`-only policy is
      the actual security boundary; calendar rotation adds little.
 
-     Store the token in the environment:
+     Have the user paste the PAT back, then store it in the
+     environment:
 
      ```bash
      gh secret set CODEX_REFRESH_PAT --env codex-auth-refresh \

--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -458,13 +458,56 @@ If not set:
 
    - **Manual** (low-volume bots): re-run the device-code mint every
      ~6 days and re-set the secret.
-   - **Automated refresher workflow** (concurrent CI): a scheduled
-     workflow updates the secret before any consumer can trigger a
-     rotation. Requires a `CODEX_REFRESH_PAT` secret (fine-grained
-     PAT, `secrets: read and write` on the repo). See
-     `docs/security-model.md` for the pattern and
-     `.github/workflows/codex-auth-refresh.yaml` for a reference
-     implementation.
+   - **Automated refresher** (recommended for concurrent CI): a
+     scheduled workflow updates the secret before any consumer can
+     trigger a rotation. See `docs/security-model.md` for the threat
+     model and `.github/workflows/codex-auth-refresh.yaml` in the
+     tend repo as the reference workflow to copy in.
+
+     The refresher needs a fine-grained PAT with `secrets: read and
+     write`. The bot has `workflow` scope and can push workflow
+     files to feature branches that read repo secrets, so a plain
+     repo secret would hand the bot a "rewrite any secret"
+     credential. Store the PAT in an **Environment** pinned to
+     `main` — GitHub rejects branch refs that fail the policy
+     *before* injecting secrets, so a bot-pushed feature-branch run
+     can't read it.
+
+     Create the environment and pin it to `main`:
+
+     ```bash
+     gh api -X PUT "repos/$REPO/environments/codex-auth-refresh" \
+       -F 'deployment_branch_policy[protected_branches]=false' \
+       -F 'deployment_branch_policy[custom_branch_policies]=true' \
+       > /dev/null
+     gh api -X POST \
+       "repos/$REPO/environments/codex-auth-refresh/deployment-branch-policies" \
+       -F 'name=main' -F 'type=branch' > /dev/null
+     ```
+
+     Have the user mint a fine-grained PAT on the repo owner's
+     account (the bot doesn't have admin) via a pre-filled URL —
+     substitute `$OWNER` with the repo owner:
+
+     ```
+     https://github.com/settings/personal-access-tokens/new?name=tend-codex-refresh&description=Refresher%20for%20CODEX_AUTH_JSON&target_name=$OWNER&expires_in=none&secrets=write
+     ```
+
+     The URL pre-fills name, description, owner, no expiry, and
+     `secrets: read+write`. One manual step remains: under
+     **Repository access** pick "Only select repositories" →
+     this repo. No expiry because the env's `main`-only policy is
+     the actual security boundary; calendar rotation adds little.
+
+     Store the token in the environment:
+
+     ```bash
+     gh secret set CODEX_REFRESH_PAT --env codex-auth-refresh \
+       --repo "$REPO" --body "$PAT"
+     ```
+
+     The reference workflow already includes
+     `environment: codex-auth-refresh`.
 
 For **API key**:
 


### PR DESCRIPTION
## Summary

The `codex-auth-refresh` workflow needs a fine-grained PAT with `secrets: read+write` to update `CODEX_AUTH_JSON` from outside a consumer run. Stored as a plain repo secret, that PAT is a meaningful escalation over the bot's existing write-collaborator role — the bot has `workflow` scope and can push workflow files to feature branches that read repo secrets, so any bot-controlled workflow could read the PAT and rewrite every repo secret (including `BOT_TOKEN` and `CODEX_AUTH_JSON` itself).

This change scopes the PAT to a GitHub **Environment** (`codex-auth-refresh`) pinned to `main` only. GitHub evaluates the workflow's ref against the environment's branch policy *before* injecting secrets, so a bot-pushed feature-branch dispatch is rejected before the secret is exposed. Branch protection on `main` already prevents the bot from landing workflow changes there.

## Changes

- `.github/workflows/codex-auth-refresh.yaml` — add `environment: codex-auth-refresh` to the refresher job.
- `docs/security-model.md` — extend the rotation-hazard writeup with the env-scoping rationale.
- `plugins/install-tend/skills/install-tend/SKILL.md` §7b step 4 — walk through env creation, branch-policy pinning, and PAT storage. Pre-filled fine-grained PAT URL with no expiry (the env's branch policy is the actual security boundary; calendar rotation adds little here).

The env, branch policy, and PAT are already provisioned on `max-sixty/tend` — this PR just lands the workflow change that makes the refresher reference them.

## Test plan

- [ ] Pre-commit + actionlint pass (verified locally)
- [ ] After merge: `gh workflow run codex-auth-refresh.yaml --repo max-sixty/tend` succeeds and `CODEX_AUTH_JSON.updated_at` advances
- [ ] Subsequent nightly cron fires unattended
