### PR TITLE
site: refresh Stats and Activity on a timer

### DIFF
--- a/site/src/components/Activity.astro
+++ b/site/src/components/Activity.astro
@@ -198,9 +198,12 @@ const MAX_ROWS = 12;
       ul.appendChild(li);
     }
 
-    if (top.some((r) => r.kind === "tending")) {
-      setInterval(updateTendingTimes, 1000);
-    }
     return true;
-  });
+  }, 60_000);
+
+  // One ticker for the lifetime of the page — it no-ops when no tending
+  // rows are present, so it costs a cheap querySelectorAll per second. It
+  // must live outside the render callback: liveData re-runs that callback
+  // on every refresh, and a per-render setInterval would stack.
+  setInterval(updateTendingTimes, 1000);
 </script>

--- a/site/src/components/Stats.astro
+++ b/site/src/components/Stats.astro
@@ -75,5 +75,5 @@
       strip.appendChild(div);
     }
     return true;
-  });
+  }, 300_000);
 </script>


### PR DESCRIPTION
Follow-up to #549, which taught `liveData` to refetch on a timer but only opted in `CurrentlyTending`. `Stats` and the `Activity` feed had the same fetch-once staleness:

- "to date" totals froze at page load and never moved while the tab stayed open.
- A finished tending job's elapsed timer in the Activity feed kept incrementing forever, because the row was never refetched and replaced by its settled representation.

## Changes

- **Stats** — opt into `intervalMs` at 5 min. Render is already idempotent (`replaceChildren`), no structural change needed. Slow-moving and no pulse, so a long period is fine.
- **Activity** — opt in at 60s, and hoist `setInterval(updateTendingTimes, 1000)` out of the render callback to a single module-level ticker. The old per-render `setInterval` would stack a new 1s interval on every refresh; the hoisted ticker no-ops when no tending rows exist, so always-on is trivially cheap. The 60s refetch is what actually fixes the forever-ticking timer — a completed job drops out of `/currently-tending` and re-renders as a settled `pr`/`review` row (or ages out).

## Transient-outage note

Covered by #547: the worker's stale-while-revalidate path preserves the last good cached entry on a GitHub fanout failure, so a client refetch during a blip gets stale-but-valid data (HTTP 200, real numbers), not `null`. Only a true worker-down returns `null` and hides the section — and there the refresh self-heals on the next tick, whereas fetch-once stayed hidden until manual reload. Strictly better, not a regression.

## Verification

`tsc --noEmit` and `npm run build` clean. Not visually confirmed in a running browser (Chrome extension disconnected this session) — worth an eyeball of an actual feed refresh settling a finished job, alongside the same outstanding check for #549.
