### PR TITLE
skills(running-in-ci): recheck PR state before pushing follow-up commits

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -247,20 +247,6 @@ gh api "repos/{owner}/{repo}/actions/runs?branch=main&status=completed&per_page=
 
 If you cannot verify, say "I haven't confirmed whether these failures are pre-existing."
 
-### Bound every polling loop
-
-Use `for i in $(seq 1 N); do ... done` — never an unbounded `until <check>; do sleep N; done` from Bash. A backgrounded `until` loop survives the agent exiting and holds the GitHub Actions job alive until the workflow timeout (default 360 min) cancels it. If the harness blocks `sleep N && check` and suggests `until <check>; do sleep 2; done`, add a counter:
-
-```bash
-# Wait up to ~5 min, then bail rather than loop forever.
-for i in $(seq 1 60); do
-  <check> && break
-  sleep 5
-done
-```
-
-`Monitor` with an `until` predicate is fine — the harness caps it. The hazard is Bash `until` loops launched via `run_in_background: true`.
-
 ### Polling `gh run rerun --failed`
 
 After `gh run rerun <run-id> --failed`, poll the rerun jobs directly. The parent run's `.status` stays `in_progress` until every sibling job finishes, including unrelated long-running ones, and the `pending()` recipe above also doesn't help — sibling check-runs on the head SHA still appear pending. Polling specific job IDs is the only fix.

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -134,6 +134,17 @@ Always use `git push` without specifying a remote — `gh pr checkout` configure
 
 If pushing fails (fork PR with edits disabled), fall back to posting code snippets in a comment. Don't reference commit SHAs from temporary branches — post code inline.
 
+### Re-check PR state before pushing a follow-up commit
+
+Any wait that lets time pass — a CI poll, coverage fetch, sleep, background task — also gives a maintainer time to merge or close the PR. After waiting:
+
+```bash
+STATE=$(gh pr view <N> --json state --jq '.state')
+[ "$STATE" = "OPEN" ] || { echo "PR #<N> is $STATE — skipping push"; exit 0; }
+```
+
+If the PR is merged, the work is superseded. Comment if a real gap remains; do not push to the now-orphan branch. After merge, `gh pr view <N> --json headRefOid` returns the SHA at merge time and never advances — polling it for a new push is a guaranteed deadlock.
+
 ## Merging Upstream into PR Branches
 
 When asked to merge the default branch into a PR branch:
@@ -235,6 +246,20 @@ gh api "repos/{owner}/{repo}/actions/runs?branch=main&status=completed&per_page=
 ```
 
 If you cannot verify, say "I haven't confirmed whether these failures are pre-existing."
+
+### Bound every polling loop
+
+Use `for i in $(seq 1 N); do ... done` — never an unbounded `until <check>; do sleep N; done` from Bash. A backgrounded `until` loop survives the agent exiting and holds the GitHub Actions job alive until the workflow timeout (default 360 min) cancels it. If the harness blocks `sleep N && check` and suggests `until <check>; do sleep 2; done`, add a counter:
+
+```bash
+# Wait up to ~5 min, then bail rather than loop forever.
+for i in $(seq 1 60); do
+  <check> && break
+  sleep 5
+done
+```
+
+`Monitor` with an `until` predicate is fine — the harness caps it. The hazard is Bash `until` loops launched via `run_in_background: true`.
 
 ### Polling `gh run rerun --failed`
 


### PR DESCRIPTION
## Problem

A `tend-mention` handle job in a consumer repo deadlocked for ~6 hours after pushing a follow-up commit to a PR that had been merged minutes earlier. The bot polled the merged PR's `headRefOid` in an unbounded background `until` loop, holding the GitHub Actions job alive until the workflow's 360-minute cap cancelled it. Side effects: an orphan commit left on the now-deleted branch, the next handle job queued for 5h53m behind the deadlocked one (`cancel-in-progress: false`), and `token-usage.json` reporting `0` for the cancelled run.

The push-after-merge cause is intrinsic to tend's design (push follow-ups on PRs) and not adopter-specific.

## Solution

One rule added to `plugins/tend-ci-runner/skills/running-in-ci/SKILL.md`, under *Pushing to PR Branches*: **re-check PR state before pushing a follow-up commit.** Any wait — CI poll, coverage fetch, sleep, background task — lets a maintainer merge or close the PR. If state isn't `OPEN`, skip the push. After merge, `gh pr view --json headRefOid` returns the SHA at merge time forever, so polling it for a new push is a guaranteed deadlock.

The originally-proposed second rule ("bound every polling loop") was dropped during review — the *CI Monitoring* section already shows the bounded-`for` recipe, and a negative-form restating added little.

## Testing

Skill text only — no code paths to test.

---
Closes #572 — automated triage
