### PR TITLE
chore: release 0.0.21

### DIFF
--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tend"
-version = "0.0.20"
+version = "0.0.21"
 description = "An autonomous junior maintainer for GitHub repos, powered by Claude — reviews PRs, triages issues, fixes CI"
 license = "MIT"
 requires-python = ">=3.11"

--- a/generator/uv.lock
+++ b/generator/uv.lock
@@ -98,7 +98,7 @@ wheels = [
 
 [[package]]
 name = "tend"
-version = "0.0.20"
+version = "0.0.21"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Release 0.0.21 — makes the Codex harness functional on GitHub Actions runners.

3 commits since 0.0.20:
- #519 — codex sandbox defaults to `danger-full-access` for CI (the runner VM is the isolation boundary; `bwrap` isn't on the runner image)
- #521 — random heredoc delimiter for `final_message` output (static `TEND_EOF` broke on awkward agent output)
- #522 — codex CLI installed from npm prebuilt instead of ~45min source build

## Test plan

- [ ] CI green (test, test-worker, lint)
- [ ] After merge: tag `0.0.21`, PyPI publish succeeds, `uvx tend@0.0.21 --help` works
- [ ] Regenerate tend's own workflows to pin `@0.0.21`