### PR TITLE
generator: per-workflow harness override

### DIFF
--- a/generator/src/tend/config.py
+++ b/generator/src/tend/config.py
@@ -102,9 +102,11 @@ class WorkflowConfig:
     # Per-workflow harness override. Lets adopters trial a new harness on
     # a single workflow (e.g. `claude-interactive` on nightly only) before
     # flipping the whole bot. None means inherit from top-level `harness`.
-    # Cross-family overrides (claude → codex or vice versa) require also
-    # overriding the model, since model defaults are per-harness.
     harness: str | None = None
+    # Per-workflow model override. Pairs with `harness` for cross-family
+    # overrides — top-level `model` may not be valid for the new harness.
+    # None means inherit from top-level `model`.
+    model: str | None = None
 
 
 # Claude model allowlist — the set is small and stable enough that a
@@ -307,24 +309,55 @@ class Config:
                         f"workflows.{name}.jobs must be a mapping of mappings"
                     )
                 wf_harness = wf_raw.get("harness")
-                if wf_harness is not None:
-                    if wf_harness not in KNOWN_HARNESSES:
-                        raise click.ClickException(
-                            f"workflows.{name}.harness '{wf_harness}' is not recognized "
-                            f"(known: {', '.join(sorted(KNOWN_HARNESSES))})"
-                        )
-                    # Cross-family overrides need a compatible model. Same-family
-                    # overrides (claude ↔ claude-interactive) share the model set.
-                    eff_known = KNOWN_MODELS_BY_HARNESS.get(wf_harness)
-                    if eff_known is not None and model not in eff_known:
-                        raise click.ClickException(
-                            f"workflows.{name}.harness '{wf_harness}' is incompatible "
-                            f"with the top-level model '{model}' "
-                            f"(known for {wf_harness}: {', '.join(sorted(eff_known))}). "
-                            f"Cross-family per-workflow harness overrides require "
-                            "setting `model:` per-workflow too, or changing the "
-                            "top-level model."
-                        )
+                wf_model = wf_raw.get("model")
+                if wf_harness is not None and wf_harness not in KNOWN_HARNESSES:
+                    raise click.ClickException(
+                        f"workflows.{name}.harness '{wf_harness}' is not recognized "
+                        f"(known: {', '.join(sorted(KNOWN_HARNESSES))})"
+                    )
+                # Validate the effective (harness, model) pair this workflow
+                # will run with. Symmetric in both directions: claude → codex
+                # picks up gpt-5.5 absence-of-validation but the reverse
+                # (codex → claude) checks the model is in the Claude allowlist.
+                # Same-family overrides (claude ↔ claude-interactive) share
+                # the model set, no error.
+                eff_harness = wf_harness or harness
+                eff_model = wf_model or model
+                eff_known = KNOWN_MODELS_BY_HARNESS.get(eff_harness)
+                if (
+                    wf_harness is not None
+                    and eff_known is not None
+                    and eff_model not in eff_known
+                ):
+                    raise click.ClickException(
+                        f"workflows.{name} harness '{eff_harness}' is incompatible "
+                        f"with model '{eff_model}' "
+                        f"(known for {eff_harness}: {', '.join(sorted(eff_known))}). "
+                        f"Cross-family per-workflow harness overrides need a "
+                        f"compatible model — set `workflows.{name}.model:` to "
+                        "a valid value for the target harness."
+                    )
+                # Reverse direction: per-workflow override switches AWAY from
+                # a harness with a model allowlist (claude → codex) — the
+                # effective model is the top-level Claude model, which codex
+                # won't accept. Caught by the same check via eff_harness/eff_known
+                # being None for codex, so we additionally check the *source*
+                # had an allowlist that the new harness doesn't satisfy.
+                src_known = KNOWN_MODELS_BY_HARNESS.get(harness)
+                if (
+                    wf_harness is not None
+                    and wf_harness != harness
+                    and src_known is not None
+                    and eff_known is None
+                    and wf_model is None
+                ):
+                    raise click.ClickException(
+                        f"workflows.{name} crosses harness families "
+                        f"({harness} → {wf_harness}) without a model override. "
+                        f"The top-level model '{model}' is from the {harness} "
+                        f"allowlist and likely won't apply to {wf_harness}. "
+                        f"Set `workflows.{name}.model:` to a valid {wf_harness} model."
+                    )
                 workflows[name] = WorkflowConfig(
                     enabled=wf_raw.get("enabled", True),
                     prompt=wf_raw.get("prompt", ""),
@@ -334,6 +367,7 @@ class Config:
                     workflow_extra=workflow_extra,
                     jobs=jobs_raw,
                     harness=wf_harness,
+                    model=wf_model,
                 )
             else:
                 workflows[name] = WorkflowConfig(enabled=bool(wf_raw))

--- a/generator/src/tend/config.py
+++ b/generator/src/tend/config.py
@@ -316,39 +316,43 @@ class Config:
                         f"(known: {', '.join(sorted(KNOWN_HARNESSES))})"
                     )
                 # Validate the effective (harness, model) pair this workflow
-                # will run with. Symmetric in both directions: claude → codex
-                # picks up gpt-5.5 absence-of-validation but the reverse
-                # (codex → claude) checks the model is in the Claude allowlist.
-                # Same-family overrides (claude ↔ claude-interactive) share
-                # the model set, no error.
-                eff_harness = wf_harness or harness
-                eff_model = wf_model or model
-                eff_known = KNOWN_MODELS_BY_HARNESS.get(eff_harness)
-                if (
-                    wf_harness is not None
-                    and eff_known is not None
-                    and eff_model not in eff_known
-                ):
-                    raise click.ClickException(
-                        f"workflows.{name} harness '{eff_harness}' is incompatible "
-                        f"with model '{eff_model}' "
-                        f"(known for {eff_harness}: {', '.join(sorted(eff_known))}). "
-                        f"Cross-family per-workflow harness overrides need a "
-                        f"compatible model — set `workflows.{name}.model:` to "
-                        "a valid value for the target harness."
-                    )
-                # Reverse direction: per-workflow override switches AWAY from
-                # a harness with a model allowlist (claude → codex) — the
-                # effective model is the top-level Claude model, which codex
-                # won't accept. Caught by the same check via eff_harness/eff_known
-                # being None for codex, so we additionally check the *source*
-                # had an allowlist that the new harness doesn't satisfy.
-                src_known = KNOWN_MODELS_BY_HARNESS.get(harness)
+                # will run with. Three cases to cover, all gated on "the
+                # user overrode something at the workflow level":
+                #
+                #   (A) wf_model set, eff_harness has an allowlist, eff_model
+                #       not in it: fail. Covers `model: opus-99` typo with no
+                #       harness override (top-level claude harness).
+                #   (B) wf_harness flips into a harness with an allowlist
+                #       (e.g. codex → claude) and the effective model isn't
+                #       in it: fail.
+                #   (C) wf_harness flips OUT of a harness with an allowlist
+                #       (claude → codex) without a per-workflow model: fail
+                #       (effective model is opus, codex won't accept).
+                if wf_harness is not None or wf_model is not None:
+                    eff_harness = wf_harness or harness
+                    eff_model = wf_model or model
+                    eff_known = KNOWN_MODELS_BY_HARNESS.get(eff_harness)
+                    src_known = KNOWN_MODELS_BY_HARNESS.get(harness)
+
+                    # Cases A and B collapse: effective model isn't valid for
+                    # the effective harness's allowlist.
+                    if eff_known is not None and eff_model not in eff_known:
+                        raise click.ClickException(
+                            f"workflows.{name} harness '{eff_harness}' is incompatible "
+                            f"with model '{eff_model}' "
+                            f"(known for {eff_harness}: {', '.join(sorted(eff_known))}). "
+                            f"Set `workflows.{name}.model:` (or change the top-level "
+                            "`model:`) to a valid value for this harness."
+                        )
+
+                    # Case C: cross-family flip AWAY from an allowlist harness
+                    # without an explicit model. eff_harness has no allowlist
+                    # to catch it, so check the source.
                 if (
                     wf_harness is not None
                     and wf_harness != harness
-                    and src_known is not None
-                    and eff_known is None
+                    and KNOWN_MODELS_BY_HARNESS.get(harness) is not None
+                    and KNOWN_MODELS_BY_HARNESS.get(wf_harness) is None
                     and wf_model is None
                 ):
                     raise click.ClickException(

--- a/generator/src/tend/config.py
+++ b/generator/src/tend/config.py
@@ -332,7 +332,6 @@ class Config:
                     eff_harness = wf_harness or harness
                     eff_model = wf_model or model
                     eff_known = KNOWN_MODELS_BY_HARNESS.get(eff_harness)
-                    src_known = KNOWN_MODELS_BY_HARNESS.get(harness)
 
                     # Cases A and B collapse: effective model isn't valid for
                     # the effective harness's allowlist.

--- a/generator/src/tend/config.py
+++ b/generator/src/tend/config.py
@@ -99,6 +99,12 @@ class WorkflowConfig:
     branches: list[str] | None = None
     workflow_extra: dict | None = None
     jobs: dict[str, dict] | None = None
+    # Per-workflow harness override. Lets adopters trial a new harness on
+    # a single workflow (e.g. `claude-interactive` on nightly only) before
+    # flipping the whole bot. None means inherit from top-level `harness`.
+    # Cross-family overrides (claude → codex or vice versa) require also
+    # overriding the model, since model defaults are per-harness.
+    harness: str | None = None
 
 
 # Claude model allowlist — the set is small and stable enough that a
@@ -300,6 +306,25 @@ class Config:
                     raise click.ClickException(
                         f"workflows.{name}.jobs must be a mapping of mappings"
                     )
+                wf_harness = wf_raw.get("harness")
+                if wf_harness is not None:
+                    if wf_harness not in KNOWN_HARNESSES:
+                        raise click.ClickException(
+                            f"workflows.{name}.harness '{wf_harness}' is not recognized "
+                            f"(known: {', '.join(sorted(KNOWN_HARNESSES))})"
+                        )
+                    # Cross-family overrides need a compatible model. Same-family
+                    # overrides (claude ↔ claude-interactive) share the model set.
+                    eff_known = KNOWN_MODELS_BY_HARNESS.get(wf_harness)
+                    if eff_known is not None and model not in eff_known:
+                        raise click.ClickException(
+                            f"workflows.{name}.harness '{wf_harness}' is incompatible "
+                            f"with the top-level model '{model}' "
+                            f"(known for {wf_harness}: {', '.join(sorted(eff_known))}). "
+                            f"Cross-family per-workflow harness overrides require "
+                            "setting `model:` per-workflow too, or changing the "
+                            "top-level model."
+                        )
                 workflows[name] = WorkflowConfig(
                     enabled=wf_raw.get("enabled", True),
                     prompt=wf_raw.get("prompt", ""),
@@ -308,6 +333,7 @@ class Config:
                     branches=wf_raw.get("branches"),
                     workflow_extra=workflow_extra,
                     jobs=jobs_raw,
+                    harness=wf_harness,
                 )
             else:
                 workflows[name] = WorkflowConfig(enabled=bool(wf_raw))

--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -163,16 +163,22 @@ def _escape_braces(prompt: str, placeholder: str) -> tuple[str, bool]:
 
 
 def _effective_cfg(cfg: Config, wf: WorkflowConfig) -> Config:
-    """Return cfg, or a shallow clone with workflow's harness override applied.
+    """Return cfg, or a shallow clone with workflow overrides applied.
 
-    Per-workflow harness lets an adopter trial a new harness on one
-    workflow without flipping the whole bot. Validation (model
-    compatibility, known-harness check) happens in `Config.load`; this
-    helper just produces the effective config the renderer sees.
+    Per-workflow `harness` and `model` let an adopter trial a different
+    harness on one workflow (e.g. claude-interactive on nightly only)
+    without flipping the whole bot. Validation (model compatibility,
+    known-harness check) happens in `Config.load`; this helper just
+    produces the effective config the renderer sees.
     """
-    if wf.harness is None or wf.harness == cfg.harness:
+    if wf.harness is None and wf.model is None:
         return cfg
-    return dataclasses.replace(cfg, harness=wf.harness)
+    updates = {}
+    if wf.harness is not None:
+        updates["harness"] = wf.harness
+    if wf.model is not None:
+        updates["model"] = wf.model
+    return dataclasses.replace(cfg, **updates)
 
 
 _REVIEW_TMPL = _JINJA.get_template("review.yaml.j2")

--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import dataclasses
 import io
 import textwrap
 from collections.abc import Callable
@@ -161,12 +162,26 @@ def _escape_braces(prompt: str, placeholder: str) -> tuple[str, bool]:
     return text, has_placeholder
 
 
+def _effective_cfg(cfg: Config, wf: WorkflowConfig) -> Config:
+    """Return cfg, or a shallow clone with workflow's harness override applied.
+
+    Per-workflow harness lets an adopter trial a new harness on one
+    workflow without flipping the whole bot. Validation (model
+    compatibility, known-harness check) happens in `Config.load`; this
+    helper just produces the effective config the renderer sees.
+    """
+    if wf.harness is None or wf.harness == cfg.harness:
+        return cfg
+    return dataclasses.replace(cfg, harness=wf.harness)
+
+
 _REVIEW_TMPL = _JINJA.get_template("review.yaml.j2")
 
 
 def generate_review(cfg: Config) -> GeneratedWorkflow:
     wf = cfg.workflows.get("review", WorkflowConfig())
-    raw_prompt = wf.prompt or cfg.default_prompt("review", "{pr_number}")
+    eff = _effective_cfg(cfg, wf)
+    raw_prompt = wf.prompt or eff.default_prompt("review", "{pr_number}")
     format_body, needs_format = _escape_braces(raw_prompt, "pr_number")
     escaped = format_body.replace("'", "''")
     if needs_format:
@@ -175,8 +190,8 @@ def generate_review(cfg: Config) -> GeneratedWorkflow:
         prompt_expr = f"'{escaped}'"
 
     content = _REVIEW_TMPL.render(
-        cfg=cfg,
-        setup=_setup_yaml(cfg),
+        cfg=eff,
+        setup=_setup_yaml(eff),
         prompt_expr=prompt_expr,
     )
     return GeneratedWorkflow(filename="tend-review.yaml", content=content)
@@ -191,7 +206,9 @@ _MENTION_TMPL = _JINJA.get_template("mention.yaml.j2")
 
 
 def generate_mention(cfg: Config) -> GeneratedWorkflow:
-    content = _MENTION_TMPL.render(cfg=cfg, setup=_setup_yaml(cfg))
+    wf = cfg.workflows.get("mention", WorkflowConfig())
+    eff = _effective_cfg(cfg, wf)
+    content = _MENTION_TMPL.render(cfg=eff, setup=_setup_yaml(eff))
     return GeneratedWorkflow(filename="tend-mention.yaml", content=content)
 
 
@@ -205,11 +222,12 @@ _TRIAGE_TMPL = _JINJA.get_template("triage.yaml.j2")
 
 def generate_triage(cfg: Config) -> GeneratedWorkflow:
     wf = cfg.workflows.get("triage", WorkflowConfig())
-    prompt = (wf.prompt or cfg.default_prompt("triage", "{issue_number}")).replace(
+    eff = _effective_cfg(cfg, wf)
+    prompt = (wf.prompt or eff.default_prompt("triage", "{issue_number}")).replace(
         "{issue_number}", "${{ github.event.issue.number }}"
     )
 
-    content = _TRIAGE_TMPL.render(cfg=cfg, setup=_setup_yaml(cfg), prompt=prompt)
+    content = _TRIAGE_TMPL.render(cfg=eff, setup=_setup_yaml(eff), prompt=prompt)
     return GeneratedWorkflow(filename="tend-triage.yaml", content=content)
 
 
@@ -230,17 +248,18 @@ def generate_ci_fix(cfg: Config) -> GeneratedWorkflow:
             "    ci-fix:\n"
             '      watched_workflows: ["ci"]'
         )
+    eff = _effective_cfg(cfg, wf)
     watched = wf.watched_workflows
-    branches = wf.branches if wf.branches is not None else [cfg.default_branch]
-    prompt = (wf.prompt or cfg.default_prompt("ci-fix", "{run_id}")).replace(
+    branches = wf.branches if wf.branches is not None else [eff.default_branch]
+    prompt = (wf.prompt or eff.default_prompt("ci-fix", "{run_id}")).replace(
         "{run_id}", "${{ github.event.workflow_run.id }}"
     )
 
     content = _CI_FIX_TMPL.render(
-        cfg=cfg,
+        cfg=eff,
         watched=watched,
         branches=branches,
-        setup=_setup_yaml(cfg),
+        setup=_setup_yaml(eff),
         prompt=prompt,
     )
     return GeneratedWorkflow(filename="tend-ci-fix.yaml", content=content)
@@ -265,14 +284,15 @@ _SCHEDULED_DEFAULT_CRON = {
 
 def _generate_scheduled(cfg: Config, name: str) -> GeneratedWorkflow:
     wf = cfg.workflows.get(name, WorkflowConfig())
+    eff = _effective_cfg(cfg, wf)
     cron = wf.cron or _SCHEDULED_DEFAULT_CRON[name]
-    prompt = wf.prompt or cfg.default_prompt(name)
+    prompt = wf.prompt or eff.default_prompt(name)
 
     content = _SCHEDULED_TMPL.render(
-        cfg=cfg,
+        cfg=eff,
         name=name,
         cron=cron,
-        setup=_setup_yaml(cfg),
+        setup=_setup_yaml(eff),
         prompt=prompt,
     )
     return GeneratedWorkflow(filename=f"tend-{name}.yaml", content=content)
@@ -283,18 +303,19 @@ _NOTIFICATIONS_TMPL = _JINJA.get_template("notifications.yaml.j2")
 
 def generate_notifications(cfg: Config) -> GeneratedWorkflow:
     wf = cfg.workflows.get("notifications", WorkflowConfig())
+    eff = _effective_cfg(cfg, wf)
     cron = wf.cron or "*/15 * * * *"
-    prompt = wf.prompt or cfg.default_prompt("notifications")
+    prompt = wf.prompt or eff.default_prompt("notifications")
 
     skip_condition = (
         "steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'"
     )
 
     content = _NOTIFICATIONS_TMPL.render(
-        cfg=cfg,
+        cfg=eff,
         cron=cron,
         skip_condition=skip_condition,
-        setup=_setup_yaml(cfg, condition=skip_condition),
+        setup=_setup_yaml(eff, condition=skip_condition),
         prompt=prompt,
     )
     return GeneratedWorkflow(filename="tend-notifications.yaml", content=content)

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -1156,6 +1156,85 @@ def test_claude_interactive_prompt_uses_slash_command(tmp_path: Path) -> None:
     assert cfg.default_prompt("review") == "/tend-ci-runner:review"
 
 
+# ---------------------------------------------------------------------------
+# Per-workflow harness override
+# ---------------------------------------------------------------------------
+
+
+def test_per_workflow_harness_override_targets_only_named_workflow(
+    tmp_path: Path,
+) -> None:
+    """`workflows.<name>.harness` flips the action ref for that workflow
+    only; sibling workflows keep the top-level harness. This is what lets
+    an adopter trial claude-interactive on nightly without flipping their
+    PR-review workflow."""
+    extra = dedent("""\
+        workflows:
+          nightly:
+            harness: claude-interactive
+    """)
+    cfg = Config.load(_minimal_config(tmp_path, extra))
+    workflows = {wf.filename: wf for wf in generate_all(cfg)}
+
+    nightly = workflows["tend-nightly.yaml"]
+    assert f"max-sixty/tend/interactive@{ACTION_VERSION}" in nightly.content
+    assert f"max-sixty/tend@{ACTION_VERSION}" not in nightly.content
+
+    # Sibling workflows still use the top-level claude harness.
+    review = workflows["tend-review.yaml"]
+    assert f"max-sixty/tend@{ACTION_VERSION}" in review.content
+    assert f"max-sixty/tend/interactive@{ACTION_VERSION}" not in review.content
+
+
+def test_per_workflow_harness_unknown_rejected(tmp_path: Path) -> None:
+    extra = dedent("""\
+        workflows:
+          nightly:
+            harness: gpt
+    """)
+    with pytest.raises(
+        click.ClickException, match="workflows.nightly.harness 'gpt' is not recognized"
+    ):
+        Config.load(_minimal_config(tmp_path, extra))
+
+
+def test_per_workflow_harness_incompatible_model_rejected(tmp_path: Path) -> None:
+    """Cross-family override needs a compatible model.
+
+    codex's catalog churns so we don't validate codex model strings — the
+    error fires when the top-level model is from a churnable harness and
+    the per-workflow override is to one with an allowlist. Concretely:
+    codex (gpt-5.5) → claude per-workflow yields a model invalid for the
+    target harness."""
+    extra = dedent("""\
+        harness: codex
+        model: gpt-5.5
+        workflows:
+          nightly:
+            harness: claude
+    """)
+    with pytest.raises(
+        click.ClickException,
+        match="workflows.nightly.harness 'claude' is incompatible with the top-level model 'gpt-5.5'",
+    ):
+        Config.load(_minimal_config(tmp_path, extra))
+
+
+def test_per_workflow_harness_same_family_no_model_clash(tmp_path: Path) -> None:
+    """claude → claude-interactive shares the model set; no compatibility
+    error even though it's a per-workflow override."""
+    extra = dedent("""\
+        workflows:
+          nightly:
+            harness: claude-interactive
+          review:
+            harness: claude-interactive
+    """)
+    cfg = Config.load(_minimal_config(tmp_path, extra))
+    assert cfg.workflows["nightly"].harness == "claude-interactive"
+    assert cfg.workflows["review"].harness == "claude-interactive"
+
+
 def test_codex_model_unrestricted(tmp_path: Path) -> None:
     """Codex model strings pass through unvalidated.
 

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -1198,14 +1198,11 @@ def test_per_workflow_harness_unknown_rejected(tmp_path: Path) -> None:
         Config.load(_minimal_config(tmp_path, extra))
 
 
-def test_per_workflow_harness_incompatible_model_rejected(tmp_path: Path) -> None:
-    """Cross-family override needs a compatible model.
-
-    codex's catalog churns so we don't validate codex model strings — the
-    error fires when the top-level model is from a churnable harness and
-    the per-workflow override is to one with an allowlist. Concretely:
-    codex (gpt-5.5) → claude per-workflow yields a model invalid for the
-    target harness."""
+def test_per_workflow_harness_incompatible_model_rejected_codex_target(
+    tmp_path: Path,
+) -> None:
+    """codex (gpt-5.5) → claude per-workflow: top-level model 'gpt-5.5' isn't
+    in claude's allowlist. Fail at config load."""
     extra = dedent("""\
         harness: codex
         model: gpt-5.5
@@ -1215,9 +1212,52 @@ def test_per_workflow_harness_incompatible_model_rejected(tmp_path: Path) -> Non
     """)
     with pytest.raises(
         click.ClickException,
-        match="workflows.nightly.harness 'claude' is incompatible with the top-level model 'gpt-5.5'",
+        match=r"workflows.nightly harness 'claude' is incompatible with model 'gpt-5.5'",
     ):
         Config.load(_minimal_config(tmp_path, extra))
+
+
+def test_per_workflow_harness_incompatible_model_rejected_codex_source(
+    tmp_path: Path,
+) -> None:
+    """Symmetric case: claude (opus) → codex per-workflow without a model
+    override. codex doesn't accept 'opus' but has no allowlist, so the
+    cross-family-source check catches it instead of the target-allowlist
+    check. Reviewer-flagged asymmetry in #612.
+
+    Without this guard, the renderer would emit `model: opus` on a codex
+    action step that codex would reject at runtime."""
+    extra = dedent("""\
+        harness: claude
+        workflows:
+          nightly:
+            harness: codex
+    """)
+    with pytest.raises(
+        click.ClickException,
+        match=r"workflows.nightly crosses harness families \(claude → codex\)",
+    ):
+        Config.load(_minimal_config(tmp_path, extra))
+
+
+def test_per_workflow_model_override_unblocks_cross_family(tmp_path: Path) -> None:
+    """Cross-family override succeeds when paired with a per-workflow model."""
+    extra = dedent("""\
+        harness: claude
+        workflows:
+          nightly:
+            harness: codex
+            model: gpt-5.5
+    """)
+    cfg = Config.load(_minimal_config(tmp_path, extra))
+    workflows = {wf.filename: wf for wf in generate_all(cfg)}
+    nightly = workflows["tend-nightly.yaml"]
+    assert f"max-sixty/tend/codex@{ACTION_VERSION}" in nightly.content
+    assert "model: gpt-5.5" in nightly.content
+    # Sibling workflows still on claude with opus
+    review = workflows["tend-review.yaml"]
+    assert f"max-sixty/tend@{ACTION_VERSION}" in review.content
+    assert "model: opus" in review.content
 
 
 def test_per_workflow_harness_same_family_no_model_clash(tmp_path: Path) -> None:

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -1260,6 +1260,39 @@ def test_per_workflow_model_override_unblocks_cross_family(tmp_path: Path) -> No
     assert "model: opus" in review.content
 
 
+def test_per_workflow_model_typo_without_harness_rejected(tmp_path: Path) -> None:
+    """Reviewer-flagged gap (#612): per-workflow `model:` override WITHOUT
+    a `harness:` change must still be validated against the top-level
+    harness's allowlist. Previously skipped because both checks gated on
+    `wf_harness is not None`."""
+    extra = dedent("""\
+        workflows:
+          nightly:
+            model: opus-99
+    """)
+    with pytest.raises(
+        click.ClickException,
+        match=r"workflows.nightly harness 'claude' is incompatible with model 'opus-99'",
+    ):
+        Config.load(_minimal_config(tmp_path, extra))
+
+
+def test_per_workflow_model_only_override_valid(tmp_path: Path) -> None:
+    """Per-workflow `model:` override (no harness change) to a valid model
+    in the top-level harness's allowlist loads cleanly and renders."""
+    extra = dedent("""\
+        workflows:
+          nightly:
+            model: haiku
+    """)
+    cfg = Config.load(_minimal_config(tmp_path, extra))
+    workflows = {wf.filename: wf for wf in generate_all(cfg)}
+    nightly = workflows["tend-nightly.yaml"]
+    assert "model: haiku" in nightly.content
+    review = workflows["tend-review.yaml"]
+    assert "model: opus" in review.content
+
+
 def test_per_workflow_harness_same_family_no_model_clash(tmp_path: Path) -> None:
     """claude → claude-interactive shares the model set; no compatibility
     error even though it's a per-workflow override."""


### PR DESCRIPTION
## Why

Lets adopters trial a new harness on a single workflow without flipping the whole bot. Concrete use case: try `harness: claude-interactive` on `nightly` while keeping PR review / mention on the production `claude` harness. Trial-safe rollout for the interactive harness added in #609 / #611.

## What

- `WorkflowConfig` gains an optional `harness` field. `Config.load` validates the value is a known harness and (cross-family only) compatible with the top-level model.
  - Same-family overrides (claude ↔ claude-interactive) share the model set, no compatibility error.
  - Cross-family overrides (codex → claude/claude-interactive with a codex model name like `gpt-5.5`, or vice versa with a per-workflow model unset) fail at config load with a clear message: "workflows.X.harness 'claude' is incompatible with the top-level model 'gpt-5.5'… Cross-family per-workflow harness overrides require setting `model:` per-workflow too, or changing the top-level model."
- `workflows.py`: a new `_effective_cfg(cfg, wf)` helper returns `cfg` unchanged when there's no override, or `dataclasses.replace(cfg, harness=wf.harness)` otherwise. Each generator function (review, mention, triage, ci-fix, scheduled, notifications) calls it once and passes the effective config to both the template and `default_prompt`. No template changes — `agent_step` still reads `cfg.harness` from whatever `cfg` it gets.
- Tests: per-workflow override targets only the named workflow (sibling workflows keep the top-level harness), unknown harness rejected, cross-family model mismatch rejected, same-family override loads cleanly.

## Example

```yaml
bot_name: tend-agent
harness: claude
# Trial the interactive harness on nightly only — review/mention/triage
# stay on the SDK-based claude harness until we're confident.
workflows:
  nightly:
    harness: claude-interactive
```

## Test plan

- [x] 252 tests pass (4 new); existing snapshots untouched
- [x] `pre-commit run --all-files` passes
