### PR TITLE
fix(interactive): set -o pipefail in claude install retry loop

### DIFF
--- a/interactive/action.yaml
+++ b/interactive/action.yaml
@@ -275,8 +275,13 @@ runs:
       env:
         CLAUDE_VERSION: ${{ inputs.claude_version }}
       run: |
+        # `set -o pipefail` inside the bash -c subshell is required: without it
+        # a curl failure (e.g. a 403 from the claude.ai CDN) passes empty
+        # stdin to the downstream `bash -s --`, which exits 0, so the if
+        # branch succeeds and the loop breaks after one attempt without
+        # actually retrying.
         for i in 1 2 3; do
-          if timeout 60 bash -c "curl -fsSL https://claude.ai/install.sh | bash -s -- $CLAUDE_VERSION"; then
+          if timeout 60 bash -c "set -o pipefail; curl -fsSL https://claude.ai/install.sh | bash -s -- $CLAUDE_VERSION"; then
             break
           fi
           echo "Install attempt $i failed; retrying"


### PR DESCRIPTION
## Summary

The install-retry loop in the interactive harness silently breaks after one attempt: a transient curl failure (e.g. a 403 from `claude.ai/install.sh`) leaves the loop satisfied even though curl never delivered the install script.

Root cause is the pipeline inside `bash -c`:

```bash
if timeout 60 bash -c "curl -fsSL https://claude.ai/install.sh | bash -s -- $CLAUDE_VERSION"; then
```

The inner `bash -c` runs without `pipefail`, so when `curl -fsSL` exits non-zero (curl `-f` returns 22 on a 4xx/5xx), the downstream `bash -s --` reads empty stdin, runs nothing, and exits 0. The subshell's overall exit code is the last command's exit code → the `if` branch succeeds, the loop breaks, and only the final "claude binary not found" guard catches the failure — by which point all three retries have been skipped.

Reproduced locally:

```text
$ bash -c "curl -fsSL https://example.invalid/foo.sh | bash -s -- 1.0.130"; echo exit=$?
curl: (6) Could not resolve host: example.invalid
exit=0

$ bash -c "set -o pipefail; curl -fsSL https://example.invalid/foo.sh | bash -s -- 1.0.130"; echo exit=$?
curl: (6) Could not resolve host: example.invalid
exit=6
```

Run [26723255654 / `review-reviewers (max-sixty/worktrunk)`](https://github.com/max-sixty/tend/actions/runs/26723255654/job/78754023670) on 2026-05-31 20:12Z is the observed casualty: a single `curl: (22) The requested URL returned error: 403` from `https://claude.ai/install.sh`, ~50 ms later `claude binary not found`, no `Install attempt N failed; retrying` runtime lines printed, no sleeps observed. The "retries" never ran.

## Fix

One-line: prepend `set -o pipefail;` inside the `bash -c "..."` so the inner pipeline propagates `curl`'s exit code to the `if`, allowing the retry loop to actually retry.

## Blast radius

Affects every consumer using `max-sixty/tend/interactive@*` (the Claude harness for `tend-*` and `review-reviewers` workflows). The legacy `action.yaml` (SDK harness) and `codex/action.yaml` don't have this install pattern.

The follow-on `[ -x "$HOME/.local/bin/claude" ]` guard does correctly catch the bottom of the funnel — the job fails rather than silently running with no binary. But the auto-outage tracker step only fires on `steps.claude.outcome == 'failure'`, and the claude step never runs when install dies, so this class of failure is invisible to the existing failure-tracking flow.

## Test plan

- [x] Reproduce the empty-pipe-success on `bash -c` with an invalid URL (above).
- [x] Confirm `set -o pipefail` inside the subshell surfaces the curl error and lets the `for i in 1 2 3` loop retry with backoff.
- [ ] Smoke-test: next `tend-*` run on the resulting tag installs claude successfully (CI will exercise this naturally).
