### PR TITLE
chore(review-reviewers): bump action pin to 0.1.2 (interactive harness)

### DIFF
--- a/.github/workflows/review-reviewers.yaml
+++ b/.github/workflows/review-reviewers.yaml
@@ -38,7 +38,7 @@ jobs:
           fetch-tags: true
           token: ${{ secrets.TEND_BOT_TOKEN }}
 
-      - uses: max-sixty/tend@0.0.24
+      - uses: max-sixty/tend/interactive@0.1.2
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

- `.github/workflows/review-reviewers.yaml` is hand-maintained, so it didn't pick up the dogfood switch in #622 that moved every generated `tend-*` workflow to `max-sixty/tend/interactive@0.1.2`. It was still pinned at `max-sixty/tend@0.0.24`.
- Bump it to `max-sixty/tend/interactive@0.1.2` so it shares the same composite action (and same security preflight, setup, and session-log upload) as the generated workflows.

Surfaced by nightly's Step 4 / Step 6 review when comparing action refs across all `.github/workflows/*.yaml` files.

## Test plan

- [ ] actionlint passes (pre-commit hook)
- [ ] First scheduled hourly run completes successfully across the matrix
- [ ] Session-log artifacts upload as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
