### PR TITLE
fix(worker): throw on Search failures instead of caching empty activity

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -53,10 +53,39 @@ Artifact paths: `-home-runner-work-tend-tend/<session-id>.jsonl`
 `review-reviewers` runs produce one session log per matrix repo in
 `.github/workflows/review-reviewers.yaml`.
 
+## Nightly: verify website live data
+
+`tend-src.com` renders its stat strip, activity feed, and currently-tending
+dot entirely from the data Worker at `api.tend-src.com`. Each section *hides
+itself* when its fetch fails or returns empty, so a Worker outage shows as a
+blank page, not an error. Check the Worker directly — it serves the data the
+site renders. See [`worker/README.md`](../../../worker/README.md).
+
+```bash
+curl -fsS https://api.tend-src.com/activity | jq '{
+  prs: .prs.count, reviews: .reviews.count,
+  comments: .comments.count, issues: .issues.count,
+  recent: ([.prs, .issues, .reviews, .comments] | map(.recent | length) | add)
+}'
+curl -fsSI https://tend-src.com/ | head -1   # GitHub Pages serving the HTML
+```
+
+Healthy: both return HTTP 200, every lifetime `count` > 0, and `recent` > 0.
+An empty `/currently-tending` is normal between runs — don't alarm on it.
+
+If `/activity` is non-200, all-zero, or `recent` is 0, wait ~60s and retry
+once. (Transient GitHub errors keep the last good data rather than caching
+zeros, so a persistent empty is a real signal.) If it persists, file or update
+**one** tracking issue (dedup by title, e.g. `website: data Worker returning
+empty`) with the failing endpoint, the counts seen, and whether the bots still
+have recent activity on GitHub — that localizes the fault to the Worker. The
+bot can't rotate the Worker's Cloudflare-side secret itself, so leave the
+diagnosis to a maintainer; `worker/README.md` covers the Worker's setup.
+
 ## Weekly: refresh `data/consumers.json`
 
 Public repos that have installed tend. Read by the website's data Worker
-(see [`docs/website-data.md`](../../../docs/website-data.md)) to power the
+(see [`worker/README.md`](../../../worker/README.md)) to power the
 currently-tending dot, activity feed, and stat strip. Needs no opt-in
 because the workflow files are public.
 

--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -9,6 +9,12 @@ metadata:
 
 Resolve conflicts on bot PRs, review recent commits, survey a slice of existing code/docs, and update tend workflows.
 
+## Step 0: Load environment skills
+
+Load `/tend-ci-runner:running-in-ci` first — it contains CI security rules,
+polling conventions, and comment formatting guidance. It will also prompt you
+to load any repo-specific skills (e.g., `running-tend`).
+
 ## Step 1: Verify bot PAT scopes
 
 Run the scope audit script to check the bot PAT against tend's required classic OAuth scopes (`repo`, `workflow`, `notifications`, `write:discussion`, `gist`, `user`):

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 Tend's bundled skills provide defaults; the consuming repo's `running-tend` skill overlays them. **Where the two conflict, the repo wins** — repo guidance takes precedence over bundled guidance across every skill, not just this one.
 
-If a `running-tend` skill is listed in your available skills, load it with the Skill tool before doing anything else. It typically carries PR title conventions, label policies, custom workflows to watch, and other repo-specific context.
+If a `running-tend` skill is listed in your available skills, load it with the Skill tool before doing anything else. It typically carries PR title conventions, label policies, custom workflows to watch, and other repo-specific context. It can also define extra tasks for the job you're running — additional nightly or weekly maintenance, repo-specific health checks — which you perform as part of that job, not just keep in mind.
 
 Repo-local skills are invoked by their unprefixed name — `Skill: running-tend`, not `Skill: tend-ci-runner:running-tend` (that prefix is reserved for this plugin's own skills, and trying it returns `Unknown skill`).
 

--- a/plugins/tend-ci-runner/skills/weekly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/weekly/SKILL.md
@@ -42,9 +42,7 @@ If no dependency PRs are open, note "0 dependency PRs to process" and continue t
 
 ## Step 3: Repo-specific weekly tasks
 
-Scan the loaded `running-tend` skill for sections describing weekly maintenance — typical headings include "Weekly Maintenance", "Weekly:", or task names like "MSRV bump", "toolchain update", "cache audit", "README refresh". For each such task, perform it as the repo describes and follow the repo's PR title conventions when opening a PR.
-
-If `running-tend` defines no weekly tasks (or none are due this week), say so in the summary.
+Perform any weekly maintenance the loaded `running-tend` overlay defines, following the repo's PR title conventions. If it defines no weekly tasks (or none are due this week), say so in the summary.
 
 ## Step 4: Summary
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -590,9 +590,14 @@ function repoFromApiUrl(repositoryUrl: string): string {
 // ---------------------------------------------------------------------------
 // Search API
 
-// One Search page, newest-first — the page yields both `items` (recent) and
-// `total_count` (lifetime). 401/403 throws (sinks the refresh → short fallback
-// TTL); 422/429/other degrade to `{}` so one bad bucket doesn't sink the rest.
+// One Search page, newest-first — yields both `items` (recent) and
+// `total_count` (lifetime). Any non-OK status throws, sinking the refresh: a
+// background refresh keeps the last good cached entry, a cold refresh
+// short-fallbacks (30s) and retries. We do NOT degrade a failure to `{}` —
+// that cached an all-zero payload as a successful refresh at the full budget,
+// pinning "0 PRs / 0 reviews / …" on the site for up to the stale-serve window
+// on a transient Search error (429 from the 4·N fanout, a 5xx blip). A real
+// empty bucket is a 200 with `total_count: 0`, so genuine zeros still pass.
 async function searchIssues(query: string, token: string): Promise<SearchResponse> {
   const params = new URLSearchParams({
     q: query,
@@ -604,11 +609,7 @@ async function searchIssues(query: string, token: string): Promise<SearchRespons
     headers: githubHeaders(token),
   });
   if (!resp.ok) {
-    if (resp.status === 401 || resp.status === 403) {
-      throw new Error(`search auth failure: ${resp.status}`);
-    }
-    console.error(`search failed (${resp.status}): ${query}`);
-    return {};
+    throw new Error(`search request failed (${resp.status}): ${query}`);
   }
   return (await resp.json()) as SearchResponse;
 }

--- a/worker/test/worker.test.ts
+++ b/worker/test/worker.test.ts
@@ -402,8 +402,13 @@ describe("refreshActivity", () => {
     ]);
   });
 
-  it("degrades a failed bucket query to an empty bucket without sinking the refresh", async () => {
+  it("throws when a Search query fails (rate-limit / transient) — sinks the refresh rather than caching all-zero", async () => {
     const { __test } = await import("../src/index");
+    // One bucket's query is rate-limited. Swallowing it to an empty bucket used
+    // to cache an all-zero "success" at the full TTL, so the site rendered
+    // "0 PRs / …" for up to the stale-serve window. The refresh must throw so
+    // coalesceAndRefresh keeps the last good entry (warm) and the cold path
+    // short-fallbacks and retries.
     globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
       const url = typeof input === "string" ? input : input.toString();
       if (url.endsWith("/data/consumers.json")) {
@@ -413,7 +418,7 @@ describe("refreshActivity", () => {
         );
       }
       if (url.includes("commenter")) {
-        return new Response("Validation Failed", { status: 422 });
+        return new Response("rate limited", { status: 429 });
       }
       return new Response(JSON.stringify({ total_count: 1, items: [] }), {
         status: 200,
@@ -427,11 +432,9 @@ describe("refreshActivity", () => {
       REPOS_URL:
         "https://raw.githubusercontent.com/max-sixty/tend/main/data/consumers.json",
     };
-    const out = await __test.refreshActivity(env);
-    expect(out.comments).toEqual({ count: 0, count_this_week: 0, recent: [] });
-    expect(out.prs.count).toBe(1);
-    expect(out.issues.count).toBe(1);
-    expect(out.reviews.count).toBe(1);
+    await expect(__test.refreshActivity(env)).rejects.toThrow(
+      /search request failed \(429\)/,
+    );
   });
 
   it("returns empty buckets when there are no consumers", async () => {
@@ -477,7 +480,9 @@ describe("refreshActivity", () => {
       REPOS_URL:
         "https://raw.githubusercontent.com/max-sixty/tend/main/data/consumers.json",
     };
-    await expect(__test.refreshActivity(env)).rejects.toThrow(/auth failure/);
+    await expect(__test.refreshActivity(env)).rejects.toThrow(
+      /search request failed \(401\)/,
+    );
   });
 
   it("keeps only the newest RECENT_PER_BUCKET items per bucket", async () => {


### PR DESCRIPTION
The website's stat strip and activity feed sometimes rendered "0 PRs / 0 reviews / …" with the feed gone. `searchIssues` swallowed any non-auth GitHub Search failure (a 429 from the 4·N concurrent fan-out, a 5xx blip) into `{}`, so `refreshActivity` returned an all-zero payload. That got cached as a successful refresh at the full 5-minute budget and stayed serveable for up to 50 minutes, so one transient blip pinned broken data on the site.

Now a failed Search throws, sinking the refresh. A background refresh keeps the last good cached entry; a cold refresh caches empty at the short fallback TTL and retries. A genuine empty bucket (a 200 with `total_count: 0`) still passes through.

Also adds nightly monitoring and removes duplicated overlay guidance:

- `running-tend` gains a "Nightly: verify website live data" check that curls the Worker, alarms on a persistent non-200 / all-zero / empty response, and files one deduped tracking issue for a maintainer.
- `running-in-ci` "First Steps" now states that consulting the `running-tend` overlay includes performing the job-specific tasks it defines. `nightly` gains the Step 0 it was missing (every other top-level skill already loads `running-in-ci` first); `weekly` Step 3 slims to rely on that central guidance.
- Fixes a broken link in `running-tend` (`docs/website-data.md`, which doesn't exist, now points at `worker/README.md`).

> _This was written by Claude Code on behalf of max_
