### PR TITLE
skills(review): push judgment-call fixes on bot PRs by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ file](docs/tend.example.yaml) and a repo-local `/running-tend` skill.
 
 | Workflow          | Trigger                    | What happens                                                                                                                                                |
 | ----------------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **review**        | PR opened/updated          | Reviews for correctness and duplication. Traces error paths. Monitors CI. Pushes mechanical fixes to bot-authored PRs.                                      |
+| **review**        | PR opened/updated          | Reviews for correctness and duplication. Traces error paths. Monitors CI. Pushes fixes to bot-authored PRs.                                                 |
 | **mention**       | @bot mention, review       | Responds to requests in PR and issue conversations.                                                                                                         |
 | **triage**        | Issue opened               | Classifies the issue, checks for duplicates, reproduces bugs, attempts conservative fixes.                                                                  |
 | **ci-fix**        | CI fails on default branch | Reads failure logs, identifies root cause, searches for the same pattern elsewhere, opens a fix PR.                                                         |

--- a/docs/tend.example.yaml
+++ b/docs/tend.example.yaml
@@ -177,7 +177,7 @@ bot_name: my-project-bot
 # ### review
 #
 # Triggers on PR open/update. Reviews for correctness, duplication, error paths.
-# Monitors CI. Pushes mechanical fixes to bot-authored PRs.
+# Monitors CI. Pushes fixes to bot-authored PRs.
 #
 # workflows:
 #   review:

--- a/plugins/install-tend/skills/install-tend/references/tend.example.yaml
+++ b/plugins/install-tend/skills/install-tend/references/tend.example.yaml
@@ -177,7 +177,7 @@ bot_name: my-project-bot
 # ### review
 #
 # Triggers on PR open/update. Reviews for correctness, duplication, error paths.
-# Monitors CI. Pushes mechanical fixes to bot-authored PRs.
+# Monitors CI. Pushes fixes to bot-authored PRs.
 #
 # workflows:
 #   review:

--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -356,9 +356,9 @@ gh api graphql -F query=@/tmp/resolve-thread.graphql -f threadId="THREAD_ID"
 
 Outdated comments (null line) are best-effort — skip if the original context can't be located.
 
-### 8. Push mechanical fixes
+### 8. Push fixes
 
-**Bot PRs** (Dependabot, renovate, etc.): If the review found concrete, fixable issues and there's no human author to act on feedback, commit and push the fix directly to the PR branch.
+**Bot PRs** (Dependabot, renovate, etc.): There's no human author to action a deferred offer — if the review can name a concrete fix and its reasoning, push it directly to the PR branch, even when the fix needs a judgment call. When several reasonable approaches exist, pick the one most consistent with the repo's existing patterns, push, and note the alternative in the review body. Only scope-for-maintainer when no defensible default exists — real semantic ambiguity, not "more than zero lines of thought". Otherwise the PR sits red until a human re-does the work the review already analysed.
 
 **Human PRs**: Post inline suggestions first. Additionally, offer to push a commit when the fixes are mechanical and correctness is obvious. Only push after the author accepts.
 


### PR DESCRIPTION
## Problem

Step 8's bot-PR clause already permitted pushing fixes, but the phrasing ("concrete, fixable issues") left an implicit "mechanical only" bar that the bot enforced in practice. As soon as a fix needed a judgment call, the run fell back to scoping or offering — neither of which a bot author can action — and the PR sat red until a human redid the analysis.

## Solution

Rewrite the bot-PR paragraph to:

- Drop the implicit "mechanical only" gate: pushable iff the review can name the fix and its reasoning, even when judgment is needed.
- Tiebreaker when several reasonable approaches exist: pick the one most consistent with the repo's existing patterns, push, note the alternative in the review body.
- Bounded escape hatch: only scope-for-maintainer when no defensible default exists — real semantic ambiguity, not "more than zero lines of thought".

Also renames the section heading from "Push mechanical fixes" to "Push fixes", since the new policy explicitly covers non-mechanical fixes on bot PRs. Human-PR behaviour is unchanged.

## Testing

Skill text change only. `pre-commit run --files plugins/tend-ci-runner/skills/review/SKILL.md` passes.

---
Closes #564 — automated triage
