### PR TITLE
chore: release 0.0.22

### DIFF
--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tend"
-version = "0.0.21"
+version = "0.0.22"
 description = "An autonomous junior maintainer for GitHub repos, powered by Claude or OpenAI Codex — reviews PRs, triages issues, fixes CI"
 license = "MIT"
 requires-python = ">=3.11"

--- a/generator/uv.lock
+++ b/generator/uv.lock
@@ -98,7 +98,7 @@ wheels = [
 
 [[package]]
 name = "tend"
-version = "0.0.21"
+version = "0.0.22"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Release 0.0.22 — the last known Codex-harness blocker.

3 commits since 0.0.21:
- #525 — base64-encode `final_message` so the agent's output can't break the `$GITHUB_OUTPUT` heredoc (every Codex run was exiting red *after* the agent succeeded)
- #528 — declare `CODEX_AUTH_JSON` in `secrets.allowed`
- #529 — Codex in package/CLI descriptions; fix stale `.toml` ref

## Test plan

- [ ] CI green (test, test-worker, lint)
- [ ] After merge: tag `0.0.22`, PyPI publish, `uvx tend@0.0.22 --help` works
- [ ] Regenerate tend's own workflows to `@0.0.22`