### PR TITLE
skills(running-tend): fix consumers.json search recall and integration-test secret clobber

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -65,9 +65,12 @@ because the workflow files are public.
 #    version tag (`max-sixty/tend@X.Y.Z`, or `/codex@X.Y.Z`), so search the
 #    bare `max-sixty/tend` token (version-agnostic; GitHub code search does
 #    not index `@` or `/`, so this matches both the Claude and Codex refs).
+#    `--extension yaml` is required: without it, README/CLAUDE.md/TODO.md
+#    hits on `max-sixty/tend` itself crowd out tend's own workflow files
+#    past the 100-result cap, dropping tend from its own consumers.json.
 #    The `.github/workflows/tend-` path filter below bounds precision.
 mapfile -t REPOS < <(
-  gh search code 'max-sixty/tend' --limit 100 --json repository,path \
+  gh search code 'max-sixty/tend' --extension yaml --limit 100 --json repository,path \
     | jq -r '.[] | select(.path | startswith(".github/workflows/tend-")) | .repository.nameWithOwner' \
     | sort -u
 )

--- a/.claude/skills/running-tend/references/integration-test.md
+++ b/.claude/skills/running-tend/references/integration-test.md
@@ -20,11 +20,15 @@ creates it. Once it exists, subsequent weekly runs only operate on it.
 claude step in `action.yaml`. `gh` authenticates as `tend-agent` via
 `$GITHUB_TOKEN` automatically.
 
-`$CLAUDE_CODE_OAUTH_TOKEN` is **not** available here — the harness sets
-`CLAUDE_CODE_SUBPROCESS_ENV_SCRUB`, which strips Anthropic credentials
-from this subprocess. Rotation on the integration repo is therefore a
-manual maintainer task; the reseed below is guarded so a scrubbed env
-never clobbers the stored secret.
+`$CLAUDE_CODE_OAUTH_TOKEN` is **not** available here — empirically
+unset/empty in this subprocess despite [`action.yaml`'s `env:`
+block](../../../action.yaml) exposing it on the claude step with
+`CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=0`. Some layer between the action's
+env declaration and the Bash tool's subprocess strips Anthropic
+credentials; root cause is not yet pinned down. Rotation on the
+integration repo is therefore a manual maintainer task; the reseed
+below is guarded so a missing var no-ops instead of clobbering the
+stored secret.
 
 The bot PAT needs `workflow` (to push generated workflow files) but
 **does not** need `delete_repo` — the recipe never deletes the test
@@ -101,12 +105,12 @@ fi
 printf '%s' "$GITHUB_TOKEN" \
   | gh secret set TEND_BOT_TOKEN --repo tend-agent/tend-integration
 
-# CLAUDE_CODE_OAUTH_TOKEN is scrubbed from this subprocess by the
-# harness — an unguarded reseed would pipe empty into the secret and
-# break every subsequent tend-* run on the integration repo at the
-# action's auth preflight. Only reseed if the env var actually has a
-# value (it currently never will under env-scrub; the guard exists so
-# the recipe is safe if that ever changes).
+# CLAUDE_CODE_OAUTH_TOKEN is empirically unset in this subprocess (see
+# §0 Safety preamble) — an unguarded reseed would pipe empty into the
+# secret and break every subsequent tend-* run on the integration repo
+# at the action's auth preflight. Only reseed if the env var actually
+# has a value; if the strip ever lifts, the recipe propagates rotations
+# automatically.
 if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
   printf '%s' "$CLAUDE_CODE_OAUTH_TOKEN" \
     | gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo tend-agent/tend-integration

--- a/.claude/skills/running-tend/references/integration-test.md
+++ b/.claude/skills/running-tend/references/integration-test.md
@@ -16,9 +16,15 @@ not run this recipe against any other repo.
 If `tend-agent/tend-integration` does not exist yet, the §1 bootstrap
 creates it. Once it exists, subsequent weekly runs only operate on it.
 
-`$GITHUB_TOKEN` (bot PAT) and `$CLAUDE_CODE_OAUTH_TOKEN` are both present
-in the agent's env, set on the claude step in `action.yaml`. `gh`
-authenticates as `tend-agent` via `$GITHUB_TOKEN` automatically.
+`$GITHUB_TOKEN` (bot PAT) is present in the agent's env, set on the
+claude step in `action.yaml`. `gh` authenticates as `tend-agent` via
+`$GITHUB_TOKEN` automatically.
+
+`$CLAUDE_CODE_OAUTH_TOKEN` is **not** available here — the harness sets
+`CLAUDE_CODE_SUBPROCESS_ENV_SCRUB`, which strips Anthropic credentials
+from this subprocess. Rotation on the integration repo is therefore a
+manual maintainer task; the reseed below is guarded so a scrubbed env
+never clobbers the stored secret.
 
 The bot PAT needs `workflow` (to push generated workflow files) but
 **does not** need `delete_repo` — the recipe never deletes the test
@@ -90,11 +96,21 @@ EOF
 EOF
 fi
 
-# Always (re)seed secrets — handles OAuth-token rotation in the source repo.
+# Reseed TEND_BOT_TOKEN every run (env var is present and rotates with
+# the parent workflow's secret).
 printf '%s' "$GITHUB_TOKEN" \
   | gh secret set TEND_BOT_TOKEN --repo tend-agent/tend-integration
-printf '%s' "$CLAUDE_CODE_OAUTH_TOKEN" \
-  | gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo tend-agent/tend-integration
+
+# CLAUDE_CODE_OAUTH_TOKEN is scrubbed from this subprocess by the
+# harness — an unguarded reseed would pipe empty into the secret and
+# break every subsequent tend-* run on the integration repo at the
+# action's auth preflight. Only reseed if the env var actually has a
+# value (it currently never will under env-scrub; the guard exists so
+# the recipe is safe if that ever changes).
+if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+  printf '%s' "$CLAUDE_CODE_OAUTH_TOKEN" \
+    | gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo tend-agent/tend-integration
+fi
 ```
 
 ## 2. Reset to a known-clean state


### PR DESCRIPTION
Fixes two structural bugs in `.claude/skills/running-tend/` that surfaced during this week's `/tend-ci-runner:weekly` run ([#596 update](https://github.com/max-sixty/tend/issues/596#issuecomment-4586380539)).

## 1. `consumers.json` search misses tend itself

`gh search code 'max-sixty/tend' --limit 100` returns README/CLAUDE.md/TODO.md/etc. hits ahead of workflow files. With the 100-result cap, tend's own `.github/workflows/tend-*.yaml` files are crowded out, and the `.path | startswith(".github/workflows/tend-")` filter drops tend from the regenerated list. Confirmed empirically this run: 4 repos returned, missing `max-sixty/tend`. Re-running with `--extension yaml` returns all 5.

The committed `data/consumers.json` already lists tend, so the data file is unchanged this week — but a fresh regeneration would silently drop tend.

## 2. Integration-test bootstrap clobbers `CLAUDE_CODE_OAUTH_TOKEN`

`§1 Bootstrap` unconditionally pipes `$CLAUDE_CODE_OAUTH_TOKEN` into the secret on every weekly run. The recipe claimed the variable was available from the claude step's env, but the harness sets `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB`, which scrubs Anthropic credentials from this subprocess. Verified with `[ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]` — unset, length 0.

The unguarded reseed therefore pipes empty into the integration repo's `CLAUDE_CODE_OAUTH_TOKEN` every run. This week's run did exactly that, and §3's tend-triage workflow failed at the action's auth preflight ([failed run](https://github.com/tend-agent/tend-integration/actions/runs/26709684701)).

Guard the reseed with `[ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]` so a scrubbed env no-ops instead of overwriting. Updated the §0 "Safety" preamble to be honest about which env vars are actually available and to flag rotation as a manual task.

## Follow-up

A maintainer still needs to manually re-set `CLAUDE_CODE_OAUTH_TOKEN` on `tend-agent/tend-integration` to a valid value — this PR prevents future clobbers but doesn't undo this week's. The §5 drift issue (#596 original body) is independent of this PR.
