### PR TITLE
fix(enrich-tend-outage-issues): batch into one comment per issue

### DIFF
--- a/plugins/tend-ci-runner/scripts/enrich-tend-outage-issues.sh
+++ b/plugins/tend-ci-runner/scripts/enrich-tend-outage-issues.sh
@@ -7,10 +7,17 @@
 #
 # This script runs nightly: for each open tend-outage issue, it finds run IDs
 # in the body and comments, fetches failure annotations for each failed job
-# in those runs, and posts a comment with the details. Already-processed
-# runs are skipped via an `<!-- enriched-run:RUN_ID -->` marker in prior
-# comments — the marker is posted even when no annotations were found, so
-# unenrichable runs aren't retried every night.
+# in those runs, and posts a single comment per issue with details for every
+# newly-enriched run. Already-processed runs are skipped via an
+# `<!-- enriched-run:RUN_ID -->` marker — the marker is posted even when no
+# annotations were found, so unenrichable runs aren't retried every night.
+#
+# Per-issue batching: a single nightly invocation may find dozens of unenriched
+# runs (e.g. when a failing workflow accumulated rows during the day). Posting
+# one comment per run produces a flood — visible spam, plus one sibling
+# `issue_comment` event per comment that spins up (and skips) `tend-mention`
+# at runner-minute cost. Collapsing into one comment per issue per invocation
+# avoids both.
 
 set -euo pipefail
 
@@ -28,6 +35,8 @@ gh issue list --label "$LABEL" --state open --json number --jq '.[].number' \
       .comments[].body | scan("<!-- enriched-run:([0-9]+) -->")[0]
     ' | sort -u)
 
+    : > /tmp/enrich-batch.md
+
     comm -23 <(echo "$REFERENCED") <(echo "$ENRICHED") \
       | while read -r RUN_ID; do
         [ -z "$RUN_ID" ] && continue
@@ -44,24 +53,31 @@ gh issue list --label "$LABEL" --state open --json number --jq '.[].number' \
             --jq '[.[] | select(.annotation_level == "failure") | .message
                   | select(test("^Process completed") | not)] | join("\n\n")' \
             2>/dev/null || true)
-          [ -n "$MSG" ] && printf '### %s\n\n```\n%s\n```\n\n' "$JOB_NAME" "$MSG" \
+          [ -n "$MSG" ] && printf '#### %s\n\n```\n%s\n```\n\n' "$JOB_NAME" "$MSG" \
             >> /tmp/enrich-errors.md
         done <<< "$JOBS"
 
         RUN_URL="https://github.com/$REPO/actions/runs/$RUN_ID"
         if [ -s /tmp/enrich-errors.md ]; then
           {
-            echo "Error details for [run $RUN_ID]($RUN_URL):"
+            echo "### [Run $RUN_ID]($RUN_URL)"
             echo
             cat /tmp/enrich-errors.md
             echo "<!-- enriched-run:$RUN_ID -->"
-          } > /tmp/enrich-comment.md
+            echo
+          } >> /tmp/enrich-batch.md
         else
           {
-            echo "No failure details could be extracted for [run $RUN_ID]($RUN_URL)."
+            echo "### [Run $RUN_ID]($RUN_URL)"
+            echo
+            echo "No failure details could be extracted."
+            echo
             echo "<!-- enriched-run:$RUN_ID -->"
-          } > /tmp/enrich-comment.md
+            echo
+          } >> /tmp/enrich-batch.md
         fi
-        gh issue comment "$ISSUE" --repo "$REPO" -F /tmp/enrich-comment.md
       done
+
+    [ -s /tmp/enrich-batch.md ] \
+      && gh issue comment "$ISSUE" --repo "$REPO" -F /tmp/enrich-batch.md
   done


### PR DESCRIPTION
## What

`enrich-tend-outage-issues.sh` now collapses all newly-enriched runs for a single `tend-outage` issue into one comment per nightly invocation, instead of one comment per run.

## Why

Today's nightly run [26020294231](https://github.com/max-sixty/tend/actions/runs/26020294231) processed a 57-run backlog on [#534](https://github.com/max-sixty/tend/issues/534) and posted [57 separate comments](https://github.com/max-sixty/tend/issues/534) between 07:45:44Z and 07:47:10Z. Each comment fired an `issue_comment` event, which spun up a sibling `tend-mention` run (correctly skipped by the verify step, but still consuming a runner-minute for `Set up job` + `Complete job`). The flood also bumped the issue 57 times and notified watchers each time.

The script is structurally one-comment-per-run: `for RUN in unenriched_runs; do gh issue comment ... done`. The behavior is independent of how the bot reasons — when a backlog accumulates, it always produces N sibling comments. This is the documented behavior in the nightly skill, and PR #376 introduced the per-run shape; the cost only became visible at the 57-run scale.

Batching into one comment per issue:
- Removes the visible spam (1 bump, 1 watcher notification).
- Removes ~50 wasted sibling `tend-mention` runs per backlog burst.
- Preserves the `<!-- enriched-run:RUN_ID -->` markers (multiple per comment is fine — the dedup `jq scan(...)` already extracts all matches per body).

## Notes

- Per-run sections become `### [Run N](url)` instead of a leading paragraph. Job sections demoted to `####` to keep the heading hierarchy.
- One nightly invocation could in principle produce a very large comment if hundreds of runs accumulate, but the current rate ceiling (~7/hour observed during the worst stretch) makes a 100KB body unlikely between nightly ticks. If that becomes a real risk later, a per-comment cap can split the batch.

Evidence gist: https://gist.github.com/436c053100e5a44cdac646c9ebd3ebeb (see `## Run 26021501392`).
