### PR TITLE
fix(stats): stop blacking out the section on transient worker outage

### DIFF
--- a/site/src/components/Stats.astro
+++ b/site/src/components/Stats.astro
@@ -1,7 +1,9 @@
 ---
 // Stat strip — runtime-fetched from api.tend-src.com/activity (the bucket
-// counts). Hidden until the fetch returns non-zero values, so a cold deploy
-// with empty data doesn't render a row of zeros.
+// counts). Hidden only when the fetch itself fails (network or non-OK
+// response); a successful fetch with zero counts still renders, because
+// distinguishing "data is missing" from "data is genuinely zero" matters
+// — a transient worker outage shouldn't silently black out the section.
 //
 // The strip ships with four placeholder cells of the same shape as the real
 // data so the section reserves its natural height before the fetch resolves
@@ -40,14 +42,13 @@
   }
 
   liveData<Activity>("/activity", "stats", (data) => {
-    if (!data) return false;
+    if (!data) return false; // fetch failed — hide rather than render zeros
     const cells = [
       { n: data.prs?.count ?? 0, week: data.prs?.count_this_week ?? 0, label: "PRs" },
       { n: data.reviews?.count ?? 0, week: data.reviews?.count_this_week ?? 0, label: "reviews" },
       { n: data.comments?.count ?? 0, week: data.comments?.count_this_week ?? 0, label: "comments" },
       { n: data.issues?.count ?? 0, week: data.issues?.count_this_week ?? 0, label: "issues" },
     ];
-    if (cells.every((c) => !c.n)) return false; // all zero — hide entirely
 
     const strip = document.querySelector("[data-stat-strip]");
     if (!strip) return false;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -285,32 +285,24 @@ async function serveCached<T>(
   return refreshAndCache(cacheKey, env, ctx, opts);
 }
 
-// Run the configured refresh and shape it into a Response stamped with
-// its freshness budget. On any unexpected failure return the empty
-// payload tagged with the shorter fallback budget so a transient outage
-// clears quickly instead of wedging the cache.
-async function freshResponse<T>(env: Env, opts: CacheOpts<T>): Promise<Response> {
-  let fresh: T;
-  let ttlSeconds = opts.ttl.ok;
-  try {
-    fresh = await opts.refresh();
-  } catch (e) {
-    console.error(`refresh failed for ${opts.cacheKeyPath}:`, e);
-    fresh = opts.empty();
-    ttlSeconds = opts.ttl.fallback;
-  }
-  return jsonResponse(fresh, env, ttlSeconds);
-}
-
 // Cold-cache path: the caller is waiting on this, so we return the fresh
-// Response and let the cache put run via ctx.waitUntil.
+// Response and let the cache put run via ctx.waitUntil. On refresh
+// failure return the empty payload tagged with the shorter fallback
+// budget — the caller has nothing else to render, so a brief outage
+// degrades to an empty section instead of wedging the request.
 async function refreshAndCache<T>(
   cacheKey: Request,
   env: Env,
   ctx: ExecutionContext,
   opts: CacheOpts<T>,
 ): Promise<Response> {
-  const response = await freshResponse(env, opts);
+  let response: Response;
+  try {
+    response = jsonResponse(await opts.refresh(), env, opts.ttl.ok);
+  } catch (e) {
+    console.error(`cold refresh failed for ${opts.cacheKeyPath}:`, e);
+    response = jsonResponse(opts.empty(), env, opts.ttl.fallback);
+  }
   ctx.waitUntil(caches.default.put(cacheKey, response.clone()));
   return response;
 }
@@ -318,8 +310,10 @@ async function refreshAndCache<T>(
 // Stale-hit path: coalesce concurrent refreshes by bumping the cached
 // entry's stale-at forward before running the refresh. Concurrent
 // stale-hits arriving within REFRESH_GRACE_MS read the bumped entry as
-// fresh and skip starting their own refresh. The puts are sequenced —
-// bumped first, then the fresh result — so the fresh result always wins.
+// fresh and skip starting their own refresh. On refresh failure keep the
+// bumped cached entry — a viewer keeps seeing the previous (slightly
+// stale) data instead of an empty payload overwriting it for the
+// fallback TTL, which would briefly black out every viewer.
 async function coalesceAndRefresh<T>(
   cacheKey: Request,
   cached: Response,
@@ -332,7 +326,15 @@ async function coalesceAndRefresh<T>(
   });
   bumped.headers.set(STALE_AT_HEADER, String(Date.now() + REFRESH_GRACE_MS));
   await caches.default.put(cacheKey, bumped);
-  await caches.default.put(cacheKey, await freshResponse(env, opts));
+  try {
+    const fresh = jsonResponse(await opts.refresh(), env, opts.ttl.ok);
+    await caches.default.put(cacheKey, fresh);
+  } catch (e) {
+    console.error(
+      `background refresh failed for ${opts.cacheKeyPath}; keeping stale entry:`,
+      e,
+    );
+  }
 }
 
 // A cached entry past this instant (epoch ms, from STALE_AT_HEADER) is
@@ -733,4 +735,6 @@ export const __test = {
   findBotReviewUrl,
   findBotCommentUrl,
   isStale,
+  coalesceAndRefresh,
+  STALE_AT_HEADER,
 };

--- a/worker/test/worker.test.ts
+++ b/worker/test/worker.test.ts
@@ -616,6 +616,80 @@ describe("getConsumers", () => {
   });
 });
 
+describe("coalesceAndRefresh (background refresh on stale-hit)", () => {
+  // Fake the colo cache so we can observe what gets written on success vs
+  // failure. caches.default is Cloudflare-specific; in node it's undefined.
+  function fakeCache() {
+    const store = new Map<string, Response>();
+    return {
+      store,
+      api: {
+        async match(req: Request) {
+          return store.get(req.url)?.clone();
+        },
+        async put(req: Request, resp: Response) {
+          store.set(req.url, resp.clone());
+        },
+      } as unknown as Cache,
+    };
+  }
+
+  it("keeps the previous cached entry alive when the refresh throws (does not overwrite with empty)", async () => {
+    const { __test } = await import("../src/index");
+    const { store, api } = fakeCache();
+    (globalThis as unknown as { caches: CacheStorage }).caches = {
+      default: api,
+    } as unknown as CacheStorage;
+
+    const cacheKey = new Request("https://api.example/activity");
+    const goodBody = JSON.stringify({ prs: { count: 994 } });
+    const stale = new Response(goodBody, {
+      headers: { "Content-Type": "application/json" },
+    });
+    store.set(cacheKey.url, stale);
+
+    const env = { ALLOWED_ORIGIN: "*" } as unknown as Parameters<typeof __test.coalesceAndRefresh>[2];
+    await __test.coalesceAndRefresh(cacheKey, stale, env, {
+      cacheKeyPath: "/activity",
+      ttl: { ok: 300, fallback: 30 },
+      refresh: async () => {
+        throw new Error("github down");
+      },
+      empty: () => ({ prs: { count: 0 } }),
+    });
+
+    const entry = store.get(cacheKey.url);
+    expect(entry).toBeDefined();
+    expect(await entry!.text()).toBe(goodBody); // unchanged — empty payload did NOT win
+  });
+
+  it("overwrites the cached entry with the fresh response on a successful refresh", async () => {
+    const { __test } = await import("../src/index");
+    const { store, api } = fakeCache();
+    (globalThis as unknown as { caches: CacheStorage }).caches = {
+      default: api,
+    } as unknown as CacheStorage;
+
+    const cacheKey = new Request("https://api.example/activity");
+    const stale = new Response(JSON.stringify({ prs: { count: 1 } }), {
+      headers: { "Content-Type": "application/json" },
+    });
+    store.set(cacheKey.url, stale);
+
+    const env = { ALLOWED_ORIGIN: "*" } as unknown as Parameters<typeof __test.coalesceAndRefresh>[2];
+    await __test.coalesceAndRefresh(cacheKey, stale, env, {
+      cacheKeyPath: "/activity",
+      ttl: { ok: 300, fallback: 30 },
+      refresh: async () => ({ prs: { count: 999 } }),
+      empty: () => ({ prs: { count: 0 } }),
+    });
+
+    const entry = store.get(cacheKey.url);
+    const body = JSON.parse(await entry!.text()) as { prs: { count: number } };
+    expect(body.prs.count).toBe(999);
+  });
+});
+
 describe("isStale (stale-while-revalidate decision)", () => {
   const now = 1_700_000_000_000;
 


### PR DESCRIPTION
The "to date" stats on tend-src.com were intermittently disappearing. Two cooperating bugs:

**Worker** (`worker/src/index.ts`): the stale-while-revalidate background refresh, on GitHub fanout failure, overwrote the cached entry with an empty (all-zeros) payload tagged with the 30 s fallback TTL. Every viewer in that window saw zeros.

**Stats.astro** (`site/src/components/Stats.astro`): treated "all four counts are zero" as a signal to hide the section entirely (`display: none`), so the zero payload turned into a blacked-out section rather than zeros on screen.

Net effect: a single failed background refresh blacked out the section for ~30 s for everyone, with no console signal to notice.

## Changes

- `coalesceAndRefresh` (stale-while-revalidate path) now logs and keeps the previously-cached entry alive on refresh failure. `refreshAndCache` (cold-cache path) keeps the empty-on-error behavior — the caller has nothing else to render.
- Stats render now only hides when `data === null` (fetch failed). A successful fetch with zero counts renders four "0" cells. Distinguishes "data missing" from "data is zero".
- Two regression tests for `coalesceAndRefresh` (refresh success overwrites; refresh failure preserves prior entry).

## Test plan

- [x] `npm test` in `worker/` — 21/21 pass
- [x] `tsc --noEmit` in `worker/` — clean
- [x] `astro build` in `site/` — clean
- [x] `pre-commit run --files …` — clean
- [x] Browser check on dev server: stats render normally; manual simulation confirms `null` hides and zeros render zeros
