### PR TITLE
config: switch review-reviewers back to claude, demote codex-auth-refresh to reference

### DIFF
--- a/.config/tend.yaml
+++ b/.config/tend.yaml
@@ -5,10 +5,12 @@ setup:
   - uses: astral-sh/setup-uv@v6
 
 secrets:
-  # Consumed by codex-auth-refresh.yaml (custom non-tend workflow that
-  # rotates the Codex OAuth token nightly). Intentionally lives at repo
-  # scope so any future Codex-harness consumer workflow can read it
-  # without declaring an environment. See docs/security-model.md.
+  # tend's own harness is Claude; no generated workflow consumes this. The
+  # CODEX_AUTH_JSON repo secret is retained only for the dispatch-only
+  # codex-auth-refresh.yaml reference workflow, so it stays allowlisted to
+  # keep tend's own secret audit (check_repo_secret_allowlist) from
+  # flagging it. Remove both together when the Codex dogfood path is fully
+  # retired. See the install-tend skill's security-model.md.
   allowed:
     - CODEX_AUTH_JSON
 

--- a/.github/workflows/codex-auth-refresh.yaml
+++ b/.github/workflows/codex-auth-refresh.yaml
@@ -1,18 +1,27 @@
 name: codex-auth-refresh
 
-# Refresh the CODEX_AUTH_JSON secret nightly by hitting OpenAI's OAuth
-# token endpoint directly with the current refresh_token. Decouples
-# refresh from consumer workflows so they never trigger a rotation —
-# they read a always-fresh secret and codex sees last_refresh < 8 days,
-# so no proactive refresh fires inside the consumer runs.
+# Reference implementation of the Codex OAuth-token refresher, linked from
+# the install-tend skill's security-model.md for adopters to copy. tend's
+# own harness is Claude, so this no longer runs on a schedule here — it is
+# dispatch-only and kept solely as the canonical example.
 #
-# Without this, the static secret breaks after ~8 days when the first
-# consumer workflow triggers a refresh, ephemeral runner discards the
-# new tokens, and the GitHub secret still holds the rotated-out value.
+# What it does: refresh the CODEX_AUTH_JSON secret by hitting OpenAI's
+# OAuth token endpoint directly with the current refresh_token. Adopters
+# on `harness: codex` run it nightly to decouple refresh from consumer
+# workflows so they never trigger a rotation — they read an always-fresh
+# secret and codex sees last_refresh < 8 days, so no proactive refresh
+# fires inside the consumer runs. Without it the static secret breaks
+# after ~8 days when the first consumer workflow triggers a refresh, the
+# ephemeral runner discards the new tokens, and the GitHub secret still
+# holds the rotated-out value.
 
 on:
-  schedule:
-    - cron: "17 3 * * *"
+  # Adopters on `harness: codex`: uncomment to refresh nightly (the
+  # security-model.md guidance assumes a scheduled run). Disabled here
+  # because tend's own harness is Claude — this file is dispatch-only and
+  # kept only as the reference implementation.
+  # schedule:
+  #   - cron: "17 3 * * *"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/review-reviewers.yaml
+++ b/.github/workflows/review-reviewers.yaml
@@ -38,10 +38,12 @@ jobs:
           fetch-tags: true
           token: ${{ secrets.TEND_BOT_TOKEN }}
 
-      - uses: max-sixty/tend/codex@0.0.23
+      - uses: max-sixty/tend@0.0.24
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
-          codex_auth_json: ${{ secrets.CODEX_AUTH_JSON }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: tend-agent
-          model: gpt-5.5
-          prompt: $review-reviewers ${{ matrix.repo }}
+          model: opus
+          prompt: |
+            /tend-ci-runner:review-reviewers ${{ matrix.repo }}


### PR DESCRIPTION
Follows #556, which switched tend's own harness back to Claude but only regenerated the eight generated `tend-*` workflows. `review-reviewers.yaml` is a hand-maintained custom workflow, so it stayed on Codex and kept failing every hour with the `token_invalidated` / `refresh_token_reused` 401s #556 documented — a static `CODEX_AUTH_JSON` secret can't survive OpenAI's single-use refresh-token rotation. Most recent failing run: https://github.com/max-sixty/tend/actions/runs/26002741398

**`review-reviewers.yaml` → Claude.** `max-sixty/tend/codex@0.0.23` → `max-sixty/tend@0.0.24`, `codex_auth_json` → `claude_code_oauth_token` + `anthropic_api_key`, `model: gpt-5.5` → `opus`, prompt `$review-reviewers` → `/tend-ci-runner:review-reviewers`. Identical input/model/ref shape to the #556-regenerated workflows.

**`codex-auth-refresh.yaml` → dispatch-only reference.** Nothing on tend consumes `CODEX_AUTH_JSON` anymore, but this file is the reference implementation `security-model.md` links for adopters to copy, and Codex is still a shipped harness option. So instead of deleting it, the `schedule:` trigger is commented out (not removed) — tend itself stops running it nightly and failing, while adopters still see the cron they need. Header reframed as the canonical example.

**`.config/tend.yaml`.** `CODEX_AUTH_JSON` stays in `secrets.allowed`: the repo secret is intentionally retained for now, and dropping the allowlist entry while the secret still exists would trip tend's own `check_repo_secret_allowlist` audit. The comment now explains that coupling — the entry and the secret get removed together when the Codex dogfood path is fully retired.

Deferred deliberately: the `CODEX_AUTH_JSON` / `CODEX_REFRESH_PAT` secrets and the `codex-auth-refresh` environment on this repo are left in place pending a decision on the Codex direction.
