### PR TITLE
chore: release 0.0.20

### DIFF
--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tend"
-version = "0.0.19"
+version = "0.0.20"
 description = "An autonomous junior maintainer for GitHub repos, powered by Claude — reviews PRs, triages issues, fixes CI"
 license = "MIT"
 requires-python = ">=3.11"

--- a/generator/uv.lock
+++ b/generator/uv.lock
@@ -98,7 +98,7 @@ wheels = [
 
 [[package]]
 name = "tend"
-version = "0.0.19"
+version = "0.0.20"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Bumps the generator to 0.0.20 and syncs the lockfile.

This is the release that switches consumers from the `@v1` floating branch to the version-pinned `max-sixty/tend@0.0.20` ref (#515). On their next nightly `uvx tend@latest init`, consumer workflows regenerate with the pinned tag.

Follow-up after this lands and tags: create the tag-immutability ruleset on `max-sixty/tend`, then remove `refs/heads/v1` from the existing branch ruleset and delete the stale `v1` branch and tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)