### PR TITLE
nightly: surface tend check drift as a tracked issue

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -136,6 +136,38 @@ implemented yet:
   Significant complexity — every workflow becomes two with artifact
   passing between them.
 
+## Security channel for `tend check` drift (PVR)
+
+The nightly `tend check` step (`plugins/tend-ci-runner/skills/nightly/`)
+files one normal tracking issue for any configuration drift. Some failures
+are real security regressions — missing branch protection, bot escalated to
+`admin`, a deploy token (e.g. `CLOUDFLARE_API_TOKEN`) at repo level
+reachable from fork-triggered runs — others are benign drift (a runtime
+token needing allowlisting, a missing secret). On a *public* repo a labeled
+public issue broadcasts the misconfig before it's fixed.
+
+GitHub's native private channel is **Private Vulnerability Reporting**: a
+draft repository security advisory (`POST
+/repos/{owner}/{repo}/security-advisories` or the `/reports` intake) is
+maintainer-private — no CVE/GHSA entry, no Dependabot alerts until
+published. Deferred because:
+
+- **Semantic misfit.** Advisories model a vulnerability in the *shipped
+  package* (ecosystem, version ranges, CVSS), not a misconfiguration of
+  tend's deployment. An accidental "Publish" creates a bogus GHSA.
+- **Automation ergonomics.** The nightly loop needs idempotent
+  find-one / refresh-footer / close-when-green — `gh issue list --search`
+  gives that; an advisory's draft→triage→publish lifecycle doesn't.
+- **Permission.** A maintainer draft advisory needs repo `admin`; the bot
+  has `write`. Whether the `/reports` intake works with the bot's PAT (and
+  whether PVR is enabled) is unverified.
+
+If pursued: keep the tracking issue for operational drift, additionally
+open a draft advisory for security-classified failures. Needs (a) the
+discrimination rule (fix narrows a credential's scope → security; fix
+updates config to reflect intent → drift), (b) `install-tend` enabling PVR
+at setup, (c) confirming the bot token can hit the reports endpoint.
+
 ## Worker: Phase 2 LLM summary of `/activity`
 
 A consumer (scheduled job or the Worker calling Claude) reads `/activity`

--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -23,7 +23,41 @@ The script prints `key=value` lines. Act on `STATUS`:
 - `STATUS=fine-grained`: no `X-OAuth-Scopes` header. Fine-grained PATs have no documented self-introspection endpoint — skip.
 - `STATUS=missing`: open or update a tracking issue. Use a title containing "PAT" (e.g. `Bot PAT: missing scopes`) so future runs can dedup by title search. Before creating, run `gh issue list --state open --search "PAT in:title"` and update the existing issue with `gh issue edit` if one is already open. The body lists the values from `MISSING=` and links step 8 of the `install-tend` skill for remediation: https://github.com/max-sixty/tend/blob/main/plugins/install-tend/skills/install-tend/SKILL.md#8-bot-token-and-secret
 
-## Step 2: Resolve conflicts on bot PRs
+## Step 2: Check tend configuration drift
+
+Run `tend check` to verify this repo's tend setup (branch protection, bot
+permission, secrets, secret allowlist):
+
+```bash
+uvx tend@latest check 2>&1 | tee /tmp/tend-check.txt
+```
+
+No `FAIL` lines → close any open drift issue:
+
+```bash
+gh issue list --state open --search '"configuration drift" in:title' \
+  --json number --jq '.[].number' \
+  | xargs -r -I {} gh issue close {} --comment 'tend check now passes.'
+```
+
+Otherwise file or update **one** tracking issue with title
+`tend check: configuration drift on <owner>/<repo>`. Dedup by title:
+
+```bash
+gh issue list --state open --search '"configuration drift" in:title' \
+  --json number,title,body
+```
+
+No labels. Body lists the current `FAIL` lines (one bullet per check, with
+a one-line reason) plus a `_Last refreshed: <YYYY-MM-DD>_` footer. Updates:
+
+- **Failure set identical to the open issue** → edit body (refresh footer)
+  only, no comment.
+- **Failure set changed** → edit body to match current state and post a
+  comment describing the delta (added/removed/changed checks).
+- **No open issue** → create one.
+
+## Step 3: Resolve conflicts on bot PRs
 
 ```bash
 BOT_LOGIN=$(gh api user --jq '.login')
@@ -44,7 +78,7 @@ Run subagents in parallel. Each must work in isolation (`git worktree add /tmp/p
 
 Skip if no PRs have conflicts.
 
-## Step 3: Review recent commits
+## Step 4: Review recent commits
 
 ```bash
 git log --since='24 hours ago' --oneline main
@@ -62,7 +96,7 @@ git log --since='24 hours ago' --format='%h %s' main
 
 Read the project's CLAUDE.md before reviewing. Apply the review checklist below to the diff, focusing on changes rather than unchanged code. Also check whether CLAUDE.md itself needs updating to reflect the new code (e.g., new file paths, changed commands, removed patterns).
 
-## Step 4: Check existing issues
+## Step 5: Check existing issues
 
 ```bash
 gh issue list --state open --json number,title
@@ -84,7 +118,7 @@ The action's "Report failure" step records only a workflow run link in `tend-out
 "${CLAUDE_PLUGIN_ROOT}/scripts/enrich-tend-outage-issues.sh"
 ```
 
-## Step 5: Rolling survey
+## Step 6: Rolling survey
 
 Run the survey script to get today's file list (rotating through the full repo over 28 days):
 
@@ -98,7 +132,7 @@ Before reviewing files, read the project's CLAUDE.md and any project-specific sk
 
 ## Review checklist
 
-Used by both Step 3 (applied to recent diffs) and Step 5 (applied to full files).
+Used by both Step 4 (applied to recent diffs) and Step 6 (applied to full files).
 
 **General quality:**
 - Bugs, logic errors, unhandled edge cases
@@ -112,7 +146,7 @@ Used by both Step 3 (applied to recent diffs) and Step 5 (applied to full files)
 - Stale CLAUDE.md entries — conventions that reference renamed files, deleted functions, or outdated patterns
 - Skills that have drifted from actual project behavior (instructions that no longer match how the code works)
 
-## Step 6: Update tend workflows
+## Step 7: Update tend workflows
 
 Regenerate the tend workflow files and open a PR if anything changed. The checkout's `.github/` directory may be mounted read-only under the sandbox (protecting bots from modifying their own workflows in place), so do the regeneration in a git worktree under `$TMPDIR`, which is writable:
 
@@ -193,7 +227,7 @@ git worktree remove "$TMPDIR/tend-update-workflows" --force
 
 The version line (and the versions in the title) are omitted when either side of the detection is empty or both sides match — e.g. a template tweak at the same pinned version, or the first regen after the header stamp was added, where the pre-regen workflows still carry the unstamped header.
 
-## Step 7: Fix findings
+## Step 8: Fix findings
 
 Before acting on findings, check for duplicates and existing work:
 
@@ -224,6 +258,6 @@ Keep the project's changelog up to date with recent changes. The `running-tend` 
 5. Draft entries matching the existing file's style and format.
 6. Commit and push directly to the changelog branch — no PR needed, the branch is kept ready to merge for the next release.
 
-## Step 8: Summary
+## Step 9: Summary
 
 Report: commits reviewed, files surveyed, findings, actions taken, assessment (clean / minor issues / needs attention).

--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -32,19 +32,26 @@ permission, secrets, secret allowlist):
 uvx tend@latest check 2>&1 | tee /tmp/tend-check.txt
 ```
 
-No `FAIL` lines → close any open drift issue:
+If **every** check line is `PASS` (no `FAIL` *and* no `SKIP`), close any
+open drift issue. A run with only `SKIP` lines (e.g. lost API permission, a
+transient `gh` error) is *not* a pass — leave the issue untouched, neither
+close nor file. Scope to bot-authored issues so a maintainer-filed issue
+that happens to contain "configuration drift" is never auto-closed:
 
 ```bash
-gh issue list --state open --search '"configuration drift" in:title' \
+gh issue list --state open --author '@me' \
+  --search '"configuration drift" in:title' \
   --json number --jq '.[].number' \
   | xargs -r -I {} gh issue close {} --comment 'tend check now passes.'
 ```
 
-Otherwise file or update **one** tracking issue with title
-`tend check: configuration drift on <owner>/<repo>`. Dedup by title:
+If any check is `FAIL`, file or update **one** tracking issue with title
+`tend check: configuration drift on <owner>/<repo>`. Dedup by title,
+scoped to bot-authored issues:
 
 ```bash
-gh issue list --state open --search '"configuration drift" in:title' \
+gh issue list --state open --author '@me' \
+  --search '"configuration drift" in:title' \
   --json number,title,body
 ```
 


### PR DESCRIPTION
## Summary

Wires `uvx tend@latest check` into the nightly maintenance sweep so that configuration drift in the bot's own setup (branch protection, bot permission, required secrets, secret allowlist) surfaces as a tracked GitHub issue instead of rotting silently between releases.

New **Step 2: Check tend configuration drift** in the bundled nightly skill walks the agent through: run `tend check`, close any open drift issue when clean, otherwise file/update a single deduplicated tracking issue (`tend check: configuration drift on <owner>/<repo>`) with the failing checks and a refreshed-date footer. Same-set updates only refresh the footer; changed sets edit the body and post a delta comment. Subsequent steps renumbered 2→3 … 8→9 (including the Review-checklist cross-reference).

The logic lives in the skill, not a deterministic YAML step, per the "Agent-driven vs deterministic steps" guidance in `CLAUDE.md`.

Following auto-reviewer feedback, both issue lookups are scoped to `--author '@me'` (a maintainer-filed issue containing "configuration drift" is never auto-closed), and the close condition requires *every* check to be `PASS` — a `SKIP`-only run (lost API permission, transient `gh` error) no longer falsely clears the drift issue.

## Security escalation: deferred

The issue is filed plain and unlabeled. Some `tend check` failures are genuine security regressions (missing branch protection, a deploy token like `CLOUDFLARE_API_TOKEN` at repo level) and others are benign operational drift — but on a public repo a labeled public issue broadcasts the misconfig before it's fixed. GitHub's native private channel (Private Vulnerability Reporting / draft advisories) is the right escalation but is a semantic/ergonomic/permission mismatch for an unattended nightly. The full rationale, the security-vs-drift discrimination rule, and what a future implementation needs are captured in a new `TODO.md` section rather than built here.

## Test plan

- [ ] Docs/skill-only change — no code paths affected, no automated tests
- [ ] `pre-commit run --all-files` passes
