### PR TITLE
chore: release 0.0.24

### DIFF
--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "tend"
-version = "0.0.23"
+version = "0.0.24"
 description = "An autonomous junior maintainer for GitHub repos, powered by Claude or OpenAI Codex — reviews PRs, triages issues, fixes CI"
 license = "MIT"
 requires-python = ">=3.11"

--- a/generator/uv.lock
+++ b/generator/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "tend"
-version = "0.0.23"
+version = "0.0.24"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Release 0.0.24. 11 PRs since 0.0.23:

- #545 Rewrite the workflow generator on Jinja2 templates
- #546 generator: switch build backend to uv_build
- #544 generator: route install-test through `_apply_extras`
- #535 install-tend: unify on the chain model (admin-gated refs + env policy pin)
- #537 review-reviewers: migrate to the Codex harness
- #551 debug-tend-run: support Codex session logs; instruct Codex to read skills in full
- #552 review: stop re-posting "prior thread still applies" on every push
- #547 fix(stats): stop blacking out the section on transient worker outage
- #548 site: simplify "currently tending" to a prose repo list
- #549 site: refresh "currently tending" on a 30s timer
- #550 site: refresh Stats and Activity on a timer

#551 and #552 are the reason for cutting now: together they stop the Codex harness re-posting near-identical "the prior thread still applies" reviews on every push. The behavior is release-gated, so it only reaches tend's own dogfooded workflows once 0.0.24 is published and the nightly regen repins the action ref.

No new breaking changes since 0.0.23 (the `TEND_BOT_TOKEN` rename shipped in 0.0.23).

## Test plan

- [ ] CI green (test, test-worker, lint)
- [ ] After merge: tag `0.0.24`, PyPI publish (`pypi-release.yaml` on the tag push), `uvx tend@0.0.24 --help` works
- [ ] Regenerate tend's own workflows to `@0.0.24` (separate `chore: regenerate` PR, after the tag exists)
