### PR TITLE
fix(codex-action): export CLAUDE_PLUGIN_ROOT for plugin-bundled scripts

### DIFF
--- a/codex/action.yaml
+++ b/codex/action.yaml
@@ -210,12 +210,24 @@ runs:
     # up) registers tend-ci-runner as a local-source plugin. We add that
     # marketplace, then `codex plugin add` installs the plugin so its skills
     # become discoverable by `codex exec`.
+    #
+    # We export `CLAUDE_PLUGIN_ROOT` to the install location so skills can
+    # resolve `${CLAUDE_PLUGIN_ROOT}/scripts/...` paths the same way they do
+    # under Claude Code (which sets this variable natively). One variable
+    # name across harnesses — skills stay harness-agnostic.
     - name: Install tend-ci-runner plugin
       shell: bash
       run: |
         MARKETPLACE_ROOT="$(realpath "${{ github.action_path }}/..")"
         codex plugin marketplace add "$MARKETPLACE_ROOT"
-        codex plugin add tend-ci-runner@tend
+        INSTALL_OUTPUT=$(codex plugin add tend-ci-runner@tend)
+        echo "$INSTALL_OUTPUT"
+        PLUGIN_ROOT=$(awk -F': ' '/^Installed plugin root: /{print $2}' <<<"$INSTALL_OUTPUT")
+        if [ -z "$PLUGIN_ROOT" ] || [ ! -d "$PLUGIN_ROOT" ]; then
+          echo "::error::Failed to parse 'Installed plugin root: <path>' from codex plugin add output"
+          exit 1
+        fi
+        echo "CLAUDE_PLUGIN_ROOT=$PLUGIN_ROOT" >> "$GITHUB_ENV"
         codex plugin list 2>/dev/null || true
 
     # Stage AGENTS.md into ~/.codex so it loads alongside any AGENTS.md


### PR DESCRIPTION
## Summary

Under the Codex harness, skills calling `${CLAUDE_PLUGIN_ROOT}/scripts/...` (review-reviewers, review-runs, nightly) expanded to `/scripts/...` and failed — Claude Code sets `CLAUDE_PLUGIN_ROOT` natively, Codex didn't.

`codex plugin add` stages the tend-ci-runner plugin under `$CODEX_HOME/plugins/cache/tend/tend-ci-runner/<version>/` (with `scripts/` and `skills/` adjacent, mirroring the source repo) and prints `Installed plugin root: <path>` on stdout. Parse that line, validate the directory exists, and export `CLAUDE_PLUGIN_ROOT` via `$GITHUB_ENV` so subsequent steps (including `codex exec`) see it. Codex's default `shell_environment_policy.inherit = "all"` then propagates it through to spawned shell tools unchanged.

Same variable name across harnesses — skills stay harness-agnostic. No per-skill branching, no parallel `${CODEX_PLUGIN_ROOT}`. Caught as a blocker on #537.

## Why parse the CLI output instead of constructing the path

The path includes the plugin version (`0.1.0` today), no `current` symlink. Parsing `codex plugin add`'s own announcement makes the action robust to future schema changes (version bumps, marketplace renames, cache layout) without re-engineering each time.

## Test plan

- [x] Verified empirically against pinned `@openai/codex@0.131.0-alpha.22`: `codex plugin add tend-ci-runner@tend` prints the install root, `$CLAUDE_PLUGIN_ROOT/scripts/list-recent-runs.sh` exists at the parsed path, parsing is idempotent on re-add.
- [x] `pre-commit run --files codex/action.yaml` passes.
- [x] All 230 generator tests pass.
- [ ] CI smoke (this PR's tend-review run).
