### PR TITLE
codex: install CLI from npm prebuilt instead of building from source

### DIFF
--- a/codex/action.yaml
+++ b/codex/action.yaml
@@ -60,11 +60,13 @@ inputs:
     default: danger-full-access
     description: Codex sandbox mode (workspace-write, read-only, danger-full-access)
   codex_version:
-    default: ""
+    default: "0.131.0-alpha.22"
     description: >-
-      Codex CLI git tag to build (e.g. `rust-v0.131.0-alpha.17`). Empty
-      means the action's pinned default. Once a stable release with
-      `codex plugin add` ships to npm, this will become a version string.
+      `@openai/codex` npm version to install (e.g. `0.131.0-alpha.22`).
+      Must ship the `codex plugin add` subcommand (PR #21396, first
+      released in `rust-v0.131.0-alpha.17`). On npm this currently lives
+      on the `alpha` dist-tag — `latest` is still 0.130.0 and lacks it,
+      so the default pins an explicit alpha rather than tracking `latest`.
   allowed_bots:
     default: "*"
     description: Bots allowed to trigger workflows (engagement gate, not used yet)
@@ -168,57 +170,18 @@ runs:
         curl -LsSf https://astral.sh/uv/install.sh | sh -s -- --quiet
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-    # Build Codex from source at a known-good tag. The shipped npm releases
-    # (≤0.131.0-alpha.9) and the latest published GitHub release
-    # (alpha.16) both predate PR #21396, which is what gives us the
-    # `codex plugin add` subcommand we need to install tend-ci-runner
-    # non-interactively.
-    #
-    # When a stable release containing that PR lands on npm, swap the
-    # four steps below for the commented `Install Codex CLI` block — same
-    # interface, no Rust toolchain, ~10 min cold build → ~30 s npm install.
-    #
-    # We cache the built binary directly (~/.cargo/bin/codex) keyed on
-    # the codex version + runner OS — cache hit skips the build entirely
-    # (~22 min → ~3 s). Same idea worktrunk uses via baptiste0928/cargo-install,
-    # but that action only supports crates.io, not git tags.
-    - name: Cache codex binary
-      id: codex-cache
-      uses: actions/cache@v4
-      with:
-        path: ~/.cargo/bin/codex
-        key: codex-bin-${{ runner.os }}-${{ inputs.codex_version || 'rust-v0.131.0-alpha.17' }}
-
-    - name: Set up Rust toolchain
-      if: steps.codex-cache.outputs.cache-hit != 'true'
-      uses: dtolnay/rust-toolchain@stable
-
-    - name: Build Codex CLI from source
-      if: steps.codex-cache.outputs.cache-hit != 'true'
+    # Install the Codex CLI from npm. `@openai/codex` ships a prebuilt
+    # per-platform binary, so this is ~3 s with no Rust toolchain. We pin
+    # an explicit version (`codex_version`, default a `0.131.0-alpha.*`)
+    # because tend needs `codex plugin add` (PR #21396, first in
+    # `rust-v0.131.0-alpha.17`) and as of 2026-05-15 npm's `latest`
+    # (0.130.0) still predates it — only the `alpha` dist-tag carries it.
+    # Bump the default once a stable npm release ships PR #21396.
+    - name: Install Codex CLI
       shell: bash
       run: |
-        TAG="${{ inputs.codex_version || 'rust-v0.131.0-alpha.17' }}"
-        cargo install --locked --git https://github.com/openai/codex.git \
-          --tag "$TAG" --bin codex codex-cli
-
-    - name: Verify codex binary
-      shell: bash
-      run: codex --version
-
-    # --- Swap-in once npm has a release with `codex plugin add` ---
-    # Delete the four steps above (Cache codex / Set up Rust / Build Codex /
-    # Verify) and uncomment this single step. Update the `codex_version`
-    # input description to refer to npm versions again.
-    #
-    # - name: Install Codex CLI
-    #   shell: bash
-    #   run: |
-    #     if [ -n "${{ inputs.codex_version }}" ]; then
-    #       npm install -g "@openai/codex@${{ inputs.codex_version }}"
-    #     else
-    #       npm install -g @openai/codex
-    #     fi
-    #     codex --version
+        npm install -g "@openai/codex@${{ inputs.codex_version }}"
+        codex --version
 
     # Codex CLI prefers auth.json over $OPENAI_API_KEY when both are
     # present. We mirror that precedence here: write auth.json if supplied,


### PR DESCRIPTION
Tend's Codex action built the CLI from source via `cargo install --git` at a pinned tag — ~22 min on a cache miss, plus a Rust toolchain and a binary-cache layer to make hits fast. We did this because the `codex plugin add` subcommand tend needs (PR [#21396](https://github.com/openai/codex/pull/21396), merged 2026-05-14) postdated every npm release.

That PR is now on npm. PR #21396 first appears in release tag `rust-v0.131.0-alpha.17` (verified via merge-commit ancestry: `alpha.16` diverged from it, `alpha.17`+ contain it). On npm it's published on the `alpha` dist-tag — `latest`/stable is still `0.130.0` and lacks it. I installed `@openai/codex@0.131.0-alpha.22` from npm into a scratch dir and confirmed directly: prebuilt per-platform binary, ~3 s install, `codex plugin --help` lists `add` / `marketplace` / `list` / `remove`.

This performs the cut-over the old comment documented: the four build steps (Cache codex / Set up Rust / Build / Verify) and the commented swap-in block are gone, replaced by a single `npm install -g "@openai/codex@${codex_version}"`. `codex_version` becomes an npm version string (default `0.131.0-alpha.22`); since npm `latest` predates #21396, the default pins an explicit alpha rather than tracking `latest`. The empty-string fallback from the old commented block is dropped — its `else` resolved to `latest` (0.130.0), which silently lacks the subcommand; one canonical pinned path is correct and lower-cardinality. The explanatory comment is rewritten and date-stamped (the npm version-state note drifts).

Net: ~22 min cold build (and the toolchain + cache machinery) gone; install is ~3 s prebuilt, works without the GitHub release path.

Scope is the codex install region + the `codex_version` input only. Not touched: the `final_message`/`TEND_EOF` heredoc (handled separately on `codex-final-message-delimiter`), the `sandbox` default (#519), the generator. `pre-commit run --all-files` (incl. actionlint) and `wt test` (230 passed, 0 regtest changes — action-internal) both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
