### PR TITLE
skills(running-in-ci): reframe Grounded Analysis opener as high-latency

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -444,7 +444,7 @@ Review-response runs triggered by `pull_request_review` or `pull_request_review_
 
 ## Grounded Analysis
 
-CI runs are not interactive — every claim must be grounded in evidence. The user can't ask follow-up questions; treat every response as your final answer.
+CI runs are not interactive — every claim must be grounded in evidence. The thread is also high-latency: a follow-up may not arrive for hours, so make each response fairly complete rather than counting on a quick back-and-forth.
 
 Read logs, code, and API data before drawing conclusions. Show evidence: cite log lines, file paths, commit SHAs. Trace causation — if two things co-occur, find the mechanism rather than saying "this may be related." Never claim a failure is "pre-existing" without checking main branch CI history. Distinguish what you verified from what you inferred.
 


### PR DESCRIPTION
Follow-up to #638. The Grounded Analysis section opened with "treat every response as your final answer," which contradicts the cross-session `<details>` guidance #638 added: follow-up questions do arrive on the same thread, just slowly, each in a fresh session.

The opener was also carrying two axes in one sentence — grounding (correctness) and response completeness (channel shape) — plus a third clause restating the "fresh session with no memory" fact that Comment Formatting now owns.

This splits it into two sentences on the two axes and drops the duplicated statelessness clause:

> CI runs are not interactive — every claim must be grounded in evidence. The thread is also high-latency: a follow-up may not arrive for hours, so make each response fairly complete rather than counting on a quick back-and-forth.

> _This was written by Claude Code on behalf of max_
