### PR TITLE
codex: base64-encode final_message to fix $GITHUB_OUTPUT framing

### DIFF
--- a/codex/action.yaml
+++ b/codex/action.yaml
@@ -82,7 +82,10 @@ outputs:
       cost_usd is 0 — Codex CLI doesn't surface API list prices.
     value: ${{ steps.tokens.outputs.usage }}
   final_message:
-    description: The final assistant message Codex wrote (markdown)
+    description: >-
+      The final assistant message Codex wrote (markdown), base64-encoded.
+      Decode with `base64 -d` before use. Encoded so arbitrary agent
+      content can't break the $GITHUB_OUTPUT framing.
     value: ${{ steps.codex.outputs.final_message }}
 
 runs:
@@ -328,16 +331,13 @@ runs:
 
         # Surface the final message as a step output even if codex
         # exited non-zero — downstream steps may still want to post it.
+        # base64 -w0 → single-line key=value, no heredoc. Agent output is
+        # arbitrary content; a $GITHUB_OUTPUT heredoc fails if it lacks a
+        # trailing newline (codex writes the file without one) or contains
+        # the delimiter. Encoding sidesteps both. Consumers decode with
+        # `base64 -d`.
         if [ -f "$OUTPUT_FILE" ]; then
-          # Random delimiter: agent output is content-dependent and could
-          # otherwise contain a line matching a fixed sentinel, truncating
-          # the multiline output. See GitHub's multiline-string guidance.
-          DELIM="ghadelimiter_$(openssl rand -hex 16)"
-          {
-            echo "final_message<<$DELIM"
-            cat "$OUTPUT_FILE"
-            echo "$DELIM"
-          } >> "$GITHUB_OUTPUT"
+          echo "final_message=$(base64 -w0 "$OUTPUT_FILE")" >> "$GITHUB_OUTPUT"
         fi
         exit $EXIT
 


### PR DESCRIPTION
`codex exec --output-last-message` writes the final-message file **without a trailing newline**. The previous `$GITHUB_OUTPUT` heredoc did `cat "$OUTPUT_FILE"` then `echo "$DELIM"`, gluing the closing delimiter onto the last content line. The runner never saw `ghadelimiter_…` alone on a line and failed the step with `Invalid value. Matching delimiter not found` — turning **every** Codex run red even though the agent completed its work correctly. PR #521 randomized the delimiter (collision-proofing) but didn't fix this framing failure.

The fix replaces the heredoc with `echo "final_message=$(base64 -w0 "$OUTPUT_FILE")" >> "$GITHUB_OUTPUT"` — a single-line `key=value` assignment, no heredoc, no delimiter. Immune to both the missing trailing newline and to agent content that happens to contain the delimiter. `base64 -w0` (GNU coreutils, present on Ubuntu runners) guarantees no line wrapping.

Scope is internal to `codex/action.yaml`. `final_message` is set there and exposed as an action output, but consumed nowhere — verified exhaustively: not in the generator, generated workflows, the Claude `action.yaml` (no analogous output), plugins, or skills. The output description now documents the base64 encoding (`base64 -d` to decode) for any future consumer.

This is the last known blocker for the Codex CI cutover (#520). A release + workflow regen is required before that re-test — follow-on, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
