### PR TITLE
secrets: scope worker-deploy and codex-refresh to protected environments

### DIFF
--- a/.github/workflows/codex-auth-refresh.yaml
+++ b/.github/workflows/codex-auth-refresh.yaml
@@ -90,7 +90,7 @@ jobs:
             fi
           done
 
-          printf '%s' "$NEW_AUTH" | gh secret set CODEX_AUTH_JSON --repo "$REPO"
+          printf '%s' "$NEW_AUTH" | gh secret set CODEX_AUTH_JSON --repo "$REPO" --env codex-auth-refresh
 
           EXP=$(printf '%s' "$NEW_AUTH" | jq -r '.tokens.access_token' \
             | awk -F. '{print $2}' \

--- a/.github/workflows/worker-deploy.yaml
+++ b/.github/workflows/worker-deploy.yaml
@@ -3,8 +3,9 @@ name: worker-deploy
 # Deploys the tend-website Cloudflare Worker on push to main that touches
 # worker/** or this workflow. The Worker serves all three live data streams
 # the site renders. One-time account setup (KV namespace, GITHUB_TOKEN
-# Worker secret, CLOUDFLARE_API_TOKEN repo secret, custom domain) is
-# documented in worker/README.md and is already done for max-sixty/tend.
+# Worker secret, CLOUDFLARE_API_TOKEN in the cloudflare-deploy environment,
+# custom domain) is documented in worker/README.md and is already done for
+# max-sixty/tend.
 
 on:
   push:
@@ -18,6 +19,7 @@ jobs:
   deploy:
     if: github.repository_owner == 'max-sixty'
     runs-on: ubuntu-24.04
+    environment: cloudflare-deploy
     permissions:
       contents: read
     steps:

--- a/worker/README.md
+++ b/worker/README.md
@@ -179,9 +179,11 @@ npx wrangler deploy                                 # first deploy
 The PAT needs `actions:read` + `metadata:read` on public repos. After first
 deploy, CI handles subsequent deploys via
 [`../.github/workflows/worker-deploy.yaml`](../.github/workflows/worker-deploy.yaml),
-which authenticates with the `CLOUDFLARE_API_TOKEN` repo secret. That secret
-is a scoped token named `tend-ci-worker-deploy` (Workers Scripts + KV + Routes
-edit), generated to keep the account's Global API Key out of CI; regenerate at
+which authenticates with the `CLOUDFLARE_API_TOKEN` secret stored in the
+`cloudflare-deploy` GitHub environment (pinned to `main`, so PR-triggered
+workflow runs can't read it). That secret is a scoped token named
+`tend-ci-worker-deploy` (Workers Scripts + KV + Routes edit), generated to
+keep the account's Global API Key out of CI; regenerate at
 <https://dash.cloudflare.com/profile/api-tokens> with the "Edit Cloudflare
 Workers" template if it's ever lost.
 


### PR DESCRIPTION
`uvx tend@latest check` flagged two failures against `max-sixty/tend`; this PR carries the workflow/doc half of the fix. The GitHub-state half (ruleset, environments, secret moves) was applied out-of-band via the API.

`CLOUDFLARE_API_TOKEN` and `CODEX_AUTH_JSON` were repo-level secrets — readable by any workflow, including PR-triggered ones. Both are now stored in `main`-pinned GitHub environments (the same shape PyPI release and the codex refresher PAT already use), so PR runs can't read them. `worker-deploy` runs in the new `cloudflare-deploy` environment; the codex refresher writes the rotated secret back to its `codex-auth-refresh` environment instead of repo level. A fresh scoped Cloudflare token (`tend-ci-worker-deploy`) was minted and the old repo-level secrets deleted.

The third check failure (`branch-protection:v1`) was fixed purely via the API by extending the existing "Merge access" ruleset to cover `refs/heads/v1`; no file change.

`uvx tend@latest check` now reports all PASS.
