### PR TITLE
fix: install-test default-branch probe on shallow checkout

### DIFF
--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -429,10 +429,14 @@ jobs:
         env:
           GH_TOKEN: ${{{{ github.token }}}}
         run: |
-          # `actions/checkout` doesn't set `origin/HEAD`, so the generator's
-          # default-branch probe falls back to "main" and a repo with a
-          # non-`main` default reports spurious drift. Query the remote.
-          git remote set-head origin --auto
+          # `actions/checkout` only fetches the PR head ref, so the
+          # generator's default-branch probe (`git rev-parse --abbrev-ref
+          # origin/HEAD`) falls back to "main" and a repo with a non-`main`
+          # default reports spurious drift. Resolve the default branch via
+          # the API, fetch it, then point `origin/HEAD` at it.
+          DEFAULT_BRANCH=$(gh api "repos/$GITHUB_REPOSITORY" --jq .default_branch)
+          git fetch origin --depth 1 "+refs/heads/$DEFAULT_BRANCH:refs/remotes/origin/$DEFAULT_BRANCH"
+          git symbolic-ref "refs/remotes/origin/HEAD" "refs/remotes/origin/$DEFAULT_BRANCH"
           # Pin the regen to the version in the committed header so a tend
           # release between local `init` and this CI run doesn't fail the
           # drift check for an irrelevant reason.

--- a/generator/tests/_regtest_outputs/test_generate.test_install_test_workflow_regtest[claude].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_install_test_workflow_regtest[claude].out
@@ -44,10 +44,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # `actions/checkout` doesn't set `origin/HEAD`, so the generator's
-          # default-branch probe falls back to "main" and a repo with a
-          # non-`main` default reports spurious drift. Query the remote.
-          git remote set-head origin --auto
+          # `actions/checkout` only fetches the PR head ref, so the
+          # generator's default-branch probe (`git rev-parse --abbrev-ref
+          # origin/HEAD`) falls back to "main" and a repo with a non-`main`
+          # default reports spurious drift. Resolve the default branch via
+          # the API, fetch it, then point `origin/HEAD` at it.
+          DEFAULT_BRANCH=$(gh api "repos/$GITHUB_REPOSITORY" --jq .default_branch)
+          git fetch origin --depth 1 "+refs/heads/$DEFAULT_BRANCH:refs/remotes/origin/$DEFAULT_BRANCH"
+          git symbolic-ref "refs/remotes/origin/HEAD" "refs/remotes/origin/$DEFAULT_BRANCH"
           # Pin the regen to the version in the committed header so a tend
           # release between local `init` and this CI run doesn't fail the
           # drift check for an irrelevant reason.

--- a/generator/tests/_regtest_outputs/test_generate.test_install_test_workflow_regtest[codex].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_install_test_workflow_regtest[codex].out
@@ -44,10 +44,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # `actions/checkout` doesn't set `origin/HEAD`, so the generator's
-          # default-branch probe falls back to "main" and a repo with a
-          # non-`main` default reports spurious drift. Query the remote.
-          git remote set-head origin --auto
+          # `actions/checkout` only fetches the PR head ref, so the
+          # generator's default-branch probe (`git rev-parse --abbrev-ref
+          # origin/HEAD`) falls back to "main" and a repo with a non-`main`
+          # default reports spurious drift. Resolve the default branch via
+          # the API, fetch it, then point `origin/HEAD` at it.
+          DEFAULT_BRANCH=$(gh api "repos/$GITHUB_REPOSITORY" --jq .default_branch)
+          git fetch origin --depth 1 "+refs/heads/$DEFAULT_BRANCH:refs/remotes/origin/$DEFAULT_BRANCH"
+          git symbolic-ref "refs/remotes/origin/HEAD" "refs/remotes/origin/$DEFAULT_BRANCH"
           # Pin the regen to the version in the committed header so a tend
           # release between local `init` and this CI run doesn't fail the
           # drift check for an irrelevant reason.

--- a/generator/tests/test_integration.py
+++ b/generator/tests/test_integration.py
@@ -620,7 +620,14 @@ def test_install_test_workflow_shape(
     # mid-PR doesn't fail the drift check for an irrelevant reason.
     assert 'uvx "tend@$TEND_VERSION" init --with-install-test' in content
     assert "astral-sh/setup-uv@v6" in content
-    assert "git remote set-head origin --auto" in content
+
+    # Default-branch probe: must not use `git remote set-head origin --auto`,
+    # which errors on the default shallow `actions/checkout@v6` (only the PR
+    # head ref is fetched, so `refs/remotes/origin/<default>` doesn't exist
+    # locally). Query the API and fetch the default branch instead. See #582.
+    assert "git remote set-head" not in content
+    assert "gh api" in content and ".default_branch" in content
+    assert "git symbolic-ref" in content
 
 
 def test_install_test_workflow_codex_secrets(


### PR DESCRIPTION
## Problem

The `tend-install-test` workflow's drift-check step fails on every install PR with:

```
error: Not a valid ref: refs/remotes/origin/main
```

Root cause: `git remote set-head origin --auto` requires the target ref (e.g. `refs/remotes/origin/main`) to already exist locally. With default `actions/checkout@v6` settings, only the PR head ref is fetched — so the command errors before any default-branch detection happens.

## Solution

Resolve the default branch via the GitHub API, fetch it shallowly, then point `origin/HEAD` at it. The generator's `_detect_default_branch_local` (`git rev-parse --abbrev-ref origin/HEAD`) then sees the correct value, so a repo with a non-`main` default doesn't report spurious drift.

## Testing

- Added an assertion in `test_install_test_workflow_shape` that the workflow uses the API-based probe and not `git remote set-head` (which would fail on shallow checkouts).
- Regenerated the `test_install_test_workflow_regtest` snapshots for both Claude and Codex harnesses.
- Reproduced the original failure locally with a shallow single-branch clone — confirmed the new command sequence sets `origin/HEAD` correctly.
- Full `pytest` suite passes (242 tests); `pre-commit` clean.

---
Closes #582 — automated triage
