### PR TITLE
chore: release 0.0.23

### DIFF
--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tend"
-version = "0.0.22"
+version = "0.0.23"
 description = "An autonomous junior maintainer for GitHub repos, powered by Claude or OpenAI Codex — reviews PRs, triages issues, fixes CI"
 license = "MIT"
 requires-python = ">=3.11"

--- a/generator/uv.lock
+++ b/generator/uv.lock
@@ -98,7 +98,7 @@ wheels = [
 
 [[package]]
 name = "tend"
-version = "0.0.22"
+version = "0.0.23"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Release 0.0.23. 6 commits since 0.0.22:

- #520 Cut tend's CI over to the Codex harness — tend now dogfoods Codex
- #531 fix(nightly-survey-files): print bucket/count to stderr — keep JSON output uncontaminated
- #536 docs(claude-auth): correct June 15 2026 framing; recommend OAuth for subscribers
- #538 **breaking:** rename default bot-token secret `BOT_TOKEN` → `TEND_BOT_TOKEN`. Adopters using the default must add a `TEND_BOT_TOKEN` repo secret before their next regen (or set `secrets.bot_token` in `.config/tend.yaml` to keep using the old name)
- #539 fix(codex-action): export `CLAUDE_PLUGIN_ROOT` so plugin-bundled scripts resolve under Codex
- #533 chore: regenerate workflows with tend 0.0.22

## Test plan

- [ ] CI green (test, test-worker, lint)
- [ ] After merge: tag `0.0.23`, PyPI publish, `uvx tend@0.0.23 --help` works
- [ ] Regenerate tend's own workflows to `@0.0.23`

Co-authored-by: Claude <noreply@anthropic.com>