### PR TITLE
codex: use random heredoc delimiter for final_message output

### DIFF
--- a/codex/action.yaml
+++ b/codex/action.yaml
@@ -366,10 +366,14 @@ runs:
         # Surface the final message as a step output even if codex
         # exited non-zero — downstream steps may still want to post it.
         if [ -f "$OUTPUT_FILE" ]; then
+          # Random delimiter: agent output is content-dependent and could
+          # otherwise contain a line matching a fixed sentinel, truncating
+          # the multiline output. See GitHub's multiline-string guidance.
+          DELIM="ghadelimiter_$(openssl rand -hex 16)"
           {
-            echo 'final_message<<TEND_EOF'
+            echo "final_message<<$DELIM"
             cat "$OUTPUT_FILE"
-            echo 'TEND_EOF'
+            echo "$DELIM"
           } >> "$GITHUB_OUTPUT"
         fi
         exit $EXIT


### PR DESCRIPTION
The Codex composite action captured Codex's final assistant message into `$GITHUB_OUTPUT` with a static heredoc delimiter (`TEND_EOF`). Agent output is content- and attacker-dependent, so a line equal to that sentinel would terminate the multiline value early — `final_message` gets truncated and the remaining lines leak as malformed `key=value` pairs (or fail the step).

This switches to a random per-run delimiter (`ghadelimiter_` + 16 random bytes from `openssl rand`), matching GitHub's documented guidance for multiline step outputs. A 128-bit random delimiter cannot realistically collide with agent output.

Behavior is otherwise unchanged: the output is still emitted when `codex` exits non-zero, and the step still exits with codex's status afterward. The two other `>> "$GITHUB_OUTPUT"` writers in this action (`usage=`, `name=`) are single-line `key=value` writes with controlled values, so they don't share the bug and are left untouched.

Verified locally with an adversarial payload (a literal `TEND_EOF` line, an `=` line, and a fake `ghadelimiter_` prefix line): the multiline value round-trips exactly. `pre-commit` (incl. actionlint) and the generator regtests (`wt test`, 230 passed) are green — goldens unchanged, as expected for an action-internal shell change.
