### PR TITLE
review: push fixes to bot PRs by default, even when the fix needs a judgment call

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ file](docs/tend.example.yaml) and a repo-local `/running-tend` skill.
 
 | Workflow          | Trigger                    | What happens                                                                                                                                                |
 | ----------------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **review**        | PR opened/updated          | Reviews for correctness and duplication. Traces error paths. Monitors CI. Pushes mechanical fixes to bot-authored PRs.                                      |
+| **review**        | PR opened/updated          | Reviews for correctness and duplication. Traces error paths. Monitors CI. Pushes fixes to bot-authored PRs.                                                 |
 | **mention**       | @bot mention, review       | Responds to requests in PR and issue conversations.                                                                                                         |
 | **triage**        | Issue opened               | Classifies the issue, checks for duplicates, reproduces bugs, attempts conservative fixes.                                                                  |
 | **ci-fix**        | CI fails on default branch | Reads failure logs, identifies root cause, searches for the same pattern elsewhere, opens a fix PR.                                                         |

--- a/docs/tend.example.yaml
+++ b/docs/tend.example.yaml
@@ -177,7 +177,7 @@ bot_name: my-project-bot
 # ### review
 #
 # Triggers on PR open/update. Reviews for correctness, duplication, error paths.
-# Monitors CI. Pushes mechanical fixes to bot-authored PRs.
+# Monitors CI. Pushes fixes to bot-authored PRs.
 #
 # workflows:
 #   review:

--- a/plugins/install-tend/skills/install-tend/references/tend.example.yaml
+++ b/plugins/install-tend/skills/install-tend/references/tend.example.yaml
@@ -177,7 +177,7 @@ bot_name: my-project-bot
 # ### review
 #
 # Triggers on PR open/update. Reviews for correctness, duplication, error paths.
-# Monitors CI. Pushes mechanical fixes to bot-authored PRs.
+# Monitors CI. Pushes fixes to bot-authored PRs.
 #
 # workflows:
 #   review:

--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -288,7 +288,7 @@ Then handle the outcome:
   gh api "repos/$REPO/pulls/<number>/reviews/$REVIEW_ID/dismissals" \
     -X PUT -f message="CI failed — <reason>"
   ```
-  Skip if already dismissed. **Do not push fixes on human-authored PRs** — post the analysis and offer to fix, then wait for the author to accept.
+  Skip if already dismissed. On **human-authored PRs**, do not push fixes — post the analysis and offer to fix, then wait for the author to accept. On **bot PRs** (Dependabot, renovate, etc.), don't stop at analysis: apply the fix per step 8 so the PR can go green, since no author will act on the offer.
 - **A check was cancelled** (conclusion `cancelled`) -> do nothing. Cancellations are almost always caused by concurrency groups — a new workflow run (often triggered by your own approval event) replaces the in-progress one. The replacement run will cover the cancelled checks. **Do not re-run cancelled jobs** — that creates another run that gets cancelled again, wasting time in a loop.
 - **A check failed** (conclusion `failure`, not `cancelled`) and it's a transient flake (unrelated to the PR changes) ->
   1. **Re-run the failed jobs:**
@@ -356,9 +356,9 @@ gh api graphql -F query=@/tmp/resolve-thread.graphql -f threadId="THREAD_ID"
 
 Outdated comments (null line) are best-effort — skip if the original context can't be located.
 
-### 8. Push mechanical fixes
+### 8. Push fixes
 
-**Bot PRs** (Dependabot, renovate, etc.): If the review found concrete, fixable issues and there's no human author to act on feedback, commit and push the fix directly to the PR branch.
+**Bot PRs** (Dependabot, renovate, etc.): There is no human author to act on feedback, so a review that only describes the fix leaves the PR red and pushes the work onto a maintainer — the opposite of the point. If you can articulate the fix, apply it: commit and push it to the PR branch. "Not a one-token change" and "more than one syntactically valid form exists" are **not** reasons to defer — pick the option most consistent with the surrounding code and the repo's existing conventions, push it, and note any alternative in the review. The only bar for deferring is that *no defensible default exists*: a genuine semantic ambiguity that needs maintainer intent, not merely a fix that took thought to derive. If the review already worked out the answer, that answer is pushable. Rebase onto the latest target branch first if the branch is behind.
 
 **Human PRs**: Post inline suggestions first. Additionally, offer to push a commit when the fixes are mechanical and correctness is obvious. Only push after the author accepts.
 


### PR DESCRIPTION
Step 8 of the review skill already permitted pushing fixes to bot-authored PRs, but the "Push **mechanical** fixes" framing meant the bot only pushed pure find-replace changes. The moment a fix needed any thought — a multi-site dependency-bump API migration, or a choice between two valid config options — it fell back to describing the fix and waiting for a human. On a Dependabot PR nobody acts on that offer, so the PR sits red and a maintainer ends up doing the work the review had already worked out in full.

This reframes the deferral bar. "Not a one-token change" and "more than one syntactically valid form exists" are no longer reasons to defer. The bot picks the option most consistent with the surrounding code and the repo's existing conventions, pushes it, and notes alternatives in the review. It defers only when *no defensible default exists* — a genuine semantic ambiguity needing maintainer intent, not merely a fix that took thought to derive.

Section 6 (the CI-failed branch of Monitor CI) was silent on bot PRs, which is the exact path where this surfaced in practice — analysis posted, nothing pushed. It now points to step 8 rather than stopping at analysis. The user-facing `### review` description is synced to drop "mechanical" (both `tend.example.yaml` copies and the README workflow table).

Closes #564
