### PR TITLE
config: declare CODEX_AUTH_JSON in secrets.allowed

### DIFF
--- a/.config/tend.yaml
+++ b/.config/tend.yaml
@@ -3,6 +3,14 @@ bot_name: tend-agent
 setup:
   - uses: astral-sh/setup-uv@v6
 
+secrets:
+  # Consumed by codex-auth-refresh.yaml (custom non-tend workflow that
+  # rotates the Codex OAuth token nightly). Intentionally lives at repo
+  # scope so any future Codex-harness consumer workflow can read it
+  # without declaring an environment. See docs/security-model.md.
+  allowed:
+    - CODEX_AUTH_JSON
+
 workflows:
   ci-fix:
     watched_workflows: ["ci"]


### PR DESCRIPTION
## Problem

`uvx tend@latest check` flags `CODEX_AUTH_JSON` as an unexpected repo-level secret — the `repo-secret-allowlist` check compares actual repo secrets against `cfg.bot_token_secret + engine_auth_secrets + secrets.allowed`, and `.config/tend.yaml` has no `secrets.allowed` declaration, so `CODEX_AUTH_JSON` falls outside the allowed set under the Claude harness.

The secret is consumed by [`codex-auth-refresh.yaml`](https://github.com/max-sixty/tend/blob/main/.github/workflows/codex-auth-refresh.yaml), which rotates the Codex OAuth token nightly. The refresh workflow's own comment block notes it is repo-scoped on purpose so consumer workflows can read it without declaring an environment, and commit [`fba319e`](https://github.com/max-sixty/tend/commit/fba319e) ("write CODEX_AUTH_JSON as a repo secret, not env-scoped") locked that posture in deliberately.

## Solution

Declare `CODEX_AUTH_JSON` in `secrets.allowed` in `.config/tend.yaml`, with a comment pointing to the workflow and security model.

This is purely a check-allowlist change — `allowed_repo_secrets` is only read by `checks.py` and is not used during workflow generation, so no regeneration is required.

## Testing

- Generator tests pass (`pytest` — 230 passed).
- Simulated the check locally: with the new allowlist, the `repo-secret-allowlist` unexpected-set is empty against the current repo secrets (`BOT_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, `CODEX_AUTH_JSON`).
- `pre-commit` (typos / yaml / actionlint) clean on the edited file.

---
Closes #527 — automated triage
