### PR TITLE
interactive harness: switch off bypassPermissions to skip its disclaimer

### DIFF
--- a/interactive/action.yaml
+++ b/interactive/action.yaml
@@ -365,12 +365,18 @@ runs:
         claude plugin list 2>/dev/null || true
 
     # The supervisor pattern, in three pieces:
-    #   1. Stop hook in .claude/settings.local.json writes a sentinel file
-    #      when the model finishes a turn. StopFailure writes a separate
-    #      sentinel for API/rate-limit/auth errors. settings.local.json is
-    #      additive — adopter project settings still apply.
-    #   2. A wrapper script invokes `claude --permission-mode
-    #      bypassPermissions "$PROMPT"` so all argv/env quoting happens in
+    #   1. .claude/settings.local.json sets `permissions.defaultMode:
+    #      dontAsk` with a permissive allow list, plus Stop/StopFailure
+    #      hooks. Stop writes a success sentinel; StopFailure writes a
+    #      failure sentinel for API/rate-limit/auth errors. Adopter
+    #      project settings still apply via the layered settings system.
+    #      We avoid `--permission-mode bypassPermissions` because
+    #      interactive claude shows a one-time "I accept the risks"
+    #      disclaimer the first time bypass mode is entered, with no
+    #      documented way to pre-seed acceptance — `dontAsk` + explicit
+    #      allow is equivalent for CI's purposes.
+    #   2. A wrapper script invokes `claude` with `--permission-mode
+    #      dontAsk --allowedTools …` so all argv/env quoting happens in
     #      bash, not in nested YAML strings.
     #   3. `script(1)` allocates a PTY (GHA runners have no TTY by
     #      default; without this the Ink-based UI degrades or hangs).
@@ -412,13 +418,21 @@ runs:
         WRAPPER="$RUNNER_TEMP/tend-run-claude.sh"
         rm -f "$SENTINEL_OK" "$SENTINEL_FAIL" "$LOG"
 
-        # Stop hook → success sentinel. StopFailure → failure sentinel
-        # (fires on rate-limit, auth, max-tokens, server errors per
-        # https://code.claude.com/docs/en/hooks.md). Written to
-        # settings.local.json so adopter project settings still apply.
+        # Build the permissions allow list from the comma-separated
+        # `allowed_tools` input. defaultMode=dontAsk means anything not
+        # explicitly allowed is denied (no interactive prompt). For tools
+        # like Bash with no `(...)` suffix, the entry matches all
+        # invocations — semantically equivalent to bypassPermissions for
+        # the listed tools.
+        ALLOW_JSON=$(jq -nc --arg list "$TEND_ALLOWED_TOOLS" '$list | split(",") | map(. | gsub("^\\s+|\\s+$"; ""))')
+
         mkdir -p .claude
         cat > .claude/settings.local.json <<EOF
         {
+          "permissions": {
+            "defaultMode": "dontAsk",
+            "allow": $ALLOW_JSON
+          },
           "hooks": {
             "Stop": [
               {
@@ -436,12 +450,15 @@ runs:
         }
         EOF
 
-        # Wrapper script — keeps the argv quoting in bash, not YAML.
+        # Wrapper script — keeps the argv quoting in bash, not YAML. The
+        # --permission-mode flag matches settings.local.json above; either
+        # alone would suffice but specifying both is explicit and survives
+        # an adopter who overrides settings.local.json.
         cat > "$WRAPPER" <<'WRAPEOF'
         #!/usr/bin/env bash
         exec claude \
           --model "$TEND_MODEL" \
-          --permission-mode bypassPermissions \
+          --permission-mode dontAsk \
           --allowedTools "$TEND_ALLOWED_TOOLS" \
           --append-system-prompt "$TEND_SYSTEM_PROMPT" \
           "$TEND_PROMPT"


### PR DESCRIPTION
## Why

Second smoke-test retry on `main` (https://github.com/max-sixty/tend/actions/runs/26488931127) still timed out at 300s. The supervisor's transcript dump showed `claude` blocked on a third onboarding dialog after the trust + theme picker — the **"WARNING: Bypass Permissions mode"** disclaimer, shown the first time `claude` is invoked with `--permission-mode bypassPermissions`:

```
WARNING: Claude Code running in Bypass Permissions mode
In Bypass Permissions mode, Claude Code will not ask for your approval before running potentially dangerous commands.
…
❯ 1. No, exit
  2. Yes, I accept
```

The disclaimer state has no documented pre-seed key in `~/.claude.json`, and the binary's own error message for `--bg` says it must be accepted via an interactive run — which the supervisor can't replicate.

## What

Switch to `--permission-mode dontAsk` with an explicit allow list. `dontAsk` auto-denies anything not pre-approved (no prompt, no disclaimer); flat tool names like `"Bash"` match all invocations, so the effective permission surface matches the `bypassPermissions` intent for CI use.

- `interactive/action.yaml`: drop `--permission-mode bypassPermissions` in the wrapper script; write `permissions.defaultMode: dontAsk` + an `allow` list (built from `inputs.allowed_tools` via `jq`) into `.claude/settings.local.json`. Pass `--permission-mode dontAsk` on the CLI too as belt-and-suspenders.
- Comment in the Run-Claude step block explains why we avoid bypassPermissions and what dontAsk does for us.

No generator changes; no test changes (no behavior visible at config-render time).

## Test plan

- [ ] Re-run `interactive-smoke` after merge — expect status=ok, turns > 0
- [ ] Eventually exercise on a real CI workflow (post-merge, after #612 lands)
