### PR TITLE
debug-tend-run: support Codex logs; instruct Codex to read skills in full

### DIFF
--- a/codex/agents-tail.md
+++ b/codex/agents-tail.md
@@ -1,17 +1,24 @@
 ## Skills (Codex-specific)
 
-The `tend-ci-runner` plugin is installed; its skills (`review`,
+The `tend-ci-runner` plugin is installed. Its skills (`review`,
 `triage`, `ci-fix`, `nightly`, `weekly`, `notifications`,
 `review-runs`, `running-in-ci`, `review-reviewers`) are invocable
 via `$<skill-name>` mentions in prompts.
 
-ALWAYS load `$running-in-ci` first when handling any workflow — it
-covers CI security rules, polling conventions, and comment-formatting
-guidance. Other skills depend on it.
+**Read each tend skill in full.** When you open a `tend-ci-runner`
+`SKILL.md`, read the entire file with `cat`. Do not read a prefix with
+`sed -n '1,Np'` or `head`. These skills are short, and their trailing
+sections carry load-bearing security, dedup, and CI-polling rules. A
+prefix read silently drops those and produces wrong behavior. This
+overrides any general "read only enough" guidance for tend skills.
+
+ALWAYS read `$running-in-ci` first (in full) when handling any
+workflow. It covers CI security rules, polling conventions, and
+comment-formatting guidance. Other skills depend on it.
 
 Repo-local skills live under `.claude/skills/<name>/SKILL.md` in the
 adopter's repo (e.g. `running-tend`). The `running-in-ci` skill tells
-you when to load them.
+you when to read them; read those in full too.
 
 ## Tooling
 

--- a/plugins/install-tend/skills/debug-tend-run/SKILL.md
+++ b/plugins/install-tend/skills/debug-tend-run/SKILL.md
@@ -6,7 +6,8 @@ description: Investigates a specific tend GitHub Actions run by downloading its 
 # Debug Tend Run
 
 Investigate what tend did during a GitHub Actions run by downloading and
-parsing its session log artifacts.
+parsing its session log artifacts. Works for both supported harnesses
+(Claude and Codex); the artifact name distinguishes them.
 
 ## Identify the run
 
@@ -35,17 +36,26 @@ gh run list -R "$REPO" --branch "$HEAD" --limit 10 \
 
 ## Download session logs
 
-Session logs are uploaded as artifacts named `claude-session-logs*` (the name
-is set by `claude-code-action`, which tend wraps). Each artifact contains one
-or more JSONL files — one per agent session in that run.
+The artifact name identifies the harness:
+
+- `claude-session-logs*` — Claude harness (`claude-code-action` wraps tend)
+- `codex-session-logs-*` — Codex harness (`max-sixty/tend/codex`)
 
 ```bash
 RUN_ID=<run-id>
-gh run download "$RUN_ID" -R "$REPO" --pattern 'claude-session-logs*' --dir /tmp/session-logs/"$RUN_ID"/
+DEST=/tmp/session-logs/$RUN_ID
+gh run download "$RUN_ID" -R "$REPO" --pattern '*session-logs*' --dir "$DEST"
+ls "$DEST"  # confirm claude- or codex-
+FILE=$(find "$DEST" -name '*.jsonl' | head -1)
+echo "$FILE"
 ```
 
-If no artifacts exist, the run either had no agent session or the session was
-too short to produce logs. Check the run's console output as a fallback:
+Claude artifacts hold flat JSONL files (one per agent session). Codex
+artifacts store the rollout at `sessions/YYYY/MM/DD/rollout-*.jsonl`
+plus `projects/token-usage.json`; one rollout per session.
+
+If no artifacts exist, the run either had no agent session or ended before
+logs were uploaded. Fall back to console output:
 
 ```bash
 gh run view "$RUN_ID" -R "$REPO" --log-failed
@@ -53,79 +63,15 @@ gh run view "$RUN_ID" -R "$REPO" --log-failed
 
 ## Parse session logs
 
-Each JSONL line has a `type` field. The main message types are `user` and
-`assistant` (with `.message.content`). Other types (`system`, `progress`,
-`queue-operation`, `last-prompt`) carry metadata — ignore them for most
-debugging.
+The JSONL schema differs by harness. Open the reference matching the
+artifact name and follow its recipes:
 
-### Overview — what happened
+- `claude-session-logs*` → [`references/claude-logs.md`](references/claude-logs.md)
+- `codex-session-logs-*` → [`references/codex-logs.md`](references/codex-logs.md)
 
-Start with a high-level trace of the session:
-
-```bash
-FILE=/tmp/session-logs/$RUN_ID/<session>.jsonl
-
-# Skills loaded
-jq -r 'select(.type == "assistant") | .message.content[]? |
-  select(.type == "tool_use" and .name == "Skill") |
-  .input.skill' "$FILE"
-
-# Tool calls in order
-jq -r 'select(.type == "assistant") | .message.content[]? |
-  select(.type == "tool_use") |
-  "\(.name): \(.input | tostring | .[0:120])"' "$FILE"
-
-# Assistant text (reasoning and responses)
-jq -r 'select(.type == "assistant") | .message.content[]? |
-  select(.type == "text") | .text' "$FILE"
-```
-
-### Targeted queries
-
-```bash
-# What the bot was told (user messages including injected prompts)
-jq -r 'select(.type == "user") |
-  .message.content | if type == "string" then . else
-  [.[]? | select(.type == "text") | .text] | join("\n") end' "$FILE"
-
-# Bash commands executed
-jq -r 'select(.type == "assistant") | .message.content[]? |
-  select(.type == "tool_use" and .name == "Bash") |
-  .input.command' "$FILE"
-
-# Tool results (what the bot saw back)
-jq -r 'select(.type == "user") | .message.content[]? |
-  select(.type == "tool_result") |
-  "\(.tool_use_id): \(.content | tostring | .[0:200])"' "$FILE"
-
-# Files read
-jq -r 'select(.type == "assistant") | .message.content[]? |
-  select(.type == "tool_use" and .name == "Read") |
-  .input.file_path' "$FILE"
-
-# Files written or edited
-jq -r 'select(.type == "assistant") | .message.content[]? |
-  select(.type == "tool_use" and (.name == "Write" or .name == "Edit")) |
-  "\(.name): \(.input.file_path)"' "$FILE"
-
-# GitHub API calls (gh commands, including inside variable assignments)
-jq -r 'select(.type == "assistant") | .message.content[]? |
-  select(.type == "tool_use" and .name == "Bash") |
-  .input.command | select(test("\\bgh\\b"))' "$FILE"
-```
-
-### Searching for specific behavior
-
-```bash
-# Find where the bot mentioned a keyword
-jq -r 'select(.type == "assistant") | .message.content[]? |
-  select(.type == "text") | .text | select(test("KEYWORD"; "i"))' "$FILE"
-
-# Find tool calls with specific input
-jq -c 'select(.type == "assistant") | .message.content[]? |
-  select(.type == "tool_use") |
-  select(.input | tostring | test("KEYWORD"; "i"))' "$FILE"
-```
+Each reference covers the line schema plus copy-paste jq for an overview
+trace, targeted queries (commands, tool results, files, gh calls), and
+keyword search. Both assume `$FILE` from the download step.
 
 ## Diagnose the problem
 
@@ -134,14 +80,15 @@ After extracting the session trace, reconstruct the decision chain:
 1. **What triggered the run?** Check the event type and triggering context
    (PR comment, push, schedule).
 2. **What did the bot see?** Look at system/user messages and tool results.
-3. **What did it decide?** Follow assistant text for reasoning.
+3. **What did it decide?** Follow assistant/agent text for reasoning.
 4. **Where did it go wrong?** Compare intended behavior against actual tool
    calls and outputs.
 
 Common failure modes:
-- **Wrong skill loaded** (or skill not loaded) — check the Skill tool calls
+- **Wrong skill loaded** (or skill not loaded) — Claude logs a `Skill`
+  tool call; Codex `cat`s/`sed`s a `SKILL.md` path via `exec_command`
 - **Stale context** — bot acted on outdated PR state or missed recent commits
-- **Tool error ignored** — a Bash command failed but the bot continued
+- **Tool error ignored** — a command failed but the bot continued
 - **Hallucinated file/function** — bot referenced something that doesn't exist
 - **CI polling timeout** — bot ran out of time waiting for checks
 

--- a/plugins/install-tend/skills/debug-tend-run/references/claude-logs.md
+++ b/plugins/install-tend/skills/debug-tend-run/references/claude-logs.md
@@ -1,0 +1,74 @@
+# Parsing Claude session logs
+
+Use these recipes when the artifact is `claude-session-logs*`. `$FILE` is
+the JSONL path set in the skill's download step.
+
+Each JSONL line has a top-level `type` field. The main message types are
+`user` and `assistant` (with `.message.content`). Other types (`system`,
+`progress`, `queue-operation`, `last-prompt`) carry metadata — ignore them
+for most debugging.
+
+## Overview — what happened
+
+```bash
+# Skills loaded
+jq -r 'select(.type == "assistant") | .message.content[]? |
+  select(.type == "tool_use" and .name == "Skill") |
+  .input.skill' "$FILE"
+
+# Tool calls in order
+jq -r 'select(.type == "assistant") | .message.content[]? |
+  select(.type == "tool_use") |
+  "\(.name): \(.input | tostring | .[0:120])"' "$FILE"
+
+# Assistant text (reasoning and responses)
+jq -r 'select(.type == "assistant") | .message.content[]? |
+  select(.type == "text") | .text' "$FILE"
+```
+
+## Targeted queries
+
+```bash
+# What the bot was told (user messages including injected prompts)
+jq -r 'select(.type == "user") |
+  .message.content | if type == "string" then . else
+  [.[]? | select(.type == "text") | .text] | join("\n") end' "$FILE"
+
+# Bash commands executed
+jq -r 'select(.type == "assistant") | .message.content[]? |
+  select(.type == "tool_use" and .name == "Bash") |
+  .input.command' "$FILE"
+
+# Tool results (what the bot saw back)
+jq -r 'select(.type == "user") | .message.content[]? |
+  select(.type == "tool_result") |
+  "\(.tool_use_id): \(.content | tostring | .[0:200])"' "$FILE"
+
+# Files read
+jq -r 'select(.type == "assistant") | .message.content[]? |
+  select(.type == "tool_use" and .name == "Read") |
+  .input.file_path' "$FILE"
+
+# Files written or edited
+jq -r 'select(.type == "assistant") | .message.content[]? |
+  select(.type == "tool_use" and (.name == "Write" or .name == "Edit")) |
+  "\(.name): \(.input.file_path)"' "$FILE"
+
+# GitHub API calls (gh commands, including inside variable assignments)
+jq -r 'select(.type == "assistant") | .message.content[]? |
+  select(.type == "tool_use" and .name == "Bash") |
+  .input.command | select(test("\\bgh\\b"))' "$FILE"
+```
+
+## Searching for specific behavior
+
+```bash
+# Find where the bot mentioned a keyword
+jq -r 'select(.type == "assistant") | .message.content[]? |
+  select(.type == "text") | .text | select(test("KEYWORD"; "i"))' "$FILE"
+
+# Find tool calls with specific input
+jq -c 'select(.type == "assistant") | .message.content[]? |
+  select(.type == "tool_use") |
+  select(.input | tostring | test("KEYWORD"; "i"))' "$FILE"
+```

--- a/plugins/install-tend/skills/debug-tend-run/references/codex-logs.md
+++ b/plugins/install-tend/skills/debug-tend-run/references/codex-logs.md
@@ -1,0 +1,84 @@
+# Parsing Codex session logs
+
+Use these recipes when the artifact is `codex-session-logs-*`. `$FILE` is
+the rollout JSONL path set in the skill's download step.
+
+Each JSONL line has a top-level `type` of `session_meta`, `turn_context`,
+`event_msg`, or `response_item`. Substantive content sits under
+`response_item.payload`, with the variant in `.payload.type`:
+
+- `message` — initial input from `user` or `developer` (system prompt,
+  AGENTS.md, skill listings); text at `.payload.content[].input_text.text`
+- `agent_message` — text emitted by the model during the turn
+  (`.payload.message`)
+- `function_call` — tool invocation; `.payload.name` plus
+  `.payload.arguments` (a JSON-encoded string, parse with `fromjson`)
+- `function_call_output` — paired result; `.payload.call_id` and
+  `.payload.output`
+- `reasoning` — opaque encrypted blob; skip
+- `task_started`, `task_complete`, `token_count` — metadata;
+  `task_complete.last_agent_message` carries the final reply
+
+The bot drives shell through one tool, `exec_command`, whose arguments
+parse to `{cmd, workdir, yield_time_ms, max_output_tokens}`. Long-running
+commands also produce `write_stdin` calls. Codex has no dedicated
+Read/Write/Edit tool; file I/O appears as `cat`, `sed`, `tee`,
+`apply_patch`, etc. inside `exec_command`.
+
+## Overview — what happened
+
+```bash
+# Skills loaded (Codex reads SKILL.md via shell rather than a dedicated tool)
+jq -r 'select(.payload.type == "function_call" and .payload.name == "exec_command") |
+  .payload.arguments | fromjson | .cmd | select(test("SKILL\\.md"))' "$FILE"
+
+# Final summary the bot returned
+jq -r 'select(.payload.type == "task_complete") | .payload.last_agent_message' "$FILE"
+
+# Tool calls in order
+jq -r 'select(.payload.type == "function_call") |
+  "\(.payload.name): \(.payload.arguments | fromjson | (.cmd // tostring) | .[0:160])"' "$FILE"
+
+# Interim model narrative (its visible reasoning; the encrypted blob is opaque)
+jq -r 'select(.payload.type == "agent_message") | .payload.message' "$FILE"
+```
+
+## Targeted queries
+
+```bash
+# All shell commands
+jq -r 'select(.payload.type == "function_call" and .payload.name == "exec_command") |
+  .payload.arguments | fromjson | .cmd' "$FILE"
+
+# Pair each command with its (truncated) output. Parens are required:
+# jq binds `,` tighter than `|`, so `A | B, C | D` is `A | (B, C) | D`.
+jq -r '(select(.payload.type == "function_call" and .payload.name == "exec_command")
+        | "→ " + (.payload.arguments | fromjson | .cmd)),
+       (select(.payload.type == "function_call_output")
+        | "← " + (.payload.output | .[0:300]))' "$FILE"
+
+# gh CLI calls (including in variable assignments)
+jq -r 'select(.payload.type == "function_call" and .payload.name == "exec_command") |
+  .payload.arguments | fromjson | .cmd | select(test("\\bgh\\b"))' "$FILE"
+
+# File writes / edits (apply_patch, tee, sed -i, redirect to absolute path)
+jq -r 'select(.payload.type == "function_call" and .payload.name == "exec_command") |
+  .payload.arguments | fromjson | .cmd |
+  select(test("apply_patch|\\btee\\b|sed -i\\b|>\\s+/"))' "$FILE"
+
+# Initial prompts (AGENTS.md, skill list, triggering event description)
+jq -r 'select(.payload.type == "message" and (.payload.role == "user" or .payload.role == "developer")) |
+  .payload.content[]? | select(.type == "input_text") | .text' "$FILE"
+```
+
+## Searching for specific behavior
+
+```bash
+# Model text mentioning a keyword
+jq -r 'select(.payload.type == "agent_message") | .payload.message |
+  select(test("KEYWORD"; "i"))' "$FILE"
+
+# Commands mentioning a keyword
+jq -r 'select(.payload.type == "function_call" and .payload.name == "exec_command") |
+  .payload.arguments | fromjson | .cmd | select(test("KEYWORD"; "i"))' "$FILE"
+```


### PR DESCRIPTION
## Summary

Two related fixes from investigating why Codex re-posts near-identical reviews on long-lived PRs (e.g. #535).

**`debug-tend-run` now supports both harnesses.** The artifact download pattern matches `claude-session-logs*` and `codex-session-logs-*`; per-harness JSONL parsing recipes moved into `references/claude-logs.md` and `references/codex-logs.md`, loaded on demand. `SKILL.md` is now a thin harness router. All Codex jq recipes were validated against real PR #535 session logs.

**Codex is told to read skills in full.** Codex has no skill-loading tool: it `sed`s `SKILL.md` files, and its own injected instruction ("read only enough to follow the workflow") makes it stop at a prefix. In all four PR #535 review runs it read only lines 1-220 of the 602-line `running-in-ci`, missing the dedup rule at line 310 that prevents the repetitive "prior thread still applies" preface. The truncation was verified to be the model's own choice, not a hard context or output cap (no skills-budget event fired; the read ended cleanly under the token cap). `codex/agents-tail.md` now carries an explicit directive to `cat` each tend `SKILL.md` in full, overriding the generic "read only enough" guidance.

This is a mitigation, not a structural fix: `running-in-ci` stays a single 602-line file. The directive is a soft override of OpenAI's built-in behavior. If repetition persists, the next lever is shortening `running-in-ci` or moving the dedup rule earlier in the file.

## Test plan

- [ ] `debug-tend-run` Codex recipes produce correct output against a real `codex-session-logs-*` artifact
- [ ] A Codex CI run reads `running-in-ci` in full (`cat`, not `sed -n '1,Np'`) after this lands
- [ ] Repetitive-review behavior on long-lived PRs no longer recurs
