### PR TITLE
site: simplify "currently tending" to a prose repo list

### DIFF
--- a/site/src/components/CurrentlyTending.astro
+++ b/site/src/components/CurrentlyTending.astro
@@ -9,14 +9,10 @@
 
 <script>
   import { fetchJson, liveData } from "../lib/api";
-  import { elapsedTime, relativeTime } from "../lib/time";
+  import { relativeTime } from "../lib/time";
 
   interface Run {
     repo: string;
-    workflow: string;
-    display_title?: string;
-    pr_number?: number;
-    started_at: string;
   }
   interface Bucket {
     recent?: Array<{ at: string }>;
@@ -34,10 +30,23 @@
     return i === -1 ? repo : repo.slice(i + 1);
   }
 
-  function paint(el: HTMLElement, state: "live" | "idle", text: string): HTMLElement {
+  // Up to `cap` names with Oxford-comma joining, then "and N other(s)" for the
+  // tail. The expensive detail (workflow, target, elapsed) lives in the
+  // Activity feed below; this line conveys breadth.
+  function formatList(items: string[], cap: number): string {
+    if (items.length === 1) return items[0];
+    if (items.length === 2) return `${items[0]} and ${items[1]}`;
+    if (items.length <= cap) {
+      return `${items.slice(0, -1).join(", ")}, and ${items.at(-1)}`;
+    }
+    const shown = items.slice(0, cap);
+    const remaining = items.length - cap;
+    return `${shown.join(", ")}, and ${remaining} other${remaining === 1 ? "" : "s"}`;
+  }
+
+  function paint(el: HTMLElement, state: "live" | "idle", text: string): void {
     el.dataset.pulse = state;
     el.textContent = text;
-    return el;
   }
 
   liveData<{ currently_tending?: Run[] }>(
@@ -46,26 +55,10 @@
     async (data, el) => {
       const runs = data?.currently_tending ?? [];
       if (runs.length > 0) {
-        const r = runs[0];
-        const workflow = r.workflow.replace(/^tend-/, "");
-        const detail = r.pr_number != null && r.display_title
-          ? `${workflow} · #${r.pr_number} ${r.display_title}`
-          : r.display_title
-            ? `${workflow} · ${r.display_title}`
-            : workflow;
-        const more = runs.length > 1 ? ` (+${runs.length - 1} more)` : "";
-        const startedMs = Date.parse(r.started_at);
-        const buildText = () => {
-          const elapsed = elapsedTime(r.started_at);
-          const repo = shortRepo(r.repo);
-          return elapsed
-            ? `currently tending ${repo} · ${detail} · ${elapsed}${more}`
-            : `currently tending ${repo} · ${detail}${more}`;
-        };
-        const label = paint(el, "live", buildText());
-        if (!Number.isNaN(startedMs)) {
-          setInterval(() => { label.textContent = buildText(); }, 1000);
-        }
+        // Dedupe by repo, preserving first-seen order — two concurrent runs
+        // on the same repo (e.g. review + ci-fix) should name it once.
+        const repos = [...new Set(runs.map((r) => shortRepo(r.repo)))];
+        paint(el, "live", `Currently tending ${formatList(repos, 3)}`);
         return true;
       }
 
@@ -78,7 +71,7 @@
       if (!newest) return false;
       const ago = relativeTime(newest);
       if (!ago) return false;
-      paint(el, "idle", `last tended ${ago}`);
+      paint(el, "idle", `Last tended ${ago}`);
       return true;
     },
   );


### PR DESCRIPTION
The "currently tending" line in the hero was jamming repo, workflow, PR#, title, elapsed time, and "+N more" together with `·` separators, so the segments all looked the same and the PR title in particular swallowed the structure. Example before:

> ● currently tending worktrunk · review · #2774 feat(commit): experimental project-level commit-message guidance · 2:08 (+1 more)

After: a prose list of repo names. Up to three with Oxford-comma joining, then `and N other(s)` for the tail. The brand phrase carries the whole line.

```
● Currently tending worktrunk
● Currently tending worktrunk and cli
● Currently tending worktrunk, cli, and tend
● Currently tending worktrunk, cli, tend, and 1 other
● Currently tending worktrunk, cli, tend, and 5 others
```

Idle case unchanged in shape, now sentence-case: `● Last tended 3 min ago`.

Per-run detail (workflow, PR#, title, elapsed) was duplicating the Activity feed directly below; that's where to look for specifics. The pulse animation continues to carry the "alive right now" signal — the panel polls once on load, so the previous ticking timer wasn't reflecting fresh data between fetches anyway.

Other notes:

- Dedupes by repo, so two concurrent runs on one repo (e.g. review + ci-fix) name it once.
- Click target unchanged — link still scrolls to `#recent-activity`.
