### PR TITLE
triage: skip on tend-outage labeled issues

### DIFF
--- a/generator/src/tend/templates/triage.yaml.j2
+++ b/generator/src/tend/templates/triage.yaml.j2
@@ -10,7 +10,8 @@ concurrency:
 
 jobs:
   triage:
-<<fork_guard_if(cfg)>>    runs-on: ubuntu-24.04
+    if: <<fork_guard_prefix(cfg)>>contains(github.event.issue.labels.*.name, 'tend-outage') == false
+    runs-on: ubuntu-24.04
     permissions:
 <<permissions()>>
     steps:

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-triage.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-triage.yaml].out
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   triage:
-    if: github.repository_owner == 'test-owner'
+    if: github.repository_owner == 'test-owner' && contains(github.event.issue.labels.*.name, 'tend-outage') == false
     runs-on: ubuntu-24.04
     permissions:
       contents: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[triage].out
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   triage:
+    if: contains(github.event.issue.labels.*.name, 'tend-outage') == false
     runs-on: ubuntu-24.04
     permissions:
       contents: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[triage].out
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   triage:
+    if: contains(github.event.issue.labels.*.name, 'tend-outage') == false
     runs-on: ubuntu-24.04
     permissions:
       contents: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[triage].out
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   triage:
+    if: contains(github.event.issue.labels.*.name, 'tend-outage') == false
     runs-on: ubuntu-24.04
     permissions:
       contents: write


### PR DESCRIPTION
## Problem

When the Anthropic API returns 529 ("Overloaded") errors, the action's `Report failure` step files a `tend-outage`-labeled issue. The `on: issues.opened` event then fires `tend-triage` against that auto-filed issue. Because the same overload is still ongoing, triage hits the same 529s, fails, and the bot author's [outage cascade comments on the very issue it just filed](https://github.com/max-sixty/tend/issues/578).

This happened today: review-reviewers run [26268072849](https://github.com/max-sixty/tend/actions/runs/26268072849) failed on 4 matrix legs at 04:19 UTC, four `tend-outage` issues were filed ([#575](https://github.com/max-sixty/tend/issues/575)–[#578](https://github.com/max-sixty/tend/issues/578)), and 3 of the 4 triage runs spawned by those `issues.opened` events failed for the same 529 reason ([26268181702](https://github.com/max-sixty/tend/actions/runs/26268181702), [26268181831](https://github.com/max-sixty/tend/actions/runs/26268181831), [26268183753](https://github.com/max-sixty/tend/actions/runs/26268183753)).

The triage skill already exits silently on bot-authored outage trackers via the self-conversation guard, so this cascade is wasted work even when the API is healthy.

## Change

Gate `tend-triage` at the job level on the `tend-outage` label being absent:

```yaml
jobs:
  triage:
    if: github.repository_owner == 'OWNER' && contains(github.event.issue.labels.*.name, 'tend-outage') == false
```

`contains(...) == false` is used instead of `!contains(...)` because YAML interprets a leading `!` as a tag, which would require quoting the whole `if:` value.

The check is generic across consumers — `action.yaml`'s `Report failure` step creates the `tend-outage` label on first use, so any consumer that has ever hit an outage will have it.

## Out of scope

The other half of today's cascade — the 4 duplicate outage issues from a single matrix run — is a separate race in `action.yaml`'s check-then-act dedup. Tracked in [#580] (filed alongside).

## Test plan

- [x] `uv run --project generator pytest` — 242 passed
- [x] Regenerated 4 regtest snapshots (triage variants).
- [ ] After merge: confirm next outage incident files exactly one `tend-outage` issue (still bounded by the action.yaml race) and that no `tend-triage` runs are spawned on it.
