### PR TITLE
skills(review-runs): guard against fabricated run IDs on first comment of month

### DIFF
--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -85,36 +85,40 @@ Also check last month's tracking issue (if it exists) for recent carry-over.
 
 After analysis, find **the bot's existing comment** on the tracking issue and **append** new findings to it. If no bot comment exists yet, create one. This avoids notification spam from frequent runs.
 
+The guard must run **before any posting path** — append-existing and create-new both publish a comment that needs to embed the real run ID, and a guard placed inside one branch silently no-ops on the other. The first run after a monthly tracking issue is created always takes the create-new branch, so the guard belongs above the branch:
+
 ```bash
 REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
 BOT_LOGIN=$(gh api user --jq '.login')
 EXISTING_COMMENT=$(gh api "repos/$REPO/issues/$TRACKING_NUMBER/comments" \
   --jq "[.[] | select(.user.login == \"$BOT_LOGIN\")] | last | .id // empty")
-```
 
-If `EXISTING_COMMENT` is non-empty, check its size before appending. GitHub rejects comment bodies over 65536 characters — start a new comment when the existing one is too large.
-
-```bash
 # Verify the run heading references this run's $GITHUB_RUN_ID literally —
 # fabricated round numbers produce dead Workflow links, see @review-gates.md.
+# Unconditional: the create-new branch below also publishes a comment.
 grep -qF "$GITHUB_RUN_ID" /tmp/findings.md || {
   echo "ERROR: /tmp/findings.md does not contain \$GITHUB_RUN_ID=$GITHUB_RUN_ID — refusing to post" >&2
   exit 1
 }
-gh api "repos/$REPO/issues/comments/$EXISTING_COMMENT" --jq '.body' > /tmp/existing.md
-EXISTING_SIZE=$(wc -c < /tmp/existing.md)
-if [ "$EXISTING_SIZE" -lt 50000 ]; then
-  cat /tmp/existing.md /tmp/findings.md > /tmp/combined.md
-  gh api "repos/$REPO/issues/comments/$EXISTING_COMMENT" -X PATCH -F body=@/tmp/combined.md
+
+if [ -n "$EXISTING_COMMENT" ]; then
+  # Append to existing comment if it fits. GitHub rejects bodies over 65536
+  # characters — start a new comment when the existing one is too large.
+  gh api "repos/$REPO/issues/comments/$EXISTING_COMMENT" --jq '.body' > /tmp/existing.md
+  EXISTING_SIZE=$(wc -c < /tmp/existing.md)
+  if [ "$EXISTING_SIZE" -lt 50000 ]; then
+    cat /tmp/existing.md /tmp/findings.md > /tmp/combined.md
+    gh api "repos/$REPO/issues/comments/$EXISTING_COMMENT" -X PATCH -F body=@/tmp/combined.md
+  else
+    gh api "repos/$REPO/issues/$TRACKING_NUMBER/comments" -F body=@/tmp/findings.md
+  fi
 else
-  # Comment approaching limit — start a new one
+  # No prior bot comment on this month's tracking issue — create the first one.
   gh api "repos/$REPO/issues/$TRACKING_NUMBER/comments" -F body=@/tmp/findings.md
 fi
 ```
 
-Never replace the body — prior entries contain per-run evidence needed for gate evaluation.
-
-If `EXISTING_COMMENT` is empty, create a new comment. See the finding format in `@review-gates.md`.
+Never replace the body — prior entries contain per-run evidence needed for gate evaluation. See the finding format in `@review-gates.md`.
 
 ## Step 1: Find recent runs
 


### PR DESCRIPTION
## Problem

The `review-runs` skill's `$GITHUB_RUN_ID` guard sits **inside the existing-comment append branch**, so when `EXISTING_COMMENT` is empty (every first-of-month run after the tracking issue is freshly created, plus any new-install case), the bot improvises a `gh api ... /comments` POST without ever invoking the guard. A fabricated run ID then sails through into the public comment.

## Evidence (1 occurrence this run, structural)

Run [26757353740](https://github.com/numbagg/numbagg/actions/runs/26757353740) (`tend-review-runs` on `numbagg/numbagg`) created the June tracking issue [numbagg/numbagg#628](https://github.com/numbagg/numbagg/issues/628) and posted its first comment with the heading `## Run 26757617527 — 2026-06-01T13:18Z`, embedding `https://github.com/numbagg/numbagg/actions/runs/26757617527` — a run that does not exist (`gh run view 26757617527 -R numbagg/numbagg` returns 404). The session log confirms the real `$GITHUB_RUN_ID=26757353740` was in the environment; the model fabricated `26757617527` when authoring `/tmp/findings.md`.

The skill already documents this failure class in `review-gates.md` ("Past sessions have filled the `<run-id>` placeholder with fabricated round numbers...") and #443 added the guard recipe. The fix is incomplete: the guard only runs when there is already a bot comment to append to.

## Classification

- **Structural**: same conditions (empty `EXISTING_COMMENT`) reliably bypass the guard. Will recur at minimum once per month per consumer when the new monthly tracking issue is created.
- **Magnitude**: targeted fix — hoist the existing `grep -qF "$GITHUB_RUN_ID"` recipe above the `EXISTING_COMMENT` branch and add an explicit create-new path so the bot doesn't improvise. No new logic, just repositioning.

## Fix

Move the guard above the branch and consolidate both posting paths under one `if/else`. The guard now runs in all three terminal states: append-within-size-limit, append-overflow-creates-new, and no-prior-comment-creates-new.

## Gate assessment

- Confidence: High (structural; ID fabrication is a documented recurring failure mode; #443's guard left the create-new path unguarded by accident).
- Magnitude: small (targeted fix; ~10 lines moved, no new functionality).
- Both gates met.

Evidence gist: https://gist.github.com/39936af3c6f4ba8f6f107fb94b6a9f20
