### PR TITLE
fix(list-recent-runs): anchor completion window to intended cron tick

### DIFF
--- a/plugins/tend-ci-runner/scripts/list-recent-runs.sh
+++ b/plugins/tend-ci-runner/scripts/list-recent-runs.sh
@@ -2,10 +2,19 @@
 # Lists recently completed tend CI runs.
 #
 # Fetches runs started in the past 3 hours, then filters to only those that
-# are completed and whose updatedAt is within the past hour. This two-step
-# approach is needed because `gh run list --created` filters by *start* time,
-# not *end* time — a run started 2h ago may have just finished, and a run
-# started 50min ago may still be running.
+# are completed and whose updatedAt is within the past 2 hours. This
+# two-step approach is needed because `gh run list --created` filters by
+# *start* time, not *end* time — a run started 2h ago may have just
+# finished, and a run started 50min ago may still be running.
+#
+# The 2h completion window absorbs GitHub Actions cron delay. Hourly
+# review-reviewers runs (cron `47 * * * *`) routinely fire 20–40 min late
+# during peak hours, producing gaps of 80–100 min between consecutive
+# cycles. A tighter 1h cutoff drops everything older than the previous
+# cycle's expected start, silently hiding runs that landed in the delay
+# slack. The 2h cutoff covers all observed gaps with margin; the small
+# re-analysis overlap between cycles is cheap because gist entries are
+# keyed by run ID.
 #
 # Environment variables:
 #   TARGET_REPO - Query a different repo (default: current repo)
@@ -37,7 +46,7 @@ for prefix in "${PREFIXES[@]}"; do
 done
 
 CREATED_SINCE=$(date -d '3 hours ago' +%Y-%m-%dT%H:%M:%S)
-COMPLETED_AFTER=$(date -d '1 hour ago' +%s)
+COMPLETED_AFTER=$(date -d '2 hours ago' +%s)
 
 all_runs="[]"
 

--- a/plugins/tend-ci-runner/scripts/list-recent-runs.sh
+++ b/plugins/tend-ci-runner/scripts/list-recent-runs.sh
@@ -2,19 +2,19 @@
 # Lists recently completed tend CI runs.
 #
 # Fetches runs started in the past 3 hours, then filters to only those that
-# are completed and whose updatedAt is within the past 2 hours. This
-# two-step approach is needed because `gh run list --created` filters by
-# *start* time, not *end* time — a run started 2h ago may have just
+# are completed and whose updatedAt falls within a 1-hour completion window.
+# This two-step approach is needed because `gh run list --created` filters
+# by *start* time, not *end* time — a run started 2h ago may have just
 # finished, and a run started 50min ago may still be running.
 #
-# The 2h completion window absorbs GitHub Actions cron delay. Hourly
-# review-reviewers runs (cron `47 * * * *`) routinely fire 20–40 min late
-# during peak hours, producing gaps of 80–100 min between consecutive
-# cycles. A tighter 1h cutoff drops everything older than the previous
-# cycle's expected start, silently hiding runs that landed in the delay
-# slack. The 2h cutoff covers all observed gaps with margin; the small
-# re-analysis overlap between cycles is cheap because gist entries are
-# keyed by run ID.
+# Window anchor: when invoked under a scheduled workflow with a simple
+# hourly cron (`MM * * * *`), the completion window is anchored to the most
+# recent intended cron tick instead of `now`. Consecutive cycles then tile
+# exactly: [intended-1h, intended], then [intended, intended+1h]. Without
+# this, GHA scheduler delay (20-40 min during peak hours) shifts each
+# cycle's window relative to actual start time and drops runs that finished
+# in the slack between consecutive actual starts. For non-schedule events
+# or non-hourly crons, falls back to a now-anchored 1h window.
 #
 # Environment variables:
 #   TARGET_REPO - Query a different repo (default: current repo)
@@ -45,8 +45,30 @@ for prefix in "${PREFIXES[@]}"; do
   WORKFLOWS+=("${matches[@]}")
 done
 
-CREATED_SINCE=$(date -d '3 hours ago' +%Y-%m-%dT%H:%M:%S)
-COMPLETED_AFTER=$(date -d '2 hours ago' +%s)
+# Detect a simple hourly cron (e.g. "47 * * * *") from the workflow event
+# payload so we can anchor the window to the most recent intended tick.
+cron_minute=""
+if [ -f "${GITHUB_EVENT_PATH:-}" ]; then
+  schedule=$(jq -r '.schedule // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || true)
+  if [[ "$schedule" =~ ^([0-9]+)\ \*\ \*\ \*\ \*$ ]]; then
+    cron_minute="${BASH_REMATCH[1]}"
+  fi
+fi
+
+if [ -n "$cron_minute" ]; then
+  this_hour_tick=$(date -u -d "$(date -u +%Y-%m-%dT%H:00:00) $cron_minute minutes" +%s)
+  now_ts=$(date -u +%s)
+  if [ "$now_ts" -lt "$this_hour_tick" ]; then
+    intended=$((this_hour_tick - 3600))
+  else
+    intended=$this_hour_tick
+  fi
+  COMPLETED_AFTER=$((intended - 3600))
+  CREATED_SINCE=$(date -u -d "@$((intended - 10800))" +%Y-%m-%dT%H:%M:%S)
+else
+  CREATED_SINCE=$(date -d '3 hours ago' +%Y-%m-%dT%H:%M:%S)
+  COMPLETED_AFTER=$(date -d '1 hour ago' +%s)
+fi
 
 all_runs="[]"
 


### PR DESCRIPTION
## Summary

Anchor `list-recent-runs.sh`'s completion window to the most recent intended cron tick (read from `$GITHUB_EVENT_PATH`) instead of `now`. Consecutive `review-reviewers` cycles then tile exactly: `[intended-1h, intended]` → `[intended, intended+1h]`, regardless of GHA scheduler delay.

Replaces an earlier 2h-widening approach per maintainer feedback ([#issuecomment-4472767685](https://github.com/max-sixty/tend/pull/526#issuecomment-4472767685)). Strictly cleaner: no overlap between consecutive cycles, no slack between them.

## Background

The hourly `review-reviewers` schedule (cron `47 * * * *`) is delayed 20–40 min during peak hours, producing back-to-back cycle gaps that systematically exceed the script's 1h `now`-anchored window. Last 11 `review-reviewers` runs on `max-sixty/tend` (oldest → newest), interval to next:

| Started | Gap to next |
|---|---|
| 2026-05-15T17:16Z | 59 min |
| 2026-05-15T18:15Z | 60 min |
| 2026-05-15T19:15Z | 58 min |
| 2026-05-15T20:13Z | 59 min |
| 2026-05-15T21:12Z | 57 min |
| 2026-05-15T22:09Z | 60 min |
| 2026-05-15T23:09Z | 56 min |
| 2026-05-16T00:05Z | 77 min |
| 2026-05-16T01:22Z | 81 min |
| 2026-05-16T02:43Z | 82 min |
| 2026-05-16T04:05Z | 99 min |

The four most recent intervals exceed 1h. In the analysis run [25954184316](https://github.com/max-sixty/tend/actions/runs/25954184316) (gap 99 min from the prior `review-reviewers`), the script returned 4 of 17 in-window tend runs, missing PR #523 (release 0.0.21), PR #524 (regen workflows), and the [25952710024](https://github.com/max-sixty/tend/actions/runs/25952710024) `tend-review-runs` failure on `cutover-to-codex` — substantive activity recovered only via a direct `gh run list` sweep.

## How it works

```bash
schedule=$(jq -r '.schedule // empty' "$GITHUB_EVENT_PATH")  # "47 * * * *"
# Match simple hourly crons (MM * * * *); extract minute.
# Compute the most recent matching tick ≤ now; that's the intended fire time.
COMPLETED_AFTER=$((intended - 3600))
CREATED_SINCE=$((intended - 10800))  # keep the 2h buffer for long runs
```

Non-schedule events (`workflow_dispatch`, ad-hoc CLI use) and non-hourly crons fall back to the original `now - 1h` window — same behavior as before the change.

## Trade-offs

- **No overlap between consecutive cycles** (vs. the 2h approach, which would re-analyze each run on overlapping cycles — cheap but messy).
- **Skipped-tick edge case**: if a cron tick fires zero times (rare under sustained outage), that hour's completions fall in the gap between the previous and next cycle's windows. The 2h approach would have caught them; this one doesn't. Considered acceptable per the comment thread.
- **Daily/multi-value crons** (`0 4 * * *`, `0,30 * * * *`) keep the now-anchored fallback. Could extend later if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
