### PR TITLE
action: drop redundant CLAUDE.md pin step

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -164,29 +164,12 @@ runs:
         curl -LsSf https://astral.sh/uv/install.sh | sh -s -- --quiet
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-    # claude-code-action restores these from the base branch on all PRs
-    # (RCE vectors — hooks, env vars, MCP servers):
-    #   .claude/  .mcp.json  .claude.json  .gitmodules  .ripgreprc
-    # It does NOT restore CLAUDE.md (prompt-injection, not RCE), so we
-    # pin it ourselves for fork PRs.
-    - name: Pin CLAUDE.md to base branch (fork PRs)
-      shell: bash
-      run: |
-        if [ "$GITHUB_EVENT_NAME" != "pull_request_target" ]; then
-          exit 0
-        fi
-        IS_FORK=$(jq -r '.pull_request.head.repo.fork // false' "$GITHUB_EVENT_PATH")
-        if [ "$IS_FORK" != "true" ]; then
-          exit 0
-        fi
-        DEFAULT_BRANCH=$(jq -r '.repository.default_branch' "$GITHUB_EVENT_PATH")
-        if git show "origin/${DEFAULT_BRANCH}:CLAUDE.md" > /tmp/base-claude.md 2>/dev/null; then
-          cp /tmp/base-claude.md CLAUDE.md
-          echo "Pinned CLAUDE.md to ${DEFAULT_BRANCH}"
-        else
-          rm -f CLAUDE.md
-          echo "No CLAUDE.md on ${DEFAULT_BRANCH} — removed fork version"
-        fi
+    # claude-code-action restores every PR-controllable cwd-trusted file
+    # from the base branch on every PR — RCE vectors (.claude/, .mcp.json,
+    # .claude.json, .gitmodules, .ripgreprc, .husky) plus prompt-injection
+    # vectors (CLAUDE.md, CLAUDE.local.md). See restoreConfigFromBase in
+    # the upstream action's src/github/operations/restore-config.ts. No
+    # additional pinning is needed here.
 
     # Compose the system prompt from shared/system-prompt.md (harness-neutral
     # bulk: conduct, scope, precedence) plus a Claude-specific


### PR DESCRIPTION
## Summary

The `Pin CLAUDE.md to base branch (fork PRs)` step in `action.yaml` is dead code — upstream `claude-code-action` v1 already restores `CLAUDE.md` (along with `CLAUDE.local.md` and `.husky`) from the PR base branch on every PR event, before the CLI starts. The preceding comment incorrectly states the upstream action "does NOT restore CLAUDE.md".

## Evidence

`anthropics/claude-code-action`'s `v1/src/github/operations/restore-config.ts` defines:

```typescript
const SENSITIVE_PATHS = [
  ".claude",
  ".mcp.json",
  ".claude.json",
  ".gitmodules",
  ".ripgreprc",
  "CLAUDE.md",
  "CLAUDE.local.md",
  ".husky",
];
```

`restoreConfigFromBase` is called from `v1/src/entrypoints/run.ts` for every PR event (`pull_request`, `pull_request_target`, `pull_request_review`, `pull_request_review_comment`), restoring all `SENSITIVE_PATHS` from the PR's `base.ref` before the CLI reads them.

This was confirmed during a `tend-mention` session ([run 26498407966](https://github.com/max-sixty/tend/actions/runs/26498407966) on PR #617): the agent saw `CLAUDE.md` reverted in the working tree on a non-fork PR — proving the upstream restore fires for every PR, not only forks.

## Changes

- Remove the redundant `Pin CLAUDE.md to base branch (fork PRs)` step.
- Replace the preceding comment with an accurate summary of what `claude-code-action` restores, naming the source file so future readers can verify.

## Notes

`codex/action.yaml` still needs its own `Pin instruction files to base branch (fork PRs)` step — Codex doesn't go through `claude-code-action`, so the restore isn't free there. No change to that file.

`interactive/action.yaml` already implements a full restore with the same `SENSITIVE` list locally, so it's consistent.

## Test plan

- Composite action change only — no generator output changes.
- `pre-commit run --all-files` should pass (no `actionlint` impact; one step removed, no syntax changes elsewhere).
- Verify in a fork PR that `claude-code-action`'s upstream restore still pins `CLAUDE.md` (already demonstrated in the linked run for a same-repo PR).
