### PR TITLE
site: refresh "currently tending" on a 30s timer

### DIFF
--- a/site/src/components/CurrentlyTending.astro
+++ b/site/src/components/CurrentlyTending.astro
@@ -74,5 +74,6 @@
       paint(el, "idle", `Last tended ${ago}`);
       return true;
     },
+    30_000,
   );
 </script>

--- a/site/src/lib/api.ts
+++ b/site/src/lib/api.ts
@@ -24,13 +24,26 @@ export async function fetchJson<T>(path: string): Promise<T | null> {
 // true) or `"hidden"` (false). CSS uses these states to reserve layout space
 // during loading, fade content in on success, and collapse on failure — so
 // the page doesn't shift when the fetch resolves.
+//
+// Pass `intervalMs` to keep refetching on a timer — without it the section is
+// frozen as of page load, which lies after the data changes (a "live" pulse
+// kept animating long after the underlying job finished, etc.). Refreshes
+// re-run `render`, so the section can transition between live and idle states
+// across the page's lifetime.
 export async function liveData<T>(
   path: string,
   sectionId: string,
   render: (data: T | null, el: HTMLElement) => boolean | Promise<boolean>,
+  intervalMs?: number,
 ): Promise<void> {
   const el = document.getElementById(sectionId);
   if (!el) return;
-  const shown = await render(await fetchJson<T>(path), el);
-  el.dataset.state = shown ? "loaded" : "hidden";
+  const tick = async () => {
+    const shown = await render(await fetchJson<T>(path), el);
+    el.dataset.state = shown ? "loaded" : "hidden";
+  };
+  await tick();
+  if (intervalMs && intervalMs > 0) {
+    setInterval(tick, intervalMs);
+  }
 }


### PR DESCRIPTION
`liveData` was fetch-once, so every runtime-fetched section froze as of page load. For "currently tending" that meant the pulse animation (`now-pulse … infinite`) kept running for hours after the underlying jobs finished — leave the tab open at 2pm with three jobs running and at 8pm it still says `● Currently tending worktrunk, cli, and tend` with the dot pulsing. The idle line had the mirror problem: "Last tended 3 min ago" stayed "3 min ago" indefinitely.

`liveData` now takes an optional `intervalMs`. When set, it refetches on a timer and re-runs `render`, so the section transitions between live and idle states over the page's lifetime. `CurrentlyTending` opts in at 30s; a refresh that finds no in-flight runs falls through to the idle path, which flips `data-pulse` to `idle` and the CSS stops the pulse.

Left for separate follow-ups (each has its own wrinkle):

- **Activity feed** has the same staleness plus a worse variant — its `setInterval(updateTendingTimes, 1000)` keeps incrementing a finished job's elapsed timer. Naive refresh would also stack a new interval per tick; the interval needs guarding first.
- **Stats** goes stale slowly and has no pulse, so lower urgency — could opt into the same `intervalMs` with a longer period.

Verification: `tsc --noEmit` and `npm run build` clean. Not visually confirmed in a running browser (Chrome extension disconnected mid-session) — worth an eyeball of an actual live→idle tick.
