### PR TITLE
interactive harness: fix double-iterator in token-usage jq parser

### DIFF
--- a/interactive/action.yaml
+++ b/interactive/action.yaml
@@ -622,15 +622,20 @@ runs:
         SESSIONS=$(find "$HOME/.claude/projects" -name '*.jsonl' 2>/dev/null | tr '\n' ' ')
 
         if [ -n "$SESSIONS" ]; then
+          # `jq -s` slurps inputs from ALL files into ONE flat array of
+          # events. Iterate once with `.[]`, not twice. (Smoke 4 caught
+          # this — the double `.[]` errored "Cannot index string with
+          # string", the `|| echo '{}'` swallowed it, and the step fell
+          # through to zeros.)
           USAGE=$(jq -s -c --arg model "$MODEL" '
             def n: . // 0;
-            [.[] | .[] | select(.message.usage)] as $msgs |
+            [.[] | select(.message.usage)] as $msgs |
             {
               input_tokens:                ([$msgs[] | .message.usage.input_tokens? | n] | add // 0),
               output_tokens:               ([$msgs[] | .message.usage.output_tokens? | n] | add // 0),
               cache_creation_input_tokens: ([$msgs[] | .message.usage.cache_creation_input_tokens? | n] | add // 0),
               cache_read_input_tokens:     ([$msgs[] | .message.usage.cache_read_input_tokens? | n] | add // 0),
-              turns:                       ([.[] | .[] | select(.type? == "assistant")] | length),
+              turns:                       ([.[] | select(.type? == "assistant")] | length),
               model:                       $model,
               cost_usd:                    0
             }


### PR DESCRIPTION
## Why

Smoke 4 (https://github.com/max-sixty/tend/actions/runs/26490407419) succeeded end-to-end — Stop hook fired, claude responded `Smoke test ran at 2026-05-27T04:16:42Z` in 8s — but the token-usage step still reported `0 turns`, even after the `-newer` filter fix in #614.

Root cause is the jq filter itself:

```jq
[.[] | .[] | select(.message.usage)] as $msgs
```

`jq -s` slurps all input files into ONE flat array of events. The second `.[]` tried to iterate event OBJECTS (yielding their values, not events), which hit `Cannot index string with string "message"` on the first non-object value. The `|| echo '{}'` swallowed the error and the step fell through to zeros.

Verified against the actual smoke 4 session JSONL (downloaded from the run's artifact):

| | buggy parser | fixed parser |
|---|---|---|
| stderr | `Cannot index string with string "message"` | (clean) |
| stdout | (nothing → `{}` fallback) | `{"input_tokens":5,"output_tokens":269,"cache_creation_input_tokens":14531,"cache_read_input_tokens":44341,"turns":3,"model":"sonnet","cost_usd":0}` |

## What

Single fix: drop one `.[]` from both the `$msgs` accumulator and the turns count. Add a comment so future-me doesn't make the same mistake.
