### PR TITLE
codex-auth-refresh: write CODEX_AUTH_JSON as a repo secret, not env-scoped

### DIFF
--- a/.github/workflows/codex-auth-refresh.yaml
+++ b/.github/workflows/codex-auth-refresh.yaml
@@ -90,7 +90,10 @@ jobs:
             fi
           done
 
-          printf '%s' "$NEW_AUTH" | gh secret set CODEX_AUTH_JSON --repo "$REPO" --env codex-auth-refresh
+          # Repo secret, NOT --env: every consumer workflow (review,
+          # mention, triage, nightly, …) reads CODEX_AUTH_JSON and none
+          # declare this environment. Only CODEX_REFRESH_PAT is env-scoped.
+          printf '%s' "$NEW_AUTH" | gh secret set CODEX_AUTH_JSON --repo "$REPO"
 
           EXP=$(printf '%s' "$NEW_AUTH" | jq -r '.tokens.access_token' \
             | awk -F. '{print $2}' \


### PR DESCRIPTION
## Summary

#513 over-reached: while correctly moving `CLOUDFLARE_API_TOKEN` to the `cloudflare-deploy` environment, it also changed the codex refresher's `gh secret set` to `--repo "$REPO" --env codex-auth-refresh`, scoping `CODEX_AUTH_JSON` into the `codex-auth-refresh` environment.

`CODEX_AUTH_JSON` is the runtime Codex auth that **every consumer workflow** reads (`tend-review`, `tend-mention`, `tend-triage`, `tend-nightly`, `tend-review-runs`). None of them declare `environment: codex-auth-refresh`, so `${{ secrets.CODEX_AUTH_JSON }}` resolved to an empty string and the codex action failed its auth preflight (`No Codex auth configured`) on every consumer run. Verified on a `workflow_dispatch` of `tend-review-runs` against the codex-harness branch.

Only `CODEX_REFRESH_PAT` (the secrets-write credential) should be env-scoped. This drops the `--env` flag so the refresher writes `CODEX_AUTH_JSON` back at repo scope, and adds a comment so it doesn't regress. The job keeps `environment: codex-auth-refresh` to read the env-scoped PAT — env-scoped jobs still see repo secrets, so it reads/writes `CODEX_AUTH_JSON` at repo scope.

The `worker-deploy` → `cloudflare-deploy` parts of #513 are correct and untouched.

## Test plan

- [ ] Pre-commit + actionlint pass (verified locally)
- [ ] After merge: trigger `codex-auth-refresh` — it reads the still-env-scoped valid token, writes a repo-level `CODEX_AUTH_JSON`
- [ ] Confirm `CODEX_AUTH_JSON` appears as a repo secret
- [ ] Delete the now-redundant env-scoped `CODEX_AUTH_JSON`
- [ ] Re-run `tend-review-runs` on the codex branch — codex authenticates