### PR TITLE
fix(mention): skip no-op sessions for undirected bot comments

### DIFF
--- a/generator/src/tend/templates/mention.yaml.j2
+++ b/generator/src/tend/templates/mention.yaml.j2
@@ -82,6 +82,15 @@ jobs:
             exit 0
           fi
 
+          # Undirected bot comments (deploy notifications, CI status) on a
+          # bot-authored PR otherwise fall through to the PR-author short-circuit
+          # below and spin up a no-op session — twice per notification when the
+          # source bot edits its comment. Skip them here.
+          if [ "$EVENT_NAME" = "issue_comment" ] && [ "$COMMENT_AUTHOR_TYPE" = "Bot" ]; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           # pull_request_review payloads include review.body (checked above)
           # but NOT the bodies of inline comments attached to the review.
           # Fetch them so a first-contact @-mention inside an inline comment
@@ -140,6 +149,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.<<cfg.bot_token_secret>> }}
           EVENT_NAME: ${{ github.event_name }}
           COMMENT_BODY: ${{ github.event.comment.body || github.event.review.body }}
+          COMMENT_AUTHOR_TYPE: ${{ github.event.comment.user.type }}
           ISSUE_BODY: ${{ github.event.issue.body }}
           ISSUE_OR_PR_NUMBER: ${{ github.event.issue.number }}
           ISSUE_AUTHOR: ${{ github.event.issue.user.login }}

--- a/generator/src/tend/templates/mention.yaml.j2
+++ b/generator/src/tend/templates/mention.yaml.j2
@@ -86,6 +86,10 @@ jobs:
           # bot-authored PR otherwise fall through to the PR-author short-circuit
           # below and spin up a no-op session — twice per notification when the
           # source bot edits its comment. Skip them here.
+          # TODO: reassess — a quick pass of a small/fast model could replace
+          # this blanket skip with content-aware filtering (only drop comments
+          # that have no actionable signal), so we don't miss bot comments that
+          # actually warrant a response.
           if [ "$EVENT_NAME" = "issue_comment" ] && [ "$COMMENT_AUTHOR_TYPE" = "Bot" ]; then
             echo "should_run=false" >> "$GITHUB_OUTPUT"
             exit 0

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
@@ -71,6 +71,10 @@ jobs:
           # bot-authored PR otherwise fall through to the PR-author short-circuit
           # below and spin up a no-op session ? twice per notification when the
           # source bot edits its comment. Skip them here.
+          # TODO: reassess ? a quick pass of a small/fast model could replace
+          # this blanket skip with content-aware filtering (only drop comments
+          # that have no actionable signal), so we don't miss bot comments that
+          # actually warrant a response.
           if [ "$EVENT_NAME" = "issue_comment" ] && [ "$COMMENT_AUTHOR_TYPE" = "Bot" ]; then
             echo "should_run=false" >> "$GITHUB_OUTPUT"
             exit 0

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
@@ -67,6 +67,15 @@ jobs:
             exit 0
           fi
 
+          # Undirected bot comments (deploy notifications, CI status) on a
+          # bot-authored PR otherwise fall through to the PR-author short-circuit
+          # below and spin up a no-op session ? twice per notification when the
+          # source bot edits its comment. Skip them here.
+          if [ "$EVENT_NAME" = "issue_comment" ] && [ "$COMMENT_AUTHOR_TYPE" = "Bot" ]; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           # pull_request_review payloads include review.body (checked above)
           # but NOT the bodies of inline comments attached to the review.
           # Fetch them so a first-contact @-mention inside an inline comment
@@ -125,6 +134,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}
           COMMENT_BODY: ${{ github.event.comment.body || github.event.review.body }}
+          COMMENT_AUTHOR_TYPE: ${{ github.event.comment.user.type }}
           ISSUE_BODY: ${{ github.event.issue.body }}
           ISSUE_OR_PR_NUMBER: ${{ github.event.issue.number }}
           ISSUE_AUTHOR: ${{ github.event.issue.user.login }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
@@ -71,6 +71,10 @@ jobs:
           # bot-authored PR otherwise fall through to the PR-author short-circuit
           # below and spin up a no-op session ? twice per notification when the
           # source bot edits its comment. Skip them here.
+          # TODO: reassess ? a quick pass of a small/fast model could replace
+          # this blanket skip with content-aware filtering (only drop comments
+          # that have no actionable signal), so we don't miss bot comments that
+          # actually warrant a response.
           if [ "$EVENT_NAME" = "issue_comment" ] && [ "$COMMENT_AUTHOR_TYPE" = "Bot" ]; then
             echo "should_run=false" >> "$GITHUB_OUTPUT"
             exit 0

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
@@ -67,6 +67,15 @@ jobs:
             exit 0
           fi
 
+          # Undirected bot comments (deploy notifications, CI status) on a
+          # bot-authored PR otherwise fall through to the PR-author short-circuit
+          # below and spin up a no-op session ? twice per notification when the
+          # source bot edits its comment. Skip them here.
+          if [ "$EVENT_NAME" = "issue_comment" ] && [ "$COMMENT_AUTHOR_TYPE" = "Bot" ]; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           # pull_request_review payloads include review.body (checked above)
           # but NOT the bodies of inline comments attached to the review.
           # Fetch them so a first-contact @-mention inside an inline comment
@@ -125,6 +134,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}
           COMMENT_BODY: ${{ github.event.comment.body || github.event.review.body }}
+          COMMENT_AUTHOR_TYPE: ${{ github.event.comment.user.type }}
           ISSUE_BODY: ${{ github.event.issue.body }}
           ISSUE_OR_PR_NUMBER: ${{ github.event.issue.number }}
           ISSUE_AUTHOR: ${{ github.event.issue.user.login }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
@@ -71,6 +71,10 @@ jobs:
           # bot-authored PR otherwise fall through to the PR-author short-circuit
           # below and spin up a no-op session ? twice per notification when the
           # source bot edits its comment. Skip them here.
+          # TODO: reassess ? a quick pass of a small/fast model could replace
+          # this blanket skip with content-aware filtering (only drop comments
+          # that have no actionable signal), so we don't miss bot comments that
+          # actually warrant a response.
           if [ "$EVENT_NAME" = "issue_comment" ] && [ "$COMMENT_AUTHOR_TYPE" = "Bot" ]; then
             echo "should_run=false" >> "$GITHUB_OUTPUT"
             exit 0

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
@@ -67,6 +67,15 @@ jobs:
             exit 0
           fi
 
+          # Undirected bot comments (deploy notifications, CI status) on a
+          # bot-authored PR otherwise fall through to the PR-author short-circuit
+          # below and spin up a no-op session ? twice per notification when the
+          # source bot edits its comment. Skip them here.
+          if [ "$EVENT_NAME" = "issue_comment" ] && [ "$COMMENT_AUTHOR_TYPE" = "Bot" ]; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           # pull_request_review payloads include review.body (checked above)
           # but NOT the bodies of inline comments attached to the review.
           # Fetch them so a first-contact @-mention inside an inline comment
@@ -125,6 +134,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}
           COMMENT_BODY: ${{ github.event.comment.body || github.event.review.body }}
+          COMMENT_AUTHOR_TYPE: ${{ github.event.comment.user.type }}
           ISSUE_BODY: ${{ github.event.issue.body }}
           ISSUE_OR_PR_NUMBER: ${{ github.event.issue.number }}
           ISSUE_AUTHOR: ${{ github.event.issue.user.login }}

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -462,6 +462,53 @@ def test_mention_verify_detects_inline_mentions_on_review(tmp_path: Path) -> Non
     )
 
 
+def test_mention_verify_skips_bot_comments_without_mention(tmp_path: Path) -> None:
+    """Undirected bot comments (deploy notifications, CI status) on a
+    bot-authored PR must not spin up a session.
+
+    The bot-engagement fallback short-circuits to should_run=true whenever the
+    triggering PR's author is the bot. That branch fires even when the comment
+    is from another bot (e.g. cloudflare-pages deploy notification) with no
+    @-mention of our bot — wasting a full session per `created` event and
+    again per `edited` event (deploy bots edit their comment to update status).
+
+    Skip `issue_comment` events whose comment author is a `Bot` after the
+    @-mention check has already returned false. github.event.comment.user.type
+    is the public-API-visible discriminator (Bot vs User)."""
+    cfg = Config.load(_minimal_config(tmp_path))
+    workflows = {wf.filename: wf for wf in generate_all(cfg)}
+    mention = workflows["tend-mention.yaml"]
+    data = yaml.safe_load(mention.content)
+    check_step = next(
+        s for s in data["jobs"]["verify"]["steps"] if s.get("id") == "check"
+    )
+    run = check_step["run"]
+
+    assert check_step["env"].get("COMMENT_AUTHOR_TYPE") == (
+        "${{ github.event.comment.user.type }}"
+    ), (
+        "verify must wire github.event.comment.user.type so the script can "
+        "distinguish bot-authored comments from human ones"
+    )
+
+    assert '"$COMMENT_AUTHOR_TYPE" = "Bot"' in run, (
+        "verify must short-circuit issue_comment events from Bot accounts "
+        "(deploy notifications, CI status) when no @-mention is present"
+    )
+
+    # The guard must run for issue_comment events specifically and must come
+    # AFTER the @-mention check (so legitimate bot summons are still honored)
+    # and BEFORE the PR-author short-circuit (so it actually skips the
+    # bot-authored-PR fallback that produces the no-op session).
+    mention_idx = run.index("grep -qF '@test-bot'")
+    bot_guard_idx = run.index('"$COMMENT_AUTHOR_TYPE" = "Bot"')
+    pr_author_idx = run.index('"$PR_AUTHOR" = "test-bot"')
+    assert mention_idx < bot_guard_idx < pr_author_idx, (
+        "bot-comment guard must run after the @-mention check and before the "
+        "PR-author short-circuit"
+    )
+
+
 def test_mention_verify_no_concurrency(tmp_path: Path) -> None:
     """verify job must not have concurrency — a non-mention comment can cancel
     an explicit @bot mention if both arrive on the same PR within seconds (#93)."""


### PR DESCRIPTION
## Problem

`tend-mention`'s `verify` job short-circuits to `should_run=true` for any `issue_comment` event on a bot-authored PR, without inspecting the comment author. Undirected bot notifications (deploy status from `cloudflare-workers-and-pages[bot]`, CI bots, etc.) then spin up a full agent session that always exits silently — pure waste. Because deploy bots edit their comment to update status and the workflow listens on `issue_comment: [created, edited]`, each notification fires *two* no-op sessions.

## Solution

Add a guard in the `verify` script between the existing `@<bot>` mention check and the PR-author short-circuit:

```bash
if [ "$EVENT_NAME" = "issue_comment" ] && [ "$COMMENT_AUTHOR_TYPE" = "Bot" ]; then
  echo "should_run=false" >> "$GITHUB_OUTPUT"
  exit 0
fi
```

`COMMENT_AUTHOR_TYPE` is wired from `github.event.comment.user.type` (the public-API-visible Bot/User discriminator).

Ordering matters: the @-mention check runs first, so legitimate summons (e.g. another bot writing `@<our-bot>`) are still honored; the new guard runs before the PR-author short-circuit, which is what was producing the no-op sessions.

Tend's own bot accounts are PAT-based user accounts (`user.type == "User"`), so this does not affect tend-on-tend behavior — only true GitHub App / Bot accounts.

## Testing

- Added `test_mention_verify_skips_bot_comments_without_mention` asserting the guard is generated, `COMMENT_AUTHOR_TYPE` is wired, and the guard sits between the mention check and the PR-author short-circuit.
- Regenerated three regression snapshots (`test_workflow_minimal_regtest[mention]`, `test_workflow_with_setup_regtest[mention]`, `test_workflow_minimal_codex_regtest[mention]`).
- Full generator suite: 243 passed.

---
Closes #606 — automated triage
