### PR TITLE
fix: pin install-tend badge link to max-sixty/tend

### DIFF
--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -413,6 +413,14 @@ example, if the repo uses `style=for-the-badge`, append
 `&style=for-the-badge` to the URL. If no existing badges or no style
 parameter, use the default (no style parameter needed).
 
+Wrap the image in a link to `https://github.com/max-sixty/tend` — always
+this exact URL, regardless of the consumer's org or repo name. The full
+markdown shape:
+
+```
+[![maintained with tend](<image-url>)](https://github.com/max-sixty/tend)
+```
+
 Use `AskUserQuestion` to confirm. Describe the badge briefly in the
 question ("an olive-green 'maintained with tend' badge with the tend
 wordmark") — do NOT paste the raw `img.shields.io` URL or its base64


### PR DESCRIPTION
## Problem

When `/install-tend` adds the "maintained with tend" README badge, it sometimes links the badge to the consumer's own org (e.g. `https://github.com/diffplug/tend`) instead of the canonical `https://github.com/max-sixty/tend`. The `install-tend` skill specifies the badge image URL but never states the link target, leaving the model to guess it from surrounding repo context.

Concretely: in [diffplug/dormouse#82](https://github.com/diffplug/dormouse/pull/82) the bot inserted `[![maintained with tend](…)](https://github.com/diffplug/tend)` — that target repo does not exist.

## Solution

Add an explicit instruction in the badge section of `plugins/install-tend/skills/install-tend/SKILL.md` stating that the image must be wrapped in a link to `https://github.com/max-sixty/tend`, always — independent of the consumer's org or repo name. Includes the full markdown shape so the model has a complete template, not just an image URL.

## Testing

Skill-text fix; reproduction is the open PR in the reporter's repo cited above. No code paths affected. `uv run pytest` in `generator/` (242 passed) and `pre-commit` on the changed file both pass locally.

---
Closes #584 — automated triage
