### PR TITLE
generator: route install-test through _apply_extras

### DIFF
--- a/generator/src/tend/config.py
+++ b/generator/src/tend/config.py
@@ -22,6 +22,9 @@ KNOWN_WORKFLOWS = {
     "weekly",
     "notifications",
     "review-runs",
+    # install-test is opt-in via `tend init --with-install-test` but still
+    # honors workflow_extra / jobs overrides from .config/tend.yaml.
+    "install-test",
 }
 KNOWN_TOP_LEVEL = {
     "bot_name",

--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -1110,5 +1110,8 @@ def generate_all(
         wf = _apply_extras(wf, wf_cfg)
         results.append(wf)
     if with_install_test:
-        results.append(generate_install_test(cfg))
+        wf = generate_install_test(cfg)
+        wf_cfg = cfg.workflows.get("install-test", WorkflowConfig())
+        wf = _apply_extras(wf, wf_cfg)
+        results.append(wf)
     return results

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -1024,6 +1024,27 @@ def test_install_test_workflow_regtest(
     print(wf.content, end="", file=regtest)  # type: ignore[arg-type]
 
 
+def test_install_test_honors_workflow_extras(tmp_path: Path) -> None:
+    """install-test goes through `_apply_extras`, so `workflow_extra` and
+    per-job overrides from .config/tend.yaml take effect (e.g. injecting
+    proxy env vars or pinning runs-on for a self-hosted runner)."""
+    extra = dedent("""\
+        workflows:
+          install-test:
+            workflow_extra:
+              env:
+                HTTPS_PROXY: http://proxy.corp:8080
+            jobs:
+              install-test:
+                runs-on: ubuntu-22.04-large
+    """)
+    cfg = Config.load(_minimal_config(tmp_path, extra))
+    workflows = {wf.filename: wf for wf in generate_all(cfg, with_install_test=True)}
+    data = yaml.safe_load(workflows["tend-install-test.yaml"].content)
+    assert data["env"]["HTTPS_PROXY"] == "http://proxy.corp:8080"
+    assert data["jobs"]["install-test"]["runs-on"] == "ubuntu-22.04-large"
+
+
 def test_codex_action_ref(tmp_path: Path) -> None:
     """Codex workflows reference max-sixty/tend/codex@<release tag>."""
     cfg = Config.load(_minimal_config(tmp_path, "harness: codex"))


### PR DESCRIPTION
## Summary

- `tend-install-test.yaml` was generated outside `generate_all()`'s main loop, so `workflows.install-test.workflow_extra` and `workflows.install-test.jobs` overrides from `.config/tend.yaml` were silently dropped.
- Route the install-test workflow through `_apply_extras` and add `install-test` to `KNOWN_WORKFLOWS` so the config validator accepts the section.
- Concrete impact: an adopter on a corporate-proxy CI couldn't inject `HTTPS_PROXY` env into the install-test job; an adopter on self-hosted runners couldn't override `runs-on`. Now they can.

## Test plan

- [x] `uv run --directory generator pytest` — 242 passed, regtest snapshots unchanged (`_apply_extras` short-circuits when no extras configured)
- [x] `pre-commit run --all-files`
- [x] New regression test `test_install_test_honors_workflow_extras` covers both `workflow_extra` (top-level env) and `jobs.install-test` (per-job override)

🤖 Generated with [Claude Code](https://claude.com/claude-code)