### PR TITLE
chore: release 0.0.23

### DIFF
--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tend"
-version = "0.0.22"
+version = "0.0.23"
 description = "An autonomous junior maintainer for GitHub repos, powered by Claude or OpenAI Codex — reviews PRs, triages issues, fixes CI"
 license = "MIT"
 requires-python = ">=3.11"

--- a/generator/uv.lock
+++ b/generator/uv.lock
@@ -98,7 +98,7 @@ wheels = [
 
 [[package]]
 name = "tend"
-version = "0.0.22"
+version = "0.0.23"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Release 0.0.23 — unblocks the review-reviewers Codex migration.

Since 0.0.22:
- #539 — codex-action exports `CLAUDE_PLUGIN_ROOT` so skills using `${CLAUDE_PLUGIN_ROOT}/scripts/...` work unchanged under Codex (the blocker on PR #537)
- #538 — `TEND_BOT_TOKEN` as the default bot-token secret name
- #540 — `install-tend --with-install-test` for pre-merge verification
- #536 — docs(claude-auth) framing for 2026-06-15
- #531 — nightly-survey-files prints bucket/count to stderr
- #520 — tend's own CI flipped to the Codex harness (live; consumer regen moves it forward)

## Test plan

- [ ] CI green (test, test-worker, lint)
- [ ] After merge: tag `0.0.23`, PyPI publish, `uvx tend@0.0.23 --help` works
- [ ] Regenerate main's workflows to `@0.0.23`
- [ ] Regenerate #537's codex workflows to `@0.0.23` and unblock the review-reviewers migration