### PR TITLE
generator: drop dead use_sticky_comment in review template

### DIFF
--- a/generator/src/tend/templates/macros.yaml.j2
+++ b/generator/src/tend/templates/macros.yaml.j2
@@ -11,9 +11,8 @@
    Claude emits both `claude_code_oauth_token` and `anthropic_api_key`
    unconditionally; the action validates exactly one is set and forwards both
    to claude-code-action, which treats empty as absent. Codex follows the same
-   pattern (auth.json wins over api-key when both configured). Sticky comments
-   are Claude-only — Codex posts via gh from inside skill prompts. #}
-{% macro agent_step(cfg, prompt_body, use_sticky_comment=False, if_condition='') %}
+   pattern (auth.json wins over api-key when both configured). #}
+{% macro agent_step(cfg, prompt_body, if_condition='') %}
 {% if cfg.harness == 'claude' %}
       - uses: max-sixty/tend@<<tend_version>>
 {% elif cfg.harness == 'claude-interactive' %}
@@ -38,9 +37,6 @@
 {% endif %}
           bot_name: <<cfg.bot_name>>
           model: <<cfg.model>>
-{% if use_sticky_comment and cfg.harness == 'claude' %}
-          use_sticky_comment: true
-{% endif %}
           <<prompt_body>>
 {%- endmacro %}
 

--- a/generator/src/tend/templates/review.yaml.j2
+++ b/generator/src/tend/templates/review.yaml.j2
@@ -34,4 +34,4 @@ jobs:
           fi
 <<checkout(cfg, ref='${{ steps.pr_ref.outputs.ref }}')>>
 <<setup>>
-<<agent_step(cfg, prompt_body, use_sticky_comment=True)>>
+<<agent_step(cfg, prompt_body)>>

--- a/generator/tests/_regtest_outputs/test_generate.test_extras_apply_path_regtest.out
+++ b/generator/tests/_regtest_outputs/test_generate.test_extras_apply_path_regtest.out
@@ -56,7 +56,6 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
-          use_sticky_comment: true
           prompt: >-
             ${{ format('/tend-ci-runner:review {0}', github.event.pull_request.number) }}
     timeout-minutes: 240

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review].out
@@ -55,6 +55,5 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
-          use_sticky_comment: true
           prompt: >-
             ${{ format('/tend-ci-runner:review {0}', github.event.pull_request.number) }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review].out
@@ -57,6 +57,5 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
-          use_sticky_comment: true
           prompt: >-
             ${{ format('/tend-ci-runner:review {0}', github.event.pull_request.number) }}

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -1087,17 +1087,6 @@ def test_codex_effort_only_when_set(tmp_path: Path) -> None:
         assert "effort: high" in wf.content, f"{wf.filename} missing effort: high"
 
 
-def test_codex_review_omits_sticky_comment(tmp_path: Path) -> None:
-    """use_sticky_comment is a Claude-only feature; the Codex review step omits it."""
-    cfg = Config.load(_minimal_config(tmp_path, "harness: codex"))
-    workflows = {wf.filename: wf for wf in generate_all(cfg)}
-    review = workflows["tend-review.yaml"]
-    assert "use_sticky_comment" not in review.content, (
-        "use_sticky_comment is Claude-only; the codex action posts via gh "
-        "from skill prompts instead"
-    )
-
-
 def test_codex_default_model(tmp_path: Path) -> None:
     """Engine = codex without explicit model picks gpt-5.5."""
     cfg = Config.load(_minimal_config(tmp_path, "harness: codex"))


### PR DESCRIPTION
The review template forced `use_sticky_comment: true` on the generated `tend-review` workflow under the claude harness. Claude posts reviews as fresh review events rather than as comments, so the sticky behavior never actually applied to review output — it was dead config.

This drops the hardcoded flag and the now-unused `use_sticky_comment` parameter from `agent_step`. The `use_sticky_comment` input on the claude action itself is unchanged — adopters who want it for non-review workflows can still set it through workflow overrides.

Tend's own workflows already lost the line in #622 (claude-interactive doesn't emit it); this is the corresponding cleanup so adopters on `harness: claude` also drop it on next regen.