### PR TITLE
skills(shared): warn against `--json authorAssociation` in shared block

### DIFF
--- a/plugins/tend-ci-runner/shared/author-association.md
+++ b/plugins/tend-ci-runner/shared/author-association.md
@@ -9,6 +9,8 @@ GitHub classifies authors of comments and events by `author_association`. Use th
 gh api repos/{owner}/{repo}/issues/comments/{comment_id} --jq '.author_association'
 ```
 
+`gh issue view --json` / `gh pr view --json` / `gh issue list --json` do **not** expose an `authorAssociation` field — only the REST API does. Use `gh api … --jq '.author_association'`, never `gh … --json authorAssociation` (which errors with `Unknown JSON field`).
+
 | Tier | Values | Meaning |
 |---|---|---|
 | **Maintainer** | `OWNER`, `MEMBER`, `COLLABORATOR` | Write access — can direct bot actions on others' work |

--- a/plugins/tend-ci-runner/skills/triage/SKILL.md
+++ b/plugins/tend-ci-runner/skills/triage/SKILL.md
@@ -169,8 +169,6 @@ Always comment via `gh issue comment`. Keep it brief, polite, and specific. A ma
 gh api "repos/$GITHUB_REPOSITORY/issues/$ARGUMENTS" --jq '.author_association'
 ```
 
-`gh issue view --json` does not expose `authorAssociation` — only the REST API does.
-
 **Stay within what you verified.** State facts you found in the codebase — don't characterize something as "known" unless you find prior issues or documentation about it. Don't speculate beyond the code you read.
 
 Choose the appropriate template:


### PR DESCRIPTION
## Problem

The `--json authorAssociation` hallucination discourager landed in #571 but only inside `plugins/tend-ci-runner/skills/triage/SKILL.md`. Other skills that need author-association (`notifications`, and `nightly`/other paths that load `running-in-ci`) include `plugins/tend-ci-runner/shared/author-association.md` via `@author-association.md`, which carried no such warning — so agents kept rediscovering that `gh issue view --json …,authorAssociation` errors with `Unknown JSON field`. Issue #597 documents three occurrences across three workflows since #571 merged.

## Solution

Add the warning to `shared/author-association.md` so every skill that pulls in the shared block carries it. Drop the now-duplicate gloss from `triage/SKILL.md` — triage loads `running-in-ci` first (Step 1 of its skill), which transitively pulls in the shared block, so triage sessions still see the warning.

## Testing

Skill-text change; no automated test. Verified by inspection: the warning now lives next to the shared `gh api … --jq '.author_association'` example, and `grep -rn authorAssociation plugins/` confirms no stale duplicate remains in `triage/SKILL.md`.

---
Closes #597 — automated triage
