### PR TITLE
chore: release 0.0.25

### DIFF
--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "tend"
-version = "0.0.24"
+version = "0.0.25"
 description = "An autonomous junior maintainer for GitHub repos, powered by Claude or OpenAI Codex — reviews PRs, triages issues, fixes CI"
 license = "MIT"
 requires-python = ">=3.11"

--- a/generator/uv.lock
+++ b/generator/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "tend"
-version = "0.0.24"
+version = "0.0.25"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Release 0.0.25. 8 PRs since 0.0.24:

- #566 review: push fixes to bot PRs by default, even when the fix needs a judgment call
- #563 skills(running-tend): drop stale session-log count
- #562 skills: drop dollar-amount cost asides corrupted by arg substitution
- #526 fix(list-recent-runs): anchor completion window to the intended cron tick
- #559 fix(skills): hard-code /tmp instead of $TMPDIR in worktree recipes
- #560 fix(enrich-tend-outage-issues): batch into one comment per issue
- #557 config: switch review-reviewers back to claude, demote codex-auth-refresh to reference
- #556 config: switch tend's own harness back to claude

#566 is the reason for cutting now: it flips the bot-PR review default from "push only mechanical fixes" to "push the fix whenever the review can articulate it, defer only when no defensible default exists." The behavior is release-gated, so it only reaches tend's own dogfooded workflows (and adopters like PRQL) once 0.0.25 is published and the nightly regen repins the action ref.

No new breaking changes since 0.0.24.

## Test plan

- [ ] CI green (test, test-worker, lint)
- [ ] After merge: tag `0.0.25`, PyPI publish (`pypi-release.yaml` on the tag push), `uvx tend@0.0.25 --help` works
- [ ] Regenerate tend's own workflows to `@0.0.25` (separate `chore: regenerate` PR, after the tag exists)
