### PR TITLE
mention: skip issue_comment.edited retrigger on commenter self-edit

### DIFF
--- a/generator/src/tend/templates/mention.yaml.j2
+++ b/generator/src/tend/templates/mention.yaml.j2
@@ -82,6 +82,31 @@ jobs:
             exit 0
           fi
 
+          # Issue-comment edit-retrigger filter. GitHub fires both `created`
+          # and `edited` actions on `issue_comment`; we subscribe to both so
+          # that an edit-to-summon (adding `@bot` to an existing comment) is
+          # caught. The cost is that every refinement edit a commenter makes
+          # to their own comment in the minute after posting fires a second
+          # workflow run on the same anchor, which the agent then dedup-exits.
+          # When the editor is the commenter, no @-mention was added by the
+          # edit (checked above), and the edit happened within 120s of
+          # creation, the original `created` event is the canonical trigger
+          # and the `edited` retrigger can be dropped before the agent runs.
+          # This does not affect: maintainer-edit-of-bot-comment
+          # (sender != comment author), edit-to-summon (exits above on
+          # @-mention), or stale edits days later (120s window excludes them).
+          if [ "$EVENT_NAME" = "issue_comment" ] \
+              && [ "$EVENT_ACTION" = "edited" ] \
+              && [ -n "$SENDER_LOGIN" ] && [ "$SENDER_LOGIN" = "$COMMENT_AUTHOR" ] \
+              && [ -n "$COMMENT_CREATED_AT" ] && [ -n "$COMMENT_UPDATED_AT" ]; then
+            created_epoch=$(date -d "$COMMENT_CREATED_AT" +%s)
+            updated_epoch=$(date -d "$COMMENT_UPDATED_AT" +%s)
+            if [ "$((updated_epoch - created_epoch))" -lt 120 ]; then
+              echo "should_run=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
           # pull_request_review payloads include review.body (checked above)
           # but NOT the bodies of inline comments attached to the review.
           # Fetch them so a first-contact @-mention inside an inline comment
@@ -146,6 +171,11 @@ jobs:
           PR_URL: ${{ github.event.issue.pull_request.url }}
           EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
           REVIEW_ID: ${{ github.event.review.id }}
+          EVENT_ACTION: ${{ github.event.action }}
+          SENDER_LOGIN: ${{ github.event.sender.login }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          COMMENT_CREATED_AT: ${{ github.event.comment.created_at }}
+          COMMENT_UPDATED_AT: ${{ github.event.comment.updated_at }}
 
       - name: React to mention
         if: |

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
@@ -67,6 +67,31 @@ jobs:
             exit 0
           fi
 
+          # Issue-comment edit-retrigger filter. GitHub fires both `created`
+          # and `edited` actions on `issue_comment`; we subscribe to both so
+          # that an edit-to-summon (adding `@bot` to an existing comment) is
+          # caught. The cost is that every refinement edit a commenter makes
+          # to their own comment in the minute after posting fires a second
+          # workflow run on the same anchor, which the agent then dedup-exits.
+          # When the editor is the commenter, no @-mention was added by the
+          # edit (checked above), and the edit happened within 120s of
+          # creation, the original `created` event is the canonical trigger
+          # and the `edited` retrigger can be dropped before the agent runs.
+          # This does not affect: maintainer-edit-of-bot-comment
+          # (sender != comment author), edit-to-summon (exits above on
+          # @-mention), or stale edits days later (120s window excludes them).
+          if [ "$EVENT_NAME" = "issue_comment" ] \
+              && [ "$EVENT_ACTION" = "edited" ] \
+              && [ -n "$SENDER_LOGIN" ] && [ "$SENDER_LOGIN" = "$COMMENT_AUTHOR" ] \
+              && [ -n "$COMMENT_CREATED_AT" ] && [ -n "$COMMENT_UPDATED_AT" ]; then
+            created_epoch=$(date -d "$COMMENT_CREATED_AT" +%s)
+            updated_epoch=$(date -d "$COMMENT_UPDATED_AT" +%s)
+            if [ "$((updated_epoch - created_epoch))" -lt 120 ]; then
+              echo "should_run=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
           # pull_request_review payloads include review.body (checked above)
           # but NOT the bodies of inline comments attached to the review.
           # Fetch them so a first-contact @-mention inside an inline comment
@@ -131,6 +156,11 @@ jobs:
           PR_URL: ${{ github.event.issue.pull_request.url }}
           EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
           REVIEW_ID: ${{ github.event.review.id }}
+          EVENT_ACTION: ${{ github.event.action }}
+          SENDER_LOGIN: ${{ github.event.sender.login }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          COMMENT_CREATED_AT: ${{ github.event.comment.created_at }}
+          COMMENT_UPDATED_AT: ${{ github.event.comment.updated_at }}
 
       - name: React to mention
         if: |

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
@@ -67,6 +67,31 @@ jobs:
             exit 0
           fi
 
+          # Issue-comment edit-retrigger filter. GitHub fires both `created`
+          # and `edited` actions on `issue_comment`; we subscribe to both so
+          # that an edit-to-summon (adding `@bot` to an existing comment) is
+          # caught. The cost is that every refinement edit a commenter makes
+          # to their own comment in the minute after posting fires a second
+          # workflow run on the same anchor, which the agent then dedup-exits.
+          # When the editor is the commenter, no @-mention was added by the
+          # edit (checked above), and the edit happened within 120s of
+          # creation, the original `created` event is the canonical trigger
+          # and the `edited` retrigger can be dropped before the agent runs.
+          # This does not affect: maintainer-edit-of-bot-comment
+          # (sender != comment author), edit-to-summon (exits above on
+          # @-mention), or stale edits days later (120s window excludes them).
+          if [ "$EVENT_NAME" = "issue_comment" ] \
+              && [ "$EVENT_ACTION" = "edited" ] \
+              && [ -n "$SENDER_LOGIN" ] && [ "$SENDER_LOGIN" = "$COMMENT_AUTHOR" ] \
+              && [ -n "$COMMENT_CREATED_AT" ] && [ -n "$COMMENT_UPDATED_AT" ]; then
+            created_epoch=$(date -d "$COMMENT_CREATED_AT" +%s)
+            updated_epoch=$(date -d "$COMMENT_UPDATED_AT" +%s)
+            if [ "$((updated_epoch - created_epoch))" -lt 120 ]; then
+              echo "should_run=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
           # pull_request_review payloads include review.body (checked above)
           # but NOT the bodies of inline comments attached to the review.
           # Fetch them so a first-contact @-mention inside an inline comment
@@ -131,6 +156,11 @@ jobs:
           PR_URL: ${{ github.event.issue.pull_request.url }}
           EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
           REVIEW_ID: ${{ github.event.review.id }}
+          EVENT_ACTION: ${{ github.event.action }}
+          SENDER_LOGIN: ${{ github.event.sender.login }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          COMMENT_CREATED_AT: ${{ github.event.comment.created_at }}
+          COMMENT_UPDATED_AT: ${{ github.event.comment.updated_at }}
 
       - name: React to mention
         if: |

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
@@ -67,6 +67,31 @@ jobs:
             exit 0
           fi
 
+          # Issue-comment edit-retrigger filter. GitHub fires both `created`
+          # and `edited` actions on `issue_comment`; we subscribe to both so
+          # that an edit-to-summon (adding `@bot` to an existing comment) is
+          # caught. The cost is that every refinement edit a commenter makes
+          # to their own comment in the minute after posting fires a second
+          # workflow run on the same anchor, which the agent then dedup-exits.
+          # When the editor is the commenter, no @-mention was added by the
+          # edit (checked above), and the edit happened within 120s of
+          # creation, the original `created` event is the canonical trigger
+          # and the `edited` retrigger can be dropped before the agent runs.
+          # This does not affect: maintainer-edit-of-bot-comment
+          # (sender != comment author), edit-to-summon (exits above on
+          # @-mention), or stale edits days later (120s window excludes them).
+          if [ "$EVENT_NAME" = "issue_comment" ] \
+              && [ "$EVENT_ACTION" = "edited" ] \
+              && [ -n "$SENDER_LOGIN" ] && [ "$SENDER_LOGIN" = "$COMMENT_AUTHOR" ] \
+              && [ -n "$COMMENT_CREATED_AT" ] && [ -n "$COMMENT_UPDATED_AT" ]; then
+            created_epoch=$(date -d "$COMMENT_CREATED_AT" +%s)
+            updated_epoch=$(date -d "$COMMENT_UPDATED_AT" +%s)
+            if [ "$((updated_epoch - created_epoch))" -lt 120 ]; then
+              echo "should_run=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
           # pull_request_review payloads include review.body (checked above)
           # but NOT the bodies of inline comments attached to the review.
           # Fetch them so a first-contact @-mention inside an inline comment
@@ -131,6 +156,11 @@ jobs:
           PR_URL: ${{ github.event.issue.pull_request.url }}
           EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
           REVIEW_ID: ${{ github.event.review.id }}
+          EVENT_ACTION: ${{ github.event.action }}
+          SENDER_LOGIN: ${{ github.event.sender.login }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          COMMENT_CREATED_AT: ${{ github.event.comment.created_at }}
+          COMMENT_UPDATED_AT: ${{ github.event.comment.updated_at }}
 
       - name: React to mention
         if: |


### PR DESCRIPTION
## Summary

Skip the duplicate `tend-mention` agent run when a commenter edits their own `issue_comment` within ~2 minutes of posting and the edit did not add an `@<bot>`-mention. The original `created` event is the canonical trigger; the `edited` retrigger currently fires a second handle job that does the agent's full context-load and then exits silently via the recheck-before-posting dedup, paying ~2–7 min of agent wall-time per occurrence.

## Why this shape, why now

This is the 6th cumulative occurrence of the human-comment-edit retrigger pattern (April: 4, May: 2). The 6th was logged in this run: Oxygen66 (`author_association: NONE`) created [issue #2856 comment 4508170976](https://github.com/max-sixty/worktrunk/issues/2856#issuecomment-4508170976) at 12:16:12Z and edited it at 12:16:53Z (41s later, no `@worktrunk-bot` added). Both `tend-mention` runs ([26225338575](https://github.com/max-sixty/worktrunk/actions/runs/26225338575), [26225369828](https://github.com/max-sixty/worktrunk/actions/runs/26225369828)) reached the same handle job; the second ran ~1.7min of agent time and silent-exited. The accumulated evidence and 6th-occurrence action threshold were set by prior review-reviewers runs — see the [evidence gist](https://gist.github.com/9675d1510da32c68a68c1d45137b21e0) and [run 25313817498](https://github.com/max-sixty/tend/actions/runs/25313817498)'s verdict (the 5-condition filter sketched there is what this PR implements).

## Filter shape

Skip when **all five** conditions hold (none alone is sufficient):

1. `event_name == issue_comment`
2. `action == edited`
3. `sender.login == comment.user.login` (commenter is editing their own comment, not a maintainer editing the bot's comment)
4. `comment.updated_at - comment.created_at < 120s` (refinement window, not a stale edit days later)
5. `comment.body` does **not** contain `@<bot>` (already exits true above on @-mention, so this is implicit and is the reason the new block sits *after* the @-mention check)

## What this does NOT affect

- **Edit-to-summon** (`@<bot>` added to an existing comment): exits true at the prior @-mention check before this filter runs.
- **Maintainer editing the bot's comment** (e.g. correcting a typo): `sender != comment.user.login`, so the filter does not skip — the agent runs.
- **Stale edits days after creation**: 120s window excludes them — the agent runs.
- **`pull_request_review_comment` events**: this filter only applies to `issue_comment` events. The PR review-comment subscription is already `types: [edited]`-only, so there is no `created`-vs-`edited` duplication on that surface.
- **Bot editing its own tracking comments** (e.g. `review-runs` PATCHing a month-long tracking comment): the edit is far outside the 120s window, so the filter does not skip — the existing self-conversation-guard silent-exit pattern still handles it.

## Relation to the documented non-issue rule

The `review-reviewers` skill's non-issue list states that "sender-based or commenter-based filters on `tend-mention` are not the accepted shape" — the rationale is PR #154/#203/#212, which all gated on the **bot's own authorship**. This filter is structurally different: it gates on the editor matching the *comment's author* (human or otherwise), without referencing the bot's identity. If the maintainer judges that the rule's letter still covers this shape, closing this PR without merge would be useful signal — we'd then tighten the non-issue paragraph to call out commenter-self-edit filters explicitly and downgrade the cumulative counter to record-only-permanent.

## Test plan

- [x] `uv run --project generator pytest generator/tests/` — 97 passed
- [x] `uvx pre-commit run --files generator/src/tend/templates/mention.yaml.j2` — clean
- [x] Generated workflow parses as valid YAML; `actionlint` finds no issues
- [x] Visual diff confirms the new block sits between the @-mention check (exits `true`) and the bot-engagement check, so all three documented case shapes route correctly
- [ ] Maintainer review: confirm filter shape is acceptable given the non-issue paragraph

Evidence accumulated across runs: [evidence gist](https://gist.github.com/9675d1510da32c68a68c1d45137b21e0). Tracking issue: [review-reviewers-tracking: 2026-05](https://github.com/max-sixty/tend/issues/363).
