### PR TITLE
codex: default sandbox to danger-full-access for CI

### DIFF
--- a/codex/action.yaml
+++ b/codex/action.yaml
@@ -47,7 +47,17 @@ inputs:
       Reasoning effort — low, medium, high, or xhigh. Empty means leave
       at Codex CLI default (medium for gpt-5.5).
   sandbox:
-    default: workspace-write
+    # danger-full-access by default: this action only ever runs inside an
+    # ephemeral single-use GitHub Actions runner VM, which is itself the
+    # isolation boundary. Codex's inner bwrap jail (used by workspace-write
+    # and read-only on Linux) is redundant there — and unavailable anyway,
+    # since the standard ubuntu runner image ships no bubblewrap, so any
+    # non-full-access mode blocks codex from running even a file read. The
+    # boundaries that actually matter for tend (the bot cannot merge its own
+    # PRs; credentials are scope-limited) are enforced outside codex's
+    # local-exec sandbox and are unaffected by this. Standard codex-in-CI
+    # configuration.
+    default: danger-full-access
     description: Codex sandbox mode (workspace-write, read-only, danger-full-access)
   codex_version:
     default: ""

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -124,7 +124,13 @@ attacker wrote. A `Makefile`, `package.json` postinstall hook, or
 variables and sending them over the network. Config pinning prevents
 *Claude Code's own* startup hooks from being hijacked, but it can't prevent
 Claude from voluntarily running `make test` on a repo where `make test` has
-been weaponized.
+been weaponized. The Codex harness makes this explicit: its composite
+action runs with `sandbox: danger-full-access`, deliberately not relying
+on codex's inner bwrap jail. The ephemeral single-use runner VM is the
+isolation boundary; the inner sandbox is redundant there and unavailable
+on the standard runner image anyway. The boundaries that are load-bearing
+(merge restriction, scope-limited credentials) sit outside the harness's
+local-exec sandbox regardless.
 
 **Token exfiltration via side channels.** Log masking only catches exact
 string matches in stdout. An attacker who gets code execution can exfiltrate


### PR DESCRIPTION
On Linux, codex's `workspace-write` / `read-only` sandbox jails command execution with bubblewrap (`bwrap`). The GitHub Actions `ubuntu-24.04` runner image does not ship `bwrap`, so under the previous `workspace-write` default codex could not execute *any* local command — even reading a file — and the agent immediately reported it was blocked. This was the remaining hard blocker for the Codex harness in CI (observed in a real `tend-review-runs` run on the codex harness).

The fix flips the `sandbox` input default in `codex/action.yaml` to `danger-full-access`. The action only ever runs inside an ephemeral single-use GitHub Actions runner VM, which is itself the isolation boundary; codex's inner bwrap jail is redundant there and unavailable on the standard runner image anyway. The boundaries that are load-bearing for tend — the bot cannot merge its own PRs (branch protection), and credentials are scope-limited (env-scoped `CODEX_REFRESH_PAT`, repo-scoped `CODEX_AUTH_JSON`) — are enforced outside codex's local-exec sandbox and are unaffected. `danger-full-access` is the standard codex-in-CI configuration.

`docs/security-model.md` gets a brief note appended to the existing "Claude executes attacker-controlled code" risk (the paragraph already covering this boundary), making the Codex harness's posture explicit rather than rewriting the section.

Scope is intentionally narrow: the action default is the canonical single fix. The generator is unchanged (no per-workflow `sandbox:` option), and the two other known codex-in-CI blockers (cold cargo-install build time, static `TEND_EOF` heredoc capture) are deliberately untouched.

Validation: `pre-commit run --all-files` passes; `generator/tests/` is 230 passed with zero golden changes, confirming the default is a pure action input not referenced by the generator.
