### PR TITLE
skills(running-in-ci): offer standing exception when asking to file upstream

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -90,6 +90,12 @@ The adopter's `running-tend` overlay may grant a standing exception for **agent-
 
 Two or three convergent signals are enough; borderline cases revert to the default. Without an explicit opt-in in `running-tend`, the default also applies.
 
+When asking permission (the default path), close with a short offer so the user can record a preference for future asks:
+
+> By default I ask before filing upstream issues. If you'd prefer I file without asking, let me know and I'll add a standing exception to my guidance. If you'd rather keep approving each one but stop seeing this offer, also let me know.
+
+Either reply gets codified in the consumer repo's `running-tend` overlay per **Learning from Feedback** below — opt-in adds the target (or "all agent-equipped targets") to the exceptions list; suppress adds a one-line rule telling the bot to skip the offer for future asks.
+
 Whether filed direct or post-approval, the issue body includes:
 
 - Problem statement: what fires, where, under what conditions.


### PR DESCRIPTION
When the bot asks a user for permission to file an issue in another repo, it should also offer two preference shortcuts so the user doesn't have to re-decide every time:

- "File without asking" — bot adds a standing exception to the consumer repo's `running-tend` overlay.
- "Keep asking but stop offering this" — bot adds a one-line rule that mutes the offer.

Either choice is codified in `.claude/skills/running-tend/SKILL.md` per the existing **Learning from Feedback** flow.

Triggered by [@max-sixty's request on #357](https://github.com/max-sixty/tend/issues/357#issuecomment-4553115209):

> let's make a slight addition there: when asking to file an issue, say something like "by default I always ask before filing issues, but if you're happy for me to file them without asking, let me know and I'll add it to my guidance. The tend project values them. (also if you know you want me to ask you each time and not show this message, also let me know...)"
