### PR TITLE
skills(running-in-ci): raise the bar for repo-overlay PRs

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -557,11 +557,18 @@ When a maintainer corrects the bot's behavior during a run — points out a repo
 
 ### When to propose
 
-Only when feedback is **generalizable** — it should apply to future runs, not just the current task. Signals:
+Open a repo-overlay PR only when feedback is **generalizable** — applies to future runs, not just the current task — AND at least one of these bars is met:
+
+- **Recurrence**: the same correction has been observed at least twice, or there is direct evidence the failure mode is recurring. "Saw it once, wrote a rule" is below the bar.
+- **Invisible failure mode**: the bad behavior would not surface as a future CI failure (e.g. cancelled/timed-out runs whose actual work succeeded), so without codification it would not be caught next time.
+- **Maintainer-explicit codification request**: a maintainer has explicitly asked for the rule to be codified after a single occurrence.
+
+This mirrors the bar tend uses for bundled-skill changes — those go through human review on the tend repo before merge, which acts as an implicit recurrence/impact filter. Per-repo overlays don't get the same scrutiny, so the bar belongs here.
+
+Signals that point toward a generalizable rule:
 
 - Correction names a pattern (*"stop adding inline suggestions for formatting — the linter handles that"*), not a task detail (*"rename this variable"*)
 - Feedback references a repo convention (*"we use conventional commits"*, *"PRs go to the `develop` branch, not `main`"*)
-- The same correction has surfaced before, or would plausibly surface again
 
 Do **not** propose when:
 


### PR DESCRIPTION
## Problem

The bundled `running-in-ci` skill's `Learning from Feedback` → `When to propose` section currently lets a single observed incident qualify for a repo-overlay PR (the third "Signals" bullet reads *"The same correction has surfaced before, or would plausibly surface again"* — the "or would plausibly surface again" clause covers any one-off failure). This produces low-signal skill churn: stochastic failures get codified as repo-specific rules that every future session then has to read past.

Reported in #603. Triggering thread: [PRQL/prql#5945 comment](https://github.com/PRQL/prql/pull/5945#issuecomment-4535810004) — a single ~5h40m orphan-loop incident triggered an overlay PR that was closed at maintainer request with the ask that we apply the same bar to overlay PRs that tend's own bundled-skill changes operate under.

## Solution

Tighten `When to propose` so opening a repo-overlay PR requires generalizability **and** at least one of:

- **Recurrence**: same correction observed at least twice, or evidence the failure mode is recurring.
- **Invisible failure mode**: bad behavior would not surface as a future CI failure (cancelled/timed-out runs whose work succeeded), so without codification it would not be caught next time.
- **Maintainer-explicit codification request**: a maintainer has explicitly asked for the rule after a single occurrence.

The rationale: bundled-skill changes pass through human review on the tend repo, which acts as an implicit recurrence/impact filter. Per-repo overlays don't get that scrutiny, so the bar belongs in the bundled skill.

## Testing

Skill text change only — no executable code touched. The rule will exercise on the next maintainer-correction in any consumer.

---
Closes #603 — automated triage
