### PR TITLE
dogfood: switch tend to claude-interactive harness

### DIFF
--- a/.config/tend.yaml
+++ b/.config/tend.yaml
@@ -1,11 +1,11 @@
 bot_name: tend-agent
-harness: claude
+harness: claude-interactive
 
 setup:
   - uses: astral-sh/setup-uv@v6
 
 secrets:
-  # tend's own harness is Claude; no generated workflow consumes this. The
+  # tend's own harness is Claude (interactive); no generated workflow consumes this. The
   # CODEX_AUTH_JSON repo secret is retained only for the dispatch-only
   # codex-auth-refresh.yaml reference workflow, so it stays allowlisted to
   # keep tend's own secret audit (check_repo_secret_allowlist) from

--- a/.github/workflows/tend-ci-fix.yaml
+++ b/.github/workflows/tend-ci-fix.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@v6
 
-      - uses: max-sixty/tend@0.1.2
+      - uses: max-sixty/tend/interactive@0.1.2
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tend-mention.yaml
+++ b/.github/workflows/tend-mention.yaml
@@ -195,7 +195,7 @@ jobs:
         env:
           EVENT_TS: ${{ github.event.comment.updated_at || github.event.review.submitted_at || github.event.issue.updated_at }}
 
-      - uses: max-sixty/tend@0.1.2
+      - uses: max-sixty/tend/interactive@0.1.2
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tend-nightly.yaml
+++ b/.github/workflows/tend-nightly.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@v6
 
-      - uses: max-sixty/tend@0.1.2
+      - uses: max-sixty/tend/interactive@0.1.2
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tend-notifications.yaml
+++ b/.github/workflows/tend-notifications.yaml
@@ -99,7 +99,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@v6
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'
-      - uses: max-sixty/tend@0.1.2
+      - uses: max-sixty/tend/interactive@0.1.2
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}

--- a/.github/workflows/tend-review-runs.yaml
+++ b/.github/workflows/tend-review-runs.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@v6
 
-      - uses: max-sixty/tend@0.1.2
+      - uses: max-sixty/tend/interactive@0.1.2
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tend-review.yaml
+++ b/.github/workflows/tend-review.yaml
@@ -50,13 +50,12 @@ jobs:
 
       - uses: astral-sh/setup-uv@v6
 
-      - uses: max-sixty/tend@0.1.2
+      - uses: max-sixty/tend/interactive@0.1.2
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: tend-agent
           model: opus
-          use_sticky_comment: true
           prompt: >-
             ${{ format('/tend-ci-runner:review {0}', github.event.pull_request.number) }}

--- a/.github/workflows/tend-triage.yaml
+++ b/.github/workflows/tend-triage.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@v6
 
-      - uses: max-sixty/tend@0.1.2
+      - uses: max-sixty/tend/interactive@0.1.2
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tend-weekly.yaml
+++ b/.github/workflows/tend-weekly.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@v6
 
-      - uses: max-sixty/tend@0.1.2
+      - uses: max-sixty/tend/interactive@0.1.2
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Why

Dogfood the `claude-interactive` harness shipped in 0.1.2 on tend itself. Every
adopter benefits from tend being the first heavy user of its own opt-in path.

## What

Single config flip — `.config/tend.yaml`:

```diff
-harness: claude
+harness: claude-interactive
```

`uvx tend@latest init` regenerates all eight workflows to pin
`max-sixty/tend/interactive@0.1.2` instead of `max-sixty/tend@0.1.2`. No skill
changes, no workflow logic changes.

## Behavior changes

- `tend-review`'s `use_sticky_comment: true` is dropped — the macro gates it
  on `cfg.harness == 'claude'` because the JS sticky-comment layer doesn't
  exist in the interactive action. In practice the sticky path wasn't reaching
  review comments either, so this is mostly removing dead config. A follow-up
  will strip it from the review template so other adopters on `harness: claude`
  also drop it.

## Rollback

Single-line revert on `.config/tend.yaml`. Workflows regenerate on the next
nightly (or manually via `uvx tend@latest init`).
