### PR TITLE
docs: add user-facing coverage for the claude-interactive harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,23 +144,27 @@ Full threat model: [docs/security-model.md](docs/security-model.md).
 
 ## Configuration
 
-`.config/tend.yaml` — only `bot_name` is required. The default harness is
-Claude; set `harness: codex` to use OpenAI Codex instead.
+`.config/tend.yaml` — only `bot_name` is required. The default harness wraps
+`claude-code-action`; `harness: codex` selects OpenAI Codex, and
+`harness: claude-interactive` runs the official `claude` CLI under a PTY
+(see [Harnesses](#harnesses) below for when each fits).
 
 ```yaml
 bot_name: my-project-bot
 
 # Optional — defaults to "claude"
 # harness: codex
+# harness: claude-interactive
 # effort: medium   # codex only: minimal | low | medium | high
 ```
 
 Repo secrets depend on the harness:
 
-| Harness   | Required secrets                                                                                                        |
-| -------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `claude` | `TEND_BOT_TOKEN` + one of `CLAUDE_CODE_OAUTH_TOKEN` (subscription, see caveat below) or `ANTHROPIC_API_KEY` (API-billed) |
-| `codex`  | `TEND_BOT_TOKEN` + `OPENAI_API_KEY` (pay-per-token).                                                                     |
+| Harness               | Required secrets                                                                                                        |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `claude`              | `TEND_BOT_TOKEN` + one of `CLAUDE_CODE_OAUTH_TOKEN` (subscription, see caveat below) or `ANTHROPIC_API_KEY` (API-billed) |
+| `claude-interactive`  | Same as `claude`.                                                                                                       |
+| `codex`               | `TEND_BOT_TOKEN` + `OPENAI_API_KEY` (pay-per-token).                                                                    |
 
 `TEND_BOT_TOKEN` is the bot account's PAT — see
 [example config](docs/tend.example.yaml) for scopes.
@@ -186,8 +190,9 @@ workflow names `tend-ci-fix` watches, PR title conventions, label policies.
 
 ## Harnesses
 
-Tend supports two harnesses. Pick whichever fits the credentials you
-already have; both run with the same workflows and skills.
+Tend supports three harnesses. Pick whichever fits the credentials and
+billing path that already work for you; all three run the same workflows
+and skills.
 
 ### Claude (default)
 
@@ -221,6 +226,22 @@ authenticate; billing just shifts buckets. See Anthropic's
 and the
 [Agent SDK plan article](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan)
 for the canonical statements.
+
+### Claude (interactive)
+
+Runs the official `claude` CLI inside a PTY (via `script(1)`) instead of
+through `claude-code-action`. End-of-turn detection comes from a `Stop`
+hook that writes a sentinel file the supervisor polls for.
+
+Auth matches the default Claude harness (`CLAUDE_CODE_OAUTH_TOKEN` or
+`ANTHROPIC_API_KEY`).
+
+From 2026-06-15, subscription-funded `claude-code-action` runs draw from
+the separate metered Agent SDK credit pool described in the caveat above;
+the interactive `claude` CLI continues to draw from the flat Pro/Max
+subscription.
+
+Opt-in: `harness: claude-interactive`.
 
 ### Codex (alternative)
 

--- a/docs/tend.example.yaml
+++ b/docs/tend.example.yaml
@@ -14,17 +14,21 @@ bot_name: my-project-bot
 # ## Harness
 #
 # Which agent runtime to use. Defaults to "claude" (wraps
-# anthropics/claude-code-action). Set to "codex" to use OpenAI Codex via
-# `codex exec` instead.
+# anthropics/claude-code-action). Alternatives: "codex" runs OpenAI
+# Codex via `codex exec`; "claude-interactive" runs the official `claude`
+# CLI under a PTY (opt-in, see README "Harnesses" for the billing-path
+# motivation).
 #
 # harness: codex
+# harness: claude-interactive
 
 # ## Model
 #
 # Model to use for all workflows. Valid values depend on the harness:
 #
-# - harness: claude — opus (default), sonnet, haiku
-# - harness: codex  — gpt-5.5 (default); any string Codex CLI accepts
+# - harness: claude              — opus (default), sonnet, haiku
+# - harness: claude-interactive  — opus (default), sonnet, haiku
+# - harness: codex               — gpt-5.5 (default); any string Codex CLI accepts
 #
 # model: opus
 
@@ -48,10 +52,11 @@ bot_name: my-project-bot
 #
 # Repo secrets, by harness:
 #
-# | Harness   | Required                                                                     |
-# |----------|-------------------------------------------------------------------------------|
-# | `claude` | `TEND_BOT_TOKEN` + one of `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`    |
-# | `codex`  | `TEND_BOT_TOKEN` + `OPENAI_API_KEY`                                           |
+# | Harness               | Required                                                                  |
+# |-----------------------|---------------------------------------------------------------------------|
+# | `claude`              | `TEND_BOT_TOKEN` + one of `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` |
+# | `claude-interactive`  | Same as `claude`.                                                          |
+# | `codex`               | `TEND_BOT_TOKEN` + `OPENAI_API_KEY`                                        |
 #
 # `TEND_BOT_TOKEN` is the bot account's PAT (scopes below).
 # `CLAUDE_CODE_OAUTH_TOKEN` is from `claude setup-token` (PKCE).
@@ -81,9 +86,9 @@ bot_name: my-project-bot
 #
 # secrets:
 #   bot_token: MY_BOT_PAT
-#   claude_token: MY_CLAUDE_TOKEN      # harness: claude (OAuth)
-#   anthropic_api_key: MY_ANTHROPIC_KEY  # harness: claude (API key)
-#   openai_key: MY_OPENAI_KEY          # harness: codex
+#   claude_token: MY_CLAUDE_TOKEN        # claude / claude-interactive (OAuth)
+#   anthropic_api_key: MY_ANTHROPIC_KEY  # claude / claude-interactive (API key)
+#   openai_key: MY_OPENAI_KEY            # codex
 #
 # `tend check` flags repo-level secrets not in an explicit allowlist. Repos with
 # additional legitimate secrets must list them:

--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -77,15 +77,18 @@ as the bot, verify the logged-in user via the avatar menu.
 ## 1. Create config
 
 Create `.config/tend.yaml` with at minimum `bot_name`, plus `harness` if
-the user chose Codex (Claude is the default and can be omitted). See
-README.md for all available config sections (`secrets:`, `setup:`,
-`workflows:`).
+the user chose Codex or the interactive Claude harness (the default
+Claude harness via `claude-code-action` can be omitted). See README.md
+"Harnesses" for the comparison.
 
 ```yaml
 bot_name: <bot-name>
 # For Codex, also:
 # harness: codex
 # effort: medium   # optional: minimal | low | medium | high
+# For the interactive Claude harness (PTY-supervised `claude` CLI;
+# opt-in, see README "Harnesses"):
+# harness: claude-interactive
 ```
 
 Check whether the repo already has a bot token secret under a non-default name:

--- a/plugins/install-tend/skills/install-tend/references/security-model.md
+++ b/plugins/install-tend/skills/install-tend/references/security-model.md
@@ -102,7 +102,7 @@ harness-auth credential whose form depends on `harness` in
 |-------|---------|
 | Bot token (PAT or App) | GitHub API and git operations. Consistent bot identity. |
 | Harness auth (one of, per harness) | Authenticates the agent runtime. |
-| ↳ Claude OAuth token | `harness: claude`: authenticates Claude Code to the Anthropic API. |
+| ↳ Claude OAuth token | `harness: claude` or `harness: claude-interactive`: authenticates Claude Code to the Anthropic API. |
 | ↳ `OPENAI_API_KEY` | `harness: codex`: standard OpenAI API key, per-token billing. The subscription `auth.json` path is not supported (see above). |
 
 A single bot token is safe across workflows because the merge restriction

--- a/plugins/install-tend/skills/install-tend/references/tend.example.yaml
+++ b/plugins/install-tend/skills/install-tend/references/tend.example.yaml
@@ -14,17 +14,21 @@ bot_name: my-project-bot
 # ## Harness
 #
 # Which agent runtime to use. Defaults to "claude" (wraps
-# anthropics/claude-code-action). Set to "codex" to use OpenAI Codex via
-# `codex exec` instead.
+# anthropics/claude-code-action). Alternatives: "codex" runs OpenAI
+# Codex via `codex exec`; "claude-interactive" runs the official `claude`
+# CLI under a PTY (opt-in, see README "Harnesses" for the billing-path
+# motivation).
 #
 # harness: codex
+# harness: claude-interactive
 
 # ## Model
 #
 # Model to use for all workflows. Valid values depend on the harness:
 #
-# - harness: claude — opus (default), sonnet, haiku
-# - harness: codex  — gpt-5.5 (default); any string Codex CLI accepts
+# - harness: claude              — opus (default), sonnet, haiku
+# - harness: claude-interactive  — opus (default), sonnet, haiku
+# - harness: codex               — gpt-5.5 (default); any string Codex CLI accepts
 #
 # model: opus
 
@@ -48,10 +52,11 @@ bot_name: my-project-bot
 #
 # Repo secrets, by harness:
 #
-# | Harness   | Required                                                                     |
-# |----------|-------------------------------------------------------------------------------|
-# | `claude` | `TEND_BOT_TOKEN` + one of `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`    |
-# | `codex`  | `TEND_BOT_TOKEN` + `OPENAI_API_KEY`                                           |
+# | Harness               | Required                                                                  |
+# |-----------------------|---------------------------------------------------------------------------|
+# | `claude`              | `TEND_BOT_TOKEN` + one of `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` |
+# | `claude-interactive`  | Same as `claude`.                                                          |
+# | `codex`               | `TEND_BOT_TOKEN` + `OPENAI_API_KEY`                                        |
 #
 # `TEND_BOT_TOKEN` is the bot account's PAT (scopes below).
 # `CLAUDE_CODE_OAUTH_TOKEN` is from `claude setup-token` (PKCE).
@@ -81,9 +86,9 @@ bot_name: my-project-bot
 #
 # secrets:
 #   bot_token: MY_BOT_PAT
-#   claude_token: MY_CLAUDE_TOKEN      # harness: claude (OAuth)
-#   anthropic_api_key: MY_ANTHROPIC_KEY  # harness: claude (API key)
-#   openai_key: MY_OPENAI_KEY          # harness: codex
+#   claude_token: MY_CLAUDE_TOKEN        # claude / claude-interactive (OAuth)
+#   anthropic_api_key: MY_ANTHROPIC_KEY  # claude / claude-interactive (API key)
+#   openai_key: MY_OPENAI_KEY            # codex
 #
 # `tend check` flags repo-level secrets not in an explicit allowlist. Repos with
 # additional legitimate secrets must list them:


### PR DESCRIPTION
Until now the new harness was only documented in `docs/security-model.md` (one paragraph) and as an artifact name in the `debug-tend-run` skill. An adopter reading the README or running the `install-tend` skill would discover only `claude` and `codex`.

Adds coverage to:

- `README.md` Configuration block + secrets table + new "Claude (interactive)" subsection under Harnesses
- `docs/tend.example.yaml` harness comment + model list + secrets table + secret-override comment
- `plugins/install-tend/skills/install-tend/SKILL.md` setup snippet
- `plugins/install-tend/skills/install-tend/references/security-model.md` Claude OAuth row covers both harnesses
- `plugins/install-tend/skills/install-tend/references/tend.example.yaml` auto-synced by the pre-commit mirror hook from `docs/tend.example.yaml`

No code or behavior changes.