### PR TITLE
fix: jitter outage-issue dedup to handle concurrent matrix-leg failures

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -419,7 +419,12 @@ runs:
           "| ${TIMESTAMP} | [workflow run](${RUN_URL}) | ${REF:-N/A} |" \
           "This issue was created automatically. Close it once the outage is resolved." > /tmp/body.md
 
-        # Check-then-act with minimal gap
+        # Jittered backoff before the check-then-act narrows the race window
+        # when a matrix workflow's legs fail at near-identical times (e.g.
+        # Anthropic 529s exhausting the retry budget across every leg within
+        # a few seconds). Without this, every leg reads $EXISTING as empty
+        # in parallel and each files its own outage issue.
+        sleep $((RANDOM % 30))
         EXISTING=$(gh issue list --label "$LABEL" --state open --json number --jq '.[0].number // empty')
 
         if [ -n "$EXISTING" ]; then

--- a/codex/action.yaml
+++ b/codex/action.yaml
@@ -471,6 +471,12 @@ runs:
           "| ${TIMESTAMP} | [workflow run](${RUN_URL}) | ${REF:-N/A} |" \
           "This issue was created automatically. Close it once the outage is resolved." > /tmp/body.md
 
+        # Jittered backoff before the check-then-act narrows the race window
+        # when a matrix workflow's legs fail at near-identical times (e.g.
+        # API outages exhausting the retry budget across every leg within
+        # a few seconds). Without this, every leg reads $EXISTING as empty
+        # in parallel and each files its own outage issue.
+        sleep $((RANDOM % 30))
         EXISTING=$(gh issue list --label "$LABEL" --state open --json number --jq '.[0].number // empty')
 
         if [ -n "$EXISTING" ]; then


### PR DESCRIPTION
Implements option (1) from #580 — a jittered backoff before the dedup check in the `Report failure` step.

When a matrix workflow's legs fail at near-identical times (e.g. an Anthropic 529 burst exhausting the retry budget across every leg within ~5 seconds), all legs read `$EXISTING` as empty in parallel and each file their own `tend-outage` issue. Adding `sleep $((RANDOM % 30))` before `gh issue list` staggers the legs so later ones see the first leg's issue.

This is the cheap practical fix called out in the issue — it doesn't eliminate the race in pathological cases, but it covers the observed real-world failure mode. Applied to both `action.yaml` (Claude harness) and `codex/action.yaml` (Codex harness).

Closes #580.
