### PR TITLE
fix(worker): return 503 on cold-cache failure instead of a 200 all-zero payload

### DIFF
--- a/worker/README.md
+++ b/worker/README.md
@@ -145,9 +145,12 @@ request wait on the fanout. A cron-triggered prewarm would close even that
 gap but would trade away the zero-when-idle property; not worth it at this
 scale.
 
-When a refresh throws (GitHub outage), the empty payload is cached with a
-short **fallback budget** (5 s / 30 s) so the next request retries soon
-rather than locking in an empty response.
+When a refresh throws (GitHub outage) with no prior entry to serve, the Worker
+returns a 503 rather than a 200 all-zero payload, so the site renders nothing
+for that section instead of fabricated zeros. The 503 is negative-cached at the
+short **fallback budget** (5 s / 30 s) so the next request retries soon. On a
+warm cache a failed background refresh keeps the last good entry instead, so an
+outage never overwrites good data with zeros.
 
 ## Topology
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -219,14 +219,12 @@ export default {
           cacheKeyPath: "/currently-tending",
           ttl: TTL["currently-tending"],
           refresh: () => refreshCurrentlyTending(env),
-          empty: () => ({ generated_at: nowIso(), currently_tending: [] }),
         });
       case "/activity":
         return serveCached(url, env, ctx, {
           cacheKeyPath: "/activity",
           ttl: TTL.activity,
           refresh: () => refreshActivity(env),
-          empty: emptyActivity,
         });
       default:
         return withCors(new Response("Not Found", { status: 404 }), env);
@@ -241,7 +239,6 @@ interface CacheOpts<T> {
   cacheKeyPath: string;
   ttl: { ok: number; fallback: number };
   refresh: () => Promise<T>;
-  empty: () => T;
 }
 
 async function serveCached<T>(
@@ -286,10 +283,14 @@ async function serveCached<T>(
 }
 
 // Cold-cache path: the caller is waiting on this, so we return the fresh
-// Response and let the cache put run via ctx.waitUntil. On refresh
-// failure return the empty payload tagged with the shorter fallback
-// budget — the caller has nothing else to render, so a brief outage
-// degrades to an empty section instead of wedging the request.
+// Response and let the cache put run via ctx.waitUntil. On refresh failure
+// there's no prior data to serve, so we return a 503 rather than a 200
+// all-zero payload: the site reads the non-OK response as "no data" and hides
+// the section instead of rendering fabricated zeros. The 503 is negative-cached
+// at the short fallback budget so a sustained outage doesn't re-fan-out on
+// every request; a later stale hit revalidates and swaps in real data once the
+// source recovers. (Warm-cache failures never reach here — coalesceAndRefresh
+// keeps the last good entry, so an outage never overwrites good data.)
 async function refreshAndCache<T>(
   cacheKey: Request,
   env: Env,
@@ -301,9 +302,18 @@ async function refreshAndCache<T>(
     response = jsonResponse(await opts.refresh(), env, opts.ttl.ok);
   } catch (e) {
     console.error(`cold refresh failed for ${opts.cacheKeyPath}:`, e);
-    response = jsonResponse(opts.empty(), env, opts.ttl.fallback);
+    response = jsonResponse(
+      { error: "upstream unavailable" },
+      env,
+      opts.ttl.fallback,
+      503,
+    );
   }
-  ctx.waitUntil(caches.default.put(cacheKey, response.clone()));
+  ctx.waitUntil(
+    caches.default
+      .put(cacheKey, response.clone())
+      .catch((e) => console.error(`cache put failed for ${opts.cacheKeyPath}:`, e)),
+  );
   return response;
 }
 
@@ -687,10 +697,16 @@ function withCors(resp: Response, env: Env): Response {
   return resp;
 }
 
-function jsonResponse(data: unknown, env: Env, ttlSeconds: number): Response {
+function jsonResponse(
+  data: unknown,
+  env: Env,
+  ttlSeconds: number,
+  status = 200,
+): Response {
   const staleAtMs = Date.now() + ttlSeconds * 1000;
   return withCors(
     new Response(JSON.stringify(data), {
+      status,
       headers: {
         "Content-Type": "application/json",
         // Browsers revalidate after the freshness budget (`max-age`); the
@@ -737,5 +753,6 @@ export const __test = {
   findBotCommentUrl,
   isStale,
   coalesceAndRefresh,
+  refreshAndCache,
   STALE_AT_HEADER,
 };

--- a/worker/test/worker.test.ts
+++ b/worker/test/worker.test.ts
@@ -622,23 +622,6 @@ describe("getConsumers", () => {
 });
 
 describe("coalesceAndRefresh (background refresh on stale-hit)", () => {
-  // Fake the colo cache so we can observe what gets written on success vs
-  // failure. caches.default is Cloudflare-specific; in node it's undefined.
-  function fakeCache() {
-    const store = new Map<string, Response>();
-    return {
-      store,
-      api: {
-        async match(req: Request) {
-          return store.get(req.url)?.clone();
-        },
-        async put(req: Request, resp: Response) {
-          store.set(req.url, resp.clone());
-        },
-      } as unknown as Cache,
-    };
-  }
-
   it("keeps the previous cached entry alive when the refresh throws (does not overwrite with empty)", async () => {
     const { __test } = await import("../src/index");
     const { store, api } = fakeCache();
@@ -660,7 +643,6 @@ describe("coalesceAndRefresh (background refresh on stale-hit)", () => {
       refresh: async () => {
         throw new Error("github down");
       },
-      empty: () => ({ prs: { count: 0 } }),
     });
 
     const entry = store.get(cacheKey.url);
@@ -686,12 +668,77 @@ describe("coalesceAndRefresh (background refresh on stale-hit)", () => {
       cacheKeyPath: "/activity",
       ttl: { ok: 300, fallback: 30 },
       refresh: async () => ({ prs: { count: 999 } }),
-      empty: () => ({ prs: { count: 0 } }),
     });
 
     const entry = store.get(cacheKey.url);
     const body = JSON.parse(await entry!.text()) as { prs: { count: number } };
     expect(body.prs.count).toBe(999);
+  });
+});
+
+describe("refreshAndCache (cold cache)", () => {
+  function fakeCtx() {
+    const tasks: Promise<unknown>[] = [];
+    return {
+      tasks,
+      ctx: {
+        waitUntil: (p: Promise<unknown>) => tasks.push(p),
+      } as unknown as ExecutionContext,
+    };
+  }
+
+  function installCache() {
+    const fc = fakeCache();
+    (globalThis as unknown as { caches: CacheStorage }).caches = {
+      default: fc.api,
+    } as unknown as CacheStorage;
+    return fc;
+  }
+
+  it("caches and returns the fresh 200 on a successful cold refresh", async () => {
+    const { __test } = await import("../src/index");
+    const { store } = installCache();
+    const { tasks, ctx } = fakeCtx();
+    const cacheKey = new Request("https://api.example/activity");
+    const env = { ALLOWED_ORIGIN: "*" } as unknown as Parameters<
+      typeof __test.refreshAndCache
+    >[1];
+
+    const resp = await __test.refreshAndCache(cacheKey, env, ctx, {
+      cacheKeyPath: "/activity",
+      ttl: { ok: 300, fallback: 30 },
+      refresh: async () => ({ prs: { count: 5 } }),
+    });
+
+    expect(resp.status).toBe(200);
+    expect(JSON.parse(await resp.clone().text())).toEqual({ prs: { count: 5 } });
+    await Promise.all(tasks);
+    expect(store.get(cacheKey.url)?.status).toBe(200);
+  });
+
+  it("returns a 503 (not a 200 all-zero payload) when the cold refresh throws, and negative-caches it", async () => {
+    const { __test } = await import("../src/index");
+    const { store } = installCache();
+    const { tasks, ctx } = fakeCtx();
+    const cacheKey = new Request("https://api.example/activity");
+    const env = { ALLOWED_ORIGIN: "*" } as unknown as Parameters<
+      typeof __test.refreshAndCache
+    >[1];
+
+    const resp = await __test.refreshAndCache(cacheKey, env, ctx, {
+      cacheKeyPath: "/activity",
+      ttl: { ok: 300, fallback: 30 },
+      refresh: async () => {
+        throw new Error("github down");
+      },
+    });
+
+    // Non-OK so the site's fetchJson returns null and hides the section
+    // rather than rendering fabricated zeros from a 200 all-zero body.
+    expect(resp.ok).toBe(false);
+    expect(resp.status).toBe(503);
+    await Promise.all(tasks);
+    expect(store.get(cacheKey.url)?.status).toBe(503); // negative-cached
   });
 });
 
@@ -712,6 +759,23 @@ describe("isStale (stale-while-revalidate decision)", () => {
     expect(__test.isStale("not-a-number", now)).toBe(true);
   });
 });
+
+// Fake the colo cache so tests can observe what gets written on success vs
+// failure. caches.default is Cloudflare-specific; in node it's undefined.
+function fakeCache() {
+  const store = new Map<string, Response>();
+  return {
+    store,
+    api: {
+      async match(req: Request) {
+        return store.get(req.url)?.clone();
+      },
+      async put(req: Request, resp: Response) {
+        store.set(req.url, resp.clone());
+      },
+    } as unknown as Cache,
+  };
+}
 
 function makeFakeKv(): KVNamespace {
   const store = new Map<string, string>();


### PR DESCRIPTION
When a cold-cache refresh threw (a GitHub outage on a fresh deploy or after eviction), the Worker cached and served a 200 with an all-zero `emptyActivity()` body. The site's `Stats.astro` renders that verbatim as "0 PRs / 0 reviews / …", so viewers saw fabricated zeros rather than no data.

The cold-failure path now returns a 503. The site's `fetchJson` reads the non-OK response as null, so every section hides instead of rendering zeros. The 503 is negative-cached at the short fallback budget and carries the stale-at header, so stale-while-revalidate swaps in real data once the source recovers. Warm-cache failures are unaffected: the background refresh still keeps the last good entry.

Removes the now-unused `empty` field from `CacheOpts` and both call sites; `jsonResponse` gains an optional status argument.

> _This was written by Claude Code on behalf of max_
