### PR TITLE
skills(review-gates): structural classification doesn't override Gate 1

### DIFF
--- a/plugins/tend-ci-runner/shared/review-gates.md
+++ b/plugins/tend-ci-runner/shared/review-gates.md
@@ -33,7 +33,7 @@ If a finding doesn't meet the threshold, **skip it** — don't create a PR, don'
 
 Before applying the gates, classify each failure by asking: **did the bot have a decision point?**
 
-- **Structural**: no decision point — the same conditions produce the same failure every time, regardless of how the bot approached the task. E.g., "the checkout differs between `pull_request_target` and `issue_comment` events, so grepping always finds stale content." One clear occurrence is sufficient evidence for a targeted fix.
+- **Structural**: no decision point — the same conditions produce the same failure every time, regardless of how the bot approached the task. E.g., "the checkout differs between `pull_request_target` and `issue_comment` events, so grepping always finds stale content." Structural classification raises confidence the failure will recur, but does **not** override Gate 1 — a non-Critical structural failure still needs the occurrence count its evidence level requires (High = 2–3, Medium = 5+). Only **Critical** structural failures act on a single occurrence.
 
 - **Stochastic**: the failure is a probabilistic model behavior — e.g., "the model was too agreeable when challenged" or "the model forgot to check X." The same model might handle the next identical situation correctly without any guidance change. These need significantly more evidence (5+ occurrences) because adding guidance for a one-off stochastic lapse adds noise that can degrade performance on other tasks.
 


### PR DESCRIPTION
## Problem

The structural-vs-stochastic classification in `review-gates.md` currently includes a 1-occurrence bypass: "One clear occurrence is sufficient evidence for a targeted fix." This lets non-Critical structural findings clear Gate 1 with a single occurrence, even when the evidence level says High (needs 2–3) or Medium (needs 5+).

In practice this misroutes findings to PRs that should sit in the evidence gist until they accumulate. Feedback on [#593](https://github.com/max-sixty/tend/pull/593):

> no! we need to change our criteria; this is structural and it's not critical
> — @max-sixty

PR #593 was structural + High (1 occurrence) and passed gates only because the structural carve-out overrode the High threshold.

## Fix

Tighten the structural bullet so the classification only affects recurrence confidence, not the magnitude bar. Non-Critical structural failures fall back to their evidence-level thresholds (High = 2–3, Medium = 5+). Only Critical structural failures act on a single occurrence — which matches what Gate 1 already says for Critical.

Stochastic guidance is unchanged: still needs 5+ occurrences.

## Effect on the rejected PR

Applying the revised criteria to [#593](https://github.com/max-sixty/tend/pull/593): evidence level High, structural, 1 occurrence → falls short of High's 2–3 threshold → record in evidence gist, no PR.
