### PR TITLE
fix(token-report): also match interactive harness artifact names

### DIFF
--- a/plugins/tend-ci-runner/scripts/token-report.sh
+++ b/plugins/tend-ci-runner/scripts/token-report.sh
@@ -83,7 +83,14 @@ for row in "${ROWS[@]}"; do
   RUNDIR="$WORKDIR/$RUN_ID"
   mkdir -p "$RUNDIR"
 
-  if ! gh run download "$RUN_ID" "${repo_args[@]}" --pattern 'claude-session-logs*' --dir "$RUNDIR" 2>/dev/null; then
+  # Two artifact prefixes since the interactive harness lands: the
+  # SDK action uploads `claude-session-logs-X`, the interactive action
+  # uploads `claude-interactive-session-logs-X`. A consumer repo may
+  # have both in flight during a harness migration, so we accept either.
+  if ! gh run download "$RUN_ID" "${repo_args[@]}" \
+      --pattern 'claude-session-logs*' \
+      --pattern 'claude-interactive-session-logs*' \
+      --dir "$RUNDIR" 2>/dev/null; then
     continue
   fi
 


### PR DESCRIPTION
## Summary

`token-report.sh` uses `--pattern 'claude-session-logs*'` to find session-log artifacts in each run. The new interactive harness (`interactive/action.yaml`) uploads `claude-interactive-session-logs-<sha>` instead, which the glob does not match. As a result, every run from the interactive harness is silently skipped — the script keeps printing a token rollup, but only the runs still on the SDK action (in this repo, `review-reviewers` is hand-maintained on the old pin while every generated `tend-*` workflow switched to `interactive/` in #622) make it in.

Pass both patterns to `gh run download` so the report covers either artifact name. The pattern flag accepts repeated values (`-p stringArray`), so adding a second `--pattern` is the minimal change.

## Verification

In this repo, running the script against the last 24h before and after the fix:

| | runs covered |
|---|---|
| before | 31 |
| after | 57 |

The 26-run gap is the post-#622 interactive runs (`tend-mention`, `tend-review`, `tend-triage`, `tend-nightly`, `tend-notifications`) whose artifacts were being skipped.

Surfaced by [tend-review-runs run 26565039707](https://github.com/max-sixty/tend/actions/runs/26565039707), Step 2 of the review-runs skill, when the token rollup looked too small for the day's activity.

## Caveat

The interactive harness reports `cost_usd: 0` in its `token-usage.json` (no Claude-Code-Action SDK execution-output to read), so the cost column for those workflows reads as $0 in the report. That's a separate gap — covered here only by widening artifact coverage; an actual cost figure would need a model + token-count calculation.
