### PR TITLE
chore: release 0.1.0

### DIFF
--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "tend"
-version = "0.0.25"
+version = "0.1.0"
 description = "An autonomous junior maintainer for GitHub repos, powered by Claude or OpenAI Codex — reviews PRs, triages issues, fixes CI"
 license = "MIT"
 requires-python = ">=3.11"

--- a/generator/uv.lock
+++ b/generator/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "tend"
-version = "0.0.25"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Bumps generator version to 0.1.0 and syncs lockfile.

7 commits since 0.0.25:
- fix: jitter outage-issue dedup to handle concurrent matrix-leg failures (#586)
- fix: install-test default-branch probe on shallow checkout (#583)
- fix: pin install-tend badge link to max-sixty/tend (#585)
- skills(review-reviewers): call out commenter-self-edit filters as a non-issue (#581)
- triage: skip on tend-outage labeled issues (#579)
- fix: use REST API for author_association in triage skill (#571)
- skills(running-in-ci): catch already-merged sibling PRs in dedup (#569)

## Test plan
- [x] `wt test` passes
- [x] `pre-commit run --all-files` passes
- [ ] CI green