### PR TITLE
Brand default bot-token secret as TEND_BOT_TOKEN

### DIFF
--- a/.github/workflows/review-reviewers.yaml
+++ b/.github/workflows/review-reviewers.yaml
@@ -2,7 +2,7 @@ name: review-reviewers
 # Hourly outcome-based analysis of bot behavior across adopter repos.
 #
 # Each matrix entry is a repo to analyze. The job checks out the tend repo
-# (for creating improvement PRs/issues). BOT_TOKEN is sufficient for reading
+# (for creating improvement PRs/issues). TEND_BOT_TOKEN is sufficient for reading
 # CI data from public adopter repos.
 #
 # TODO: Move repo list to a config file so adding a repo doesn't require a workflow change
@@ -33,11 +33,11 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: max-sixty/tend@v1
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           bot_name: tend-agent
           prompt: /tend-ci-runner:review-reviewers ${{ matrix.repo }}

--- a/README.md
+++ b/README.md
@@ -154,12 +154,12 @@ bot_name: my-project-bot
 
 Repo secrets depend on the harness:
 
-| Harness   | Required secrets                                                                                                |
-| -------- | --------------------------------------------------------------------------------------------------------------- |
-| `claude` | `BOT_TOKEN` + one of `CLAUDE_CODE_OAUTH_TOKEN` (subscription, see caveat below) or `ANTHROPIC_API_KEY` (API-billed) |
-| `codex`  | `BOT_TOKEN` + one of `CODEX_AUTH_JSON` (subscription, recommended) or `OPENAI_API_KEY` (pay-per-token) |
+| Harness   | Required secrets                                                                                                        |
+| -------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `claude` | `TEND_BOT_TOKEN` + one of `CLAUDE_CODE_OAUTH_TOKEN` (subscription, see caveat below) or `ANTHROPIC_API_KEY` (API-billed) |
+| `codex`  | `TEND_BOT_TOKEN` + one of `CODEX_AUTH_JSON` (subscription, recommended) or `OPENAI_API_KEY` (pay-per-token)              |
 
-`BOT_TOKEN` is the bot account's PAT — see
+`TEND_BOT_TOKEN` is the bot account's PAT — see
 [example config](docs/tend.example.yaml) for scopes.
 `CLAUDE_CODE_OAUTH_TOKEN` is from `claude setup-token`;
 `CODEX_AUTH_JSON` is the contents of the `auth.json` Codex writes after

--- a/TODO.md
+++ b/TODO.md
@@ -97,7 +97,7 @@ in `.config/tend.yaml` would select between two models:
 own fork and creates cross-fork PRs:
 
 ```bash
-git remote add fork https://x-access-token:${BOT_TOKEN}@github.com/${BOT_NAME}/${REPO}.git
+git remote add fork https://x-access-token:${TEND_BOT_TOKEN}@github.com/${BOT_NAME}/${REPO}.git
 git push fork fix/ci-123
 gh pr create --repo ${TARGET_REPO} --head ${BOT_NAME}:fix/ci-123
 ```

--- a/docs/tend.example.yaml
+++ b/docs/tend.example.yaml
@@ -48,12 +48,12 @@ bot_name: my-project-bot
 #
 # Repo secrets, by harness:
 #
-# | Harness   | Required                                                                |
-# |----------|--------------------------------------------------------------------------|
-# | `claude` | `BOT_TOKEN` + one of `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`    |
-# | `codex`  | `BOT_TOKEN` + one of `CODEX_AUTH_JSON` or `OPENAI_API_KEY`               |
+# | Harness   | Required                                                                     |
+# |----------|-------------------------------------------------------------------------------|
+# | `claude` | `TEND_BOT_TOKEN` + one of `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`    |
+# | `codex`  | `TEND_BOT_TOKEN` + one of `CODEX_AUTH_JSON` or `OPENAI_API_KEY`               |
 #
-# `BOT_TOKEN` is the bot account's PAT (scopes below).
+# `TEND_BOT_TOKEN` is the bot account's PAT (scopes below).
 # `CLAUDE_CODE_OAUTH_TOKEN` is from `claude setup-token` (PKCE).
 # `ANTHROPIC_API_KEY` is a console.anthropic.com API key.
 # `CODEX_AUTH_JSON` is the contents of the `auth.json` Codex writes

--- a/generator/src/tend/config.py
+++ b/generator/src/tend/config.py
@@ -297,7 +297,7 @@ class Config:
             bot_name=bot_name,
             default_branch="main",
             protected_branches=protected_branches,
-            bot_token_secret=secrets.get("bot_token", "BOT_TOKEN"),
+            bot_token_secret=secrets.get("bot_token", "TEND_BOT_TOKEN"),
             claude_token_secret=secrets.get("claude_token", "CLAUDE_CODE_OAUTH_TOKEN"),
             anthropic_api_key_secret=secrets.get(
                 "anthropic_api_key", "ANTHROPIC_API_KEY"

--- a/generator/tests/_regtest_outputs/test_generate.test_extras_apply_path_regtest.out
+++ b/generator/tests/_regtest_outputs/test_generate.test_extras_apply_path_regtest.out
@@ -33,7 +33,7 @@ jobs:
       - name: Resolve PR checkout ref
         id: pr_ref
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
         run: |
           if gh api "repos/${{ github.repository }}/git/ref/pull/$PR/merge" --silent 2>/dev/null; then
@@ -47,11 +47,11 @@ jobs:
           ref: ${{ steps.pr_ref.outputs.ref }}
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: max-sixty/tend@X.Y.Z
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-ci-fix.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-ci-fix.yaml].out
@@ -28,11 +28,11 @@ jobs:
           ref: main
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: max-sixty/tend@X.Y.Z
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-nightly.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-nightly.yaml].out
@@ -28,11 +28,11 @@ jobs:
           ref: main
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: max-sixty/tend@X.Y.Z
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
@@ -87,7 +87,7 @@ jobs:
             echo "$COUNT processable notification(s) ? proceeding"
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: actions/checkout@v6
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'
@@ -95,11 +95,11 @@ jobs:
           ref: main
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
       - uses: max-sixty/tend@X.Y.Z
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-review-runs.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-review-runs.yaml].out
@@ -28,11 +28,11 @@ jobs:
           ref: main
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: max-sixty/tend@X.Y.Z
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-triage.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-triage.yaml].out
@@ -31,11 +31,11 @@ jobs:
           ref: main
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: max-sixty/tend@X.Y.Z
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-weekly.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-weekly.yaml].out
@@ -28,11 +28,11 @@ jobs:
           ref: main
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: max-sixty/tend@X.Y.Z
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[ci-fix].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[ci-fix].out
@@ -28,11 +28,11 @@ jobs:
           ref: main
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: max-sixty/tend/codex@X.Y.Z
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          github_token: ${{ secrets.TEND_BOT_TOKEN }}
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
           codex_auth_json: ${{ secrets.CODEX_AUTH_JSON }}
           bot_name: test-bot

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
@@ -122,7 +122,7 @@ jobs:
 
           echo "should_run=false" >> "$GITHUB_OUTPUT"
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}
           COMMENT_BODY: ${{ github.event.comment.body || github.event.review.body }}
           ISSUE_BODY: ${{ github.event.issue.body }}
@@ -143,7 +143,7 @@ jobs:
         env:
           REPO: ${{ github.repository }}
           COMMENT_ID: ${{ github.event.comment.id }}
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
 
   handle:
     needs: verify
@@ -163,7 +163,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - name: Check out PR branch
         if: |
@@ -178,7 +178,7 @@ jobs:
             echo "::warning::PR is $PR_STATE ? staying on default branch"
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
           PR_NUMBER: ${{ github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number }}
 
       - name: Compute queue delay
@@ -195,7 +195,7 @@ jobs:
 
       - uses: max-sixty/tend/codex@X.Y.Z
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          github_token: ${{ secrets.TEND_BOT_TOKEN }}
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
           codex_auth_json: ${{ secrets.CODEX_AUTH_JSON }}
           bot_name: test-bot
@@ -239,4 +239,4 @@ jobs:
           REPO: ${{ github.repository }}
           COMMENT_ID: ${{ github.event.comment.id }}
           BOT_NAME: test-bot
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[nightly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[nightly].out
@@ -27,11 +27,11 @@ jobs:
           ref: main
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: max-sixty/tend/codex@X.Y.Z
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          github_token: ${{ secrets.TEND_BOT_TOKEN }}
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
           codex_auth_json: ${{ secrets.CODEX_AUTH_JSON }}
           bot_name: test-bot

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[notifications].out
@@ -86,7 +86,7 @@ jobs:
             echo "$COUNT processable notification(s) ? proceeding"
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: actions/checkout@v6
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'
@@ -94,11 +94,11 @@ jobs:
           ref: main
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
       - uses: max-sixty/tend/codex@X.Y.Z
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          github_token: ${{ secrets.TEND_BOT_TOKEN }}
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
           codex_auth_json: ${{ secrets.CODEX_AUTH_JSON }}
           bot_name: test-bot

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[review-runs].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[review-runs].out
@@ -27,11 +27,11 @@ jobs:
           ref: main
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: max-sixty/tend/codex@X.Y.Z
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          github_token: ${{ secrets.TEND_BOT_TOKEN }}
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
           codex_auth_json: ${{ secrets.CODEX_AUTH_JSON }}
           bot_name: test-bot

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[review].out
@@ -32,7 +32,7 @@ jobs:
       - name: Resolve PR checkout ref
         id: pr_ref
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
         run: |
           if gh api "repos/${{ github.repository }}/git/ref/pull/$PR/merge" --silent 2>/dev/null; then
@@ -46,11 +46,11 @@ jobs:
           ref: ${{ steps.pr_ref.outputs.ref }}
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: max-sixty/tend/codex@X.Y.Z
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          github_token: ${{ secrets.TEND_BOT_TOKEN }}
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
           codex_auth_json: ${{ secrets.CODEX_AUTH_JSON }}
           bot_name: test-bot

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[triage].out
@@ -30,11 +30,11 @@ jobs:
           ref: main
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: max-sixty/tend/codex@X.Y.Z
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          github_token: ${{ secrets.TEND_BOT_TOKEN }}
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
           codex_auth_json: ${{ secrets.CODEX_AUTH_JSON }}
           bot_name: test-bot

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[weekly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[weekly].out
@@ -27,11 +27,11 @@ jobs:
           ref: main
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: max-sixty/tend/codex@X.Y.Z
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          github_token: ${{ secrets.TEND_BOT_TOKEN }}
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
           codex_auth_json: ${{ secrets.CODEX_AUTH_JSON }}
           bot_name: test-bot

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[ci-fix].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[ci-fix].out
@@ -28,11 +28,11 @@ jobs:
           ref: main
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: max-sixty/tend@X.Y.Z
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
@@ -122,7 +122,7 @@ jobs:
 
           echo "should_run=false" >> "$GITHUB_OUTPUT"
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}
           COMMENT_BODY: ${{ github.event.comment.body || github.event.review.body }}
           ISSUE_BODY: ${{ github.event.issue.body }}
@@ -143,7 +143,7 @@ jobs:
         env:
           REPO: ${{ github.repository }}
           COMMENT_ID: ${{ github.event.comment.id }}
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
 
   handle:
     needs: verify
@@ -163,7 +163,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - name: Check out PR branch
         if: |
@@ -178,7 +178,7 @@ jobs:
             echo "::warning::PR is $PR_STATE ? staying on default branch"
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
           PR_NUMBER: ${{ github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number }}
 
       - name: Compute queue delay
@@ -195,7 +195,7 @@ jobs:
 
       - uses: max-sixty/tend@X.Y.Z
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
@@ -239,4 +239,4 @@ jobs:
           REPO: ${{ github.repository }}
           COMMENT_ID: ${{ github.event.comment.id }}
           BOT_NAME: test-bot
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[nightly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[nightly].out
@@ -27,11 +27,11 @@ jobs:
           ref: main
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: max-sixty/tend@X.Y.Z
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
@@ -86,7 +86,7 @@ jobs:
             echo "$COUNT processable notification(s) ? proceeding"
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: actions/checkout@v6
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'
@@ -94,11 +94,11 @@ jobs:
           ref: main
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
       - uses: max-sixty/tend@X.Y.Z
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review-runs].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review-runs].out
@@ -27,11 +27,11 @@ jobs:
           ref: main
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: max-sixty/tend@X.Y.Z
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review].out
@@ -32,7 +32,7 @@ jobs:
       - name: Resolve PR checkout ref
         id: pr_ref
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
         run: |
           if gh api "repos/${{ github.repository }}/git/ref/pull/$PR/merge" --silent 2>/dev/null; then
@@ -46,11 +46,11 @@ jobs:
           ref: ${{ steps.pr_ref.outputs.ref }}
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: max-sixty/tend@X.Y.Z
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[triage].out
@@ -30,11 +30,11 @@ jobs:
           ref: main
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: max-sixty/tend@X.Y.Z
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[weekly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[weekly].out
@@ -27,11 +27,11 @@ jobs:
           ref: main
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: max-sixty/tend@X.Y.Z
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[ci-fix].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[ci-fix].out
@@ -28,13 +28,13 @@ jobs:
           ref: main
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: astral-sh/setup-uv@v6
 
       - uses: max-sixty/tend@X.Y.Z
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
@@ -122,7 +122,7 @@ jobs:
 
           echo "should_run=false" >> "$GITHUB_OUTPUT"
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}
           COMMENT_BODY: ${{ github.event.comment.body || github.event.review.body }}
           ISSUE_BODY: ${{ github.event.issue.body }}
@@ -143,7 +143,7 @@ jobs:
         env:
           REPO: ${{ github.repository }}
           COMMENT_ID: ${{ github.event.comment.id }}
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
 
   handle:
     needs: verify
@@ -163,7 +163,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: astral-sh/setup-uv@v6
 
@@ -180,7 +180,7 @@ jobs:
             echo "::warning::PR is $PR_STATE ? staying on default branch"
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
           PR_NUMBER: ${{ github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number }}
 
       - name: Compute queue delay
@@ -197,7 +197,7 @@ jobs:
 
       - uses: max-sixty/tend@X.Y.Z
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
@@ -241,4 +241,4 @@ jobs:
           REPO: ${{ github.repository }}
           COMMENT_ID: ${{ github.event.comment.id }}
           BOT_NAME: test-bot
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[nightly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[nightly].out
@@ -27,13 +27,13 @@ jobs:
           ref: main
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: astral-sh/setup-uv@v6
 
       - uses: max-sixty/tend@X.Y.Z
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
@@ -86,7 +86,7 @@ jobs:
             echo "$COUNT processable notification(s) ? proceeding"
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: actions/checkout@v6
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'
@@ -94,14 +94,14 @@ jobs:
           ref: main
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: astral-sh/setup-uv@v6
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'
       - uses: max-sixty/tend@X.Y.Z
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review-runs].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review-runs].out
@@ -27,13 +27,13 @@ jobs:
           ref: main
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: astral-sh/setup-uv@v6
 
       - uses: max-sixty/tend@X.Y.Z
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review].out
@@ -32,7 +32,7 @@ jobs:
       - name: Resolve PR checkout ref
         id: pr_ref
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
         run: |
           if gh api "repos/${{ github.repository }}/git/ref/pull/$PR/merge" --silent 2>/dev/null; then
@@ -46,13 +46,13 @@ jobs:
           ref: ${{ steps.pr_ref.outputs.ref }}
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: astral-sh/setup-uv@v6
 
       - uses: max-sixty/tend@X.Y.Z
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[triage].out
@@ -30,13 +30,13 @@ jobs:
           ref: main
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: astral-sh/setup-uv@v6
 
       - uses: max-sixty/tend@X.Y.Z
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[weekly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[weekly].out
@@ -27,13 +27,13 @@ jobs:
           ref: main
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: astral-sh/setup-uv@v6
 
       - uses: max-sixty/tend@X.Y.Z
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot

--- a/generator/tests/test_checks.py
+++ b/generator/tests/test_checks.py
@@ -361,15 +361,19 @@ def test_bot_permission_404_wrong_username() -> None:
 def test_secrets_present() -> None:
     with patch(
         "tend.checks._gh",
-        return_value=_make_completed('["BOT_TOKEN","CLAUDE_CODE_OAUTH_TOKEN"]\n'),
+        return_value=_make_completed('["TEND_BOT_TOKEN","CLAUDE_CODE_OAUTH_TOKEN"]\n'),
     ):
-        result = check_secrets("owner/repo", ["BOT_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"])
+        result = check_secrets(
+            "owner/repo", ["TEND_BOT_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"]
+        )
     assert result.passed is True
 
 
 def test_secrets_missing() -> None:
-    with patch("tend.checks._gh", return_value=_make_completed('["BOT_TOKEN"]\n')):
-        result = check_secrets("owner/repo", ["BOT_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"])
+    with patch("tend.checks._gh", return_value=_make_completed('["TEND_BOT_TOKEN"]\n')):
+        result = check_secrets(
+            "owner/repo", ["TEND_BOT_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"]
+        )
     assert result.passed is False
     assert "CLAUDE_CODE_OAUTH_TOKEN" in result.message
     assert "admin:org" not in result.message
@@ -378,10 +382,12 @@ def test_secrets_missing() -> None:
 def test_secrets_missing_with_org_403_hint() -> None:
     """When org secrets return 403 and secrets are missing, include the hint."""
     with (
-        patch("tend.checks._gh", return_value=_make_completed('["BOT_TOKEN"]\n')),
+        patch("tend.checks._gh", return_value=_make_completed('["TEND_BOT_TOKEN"]\n')),
         patch("tend.checks._list_org_secrets", return_value=(None, True)),
     ):
-        result = check_secrets("owner/repo", ["BOT_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"])
+        result = check_secrets(
+            "owner/repo", ["TEND_BOT_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"]
+        )
     assert result.passed is False
     assert "CLAUDE_CODE_OAUTH_TOKEN" in result.message
     assert "admin:org" in result.message
@@ -392,13 +398,13 @@ def test_secrets_api_error() -> None:
     with patch(
         "tend.checks._gh", return_value=_make_completed(returncode=1, stderr="HTTP 403")
     ):
-        result = check_secrets("owner/repo", ["BOT_TOKEN"])
+        result = check_secrets("owner/repo", ["TEND_BOT_TOKEN"])
     assert result.passed is None
 
 
 def test_secrets_bad_json() -> None:
     with patch("tend.checks._gh", return_value=_make_completed("not json")):
-        result = check_secrets("owner/repo", ["BOT_TOKEN"])
+        result = check_secrets("owner/repo", ["TEND_BOT_TOKEN"])
     assert result.passed is None
 
 
@@ -412,12 +418,14 @@ def test_repo_secret_allowlist_pass() -> None:
     with (
         patch(
             "tend.checks._gh",
-            return_value=_make_completed('["BOT_TOKEN","CLAUDE_CODE_OAUTH_TOKEN"]\n'),
+            return_value=_make_completed(
+                '["TEND_BOT_TOKEN","CLAUDE_CODE_OAUTH_TOKEN"]\n'
+            ),
         ),
         patch("tend.checks._list_org_secrets", return_value=(set(), False)),
     ):
         result = check_repo_secret_allowlist(
-            "owner/repo", {"BOT_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"}
+            "owner/repo", {"TEND_BOT_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"}
         )
     assert result.passed is True
     assert "in allowlist" in result.message
@@ -429,13 +437,13 @@ def test_repo_secret_allowlist_unexpected_repo() -> None:
         patch(
             "tend.checks._gh",
             return_value=_make_completed(
-                '["BOT_TOKEN","CLAUDE_CODE_OAUTH_TOKEN","PYPI_TOKEN"]\n'
+                '["TEND_BOT_TOKEN","CLAUDE_CODE_OAUTH_TOKEN","PYPI_TOKEN"]\n'
             ),
         ),
         patch("tend.checks._list_org_secrets", return_value=(set(), False)),
     ):
         result = check_repo_secret_allowlist(
-            "owner/repo", {"BOT_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"}
+            "owner/repo", {"TEND_BOT_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"}
         )
     assert result.passed is False
     assert "PYPI_TOKEN" in result.message
@@ -447,14 +455,14 @@ def test_repo_secret_allowlist_unexpected_org() -> None:
     with (
         patch(
             "tend.checks._gh",
-            return_value=_make_completed('["BOT_TOKEN"]\n'),
+            return_value=_make_completed('["TEND_BOT_TOKEN"]\n'),
         ),
         patch(
             "tend.checks._list_org_secrets",
-            return_value=({"BOT_TOKEN", "NPM_TOKEN"}, False),
+            return_value=({"TEND_BOT_TOKEN", "NPM_TOKEN"}, False),
         ),
     ):
-        result = check_repo_secret_allowlist("owner/repo", {"BOT_TOKEN"})
+        result = check_repo_secret_allowlist("owner/repo", {"TEND_BOT_TOKEN"})
     assert result.passed is False
     assert "NPM_TOKEN" in result.message
     assert "org-level" in result.message
@@ -465,14 +473,14 @@ def test_repo_secret_allowlist_unexpected_both() -> None:
     with (
         patch(
             "tend.checks._gh",
-            return_value=_make_completed('["BOT_TOKEN","PYPI_TOKEN"]\n'),
+            return_value=_make_completed('["TEND_BOT_TOKEN","PYPI_TOKEN"]\n'),
         ),
         patch(
             "tend.checks._list_org_secrets",
             return_value=({"NPM_TOKEN"}, False),
         ),
     ):
-        result = check_repo_secret_allowlist("owner/repo", {"BOT_TOKEN"})
+        result = check_repo_secret_allowlist("owner/repo", {"TEND_BOT_TOKEN"})
     assert result.passed is False
     assert "repo-level" in result.message
     assert "org-level" in result.message
@@ -485,7 +493,7 @@ def test_repo_secret_allowlist_org_allowed() -> None:
     with (
         patch(
             "tend.checks._gh",
-            return_value=_make_completed('["BOT_TOKEN"]\n'),
+            return_value=_make_completed('["TEND_BOT_TOKEN"]\n'),
         ),
         patch(
             "tend.checks._list_org_secrets",
@@ -493,7 +501,7 @@ def test_repo_secret_allowlist_org_allowed() -> None:
         ),
     ):
         result = check_repo_secret_allowlist(
-            "owner/repo", {"BOT_TOKEN", "CODECOV_TOKEN"}
+            "owner/repo", {"TEND_BOT_TOKEN", "CODECOV_TOKEN"}
         )
     assert result.passed is True
 
@@ -503,11 +511,11 @@ def test_repo_secret_allowlist_org_forbidden() -> None:
     with (
         patch(
             "tend.checks._gh",
-            return_value=_make_completed('["BOT_TOKEN"]\n'),
+            return_value=_make_completed('["TEND_BOT_TOKEN"]\n'),
         ),
         patch("tend.checks._list_org_secrets", return_value=(None, True)),
     ):
-        result = check_repo_secret_allowlist("owner/repo", {"BOT_TOKEN"})
+        result = check_repo_secret_allowlist("owner/repo", {"TEND_BOT_TOKEN"})
     assert result.passed is True
     assert "admin:org" in result.message
 
@@ -518,13 +526,13 @@ def test_repo_secret_allowlist_with_extra_allowed() -> None:
         patch(
             "tend.checks._gh",
             return_value=_make_completed(
-                '["BOT_TOKEN","CLAUDE_CODE_OAUTH_TOKEN","CODECOV_TOKEN"]\n'
+                '["TEND_BOT_TOKEN","CLAUDE_CODE_OAUTH_TOKEN","CODECOV_TOKEN"]\n'
             ),
         ),
         patch("tend.checks._list_org_secrets", return_value=(set(), False)),
     ):
         result = check_repo_secret_allowlist(
-            "owner/repo", {"BOT_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN", "CODECOV_TOKEN"}
+            "owner/repo", {"TEND_BOT_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN", "CODECOV_TOKEN"}
         )
     assert result.passed is True
 
@@ -535,7 +543,7 @@ def test_repo_secret_allowlist_empty_repo() -> None:
         patch("tend.checks._gh", return_value=_make_completed("[]\n")),
         patch("tend.checks._list_org_secrets", return_value=(set(), False)),
     ):
-        result = check_repo_secret_allowlist("owner/repo", {"BOT_TOKEN"})
+        result = check_repo_secret_allowlist("owner/repo", {"TEND_BOT_TOKEN"})
     assert result.passed is True
 
 
@@ -544,19 +552,19 @@ def test_repo_secret_allowlist_api_error() -> None:
         "tend.checks._gh",
         return_value=_make_completed(returncode=1, stderr="HTTP 403"),
     ):
-        result = check_repo_secret_allowlist("owner/repo", {"BOT_TOKEN"})
+        result = check_repo_secret_allowlist("owner/repo", {"TEND_BOT_TOKEN"})
     assert result.passed is None
 
 
 def test_repo_secret_allowlist_no_gh() -> None:
     with patch("tend.checks._gh", return_value=None):
-        result = check_repo_secret_allowlist("owner/repo", {"BOT_TOKEN"})
+        result = check_repo_secret_allowlist("owner/repo", {"TEND_BOT_TOKEN"})
     assert result.passed is None
 
 
 def test_repo_secret_allowlist_bad_json() -> None:
     with patch("tend.checks._gh", return_value=_make_completed("not json")):
-        result = check_repo_secret_allowlist("owner/repo", {"BOT_TOKEN"})
+        result = check_repo_secret_allowlist("owner/repo", {"TEND_BOT_TOKEN"})
     assert result.passed is None
 
 

--- a/generator/tests/test_config_edge_cases.py
+++ b/generator/tests/test_config_edge_cases.py
@@ -44,7 +44,7 @@ def test_bot_name_only(tmp_path: Path) -> None:
     assert cfg.bot_name == "my-bot"
     assert cfg.model == "opus"
     assert cfg.protected_branches == []
-    assert cfg.bot_token_secret == "BOT_TOKEN"
+    assert cfg.bot_token_secret == "TEND_BOT_TOKEN"
     assert cfg.claude_token_secret == "CLAUDE_CODE_OAUTH_TOKEN"
     assert cfg.setup == []
     assert cfg.workflows == {}

--- a/generator/tests/test_integration.py
+++ b/generator/tests/test_integration.py
@@ -303,7 +303,7 @@ def _fake_gh_all_pass(*args: str, **kwargs: str) -> subprocess.CompletedProcess[
     if "collaborators" in url:
         return _make_completed("write\n")
     if "secrets" in url:
-        return _make_completed('["BOT_TOKEN","CLAUDE_CODE_OAUTH_TOKEN"]\n')
+        return _make_completed('["TEND_BOT_TOKEN","CLAUDE_CODE_OAUTH_TOKEN"]\n')
     return _make_completed(returncode=1)
 
 
@@ -347,7 +347,7 @@ def test_check_full_pipeline_branch_not_protected(
         if "collaborators" in url:
             return _make_completed("write\n")
         if "secrets" in url:
-            return _make_completed('["BOT_TOKEN","CLAUDE_CODE_OAUTH_TOKEN"]\n')
+            return _make_completed('["TEND_BOT_TOKEN","CLAUDE_CODE_OAUTH_TOKEN"]\n')
         return _make_completed(returncode=1)
 
     with (

--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -563,7 +563,7 @@ copy the bot's token to the repo secret, and verify:
 
 ```bash
 gh auth switch --user <maintainer>
-gh auth token --user <bot-name> | gh secret set BOT_TOKEN --repo "$REPO"
+gh auth token --user <bot-name> | gh secret set TEND_BOT_TOKEN --repo "$REPO"
 gh secret list --repo "$REPO"
 ```
 
@@ -636,7 +636,7 @@ line picks the row that matches the chosen harness):
 - [ ] Bot account: `<bot-name>` exists on GitHub
 - [ ] Harness auth (claude): `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` secret set
 - [ ] Harness auth (codex): `CODEX_AUTH_JSON` (subscription, recommended) or `OPENAI_API_KEY` secret set
-- [ ] Bot token: `BOT_TOKEN` secret set with `repo`+`workflow`+`notifications`+`write:discussion`+`gist`+`user` scopes
+- [ ] Bot token: `TEND_BOT_TOKEN` secret set with `repo`+`workflow`+`notifications`+`write:discussion`+`gist`+`user` scopes
 - [ ] Bot access: repo collaborator with write access, invitation accepted
 - [ ] Bot bio: profile bio reflects the authorization stance
 - [ ] Committed (push requires explicit permission)

--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -121,7 +121,7 @@ if [ -z "$GIST_ID" ]; then
   #   Secret gist. Append-only log of below-threshold findings used for gate evaluation.
   GIST_URL=$(gh gist create --desc "$GIST_DESC" /tmp/gist-seed/findings.md)
   if [ -z "$GIST_URL" ]; then
-    echo "ERROR: gh gist create failed — BOT_TOKEN likely lacks 'gist' scope (see install-tend)" >&2
+    echo "ERROR: gh gist create failed — TEND_BOT_TOKEN likely lacks 'gist' scope (see install-tend)" >&2
     exit 1
   fi
   GIST_ID=$(basename "$GIST_URL")
@@ -133,7 +133,7 @@ else
 fi
 ```
 
-The BOT_TOKEN needs `gist` scope (see install-tend). Without it, `gh gist create` fails with `403 Forbidden` and the skill exits before posting a broken tracking-issue comment.
+The TEND_BOT_TOKEN needs `gist` scope (see install-tend). Without it, `gh gist create` fails with `403 Forbidden` and the skill exits before posting a broken tracking-issue comment.
 
 ### Reading historical evidence
 


### PR DESCRIPTION
## Summary

- Rename the generator's default `bot_token_secret` from `BOT_TOKEN` to `TEND_BOT_TOKEN`. It was the only default without a vendor/product prefix, easy to collide with an existing repo secret.
- Adopters with an explicit `secrets.bot_token` override (e.g. `WORKTRUNK_BOT_TOKEN`, `PRQL_BOT_GITHUB_TOKEN`) are unaffected.
- Updates docs (README, `docs/tend.example.yaml`, TODO), the install-tend setup steps + checklist, the review-reviewers skill prose, and the hand-written `.github/workflows/review-reviewers.yaml`.
- Tests + regtest fixtures regenerated.
- Generated `.github/workflows/tend-*.yaml` are intentionally **not** touched — they pick up the new default at the next release + nightly regen, per the project rule that the action ref pins to the released generator version.

## Adopter migration

Repos using the default need to add a `TEND_BOT_TOKEN` repo secret (same value as the existing `BOT_TOKEN`) before the next nightly regen swaps the workflow references. The three affected consumers (`max-sixty/tend`, `max-sixty/cargo-affected`, `numbagg/numbagg`) already have the new secret set; `BOT_TOKEN` can be deleted some days after each regen lands.

## Test plan

- [x] `uv run pytest tests/` — 230 passing
- [x] `pre-commit run --all-files` — clean
- [ ] First nightly run on a consumer after release picks up the new default and the regenerated workflow references `secrets.TEND_BOT_TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)