### PR TITLE
interactive harness: drop -newer filter on session JSONL parser

### DIFF
--- a/interactive/action.yaml
+++ b/interactive/action.yaml
@@ -604,7 +604,12 @@ runs:
         LOGS_DIR="$HOME/.claude/projects"
         mkdir -p "$LOGS_DIR"
 
-        SESSIONS=$(find "$HOME/.claude/projects" -name '*.jsonl' -newer "$RUNNER_TEMP/tend-run-claude.sh" 2>/dev/null | tr '\n' ' ')
+        # The whole step runs after the supervised session, on an
+        # ephemeral CI runner where ~/.claude/projects is freshly
+        # populated by this run. Take everything — no `-newer` filter
+        # (older filter once dropped a real session because mtime ties
+        # with the wrapper script were inconsistent).
+        SESSIONS=$(find "$HOME/.claude/projects" -name '*.jsonl' 2>/dev/null | tr '\n' ' ')
 
         if [ -n "$SESSIONS" ]; then
           USAGE=$(jq -s -c --arg model "$MODEL" '


### PR DESCRIPTION
## Why

Smoke 3 (https://github.com/max-sixty/tend/actions/runs/26489730646) succeeded end-to-end — Stop hook fired, claude responded `Smoke test ran at 2026-05-27T03:54:20Z` in 8s — but the token-usage step reported `0 turns` and emitted a `::warning::`. The find predicate `-newer "$RUNNER_TEMP/tend-run-claude.sh"` excluded the session JSONL because its mtime was equal-or-older than the wrapper script's (mtime tie on the GHA runner filesystem; both files created within sub-second precision).

## What

Drop the `-newer` filter. The step runs on an ephemeral CI runner where `~/.claude/projects` is freshly populated by THIS run only — no prior sessions to accidentally pull in, so the filter was paranoia without benefit.

Tiny one-line fix; comment in the action explains why we don't filter.
