### PR TITLE
fix(nightly-survey-files): print bucket/count to stderr

### DIFF
--- a/plugins/tend-ci-runner/scripts/nightly-survey-files.sh
+++ b/plugins/tend-ci-runner/scripts/nightly-survey-files.sh
@@ -12,10 +12,14 @@ set -euo pipefail
 CYCLE_LENGTH=28
 TODAY_BUCKET=$(( $(date +%s) / 86400 % CYCLE_LENGTH ))
 
-git ls-files | while read -r f; do
+count=0
+while read -r f; do
   hash=$(echo -n "$f" | cksum | awk '{print $1}')
   bucket=$(( hash % CYCLE_LENGTH ))
   if [ "$bucket" -eq "$TODAY_BUCKET" ]; then
     echo "$f"
+    count=$((count + 1))
   fi
-done
+done < <(git ls-files)
+
+echo "# bucket=$TODAY_BUCKET/$CYCLE_LENGTH files=$count" >&2


### PR DESCRIPTION
## Problem

`nightly-survey-files.sh` exits 0 with no output when today's bucket maps to zero tracked files. The nightly bot can't distinguish empty-bucket success from script breakage, so it spends extra tool calls re-running with stderr capture, `cat`ing the source, and re-deriving the bucket math before proceeding. Reported in #530 with two confirmed occurrences on `max-sixty/cargo-affected` (~5 extra tool calls each).

## Solution

Print a one-line status to stderr with the bucket index and match count. Stdout stays clean for callers that pipe the file list. The bot sees `# bucket=9/28 files=0` and proceeds immediately.

Switching from `git ls-files | while` to `while … done < <(git ls-files)` is required so the `count` increment survives outside the loop subshell.

## Testing

Verified manually in a throwaway repo whose only tracked file hashes to a non-today bucket:

```
$ bash nightly-survey-files.sh > /tmp/out 2> /tmp/err
$ echo exit=$? lines=$(wc -l < /tmp/out); cat /tmp/err
exit=0 lines=0
# bucket=9/28 files=0
```

And against this repo (non-empty bucket):

```
$ bash nightly-survey-files.sh > /tmp/out 2> /tmp/err
$ echo exit=$? lines=$(wc -l < /tmp/out); cat /tmp/err
exit=0 lines=6
# bucket=9/28 files=6
```

`shellcheck` is clean.

There is no existing shell-script test framework in this repo to add a regression test to.

---
Closes #530 — automated triage
