### PR TITLE
chore: release 0.1.2

### DIFF
--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "tend"
-version = "0.1.1"
+version = "0.1.2"
 description = "An autonomous junior maintainer for GitHub repos, powered by Claude or OpenAI Codex — reviews PRs, triages issues, fixes CI"
 license = "MIT"
 requires-python = ">=3.11"

--- a/generator/uv.lock
+++ b/generator/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "tend"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Why

Cut the 0.1.2 release so consumer repos (and tend's own nightly regen) pick up the new
`claude-interactive` harness and per-workflow `harness`/`model` overrides.

## What's new since 0.1.1

**New `claude-interactive` harness** (`max-sixty/tend/interactive@0.1.2`) — opt-in
alternative to the released `claude` harness. PTY-supervised interactive `claude` via
`script(1)`, end-of-turn detected through Stop/StopFailure hooks. Built as the
trial path ahead of Anthropic's June 15 billing split between Agent-SDK metering and
the flat Claude Code subscription. Smoke tested end-to-end on tend itself. PRs:
#609, #611, #613, #614, #615, #616.

**Per-workflow `harness` / `model` override** — adopters can flip a single workflow
to a different harness or model without changing `.config/tend.yaml` defaults. #612.

**Skill refinements** — nightly upstream-bot rebases (#605), running-in-ci PR bar
(#604) and recheck (#573), env-filter loophole fix (#599), authorAssociation warning
(#600), review-gates Gate 1 (#602).

**Bug fix** — mention queue-delay now uses `comment.updated_at` so edit events report
accurately (#595).

## Compatibility

Released `claude` harness path is byte-identical; `claude-interactive` is strictly
additive and opt-in. Consumer repos that don't touch `harness:` see no change beyond
the new skill text and the mention-edit fix.
