### PR TITLE
interactive harness: set CLAUDE_CODE_REMOTE=1 to skip remaining prompts

### DIFF
--- a/interactive/action.yaml
+++ b/interactive/action.yaml
@@ -357,6 +357,9 @@ runs:
       env:
         CLAUDE_CODE_OAUTH_TOKEN: ${{ inputs.claude_code_oauth_token }}
         ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
+        # Suppress any interactive prompts (auth confirmation, plugin
+        # install confirmation, etc.) the CLI might otherwise show.
+        CLAUDE_CODE_REMOTE: "1"
       run: |
         MARKETPLACE_ROOT="$(realpath "${{ github.action_path }}/..")"
         claude plugin marketplace add "$MARKETPLACE_ROOT"
@@ -388,6 +391,13 @@ runs:
       env:
         CLAUDE_CODE_OAUTH_TOKEN: ${{ inputs.claude_code_oauth_token }}
         ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
+        # Tells claude this is a remote/non-interactive context so it
+        # skips permission prompts that would otherwise block the
+        # supervisor (interactive mode shows a one-time disclaimer the
+        # first time bypass-permission tools are invoked). Belt-and-
+        # suspenders alongside the settings.local.json dontAsk allow
+        # list below.
+        CLAUDE_CODE_REMOTE: "1"
         # Mirrors action.yaml: the Linux bwrap wrapping path in claude-
         # code v2.1.142 corrupts argv tokens containing `!` next to `'`.
         # Setting this to 0 routes bash through the fixed quoting path.


### PR DESCRIPTION
## Why

Per user request: set `CLAUDE_CODE_REMOTE=1` in the interactive harness's env so claude knows we're in a non-interactive context and skips any remaining permission/confirmation prompts. The env var is documented in the claude binary alongside `CLAUDE_CODE_REMOTE_SESSION_ID`, `CLAUDE_CODE_REMOTE_MEMORY_DIR`, `CLAUDE_CODE_REMOTE_ENVIRONMENT_TYPE`, and `CLAUDE_CODE_REMOTE_SETTINGS_PATH`.

## What

Set `CLAUDE_CODE_REMOTE=1` in two action steps:

- **Install tend plugins** — covers `claude plugin marketplace add` / `claude plugin install`, which could in principle prompt for auth/install confirmation.
- **Run Claude** — covers the supervised session. Belt-and-suspenders alongside the `.claude/settings.local.json` `defaultMode: dontAsk` allow list landed earlier.

No generator changes; defensive add-on.
