### PR TITLE
docs: include Codex in package/CLI descriptions; fix stale .toml ref

### DIFF
--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "tend"
 version = "0.0.21"
-description = "An autonomous junior maintainer for GitHub repos, powered by Claude — reviews PRs, triages issues, fixes CI"
+description = "An autonomous junior maintainer for GitHub repos, powered by Claude or OpenAI Codex — reviews PRs, triages issues, fixes CI"
 license = "MIT"
 requires-python = ">=3.11"
 authors = [{ name = "Maximilian Roos", email = "m@maxroos.com" }]

--- a/generator/src/tend/cli.py
+++ b/generator/src/tend/cli.py
@@ -53,7 +53,7 @@ def _print_check_results(results: list[CheckResult]) -> None:
 
 @click.group()
 def main() -> None:
-    """An autonomous junior maintainer for GitHub repos, powered by Claude. Generates and manages workflows from .config/tend.yaml."""
+    """An autonomous junior maintainer for GitHub repos, powered by Claude or OpenAI Codex. Generates and manages workflows from .config/tend.yaml."""
 
 
 @main.command()

--- a/plugins/tend-ci-runner/scripts/pat-scope-audit.sh
+++ b/plugins/tend-ci-runner/scripts/pat-scope-audit.sh
@@ -12,7 +12,7 @@
 #   REQUIRED=<csv of required scopes>  (ok, missing)
 #   MISSING=<csv of missing scopes>    (missing)
 #
-# Required scopes are duplicated in prose at docs/tend.example.toml,
+# Required scopes are duplicated in prose at docs/tend.example.yaml,
 # CLAUDE.md, plugins/install-tend/skills/install-tend/SKILL.md, and
 # plugins/tend-ci-runner/skills/nightly/SKILL.md — keep in sync when adding
 # a scope. This script is the one executable reference.


### PR DESCRIPTION
## Summary

Nightly survey turned up three stale Claude-only / pre-YAML-migration references in user-facing surfaces:

- `generator/pyproject.toml` — package description (shown on PyPI) said "powered by Claude"; the project supports both the Claude and Codex harnesses (see `README.md` and `harness: claude | codex` in the config schema).
- `generator/src/tend/cli.py` — `tend --help` group docstring had the same Claude-only framing.
- `plugins/tend-ci-runner/scripts/pat-scope-audit.sh` — comment pointed to `docs/tend.example.toml`, but the file is `docs/tend.example.yaml` post-YAML migration.

Pure doc/comment edits; no code-path changes and lint passes.

## Test plan

- [x] `uvx pre-commit run --files <changed>` passes (ruff, typos, uv-lock, actionlint).
- No regression test — pure user-facing string fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)