### PR TITLE
docs(CLAUDE.md): document claude-interactive harness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Four pieces:
    from defaults only. `harness: claude | claude-interactive | codex`
    selects the harness (default `claude`). A per-workflow `harness:`
    override (and matching `model:`) lets an adopter trial a different
-   harness on one workflow at a time. All six workflows are enabled by
+   harness on one workflow at a time. All workflows are enabled by
    default.
 
 Generated workflows are standalone — full `steps:` jobs, not

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,12 +31,17 @@ Four pieces:
    floating `v1`). One per harness:
    - `max-sixty/tend@X.Y.Z` (Claude) — invokes `claude-code-action` with the
      tend plugin marketplace. Inputs documented in `action.yaml`.
+   - `max-sixty/tend/interactive@X.Y.Z` (Claude interactive) — runs the
+     official `claude` binary under a PTY supervisor (`script(1)`) with a
+     Stop-hook sentinel, instead of going through the Agent SDK. Inputs
+     mirror `action.yaml` for swap-in parity. Inputs in
+     `interactive/action.yaml`.
    - `max-sixty/tend/codex@X.Y.Z` (Codex) — installs `@openai/codex` and
      shells out to `codex exec`. Skills are staged on disk and an
      `AGENTS.md` in `$CODEX_HOME` teaches Codex to resolve
      `/tend-ci-runner:NAME` slash commands. Inputs in `codex/action.yaml`.
 
-   Both actions resolve the bot's numeric ID at runtime, run security and
+   All actions resolve the bot's numeric ID at runtime, run security and
    rate-limit preflight, and upload session logs. The actions don't know
    or care about triggers, checkout, or project setup.
 3. **Generator** (`uvx tend@latest init`) — stamps workflow files into
@@ -45,8 +50,11 @@ Four pieces:
    idempotent — running `init` again overwrites all files from the
    current config.
 4. **Config** (`.config/tend.yaml`) — inputs to the generator. Overrides
-   from defaults only. `harness: claude | codex` selects the harness
-   (default `claude`). All six workflows are enabled by default.
+   from defaults only. `harness: claude | claude-interactive | codex`
+   selects the harness (default `claude`). A per-workflow `harness:`
+   override (and matching `model:`) lets an adopter trial a different
+   harness on one workflow at a time. All six workflows are enabled by
+   default.
 
 Generated workflows are standalone — full `steps:` jobs, not
 `workflow_call`. The generator owns the entire file. Project setup (build
@@ -67,6 +75,8 @@ tend/
 │       ├── .codex-plugin/  # Codex plugin manifest
 │       └── scripts/      # Helper scripts (survey, run listing)
 ├── action.yaml           # Claude harness composite action
+├── interactive/
+│   └── action.yaml       # Claude interactive harness (PTY-supervised binary)
 ├── codex/
 │   ├── action.yaml       # Codex harness composite action
 │   └── agents-tail.md    # AGENTS.md appendix for Codex


### PR DESCRIPTION
## Summary

CLAUDE.md's Architecture and Structure sections fell behind two recent merges:

- #609 introduced the `claude-interactive` harness with a new composite action at `interactive/action.yaml`.
- #612 added per-workflow `harness:` / `model:` overrides.

Both shipped without updating the doc. A reader working off CLAUDE.md still sees only two harnesses listed.

## Changes

- Add the `max-sixty/tend/interactive@X.Y.Z` action ref to the harness list with a one-line description.
- Update "Both actions resolve…" → "All actions resolve…".
- Extend `harness: claude | codex` → `harness: claude | claude-interactive | codex`, and call out the per-workflow override knob.
- Add `interactive/action.yaml` to the directory tree, slotted between `action.yaml` and `codex/`.

Surfaced by nightly's Step 4 review of the past-24h diff against CLAUDE.md.

## Test plan

Docs-only change; no test added. Pre-commit (typos / trailing whitespace / EOF) runs clean against the modified file.
