### PR TITLE
fix: use REST API for author_association in triage skill

### DIFF
--- a/plugins/tend-ci-runner/skills/triage/SKILL.md
+++ b/plugins/tend-ci-runner/skills/triage/SKILL.md
@@ -166,8 +166,10 @@ Always comment via `gh issue comment`. Keep it brief, polite, and specific. A ma
 **Drop the "a maintainer will review" closer when `author_association` is `OWNER`, `MEMBER`, or `COLLABORATOR`** — deferring to a maintainer reads as absurd when the reporter is one. Keep it otherwise, where it signals the action isn't authoritative.
 
 ```bash
-gh issue view $ARGUMENTS --json author,authorAssociation --jq '.authorAssociation'
+gh api "repos/$GITHUB_REPOSITORY/issues/$ARGUMENTS" --jq '.author_association'
 ```
+
+`gh issue view --json` does not expose `authorAssociation` — only the REST API does.
 
 **Stay within what you verified.** State facts you found in the codebase — don't characterize something as "known" unless you find prior issues or documentation about it. Don't speculate beyond the code you read.
 


### PR DESCRIPTION
## Problem

`plugins/tend-ci-runner/skills/triage/SKILL.md` instructed the triage agent to fetch `author_association` with `gh issue view $ARGUMENTS --json author,authorAssociation --jq '.authorAssociation'`. That field is not exposed by `gh issue view --json` (or `gh pr view --json`); the command always errors with `Unknown JSON field: "authorAssociation"`. Every triage run hit this when it reached the closer-template step.

## Solution

Swap the broken `gh issue view --json` recipe for the REST form, which does expose `author_association`:

```bash
gh api "repos/$GITHUB_REPOSITORY/issues/$ARGUMENTS" --jq '.author_association'
```

Added a one-line gloss next to it explaining why the `--json` shape doesn't work, to discourage future "cleanups" back to the broken form.

## Testing

Ran the original broken command in this CI session and got the same `Unknown JSON field` error the issue describes. Ran the replacement against this issue (`#570`) and it returned `NONE` — matching the REST API.

---
Closes #570 — automated triage
