### PR TITLE
skills(notifications): pad dedup cutoff for indexing lag

### DIFF
--- a/plugins/tend-ci-runner/skills/notifications/SKILL.md
+++ b/plugins/tend-ci-runner/skills/notifications/SKILL.md
@@ -84,18 +84,23 @@ If `IN_PROGRESS > 0`, **skip without marking read** — the next poll will see t
 ```bash
 BOT_LOGIN=$(gh api user --jq '.login')
 NOTIF_UPDATED_AT=<updated_at from the notification>
+# GitHub's notification indexing can lag the triggering event by 20-60s, so a
+# bot reply posted seconds before NOTIF_UPDATED_AT can still be the response
+# to the same trigger. Compare against a 60s-padded cutoff so the dedup
+# query doesn't miss replies that landed in that window.
+DEDUP_CUTOFF=$(date -u -d "$NOTIF_UPDATED_AT -60 seconds" +%Y-%m-%dT%H:%M:%SZ)
 
 # Conversation comments — issues and PR conversation
 gh issue view {number} -R {owner}/{repo} --json comments \
   --jq "[.comments[] | select(.author.login == \"$BOT_LOGIN\"
-                              and .createdAt > \"$NOTIF_UPDATED_AT\")] | length"
+                              and .createdAt > \"$DEDUP_CUTOFF\")] | length"
 
 # For PR notifications, fold reviews into one gh pr view --json call
 gh pr view {number} -R {owner}/{repo} --json comments,reviews \
   --jq "{comments: [.comments[] | select(.author.login == \"$BOT_LOGIN\"
-                                         and .createdAt > \"$NOTIF_UPDATED_AT\")] | length,
+                                         and .createdAt > \"$DEDUP_CUTOFF\")] | length,
          reviews:  [.reviews[]  | select(.author.login == \"$BOT_LOGIN\"
-                                         and .submittedAt > \"$NOTIF_UPDATED_AT\")] | length}"
+                                         and .submittedAt > \"$DEDUP_CUTOFF\")] | length}"
 ```
 
 For issue notifications, also check the timeline for bot-authored PRs that cross-reference the issue. `tend-mention` typically handles an `@`-mention-asking-for-a-PR by opening a PR with `Refs #N` in its body — *without* commenting on the issue. The comments check above misses that path, so without this timeline check the same notification races to a duplicate PR from this skill:
@@ -105,7 +110,7 @@ gh api "repos/{owner}/{repo}/issues/{number}/timeline" \
   --jq "[.[] | select(.event == \"cross-referenced\"
     and .source.issue.pull_request
     and .source.issue.user.login == \"$BOT_LOGIN\"
-    and .created_at > \"$NOTIF_UPDATED_AT\")] | length"
+    and .created_at > \"$DEDUP_CUTOFF\")] | length"
 ```
 
 If any of the three returns `> 0`, mark read and move on:


### PR DESCRIPTION
## Problem

The notifications dedup check compares bot-reply timestamps to the notification's `updated_at` with strict `>`. GitHub's notification indexing lags the underlying event by ~20-30 seconds, so a bot reply posted seconds *before* `NOTIF_UPDATED_AT` can be the response to the same trigger — and the strict comparison treats the notification as unhandled.

## Evidence (3 occurrences over 5 weeks)

All same shape: bot reply timestamp earlier than the notification's `updated_at`, dedup query returns 0, agent has to verify manually via additional tool calls, then marks the thread read with no public output.

- **2026-04-24** on PR [#327](https://github.com/max-sixty/tend/pull/327): bot summary comment at `00:23:45Z`, notification `updated_at` at `00:24:06Z` (21s gap). Recorded as first-occurrence below threshold in the 2026-04 evidence gist.
- **2026-05-09** in [`tend-notifications` run 25637566840](https://github.com/max-sixty/tend/actions/runs/25637566840): 3 notification threads, bot replies pre-empted by a sibling `tend-mention` run. Agent explicitly noted "the standard dedup-by-cutoff returned 0 because its own reply landed before the notification's `updated_at`".
- **2026-05-31** in [`tend-notifications` run 26698867926](https://github.com/max-sixty/tend/actions/runs/26698867926) on issue [#624](https://github.com/max-sixty/tend/issues/624): bot reply at `23:59:02Z`, notification `updated_at` at `23:59:24Z` (22s gap). Agent surfaced the gap in its final summary: *"Worth considering in a future skill update — e.g. checking for any bot reply newer than the latest non-bot comment, rather than newer than `updated_at`. Not codifying tonight since it's a single observation."*

Classification: **structural** — same conditions produce the same failure every time. **High** evidence (3 sessions). Per `review-gates.md` (Gate 1 High = 2-3 occurrences; Gate 2 targeted fix = normal thresholds), both gates pass.

User-facing outcome was correct in every case (no duplicate output), but each occurrence cost ~10 extra tool calls of manual verification.

## Fix

Compute a `DEDUP_CUTOFF` once, padded 60s before `NOTIF_UPDATED_AT`, and use it in all four dedup queries (issue comments, PR comments, PR reviews, timeline cross-references). 60s comfortably exceeds the observed indexing lag while staying small enough that an unrelated bot comment on the same subject is vanishingly unlikely to land within the window.

Orthogonal to the in-flight-run check added in [#322](https://github.com/max-sixty/tend/pull/322): that check fires only when a concurrent `tend-*` run is *still running* on the same subject. In all three occurrences above, the prior tend run had already completed by the time the notifications poll ran, so only the post-completion dedup is in play.

## Evidence gist

Full per-run trail: <https://gist.github.com/436c053100e5a44cdac646c9ebd3ebeb> (current month) and <https://gist.github.com/8f10d7c1abcb07c79bef00ee6d02d315> (prior month, line 102).
