### PR TITLE
skills(running-tend): drop stale session-log count

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -50,8 +50,8 @@ TARGET_REPO=max-sixty/tend "${CLAUDE_PLUGIN_ROOT}/scripts/list-recent-runs.sh" "
 
 Artifact paths: `-home-runner-work-tend-tend/<session-id>.jsonl`
 
-`review-reviewers` runs produce 3 session logs per run (one per matrix repo:
-`max-sixty/worktrunk`, `max-sixty/tend`, `PRQL/prql`).
+`review-reviewers` runs produce one session log per matrix repo in
+`.github/workflows/review-reviewers.yaml`.
 
 ## Weekly: refresh `data/consumers.json`
 


### PR DESCRIPTION
## Summary

The `running-tend` skill claims `review-reviewers` produces "3 session logs per run (one per matrix repo: `max-sixty/worktrunk`, `max-sixty/tend`, `PRQL/prql`)". The matrix in `.github/workflows/review-reviewers.yaml` now has 5 entries (`PRQL/prql`, `max-sixty/cargo-affected`, `max-sixty/tend`, `max-sixty/worktrunk`, `numbagg/numbagg`), so the count and enumeration are both stale.

Replace the enumeration with a pointer to the workflow file — that stays accurate the next time the matrix changes.

## Evidence

This run's `review-runs` analysis found 5 session logs in the most recent `review-reviewers` run ([26084280266](https://github.com/max-sixty/tend/actions/runs/26084280266)), one per matrix repo:

```
review-reviewers (max-sixty/tend)            success  7 min
review-reviewers (numbagg/numbagg)           success  1 min
review-reviewers (PRQL/prql)                 success  8 min
review-reviewers (max-sixty/cargo-affected)  success  5 min
review-reviewers (max-sixty/worktrunk)       success  13 min
```

`data/consumers.json` and the workflow matrix already agree at 5 repos.

## Gate assessment

- **Confidence**: Structural — the enumeration is a static list that drifts whenever a consumer is added to the matrix. One occurrence is sufficient.
- **Magnitude**: Removal / simplification (Low bar). Two-line change replacing the enumeration with a `.github/workflows/review-reviewers.yaml` reference. Per `CLAUDE.md` skill-authoring guidance ("Cut motivation, anecdotes, and historical context unless required to apply the rule"), the count and list are exactly the kind of detail that ages into trivia.
- Passes both gates.
