### PR TITLE
action: pin Claude plugin marketplace to the action checkout

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -240,7 +240,12 @@ runs:
         use_sticky_comment: ${{ inputs.use_sticky_comment }}
         additional_permissions: ${{ inputs.additional_permissions }}
         prompt: ${{ inputs.prompt }}
-        plugin_marketplaces: https://github.com/max-sixty/tend.git
+        # Load the marketplace from this action's own checkout (pinned to
+        # the release tag the workflow used) rather than the remote URL,
+        # which floats on main. Skills move with the action version — same
+        # as the Codex harness (codex/action.yaml). claude-code-action
+        # passes absolute paths straight to `claude plugin marketplace add`.
+        plugin_marketplaces: ${{ github.action_path }}
         plugins: |
           install-tend@tend
           tend-ci-runner@tend


### PR DESCRIPTION
The Claude harness loaded its plugin marketplace by remote URL (`https://github.com/max-sixty/tend.git`), which `claude-code-action` clones at the **default branch**. So an adopter pinned to `max-sixty/tend@X.Y.Z` got X.Y.Z action wiring but skill content from whatever was on `main` at run time — including unreleased, in-flight skill edits. That contradicts the "composite action is the stable interface, pinned to an immutable release tag" design, where skills are the bulk of tend's behavior.

This points `plugin_marketplaces` at `${{ github.action_path }}` — the action's own checkout, pinned to the release tag the workflow used. Verified against `claude-code-action@v1` (`base-action/src/install-plugins.ts`): `isLocalPath()` treats any `/`-prefixed input as a local path, `validateMarketplaceInput()` accepts it ("Local paths are passed directly to Claude Code"), and it runs `claude plugin marketplace add <path>`. `.claude-plugin/marketplace.json` sits at the checkout root with `name: tend`, so `install-tend@tend` / `tend-ci-runner@tend` still resolve.

The Codex harness already loads from its pinned checkout (`realpath ${{ github.action_path }}/..`); this brings Claude in line — skills now move with the action version on both harnesses. The intended behavioral change: skill content advances at release tags, not instantly on every merge to `main`.
