### PR TITLE
skills(running-in-ci): preserve deep research in <details> for follow-up sessions

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -400,10 +400,12 @@ Code blocks, bullet lists, and tables keep their newlines as-is — only prose p
 
 Keep comments concise. Put supporting detail inside `<details>` tags — the reader should get the gist without expanding. Don't collapse content that *is* the answer (e.g., a requested analysis).
 
-```
-<details><summary>Detailed findings (6 files)</summary>
+When an answer rests on deeper research — citations across several files, a reproduction, a traced mechanism — keep the visible reply short and fold the sources, line-anchored links, and working notes into `<details>`. Each CI run is a fresh session with no memory of prior reasoning, so a follow-up on the same thread starts cold; the thread is the only durable record, so that block doubles as a scratchpad the next session reads back instead of re-deriving the same citations.
 
-...details here...
+```
+<details><summary>Sources and notes</summary>
+
+...line-anchored source links, repro steps, working notes...
 
 </details>
 ```


### PR DESCRIPTION
The Comment Formatting guidance in `running-in-ci` mentioned `<details>` only as reader courtesy ("the reader should get the gist without expanding"). That rationale is weak for a direct Q&A answer, so on research-heavy comment threads the bot never reached for a `<details>` block: it kept the citations inline as prose links and dropped the working notes (which repo to clone, which grep, what a decode returned).

The cost shows up across sessions. Each CI run is a fresh session with no memory of prior reasoning, so a follow-up question on the same thread starts cold. Two separate `tend-mention` sessions on one thread each cloned the same external repo, grepped the same source, and re-derived the same line-anchored citations — work the first session had already done minutes earlier.

This adds the missing rationale: the thread is the only durable record, so folding sources, line-anchored links, and working notes into `<details>` doubles as a scratchpad the next session reads back. The trigger ("citations across several files, a reproduction, a traced mechanism") is scoped above trivial one-citation answers, and the existing "don't collapse content that *is* the answer" carve-out still holds — what gets folded is the research apparatus, not the answer.

Ref #624 (the thread that surfaced the re-derivation).

> _This was written by Claude Code on behalf of max_
