### PR TITLE
fix(mention): use comment.updated_at so edit events report accurate queue delay

### DIFF
--- a/generator/src/tend/templates/mention.yaml.j2
+++ b/generator/src/tend/templates/mention.yaml.j2
@@ -198,7 +198,7 @@ jobs:
           event_epoch=$(date -d "$EVENT_TS" +%s)
           echo "seconds=$(( $(date +%s) - event_epoch ))" >> "$GITHUB_OUTPUT"
         env:
-          EVENT_TS: ${{ github.event.comment.created_at || github.event.review.submitted_at || github.event.issue.updated_at }}
+          EVENT_TS: ${{ github.event.comment.updated_at || github.event.review.submitted_at || github.event.issue.updated_at }}
 
 <<agent_step(cfg, prompt_body)>>
 

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
@@ -191,7 +191,7 @@ jobs:
           event_epoch=$(date -d "$EVENT_TS" +%s)
           echo "seconds=$(( $(date +%s) - event_epoch ))" >> "$GITHUB_OUTPUT"
         env:
-          EVENT_TS: ${{ github.event.comment.created_at || github.event.review.submitted_at || github.event.issue.updated_at }}
+          EVENT_TS: ${{ github.event.comment.updated_at || github.event.review.submitted_at || github.event.issue.updated_at }}
 
       - uses: max-sixty/tend/codex@X.Y.Z
         with:

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
@@ -191,7 +191,7 @@ jobs:
           event_epoch=$(date -d "$EVENT_TS" +%s)
           echo "seconds=$(( $(date +%s) - event_epoch ))" >> "$GITHUB_OUTPUT"
         env:
-          EVENT_TS: ${{ github.event.comment.created_at || github.event.review.submitted_at || github.event.issue.updated_at }}
+          EVENT_TS: ${{ github.event.comment.updated_at || github.event.review.submitted_at || github.event.issue.updated_at }}
 
       - uses: max-sixty/tend@X.Y.Z
         with:

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
@@ -193,7 +193,7 @@ jobs:
           event_epoch=$(date -d "$EVENT_TS" +%s)
           echo "seconds=$(( $(date +%s) - event_epoch ))" >> "$GITHUB_OUTPUT"
         env:
-          EVENT_TS: ${{ github.event.comment.created_at || github.event.review.submitted_at || github.event.issue.updated_at }}
+          EVENT_TS: ${{ github.event.comment.updated_at || github.event.review.submitted_at || github.event.issue.updated_at }}
 
       - uses: max-sixty/tend@X.Y.Z
         with:


### PR DESCRIPTION
## Summary

For `issue_comment.edited` events, the `tend-mention` workflow's queue-delay computation in `mention.yaml.j2:201` reads `github.event.comment.created_at` — the **original** post time, not the edit time. The "X seconds queued" prompt then reports elapsed-since-creation, which can be days or weeks when the trigger is an edit to a long-lived comment.

`updated_at` equals `created_at` for `issue_comment.created` events and reflects the edit time for `issue_comment.edited`, so one fallback ordering covers both cases. Same `submitted_at` / `issue.updated_at` fallbacks remain for `pull_request_review` and `issues` events. No behavior change for the bot's decision path — only the displayed delta becomes accurate.

## Evidence

Observed this hour on `max-sixty/worktrunk` ([run 26356819978](https://github.com/max-sixty/worktrunk/actions/runs/26356819978)):

- `tend-review-runs` ([run 26356566271](https://github.com/max-sixty/worktrunk/actions/runs/26356566271)) PATCHed its existing review-runs tracking comment ([#2522 issuecomment-4496442260](https://github.com/max-sixty/worktrunk/issues/2522#issuecomment-4496442260), created 2026-05-20, edited 2026-05-24T08:51:35Z).
- The PATCH fired an `issue_comment.edited` event 2 seconds later, triggering `tend-mention` 26356819978.
- The agent prompt opened with: *"This job started **345461s** after the triggering event (over ~40s means it was queued)."* — 345,461 seconds ≈ 4 days, which is the comment's age, not the queue delay. Actual dispatch-to-start gap was a couple of seconds.

The agent still made the correct decision (silent exit via self-loop guard), so this is **not** a behavioral failure. It's a misleading number in the prompt that future agents could weight as "stale conversation" context.

Per [review-reviewers evidence gist](https://gist.github.com/9675d1510da32c68a68c1d45137b21e0) and [last month's](https://gist.github.com/44ab1483b29406255dd36141650c894d), `issue_comment.edited` events firing additional `tend-mention` runs is a documented-recurring shape (bot-self-PATCHes of tracking comments, conflict-resolution replies, daily review-runs appends, plus human-edit retriggers). Every one of those edit-triggered runs hits this same calculation.

## Classification

- **Structural** failure — `comment.created_at` deterministically returns the original post time for `edited` events, so every such event misreports its queue delay.
- **Gate 1** (Confidence): structural classification, 1 clear occurrence with multi-month historical pattern → meets bar.
- **Gate 2** (Magnitude): targeted one-line template fix → proportionate.

## Scope (not changed)

This PR does **not** filter `edited` events, change concurrency keys, or add sender/commenter-based guards — those structural shapes were rejected in #154, #203, #212. The change is purely a prompt-accuracy fix.

## Test plan

- [x] `uv run pytest` passes (3 regtest fixtures updated under `--regtest-reset`).
- [ ] Reviewer confirms the `comment.updated_at` fallback chain is correct for the three event surfaces (`issue_comment`, `pull_request_review`, `issues`).
