### PR TITLE
interactive: isolate the GitHub PAT behind a credential-injecting proxy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7
-      - run: uv run --no-project --with mitmproxy --with pytest pytest
+      # Pin to match interactive/action.yaml's mitmproxy_version default so the
+      # test exercises the same version the production proxy runs — the addon
+      # imports mitmproxy.test (an internal helper), so version skew could green
+      # the test while production breaks.
+      - run: uv run --no-project --with 'mitmproxy==12.2.1' --with pytest pytest
 
   test-worker:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,19 @@ jobs:
       - uses: astral-sh/setup-uv@v7
       - run: uv run pytest
 
+  # Tests for the claude-interactive credential-injection proxy addon. Run
+  # standalone (no project) with mitmproxy + pytest pulled in ad hoc, since the
+  # proxy isn't part of the generator package.
+  test-proxy:
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        working-directory: interactive/proxy
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+      - run: uv run --no-project --with mitmproxy --with pytest pytest
+
   test-worker:
     runs-on: ubuntu-24.04
     defaults:

--- a/.github/workflows/interactive-smoke.yaml
+++ b/.github/workflows/interactive-smoke.yaml
@@ -73,6 +73,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 1
+          # The agent runs as a non-sudo sandbox user and authenticates to
+          # GitHub only through the injecting proxy, so it needs no persisted
+          # git credential — and persisting one would leave it on disk in the
+          # sandbox-owned checkout. (Real generated workflows persist the bot
+          # PAT; setup-sandbox.sh neutralizes it there.)
+          persist-credentials: false
 
       - name: Run interactive harness
         id: claude

--- a/.github/workflows/interactive-smoke.yaml
+++ b/.github/workflows/interactive-smoke.yaml
@@ -45,8 +45,11 @@ on:
              through the credential-injecting proxy — it should print the bot
              account's login even though your environment only holds a dummy
              token.
-          3. Reply with one line in the form:
-             "Smoke test ran at <date>; gh authenticated as <login>".
+          3. Use the Bash tool to run: `git ls-remote origin HEAD`. This must
+             succeed (not fatal): it proves the persisted-credential strip
+             didn't break git and that git reaches origin through the proxy.
+          4. Reply with one line in the form:
+             "Smoke test ran at <date>; gh authenticated as <login>; git ls-remote ok".
 
           Do not push, comment, or modify files. Use only the Bash tool.
       model:
@@ -73,12 +76,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 1
-          # The agent runs as a non-sudo sandbox user and authenticates to
-          # GitHub only through the injecting proxy, so it needs no persisted
-          # git credential — and persisting one would leave it on disk in the
-          # sandbox-owned checkout. (Real generated workflows persist the bot
-          # PAT; setup-sandbox.sh neutralizes it there.)
-          persist-credentials: false
+          # Keep the DEFAULT persist-credentials: true so the smoke exercises
+          # the production shape — checkout persists a git credential, and
+          # setup-sandbox.sh must neutralize it. (An earlier cut set this to
+          # false, which silently skipped the strip path; the git ls-remote
+          # step in the prompt now asserts the strip didn't break git.)
+          persist-credentials: true
 
       - name: Run interactive harness
         id: claude

--- a/.github/workflows/interactive-smoke.yaml
+++ b/.github/workflows/interactive-smoke.yaml
@@ -18,6 +18,9 @@ name: interactive-smoke
 #   4. The Stop hook fires after a turn that uses a tool, and the
 #      supervisor exits 0.
 #   5. Token usage is parseable from the session JSONL.
+#   6. Credential isolation: the agent runs as the tend-sandbox user with
+#      only a dummy GitHub token, yet `gh api user` succeeds — proving the
+#      injecting proxy attached the real PAT. A broken proxy would 401.
 #
 # Failure modes the supervisor distinguishes (see Run Claude step in the
 # action):
@@ -38,10 +41,14 @@ on:
           questions:
 
           1. Use the Bash tool to run: `pwd && date -u +%FT%TZ && uname -a`.
-          2. Reply with one line summarizing the date the command printed,
-             in the form: "Smoke test ran at <date>".
+          2. Use the Bash tool to run: `gh api user --jq .login`. This goes
+             through the credential-injecting proxy — it should print the bot
+             account's login even though your environment only holds a dummy
+             token.
+          3. Reply with one line in the form:
+             "Smoke test ran at <date>; gh authenticated as <login>".
 
-          Do not push, comment, modify files, or use any tool other than Bash.
+          Do not push, comment, or modify files. Use only the Bash tool.
       model:
         description: Claude model
         required: false

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -91,6 +91,20 @@ overwritten, matching claude-code-action's behavior so review skills can
 optionally inspect what the PR changed without those files ever being
 executed.
 
+**Credential isolation (`claude-interactive` harness).** The agent runs as a
+separate non-sudo `tend-sandbox` user. The bot PAT lives only in a local
+mitmproxy that the agent reaches over `HTTPS_PROXY`; the proxy injects the
+token into requests to GitHub hosts and tunnels everything else. The agent
+holds only a dummy token, so it can't read the real one: a different UID with
+no sudo can't read the proxy's `/proc/<pid>/environ`, and the credential
+`actions/checkout` persists in `.git/config` is stripped before the workspace
+is handed over. The injection allowlist is exact-match on the connection's real
+destination, so a request to a lookalike host gets no token. This covers the
+GitHub credential only; the Claude OAuth/API token still reaches the agent's
+env, and the other two harnesses (`action.yaml`, `codex/action.yaml`) pass the
+PAT directly. The merge restriction and `tend check` remain the load-bearing
+boundaries regardless of harness.
+
 **Rate limiting.** Burst detection (10 PRs or issues per 20 minutes) and
 spike detection (today's volume vs 6-day baseline, scaled per repo) abort
 the run before Claude starts, catching runaway loops between workflows.
@@ -159,7 +173,10 @@ to restrict outbound network access.
 access to every repo the bot account can reach. A single successful
 exfiltration gives the attacker persistent, broad write access. The merge
 restriction limits what they can *do* with it, but they can still push
-branches, create PRs, and post comments indefinitely.
+branches, create PRs, and post comments indefinitely. The credential isolation
+above keeps the PAT out of the agent on the `claude-interactive` harness; it
+remains directly exposed on the other harnesses and the Claude token on all of
+them.
 
 **Prompt injection without code execution.** Even without hijacking the
 tools, an attacker who controls what Claude reads can influence its behavior.

--- a/interactive/action.yaml
+++ b/interactive/action.yaml
@@ -63,6 +63,11 @@ inputs:
       Maximum time the supervised Claude session is allowed to run before
       the supervisor kills it. Defaults to 60 minutes — well above any
       single-turn skill we have today.
+  mitmproxy_version:
+    default: "12.2.1"
+    description: >-
+      Pinned `mitmproxy` version for the credential-injection proxy. Pinned
+      so the uv download cache key is stable; bump to upgrade.
 
 outputs:
   token_usage:
@@ -279,11 +284,23 @@ runs:
     # Runs after "Restore sensitive config" (which needs the persisted git
     # credential for its base fetch) and before the claude lifecycle, which
     # from here on executes as the sandbox user.
+    # Cache the proxy's mitmproxy download (a sizeable dependency) in an
+    # isolated uv cache dir, keyed on the pinned version. First run populates;
+    # every run after restores in seconds instead of a cold ~20s resolve. The
+    # agent's own uvx usage keeps its default cache, untouched.
+    - name: Cache mitmproxy
+      uses: actions/cache@v4
+      with:
+        path: ${{ runner.temp }}/tend-mitmproxy-uv
+        key: tend-mitmproxy-${{ runner.os }}-${{ inputs.mitmproxy_version }}
+
     - name: Set up credential-isolation sandbox
       shell: bash
       env:
         TEND_GH_TOKEN: ${{ inputs.github_token }}
         ACTION_PATH: ${{ github.action_path }}
+        MITMPROXY_VERSION: ${{ inputs.mitmproxy_version }}
+        UV_CACHE_DIR: ${{ runner.temp }}/tend-mitmproxy-uv
       run: bash "${{ github.action_path }}/proxy/setup-sandbox.sh"
 
     # Install the claude binary. Same recipe and pinned version as

--- a/interactive/action.yaml
+++ b/interactive/action.yaml
@@ -382,21 +382,22 @@ runs:
         claude plugin list 2>/dev/null || true
 
     # The claude binary, uv, plugins, and onboarding state were installed
-    # into the runner's home by the steps above. Copy them into the sandbox
+    # into the runner's home by the steps above. Move them into the sandbox
     # user's home so the agent — which runs as tend-sandbox from here — finds
-    # its toolchain and config natively (no CLAUDE_CONFIG_DIR guesswork). The
-    # bot PAT is in none of these paths, so the copy carries no GitHub
-    # credential into the sandbox.
+    # its toolchain and config natively (no CLAUDE_CONFIG_DIR guesswork). `mv`
+    # not `cp`: the runner copy is dead after this, and a same-filesystem rename
+    # avoids copying the ~200MB claude binary on every run. The bot PAT is in
+    # none of these paths, so nothing carries a GitHub credential into the sandbox.
     - name: Hand off Claude toolchain to sandbox
       shell: bash
       run: |
         sudo mkdir -p "$AGENT_HOME/.local"
-        sudo cp -a /home/runner/.local/bin "$AGENT_HOME/.local/bin"
+        sudo mv /home/runner/.local/bin "$AGENT_HOME/.local/bin"
         if [ -d /home/runner/.local/share ]; then
-          sudo cp -a /home/runner/.local/share "$AGENT_HOME/.local/share"
+          sudo mv /home/runner/.local/share "$AGENT_HOME/.local/share"
         fi
-        sudo cp -a /home/runner/.claude "$AGENT_HOME/.claude"
-        sudo cp -a /home/runner/.claude.json "$AGENT_HOME/.claude.json"
+        sudo mv /home/runner/.claude "$AGENT_HOME/.claude"
+        sudo mv /home/runner/.claude.json "$AGENT_HOME/.claude.json"
         sudo chown -R "${SANDBOX}:${SANDBOX}" "$AGENT_HOME"
         sudo -u "$SANDBOX" "$AGENT_HOME/.local/bin/claude" --version
 
@@ -468,31 +469,23 @@ runs:
         # the listed tools.
         ALLOW_JSON=$(jq -nc --arg list "$TEND_ALLOWED_TOOLS" '$list | split(",") | map(. | gsub("^\\s+|\\s+$"; ""))')
 
-        # Settings and wrapper are written into sandbox-owned locations as the
-        # sandbox user. The `< file` redirects are opened by the runner shell,
-        # so tee needs no read access to the runner-owned temp files.
-        cat > "$RUNNER_TEMP/tend-settings.json" <<EOF
-        {
-          "permissions": {
-            "defaultMode": "dontAsk",
-            "allow": $ALLOW_JSON
-          },
-          "hooks": {
-            "Stop": [
-              {
-                "matcher": "",
-                "hooks": [{"type": "command", "command": "touch '$SENTINEL_OK'"}]
-              }
-            ],
-            "StopFailure": [
-              {
-                "matcher": "",
-                "hooks": [{"type": "command", "command": "touch '$SENTINEL_FAIL'"}]
-              }
-            ]
-          }
-        }
-        EOF
+        # Build settings.local.json with jq, not a heredoc — jq escapes the
+        # (adopter-controlled) tool list and the sentinel paths, so nothing in
+        # them is re-expanded by the shell. @sh quotes the paths for the hook's
+        # shell command. Settings and wrapper are written into sandbox-owned
+        # locations as the sandbox user; the `< file` redirect is opened by the
+        # runner shell, so tee needs no read access to the runner temp file.
+        jq -nc \
+          --argjson allow "$ALLOW_JSON" \
+          --arg ok "$SENTINEL_OK" \
+          --arg fail "$SENTINEL_FAIL" \
+          '{
+            permissions: {defaultMode: "dontAsk", allow: $allow},
+            hooks: {
+              Stop:        [{matcher: "", hooks: [{type: "command", command: ("touch " + ($ok   | @sh))}]}],
+              StopFailure: [{matcher: "", hooks: [{type: "command", command: ("touch " + ($fail | @sh))}]}]
+            }
+          }' > "$RUNNER_TEMP/tend-settings.json"
         sudo -u "$SANDBOX" mkdir -p "$GITHUB_WORKSPACE/.claude"
         sudo -u "$SANDBOX" tee "$GITHUB_WORKSPACE/.claude/settings.local.json" \
           < "$RUNNER_TEMP/tend-settings.json" >/dev/null
@@ -564,17 +557,25 @@ runs:
           sleep 2
         done
 
-        # Clean termination — SIGTERM, wait up to 5s, then SIGKILL.
+        # Clean termination — SIGTERM, wait up to 5s, then SIGKILL. Killing the
+        # `sudo` PID may leave the agent tree (script→claude→node) orphaned
+        # since SIGKILL can't be relayed, so also reap every process owned by
+        # the dedicated sandbox user.
         if sudo kill -0 "$CLAUDE_PID" 2>/dev/null; then
           sudo kill -TERM "$CLAUDE_PID" 2>/dev/null || true
-          for i in 1 2 3 4 5; do
+          for _ in 1 2 3 4 5; do
             sleep 1
             sudo kill -0 "$CLAUDE_PID" 2>/dev/null || break
           done
           sudo kill -KILL "$CLAUDE_PID" 2>/dev/null || true
         fi
-        wait "$CLAUDE_PID" 2>/dev/null || true
-        CLAUDE_EXIT=$?
+        sudo pkill -KILL -u "$SANDBOX" 2>/dev/null || true
+
+        # Capture the real exit, but NOT via `|| true` — that would make
+        # CLAUDE_EXIT always 0 (the exit of `true`) and report a crashed run as
+        # success. The process is dead by now, so wait returns promptly.
+        CLAUDE_EXIT=0
+        wait "$CLAUDE_PID" 2>/dev/null || CLAUDE_EXIT=$?
 
         elapsed=$(($(date +%s) - start))
         echo "Supervisor: status=$status elapsed=${elapsed}s claude_exit=$CLAUDE_EXIT"
@@ -669,10 +670,12 @@ runs:
         MODEL: ${{ inputs.model }}
       run: |
         # The agent ran as the sandbox user, so its session JSONL lives under
-        # the sandbox home (created with restrictive perms). Make it
-        # runner-readable, then consolidate the sessions and PTY log into a
-        # runner-owned dir for token parsing and the uploaded artifact.
-        sudo chmod -R a+rX "${AGENT_HOME:-/nonexistent}/.claude" 2>/dev/null || true
+        # the sandbox home (created with restrictive perms). Make just the
+        # session dir runner-readable (not the whole plugin tree under .claude),
+        # then consolidate the sessions and PTY log into a runner-owned dir for
+        # token parsing and the uploaded artifact.
+        sudo chmod a+x "${AGENT_HOME:-/nonexistent}" "${AGENT_HOME:-/nonexistent}/.claude" 2>/dev/null || true
+        sudo chmod -R a+rX "${AGENT_HOME:-/nonexistent}/.claude/projects" 2>/dev/null || true
         LOGS_DIR="$RUNNER_TEMP/tend-logs"
         mkdir -p "$LOGS_DIR"
         cp -a "${AGENT_HOME}/.claude/projects/." "$LOGS_DIR/" 2>/dev/null || true

--- a/interactive/action.yaml
+++ b/interactive/action.yaml
@@ -382,22 +382,23 @@ runs:
         claude plugin list 2>/dev/null || true
 
     # The claude binary, uv, plugins, and onboarding state were installed
-    # into the runner's home by the steps above. Move them into the sandbox
+    # into the runner's home by the steps above. Copy them into the sandbox
     # user's home so the agent — which runs as tend-sandbox from here — finds
-    # its toolchain and config natively (no CLAUDE_CONFIG_DIR guesswork). `mv`
-    # not `cp`: the runner copy is dead after this, and a same-filesystem rename
-    # avoids copying the ~200MB claude binary on every run. The bot PAT is in
-    # none of these paths, so nothing carries a GitHub credential into the sandbox.
+    # its toolchain and config natively (no CLAUDE_CONFIG_DIR guesswork). cp -a,
+    # not mv: the claude binary has absolute-path references into ~/.local/share,
+    # so moving the originals out breaks it. (The cheaper fix — installing the
+    # toolchain as the sandbox user directly — is a follow-up.) The bot PAT is in
+    # none of these paths, so the copy carries no GitHub credential into the sandbox.
     - name: Hand off Claude toolchain to sandbox
       shell: bash
       run: |
         sudo mkdir -p "$AGENT_HOME/.local"
-        sudo mv /home/runner/.local/bin "$AGENT_HOME/.local/bin"
+        sudo cp -a /home/runner/.local/bin "$AGENT_HOME/.local/bin"
         if [ -d /home/runner/.local/share ]; then
-          sudo mv /home/runner/.local/share "$AGENT_HOME/.local/share"
+          sudo cp -a /home/runner/.local/share "$AGENT_HOME/.local/share"
         fi
-        sudo mv /home/runner/.claude "$AGENT_HOME/.claude"
-        sudo mv /home/runner/.claude.json "$AGENT_HOME/.claude.json"
+        sudo cp -a /home/runner/.claude "$AGENT_HOME/.claude"
+        sudo cp -a /home/runner/.claude.json "$AGENT_HOME/.claude.json"
         sudo chown -R "${SANDBOX}:${SANDBOX}" "$AGENT_HOME"
         sudo -u "$SANDBOX" "$AGENT_HOME/.local/bin/claude" --version
 

--- a/interactive/action.yaml
+++ b/interactive/action.yaml
@@ -268,6 +268,24 @@ runs:
           echo 'TEND_EOF'
         } >> "$GITHUB_OUTPUT"
 
+    # Credential isolation (gh/git): run the agent as a separate, non-sudo
+    # `tend-sandbox` user while the bot PAT lives only in a local mitmproxy
+    # that injects it into GitHub requests. The agent never holds the PAT —
+    # not in its env, and not in .git/config (the setup script strips the
+    # credential `actions/checkout` persists there). Claude's own auth
+    # (OAuth / API key) is out of scope for this cut and still reaches the
+    # agent's env. See proxy/setup-sandbox.sh and proxy/github_auth.py.
+    #
+    # Runs after "Restore sensitive config" (which needs the persisted git
+    # credential for its base fetch) and before the claude lifecycle, which
+    # from here on executes as the sandbox user.
+    - name: Set up credential-isolation sandbox
+      shell: bash
+      env:
+        TEND_GH_TOKEN: ${{ inputs.github_token }}
+        ACTION_PATH: ${{ github.action_path }}
+      run: bash "${{ github.action_path }}/proxy/setup-sandbox.sh"
+
     # Install the claude binary. Same recipe and pinned version as
     # claude-code-base-action's install step.
     - name: Install Claude Code
@@ -346,6 +364,25 @@ runs:
         claude plugin install tend-ci-runner@tend
         claude plugin list 2>/dev/null || true
 
+    # The claude binary, uv, plugins, and onboarding state were installed
+    # into the runner's home by the steps above. Copy them into the sandbox
+    # user's home so the agent — which runs as tend-sandbox from here — finds
+    # its toolchain and config natively (no CLAUDE_CONFIG_DIR guesswork). The
+    # bot PAT is in none of these paths, so the copy carries no GitHub
+    # credential into the sandbox.
+    - name: Hand off Claude toolchain to sandbox
+      shell: bash
+      run: |
+        sudo mkdir -p "$AGENT_HOME/.local"
+        sudo cp -a /home/runner/.local/bin "$AGENT_HOME/.local/bin"
+        if [ -d /home/runner/.local/share ]; then
+          sudo cp -a /home/runner/.local/share "$AGENT_HOME/.local/share"
+        fi
+        sudo cp -a /home/runner/.claude "$AGENT_HOME/.claude"
+        sudo cp -a /home/runner/.claude.json "$AGENT_HOME/.claude.json"
+        sudo chown -R "${SANDBOX}:${SANDBOX}" "$AGENT_HOME"
+        sudo -u "$SANDBOX" "$AGENT_HOME/.local/bin/claude" --version
+
     # The supervisor pattern, in three pieces:
     #   1. .claude/settings.local.json sets `permissions.defaultMode:
     #      dontAsk` with a permissive allow list, plus Stop/StopFailure
@@ -382,8 +419,10 @@ runs:
         # Setting this to 0 routes bash through the fixed quoting path.
         # See anthropics/claude-code#35701.
         CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "0"
-        GH_TOKEN: ${{ inputs.github_token }}
-        GITHUB_TOKEN: ${{ inputs.github_token }}
+        # No GH_TOKEN/GITHUB_TOKEN here — the agent runs as the sandbox user
+        # with only a dummy token; the real PAT lives in the proxy. With the
+        # secrets gone from the agent's env, the SUBPROCESS_ENV_SCRUB=0
+        # quoting workaround above no longer carries any credential cost.
         BOT_NAME: ${{ inputs.bot_name }}
         BOT_ID: ${{ steps.bot.outputs.id }}
         TEND_MODEL: ${{ inputs.model }}
@@ -394,11 +433,15 @@ runs:
       run: |
         set -u
 
-        SENTINEL_OK="$RUNNER_TEMP/tend-turn-done"
-        SENTINEL_FAIL="$RUNNER_TEMP/tend-turn-failed"
-        LOG="$RUNNER_TEMP/tend-claude.log"
-        WRAPPER="$RUNNER_TEMP/tend-run-claude.sh"
-        rm -f "$SENTINEL_OK" "$SENTINEL_FAIL" "$LOG"
+        # Sentinels, PTY log, and wrapper live in the sandbox-writable run
+        # dir ($TEND_RUN_DIR, created by setup-sandbox.sh) so the agent's
+        # Stop hook — running as tend-sandbox — can touch the sentinels and
+        # the runner-side supervisor can poll them.
+        SENTINEL_OK="$TEND_RUN_DIR/tend-turn-done"
+        SENTINEL_FAIL="$TEND_RUN_DIR/tend-turn-failed"
+        LOG="$TEND_RUN_DIR/tend-claude.log"
+        WRAPPER="$TEND_RUN_DIR/tend-run-claude.sh"
+        sudo -u "$SANDBOX" rm -f "$SENTINEL_OK" "$SENTINEL_FAIL" "$LOG"
 
         # Build the permissions allow list from the comma-separated
         # `allowed_tools` input. defaultMode=dontAsk means anything not
@@ -408,8 +451,10 @@ runs:
         # the listed tools.
         ALLOW_JSON=$(jq -nc --arg list "$TEND_ALLOWED_TOOLS" '$list | split(",") | map(. | gsub("^\\s+|\\s+$"; ""))')
 
-        mkdir -p .claude
-        cat > .claude/settings.local.json <<EOF
+        # Settings and wrapper are written into sandbox-owned locations as the
+        # sandbox user. The `< file` redirects are opened by the runner shell,
+        # so tee needs no read access to the runner-owned temp files.
+        cat > "$RUNNER_TEMP/tend-settings.json" <<EOF
         {
           "permissions": {
             "defaultMode": "dontAsk",
@@ -431,12 +476,15 @@ runs:
           }
         }
         EOF
+        sudo -u "$SANDBOX" mkdir -p "$GITHUB_WORKSPACE/.claude"
+        sudo -u "$SANDBOX" tee "$GITHUB_WORKSPACE/.claude/settings.local.json" \
+          < "$RUNNER_TEMP/tend-settings.json" >/dev/null
 
         # Wrapper script — keeps the argv quoting in bash, not YAML. The
         # --permission-mode flag matches settings.local.json above; either
         # alone would suffice but specifying both is explicit and survives
         # an adopter who overrides settings.local.json.
-        cat > "$WRAPPER" <<'WRAPEOF'
+        cat > "$RUNNER_TEMP/tend-wrapper.sh" <<'WRAPEOF'
         #!/usr/bin/env bash
         exec claude \
           --model "$TEND_MODEL" \
@@ -445,18 +493,38 @@ runs:
           --append-system-prompt "$TEND_SYSTEM_PROMPT" \
           "$TEND_PROMPT"
         WRAPEOF
-        chmod +x "$WRAPPER"
+        sudo -u "$SANDBOX" tee "$WRAPPER" < "$RUNNER_TEMP/tend-wrapper.sh" >/dev/null
+        sudo -u "$SANDBOX" chmod +x "$WRAPPER"
 
-        # Run under script(1) for PTY allocation. -q quiet, -e propagate
-        # exit code, -f flush after each write, -c "command" specifies
-        # the command, last positional is the typescript log file. Linux
-        # util-linux syntax (BSD differs); GHA runners are Ubuntu.
-        script -qefc "$WRAPPER" "$LOG" &
+        # Launch the agent as the non-sudo sandbox user. Its env carries a
+        # DUMMY GitHub token (gh refuses to run without one); the proxy
+        # replaces it with the real PAT for GitHub hosts only. HTTPS_PROXY
+        # routes gh/git through the proxy; non-GitHub traffic tunnels through
+        # untouched. The real PAT is in none of this env. script(1) allocates
+        # the PTY (GHA runners have no TTY; without it the Ink UI hangs).
+        DUMMY_GH_TOKEN="ghp_tendproxydummy000000000000000000000"
+        sudo -u "$SANDBOX" env \
+          HOME="$AGENT_HOME" \
+          PATH="$AGENT_HOME/.local/bin:/usr/local/bin:/usr/bin:/bin" \
+          HTTPS_PROXY="$PROXY_URL" HTTP_PROXY="$PROXY_URL" \
+          https_proxy="$PROXY_URL" http_proxy="$PROXY_URL" \
+          NO_PROXY="localhost,127.0.0.1" no_proxy="localhost,127.0.0.1" \
+          GH_TOKEN="$DUMMY_GH_TOKEN" GITHUB_TOKEN="$DUMMY_GH_TOKEN" \
+          CLAUDE_CODE_OAUTH_TOKEN="$CLAUDE_CODE_OAUTH_TOKEN" \
+          ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
+          CLAUDE_CODE_REMOTE="$CLAUDE_CODE_REMOTE" \
+          CLAUDE_CODE_SUBPROCESS_ENV_SCRUB="$CLAUDE_CODE_SUBPROCESS_ENV_SCRUB" \
+          BOT_NAME="$BOT_NAME" BOT_ID="$BOT_ID" \
+          TEND_MODEL="$TEND_MODEL" TEND_ALLOWED_TOOLS="$TEND_ALLOWED_TOOLS" \
+          TEND_SYSTEM_PROMPT="$TEND_SYSTEM_PROMPT" TEND_PROMPT="$TEND_PROMPT" \
+          script -qefc "$WRAPPER" "$LOG" &
         CLAUDE_PID=$!
-        echo "Claude PID: $CLAUDE_PID"
+        echo "Claude PID: $CLAUDE_PID (running as $SANDBOX)"
 
         # Supervisor poll loop: success sentinel, failure sentinel,
-        # process exit, or timeout — whichever comes first.
+        # process exit, or timeout — whichever comes first. The agent tree
+        # runs as the sandbox user, so liveness/termination signals from the
+        # runner cross the UID boundary and go through sudo.
         start=$(date +%s)
         status=running
         while true; do
@@ -468,7 +536,7 @@ runs:
             status=stop-failure
             break
           fi
-          if ! kill -0 "$CLAUDE_PID" 2>/dev/null; then
+          if ! sudo kill -0 "$CLAUDE_PID" 2>/dev/null; then
             status=exited
             break
           fi
@@ -480,13 +548,13 @@ runs:
         done
 
         # Clean termination — SIGTERM, wait up to 5s, then SIGKILL.
-        if kill -0 "$CLAUDE_PID" 2>/dev/null; then
-          kill -TERM "$CLAUDE_PID" 2>/dev/null || true
+        if sudo kill -0 "$CLAUDE_PID" 2>/dev/null; then
+          sudo kill -TERM "$CLAUDE_PID" 2>/dev/null || true
           for i in 1 2 3 4 5; do
             sleep 1
-            kill -0 "$CLAUDE_PID" 2>/dev/null || break
+            sudo kill -0 "$CLAUDE_PID" 2>/dev/null || break
           done
-          kill -KILL "$CLAUDE_PID" 2>/dev/null || true
+          sudo kill -KILL "$CLAUDE_PID" 2>/dev/null || true
         fi
         wait "$CLAUDE_PID" 2>/dev/null || true
         CLAUDE_EXIT=$?
@@ -583,15 +651,20 @@ runs:
       env:
         MODEL: ${{ inputs.model }}
       run: |
-        LOGS_DIR="$HOME/.claude/projects"
+        # The agent ran as the sandbox user, so its session JSONL lives under
+        # the sandbox home (created with restrictive perms). Make it
+        # runner-readable, then consolidate the sessions and PTY log into a
+        # runner-owned dir for token parsing and the uploaded artifact.
+        sudo chmod -R a+rX "${AGENT_HOME:-/nonexistent}/.claude" 2>/dev/null || true
+        LOGS_DIR="$RUNNER_TEMP/tend-logs"
         mkdir -p "$LOGS_DIR"
+        cp -a "${AGENT_HOME}/.claude/projects/." "$LOGS_DIR/" 2>/dev/null || true
+        cp -a "${TEND_RUN_DIR}/tend-claude.log" "$LOGS_DIR/" 2>/dev/null || true
 
-        # The whole step runs after the supervised session, on an
-        # ephemeral CI runner where ~/.claude/projects is freshly
-        # populated by this run. Take everything — no `-newer` filter
-        # (older filter once dropped a real session because mtime ties
-        # with the wrapper script were inconsistent).
-        SESSIONS=$(find "$HOME/.claude/projects" -name '*.jsonl' 2>/dev/null | tr '\n' ' ')
+        # Everything in $LOGS_DIR is freshly populated by this run. Take all
+        # of it — no `-newer` filter (an older filter once dropped a real
+        # session because mtime ties were inconsistent).
+        SESSIONS=$(find "$LOGS_DIR" -name '*.jsonl' 2>/dev/null | tr '\n' ' ')
 
         if [ -n "$SESSIONS" ]; then
           # `jq -s` slurps inputs from ALL files into ONE flat array of
@@ -689,8 +762,8 @@ runs:
       uses: actions/upload-artifact@v7
       with:
         name: ${{ steps.artifact.outputs.name }}
-        path: |
-          ~/.claude/projects/
-          ${{ runner.temp }}/tend-claude.log
+        # The Token usage step consolidates the sandbox user's session JSONL,
+        # token-usage.json, and the PTY log into this runner-owned dir.
+        path: ${{ runner.temp }}/tend-logs/
         retention-days: 30
         if-no-files-found: warn

--- a/interactive/proxy/conftest.py
+++ b/interactive/proxy/conftest.py
@@ -1,0 +1,10 @@
+"""mitmproxy imports the addon module and reads its module-level ``addons``
+list, so the addon is constructed at import — which requires ``TEND_GH_TOKEN``.
+In production the proxy is always launched with it set; seed a dummy here so
+importing the module for tests behaves the same. Individual tests override it
+via ``monkeypatch``.
+"""
+
+import os
+
+os.environ.setdefault("TEND_GH_TOKEN", "ghp_conftest_dummy")

--- a/interactive/proxy/github_auth.py
+++ b/interactive/proxy/github_auth.py
@@ -29,8 +29,12 @@ import os
 from mitmproxy import http
 
 # git's smart-HTTP transport authenticates with Basic (token as the password);
-# the REST and upload hosts take the ``token`` scheme. ``pretty_host`` carries
-# no port, so these are bare hostnames.
+# the REST and upload hosts take the ``token`` scheme. These are bare hostnames
+# (``flow.request.host`` carries no port).
+#
+# Not covered: ``*.githubusercontent.com`` (raw content, release assets, LFS).
+# Those are served from signed/anonymous URLs in the common path; private-asset
+# fetches that need auth are out of scope for this cut.
 GIT_HOSTS = frozenset({"github.com", "codeload.github.com"})
 API_HOSTS = frozenset({"api.github.com", "uploads.github.com"})
 
@@ -51,7 +55,11 @@ class GitHubAuthInjector:
         ).decode()
 
     def request(self, flow: http.HTTPFlow) -> None:
-        host = flow.request.pretty_host
+        # Gate on `host` — the real connection target — NOT `pretty_host`, which
+        # mitmproxy derives from the client-supplied Host header. A sandboxed
+        # agent could otherwise send `Host: api.github.com` to an attacker host
+        # and have the real token injected and forwarded there.
+        host = flow.request.host
         if host in API_HOSTS:
             flow.request.headers["Authorization"] = f"token {self._token}"
         elif host in GIT_HOSTS:

--- a/interactive/proxy/github_auth.py
+++ b/interactive/proxy/github_auth.py
@@ -1,0 +1,66 @@
+"""mitmproxy addon: inject the bot's GitHub token into requests to GitHub.
+
+This process runs as the privileged runner user, OUTSIDE the agent's sandbox.
+The real token is read once from ``TEND_GH_TOKEN`` at startup and lives only in
+this process's memory. The sandboxed agent runs as a separate, non-sudo UID and
+therefore cannot read this process's environment (``/proc/<pid>/environ`` is
+owner-only) or escalate to it. The agent holds only a throwaway dummy token;
+every request it makes to a GitHub host has its ``Authorization`` header
+replaced here with the real token, so ``gh`` and ``git`` authenticate without
+the credential ever entering the sandbox.
+
+Security boundary: the injection allowlist below is exact-match. The token is
+attached to those four GitHub hosts and nothing else — a request to any other
+host (including ``api.github.com.evil.com`` or a host mitmproxy intercepts by
+misconfiguration) is passed through untouched. The proxy's ``--allow-hosts``
+flag is a functionality optimization (don't TLS-intercept non-GitHub traffic so
+package managers keep working); this allowlist is the credential boundary.
+
+Scope: GitHub only. The Claude/LLM credential is out of scope for this cut and
+still reaches the agent through its own environment.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+
+from mitmproxy import http
+
+# git's smart-HTTP transport authenticates with Basic (token as the password);
+# the REST and upload hosts take the ``token`` scheme. ``pretty_host`` carries
+# no port, so these are bare hostnames.
+GIT_HOSTS = frozenset({"github.com", "codeload.github.com"})
+API_HOSTS = frozenset({"api.github.com", "uploads.github.com"})
+
+
+class GitHubAuthInjector:
+    def __init__(self) -> None:
+        token = os.environ.get("TEND_GH_TOKEN", "")
+        if not token:
+            raise RuntimeError(
+                "TEND_GH_TOKEN is unset — refusing to start the credential "
+                "proxy with no token to inject"
+            )
+        self._token = token
+        # Basic base64("x-access-token:<token>") — GitHub's git endpoint accepts
+        # the token as the password with this fixed username.
+        self._basic = "Basic " + base64.b64encode(
+            f"x-access-token:{token}".encode()
+        ).decode()
+
+    def request(self, flow: http.HTTPFlow) -> None:
+        host = flow.request.pretty_host
+        if host in API_HOSTS:
+            flow.request.headers["Authorization"] = f"token {self._token}"
+        elif host in GIT_HOSTS:
+            flow.request.headers["Authorization"] = self._basic
+        else:
+            # Not a GitHub host — never attach the token. Leave the request
+            # exactly as the agent sent it.
+            return
+        logging.info("injected GitHub credential for %s %s", flow.request.method, host)
+
+
+addons = [GitHubAuthInjector()]

--- a/interactive/proxy/setup-sandbox.sh
+++ b/interactive/proxy/setup-sandbox.sh
@@ -84,9 +84,12 @@ mkdir -p "$CONFDIR"
 chmod 700 "$CONFDIR"
 # Warm the uvx cache first so the backgrounded launch starts immediately and
 # the readiness wait below measures startup, not a cold dependency resolve.
-uvx --from mitmproxy mitmdump --version >/dev/null
+# Pinned + UV_CACHE_DIR (set by the action) point at the actions/cache-backed
+# dir, so this is a fast restore after the first run.
+MITMPROXY="mitmproxy==${MITMPROXY_VERSION:-12.2.1}"
+uvx --from "$MITMPROXY" mitmdump --version >/dev/null
 log "starting proxy"
-nohup uvx --from mitmproxy mitmdump \
+nohup uvx --from "$MITMPROXY" mitmdump \
   -s "${ACTION_PATH}/proxy/github_auth.py" \
   --listen-host 127.0.0.1 --listen-port "$PROXY_PORT" \
   --set confdir="$CONFDIR" \

--- a/interactive/proxy/setup-sandbox.sh
+++ b/interactive/proxy/setup-sandbox.sh
@@ -24,7 +24,10 @@ SANDBOX=tend-sandbox
 AGENT_HOME="/home/${SANDBOX}"
 PROXY_PORT="${PROXY_PORT:-8899}"
 PROXY_URL="http://127.0.0.1:${PROXY_PORT}"
-TEND_RUN_DIR="${RUNNER_TEMP}/tend-sandbox"
+# Run dir (sentinels, PTY log, wrapper) lives in the sandbox's own home so it
+# can write there freely; the runner reads it via the 0755 home path. (Under
+# RUNNER_TEMP the sandbox can't create it — that dir is runner-owned.)
+TEND_RUN_DIR="${AGENT_HOME}/run"
 CONFDIR="${RUNNER_TEMP}/tend-proxy"
 
 log() { echo "[setup-sandbox] $*"; }

--- a/interactive/proxy/setup-sandbox.sh
+++ b/interactive/proxy/setup-sandbox.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Runner-side setup for credential isolation (gh/git cut).
+#
+# Runs as the privileged `runner` user. Stands up everything needed to run the
+# agent as a separate, non-sudo `tend-sandbox` user whose only path to an
+# authenticated GitHub call is a local mitmproxy that holds the real token:
+#
+#   1. Create the tend-sandbox user (no sudo, distinct UID).
+#   2. Strip the bot PAT that `actions/checkout` persisted into .git/config —
+#      otherwise the sandbox reads it straight off disk and isolation is moot.
+#   3. Hand the checkout to tend-sandbox so the agent can edit and commit.
+#   4. Start the injecting proxy (holds TEND_GH_TOKEN in its own memory) and
+#      system-trust its CA so the sandbox's gh/git accept the intercepted TLS.
+#
+# Exports for later steps via $GITHUB_ENV: SANDBOX, AGENT_HOME, PROXY_URL,
+# TEND_RUN_DIR.
+#
+# Inputs (env): TEND_GH_TOKEN (real PAT), ACTION_PATH (this action's checkout),
+# PROXY_PORT (default 8899). GITHUB_WORKSPACE / RUNNER_TEMP come from Actions.
+set -euo pipefail
+
+SANDBOX=tend-sandbox
+AGENT_HOME="/home/${SANDBOX}"
+PROXY_PORT="${PROXY_PORT:-8899}"
+PROXY_URL="http://127.0.0.1:${PROXY_PORT}"
+TEND_RUN_DIR="${RUNNER_TEMP}/tend-sandbox"
+CONFDIR="${RUNNER_TEMP}/tend-proxy"
+
+if [ -z "${TEND_GH_TOKEN:-}" ]; then
+  echo "::error::TEND_GH_TOKEN is unset; cannot start the credential proxy"
+  exit 1
+fi
+
+# 1. Non-sudo sandbox user. -m gives it /home/tend-sandbox (0755, so the
+#    runner can still read the session logs it writes).
+if ! id "$SANDBOX" >/dev/null 2>&1; then
+  sudo useradd -m -s /usr/bin/bash "$SANDBOX"
+fi
+
+# 2. Strip the PAT that `actions/checkout` (persist-credentials: true) wrote
+#    into .git/config. After this the only authenticated path to GitHub is the
+#    proxy. Run before the chown while the file is still runner-owned.
+git -C "$GITHUB_WORKSPACE" config --unset-all \
+  'http.https://github.com/.extraheader' 2>/dev/null || true
+
+# 3. Hand the checkout to the sandbox and mark it a safe git directory for it.
+sudo chown -R "${SANDBOX}:${SANDBOX}" "$GITHUB_WORKSPACE"
+sudo -u "$SANDBOX" git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+# Shared dir the sandbox writes (sentinels, PTY log, wrapper) and the runner
+# reads. Sandbox-owned so its hooks can touch the sentinels; 0755 so the
+# runner supervisor can poll them.
+sudo -u "$SANDBOX" mkdir -p "$TEND_RUN_DIR"
+
+# 4. Start the injecting proxy. It inherits TEND_GH_TOKEN from this shell; the
+#    token never leaves this runner-owned process. confdir is 0700 runner-only
+#    so the sandbox can't read the CA private key (it only needs the public
+#    cert, added to the system trust store below).
+mkdir -p "$CONFDIR"
+chmod 700 "$CONFDIR"
+# Warm the uvx cache first so the backgrounded launch starts immediately and
+# the readiness wait below measures startup, not a cold dependency resolve.
+uvx --from mitmproxy mitmdump --version >/dev/null
+nohup uvx --from mitmproxy mitmdump \
+  -s "${ACTION_PATH}/proxy/github_auth.py" \
+  --listen-host 127.0.0.1 --listen-port "$PROXY_PORT" \
+  --set confdir="$CONFDIR" \
+  --allow-hosts 'github\.com' \
+  </dev/null >"${RUNNER_TEMP}/tend-proxy.log" 2>&1 &
+echo $! >"${RUNNER_TEMP}/tend-proxy.pid"
+disown
+
+# Wait for the proxy to generate its CA (proof it's listening).
+for _ in $(seq 1 60); do
+  [ -f "${CONFDIR}/mitmproxy-ca-cert.pem" ] && break
+  sleep 0.5
+done
+if [ ! -f "${CONFDIR}/mitmproxy-ca-cert.pem" ]; then
+  echo "::error::proxy CA not generated after 20s; mitmdump failed to start"
+  cat "${RUNNER_TEMP}/tend-proxy.log" || true
+  exit 1
+fi
+
+# System-trust the proxy CA so the sandbox's gh (Go) and git (libcurl) accept
+# the intercepted GitHub TLS. Only the public cert is exported.
+sudo cp "${CONFDIR}/mitmproxy-ca-cert.pem" /usr/local/share/ca-certificates/tend-proxy.crt
+sudo update-ca-certificates >/dev/null
+
+{
+  echo "SANDBOX=${SANDBOX}"
+  echo "AGENT_HOME=${AGENT_HOME}"
+  echo "PROXY_URL=${PROXY_URL}"
+  echo "TEND_RUN_DIR=${TEND_RUN_DIR}"
+} >>"$GITHUB_ENV"
+
+echo "Sandbox ready: agent runs as ${SANDBOX}; GitHub auth via ${PROXY_URL}"

--- a/interactive/proxy/setup-sandbox.sh
+++ b/interactive/proxy/setup-sandbox.sh
@@ -17,12 +17,13 @@
 # TEND_RUN_DIR.
 #
 # Inputs (env): TEND_GH_TOKEN (real PAT), ACTION_PATH (this action's checkout),
-# PROXY_PORT (default 8899). GITHUB_WORKSPACE / RUNNER_TEMP come from Actions.
+# MITMPROXY_VERSION (pinned mitmproxy version). GITHUB_WORKSPACE / RUNNER_TEMP /
+# UV_CACHE_DIR come from Actions.
 set -euo pipefail
 
 SANDBOX=tend-sandbox
 AGENT_HOME="/home/${SANDBOX}"
-PROXY_PORT="${PROXY_PORT:-8899}"
+PROXY_PORT=8899
 PROXY_URL="http://127.0.0.1:${PROXY_PORT}"
 # Run dir (sentinels, PTY log, wrapper) lives in the sandbox's own home so it
 # can write there freely; the runner reads it via the 0755 home path. (Under
@@ -36,6 +37,10 @@ if [ -z "${TEND_GH_TOKEN:-}" ]; then
   echo "::error::TEND_GH_TOKEN is unset; cannot start the credential proxy"
   exit 1
 fi
+if [ -z "${MITMPROXY_VERSION:-}" ]; then
+  echo "::error::MITMPROXY_VERSION is unset; the action must pin it"
+  exit 1
+fi
 
 # 1. Non-sudo sandbox user. -m gives it /home/tend-sandbox (0755, so the
 #    runner can still read the session logs it writes).
@@ -46,25 +51,41 @@ log "user $SANDBOX uid=$(id -u "$SANDBOX")"
 
 # 2. Neutralize the credential actions/checkout persisted for git. Modern
 #    checkout stores it in an external file referenced by an includeIf, not as
-#    a plain extraheader — so drop the extraheader (older form), remove any
-#    includeIf sections, and lock the external credential files to runner-only.
-#    Belt: even if an include survives, git can't read a 0600 runner-owned file
-#    as the sandbox, so no credential reaches the agent. The proxy is the only
-#    authenticated path left.
+#    a plain extraheader. So: drop the extraheader (older form); unset each
+#    includeIf key (--unset on the FULL key — --remove-section can't match the
+#    dotted subsection name); and DELETE the external credential files. Deleting
+#    (not chmod) is load-bearing: the PAT is gone from disk, and git silently
+#    skips a now-missing include — whereas an unreadable include is *fatal* and
+#    would break every agent git operation. The proxy is the only auth path left.
 git -C "$GITHUB_WORKSPACE" config --local --unset-all \
   'http.https://github.com/.extraheader' 2>/dev/null || true
 while read -r key; do
   [ -n "$key" ] || continue
-  git -C "$GITHUB_WORKSPACE" config --local --remove-section "${key%.path}" 2>/dev/null || true
+  git -C "$GITHUB_WORKSPACE" config --local --unset "$key" 2>/dev/null || true
 done < <(git -C "$GITHUB_WORKSPACE" config --local --name-only --get-regexp '^includeif\.' 2>/dev/null || true)
-sudo find "$RUNNER_TEMP" -maxdepth 1 -name 'git-credentials-*' -exec chmod 600 {} + 2>/dev/null || true
+sudo find "$RUNNER_TEMP" -maxdepth 2 -name 'git-credentials-*' -delete 2>/dev/null || true
+
+# Verify the strip actually worked (the load-bearing security step): fail loudly
+# if any GitHub credential still resolves in the workspace config. The repo rule
+# is that an unhandled format fails with a clear error, not silently.
+if git -C "$GITHUB_WORKSPACE" config --local --list 2>/dev/null \
+     | grep -qiE 'extraheader=|^includeif\.gitdir'; then
+  echo "::error::failed to neutralize the persisted git credential in $GITHUB_WORKSPACE/.git/config"
+  git -C "$GITHUB_WORKSPACE" config --local --list | grep -iE 'extraheader=|^includeif\.gitdir' || true
+  exit 1
+fi
 log "neutralized persisted git credentials"
 
 # 3. Make the path to the workspace traversable by the sandbox, then hand it
 #    the checkout so the agent can edit and commit. The sandbox owns the tree,
-#    so no safe.directory entry is needed. o+x grants traversal only (not read)
-#    on the runner's home — fine on a single-use runner.
-sudo chmod o+x /home/runner /home/runner/work "$(dirname "$GITHUB_WORKSPACE")"
+#    so no safe.directory entry is needed. Grant o+x (traversal only, not read)
+#    on every ancestor of the workspace — derived, not hard-coded to /home/runner,
+#    so it works wherever the runner places the checkout. Fine on a single-use runner.
+parent="$(dirname "$GITHUB_WORKSPACE")"
+while [ "$parent" != "/" ]; do
+  sudo chmod o+x "$parent" 2>/dev/null || true
+  parent="$(dirname "$parent")"
+done
 sudo chown -R "${SANDBOX}:${SANDBOX}" "$GITHUB_WORKSPACE"
 sudo -u "$SANDBOX" test -r "$GITHUB_WORKSPACE/.git/config" \
   || { echo "::error::sandbox cannot access the workspace at $GITHUB_WORKSPACE"; exit 1; }
@@ -86,14 +107,14 @@ chmod 700 "$CONFDIR"
 # the readiness wait below measures startup, not a cold dependency resolve.
 # Pinned + UV_CACHE_DIR (set by the action) point at the actions/cache-backed
 # dir, so this is a fast restore after the first run.
-MITMPROXY="mitmproxy==${MITMPROXY_VERSION:-12.2.1}"
+MITMPROXY="mitmproxy==${MITMPROXY_VERSION}"
 uvx --from "$MITMPROXY" mitmdump --version >/dev/null
 log "starting proxy"
 nohup uvx --from "$MITMPROXY" mitmdump \
   -s "${ACTION_PATH}/proxy/github_auth.py" \
   --listen-host 127.0.0.1 --listen-port "$PROXY_PORT" \
   --set confdir="$CONFDIR" \
-  --allow-hosts 'github\.com' \
+  --allow-hosts '^(api\.|codeload\.|uploads\.)?github\.com(:[0-9]+)?$' \
   </dev/null >"${RUNNER_TEMP}/tend-proxy.log" 2>&1 &
 echo $! >"${RUNNER_TEMP}/tend-proxy.pid"
 disown

--- a/interactive/proxy/setup-sandbox.sh
+++ b/interactive/proxy/setup-sandbox.sh
@@ -6,9 +6,10 @@
 # authenticated GitHub call is a local mitmproxy that holds the real token:
 #
 #   1. Create the tend-sandbox user (no sudo, distinct UID).
-#   2. Strip the bot PAT that `actions/checkout` persisted into .git/config —
-#      otherwise the sandbox reads it straight off disk and isolation is moot.
-#   3. Hand the checkout to tend-sandbox so the agent can edit and commit.
+#   2. Neutralize the bot PAT actions/checkout persists for git — otherwise the
+#      sandbox reads it off disk and isolation is moot.
+#   3. Hand the checkout to tend-sandbox (and make the path traversable) so the
+#      agent can edit and commit.
 #   4. Start the injecting proxy (holds TEND_GH_TOKEN in its own memory) and
 #      system-trust its CA so the sandbox's gh/git accept the intercepted TLS.
 #
@@ -26,6 +27,8 @@ PROXY_URL="http://127.0.0.1:${PROXY_PORT}"
 TEND_RUN_DIR="${RUNNER_TEMP}/tend-sandbox"
 CONFDIR="${RUNNER_TEMP}/tend-proxy"
 
+log() { echo "[setup-sandbox] $*"; }
+
 if [ -z "${TEND_GH_TOKEN:-}" ]; then
   echo "::error::TEND_GH_TOKEN is unset; cannot start the credential proxy"
   exit 1
@@ -36,21 +39,39 @@ fi
 if ! id "$SANDBOX" >/dev/null 2>&1; then
   sudo useradd -m -s /usr/bin/bash "$SANDBOX"
 fi
+log "user $SANDBOX uid=$(id -u "$SANDBOX")"
 
-# 2. Strip the PAT that `actions/checkout` (persist-credentials: true) wrote
-#    into .git/config. After this the only authenticated path to GitHub is the
-#    proxy. Run before the chown while the file is still runner-owned.
-git -C "$GITHUB_WORKSPACE" config --unset-all \
+# 2. Neutralize the credential actions/checkout persisted for git. Modern
+#    checkout stores it in an external file referenced by an includeIf, not as
+#    a plain extraheader — so drop the extraheader (older form), remove any
+#    includeIf sections, and lock the external credential files to runner-only.
+#    Belt: even if an include survives, git can't read a 0600 runner-owned file
+#    as the sandbox, so no credential reaches the agent. The proxy is the only
+#    authenticated path left.
+git -C "$GITHUB_WORKSPACE" config --local --unset-all \
   'http.https://github.com/.extraheader' 2>/dev/null || true
+while read -r key; do
+  [ -n "$key" ] || continue
+  git -C "$GITHUB_WORKSPACE" config --local --remove-section "${key%.path}" 2>/dev/null || true
+done < <(git -C "$GITHUB_WORKSPACE" config --local --name-only --get-regexp '^includeif\.' 2>/dev/null || true)
+sudo find "$RUNNER_TEMP" -maxdepth 1 -name 'git-credentials-*' -exec chmod 600 {} + 2>/dev/null || true
+log "neutralized persisted git credentials"
 
-# 3. Hand the checkout to the sandbox and mark it a safe git directory for it.
+# 3. Make the path to the workspace traversable by the sandbox, then hand it
+#    the checkout so the agent can edit and commit. The sandbox owns the tree,
+#    so no safe.directory entry is needed. o+x grants traversal only (not read)
+#    on the runner's home — fine on a single-use runner.
+sudo chmod o+x /home/runner /home/runner/work "$(dirname "$GITHUB_WORKSPACE")"
 sudo chown -R "${SANDBOX}:${SANDBOX}" "$GITHUB_WORKSPACE"
-sudo -u "$SANDBOX" git config --global --add safe.directory "$GITHUB_WORKSPACE"
+sudo -u "$SANDBOX" test -r "$GITHUB_WORKSPACE/.git/config" \
+  || { echo "::error::sandbox cannot access the workspace at $GITHUB_WORKSPACE"; exit 1; }
+log "workspace handed to $SANDBOX"
 
 # Shared dir the sandbox writes (sentinels, PTY log, wrapper) and the runner
-# reads. Sandbox-owned so its hooks can touch the sentinels; 0755 so the
-# runner supervisor can poll them.
+# reads. Sandbox-owned so its hooks can touch the sentinels; the runner
+# supervisor polls them via the 0755 home/temp path.
 sudo -u "$SANDBOX" mkdir -p "$TEND_RUN_DIR"
+log "run dir $TEND_RUN_DIR"
 
 # 4. Start the injecting proxy. It inherits TEND_GH_TOKEN from this shell; the
 #    token never leaves this runner-owned process. confdir is 0700 runner-only
@@ -61,6 +82,7 @@ chmod 700 "$CONFDIR"
 # Warm the uvx cache first so the backgrounded launch starts immediately and
 # the readiness wait below measures startup, not a cold dependency resolve.
 uvx --from mitmproxy mitmdump --version >/dev/null
+log "starting proxy"
 nohup uvx --from mitmproxy mitmdump \
   -s "${ACTION_PATH}/proxy/github_auth.py" \
   --listen-host 127.0.0.1 --listen-port "$PROXY_PORT" \
@@ -76,7 +98,7 @@ for _ in $(seq 1 60); do
   sleep 0.5
 done
 if [ ! -f "${CONFDIR}/mitmproxy-ca-cert.pem" ]; then
-  echo "::error::proxy CA not generated after 20s; mitmdump failed to start"
+  echo "::error::proxy CA not generated after 30s; mitmdump failed to start"
   cat "${RUNNER_TEMP}/tend-proxy.log" || true
   exit 1
 fi
@@ -85,6 +107,7 @@ fi
 # the intercepted GitHub TLS. Only the public cert is exported.
 sudo cp "${CONFDIR}/mitmproxy-ca-cert.pem" /usr/local/share/ca-certificates/tend-proxy.crt
 sudo update-ca-certificates >/dev/null
+log "proxy up at $PROXY_URL; CA trusted"
 
 {
   echo "SANDBOX=${SANDBOX}"
@@ -93,4 +116,4 @@ sudo update-ca-certificates >/dev/null
   echo "TEND_RUN_DIR=${TEND_RUN_DIR}"
 } >>"$GITHUB_ENV"
 
-echo "Sandbox ready: agent runs as ${SANDBOX}; GitHub auth via ${PROXY_URL}"
+log "done; agent runs as ${SANDBOX}, GitHub auth via the proxy"

--- a/interactive/proxy/test_github_auth.py
+++ b/interactive/proxy/test_github_auth.py
@@ -1,0 +1,65 @@
+"""Tests for the GitHub credential-injection addon.
+
+Run: ``uv run --with mitmproxy --with pytest python -m pytest interactive/proxy``
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+from mitmproxy.test import tflow, tutils
+
+from github_auth import GitHubAuthInjector
+
+
+def _flow(host: str, authorization: str | None = None) -> object:
+    flow = tflow.tflow(req=tutils.treq(host=host))
+    if authorization is not None:
+        flow.request.headers["Authorization"] = authorization
+    return flow
+
+
+@pytest.fixture
+def injector(monkeypatch: pytest.MonkeyPatch) -> GitHubAuthInjector:
+    monkeypatch.setenv("TEND_GH_TOKEN", "ghp_REALTOKEN")
+    return GitHubAuthInjector()
+
+
+def test_api_host_gets_token_scheme(injector: GitHubAuthInjector) -> None:
+    flow = _flow("api.github.com", "token ghp_dummy")
+    injector.request(flow)
+    assert flow.request.headers["Authorization"] == "token ghp_REALTOKEN"
+
+
+def test_git_host_gets_basic_scheme(injector: GitHubAuthInjector) -> None:
+    flow = _flow("github.com", "Basic " + base64.b64encode(b"x:dummy").decode())
+    injector.request(flow)
+    expected = "Basic " + base64.b64encode(b"x-access-token:ghp_REALTOKEN").decode()
+    assert flow.request.headers["Authorization"] == expected
+
+
+def test_missing_authorization_is_added_for_github(injector: GitHubAuthInjector) -> None:
+    # git's first request is unauthenticated; the proxy authenticates it so git
+    # never needs a credential of its own.
+    flow = _flow("github.com")
+    injector.request(flow)
+    assert flow.request.headers["Authorization"].startswith("Basic ")
+
+
+def test_non_github_host_is_untouched(injector: GitHubAuthInjector) -> None:
+    flow = _flow("pypi.org", "token ghp_dummy")
+    injector.request(flow)
+    assert flow.request.headers["Authorization"] == "token ghp_dummy"
+
+
+def test_lookalike_host_is_untouched(injector: GitHubAuthInjector) -> None:
+    flow = _flow("api.github.com.evil.example", "token ghp_dummy")
+    injector.request(flow)
+    assert flow.request.headers["Authorization"] == "token ghp_dummy"
+
+
+def test_no_token_refuses_to_start(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TEND_GH_TOKEN", raising=False)
+    with pytest.raises(RuntimeError, match="TEND_GH_TOKEN is unset"):
+        GitHubAuthInjector()

--- a/interactive/proxy/test_github_auth.py
+++ b/interactive/proxy/test_github_auth.py
@@ -59,6 +59,17 @@ def test_lookalike_host_is_untouched(injector: GitHubAuthInjector) -> None:
     assert flow.request.headers["Authorization"] == "token ghp_dummy"
 
 
+def test_spoofed_host_header_does_not_leak_token(injector: GitHubAuthInjector) -> None:
+    # The real connection target is an attacker host, but the client spoofs the
+    # Host header to a GitHub host. The token must NOT be injected — otherwise it
+    # would be forwarded to the attacker. Guards against gating on pretty_host.
+    flow = _flow("attacker.example", "token ghp_dummy")
+    flow.request.headers["Host"] = "api.github.com"
+    assert flow.request.pretty_host == "api.github.com"  # the spoofable view
+    injector.request(flow)
+    assert flow.request.headers["Authorization"] == "token ghp_dummy"
+
+
 def test_no_token_refuses_to_start(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("TEND_GH_TOKEN", raising=False)
     with pytest.raises(RuntimeError, match="TEND_GH_TOKEN is unset"):


### PR DESCRIPTION
Keeps a prompt-injected CI agent from reading the bot's GitHub PAT, on the `claude-interactive` harness. Prompted by a critique that tend's tokens are accessible to the model.

## Approach

The agent runs as a separate, non-sudo `tend-sandbox` user. The real PAT lives only in a local `mitmproxy` (running as `runner`) that injects it into requests to GitHub hosts. The agent holds only a dummy `GH_TOKEN` plus `HTTPS_PROXY`, so it can authenticate to GitHub only *through* the proxy and can't read the real token: different UID, no sudo, and `/proc/<pid>/environ` is owner-only. The PAT is also stripped from `.git/config` (where `actions/checkout` persists it via an `includeIf` → external file).

The proxy gates injection on the connection's real destination (`flow.request.host`), not the client-supplied `Host` header, so a spoofed `Host: api.github.com` to an attacker host gets no token. The injection allowlist is exact-match on four GitHub hosts.

bwrap was the obvious alternative but isn't on the stock runner image and Ubuntu 24.04 restricts unprivileged user namespaces; UID separation alone gives the credential isolation. The namespaces would mainly buy egress lockdown, which conflicts with tend needing to build and test arbitrary repos.

## Scope

GitHub credential only. The Claude OAuth/API token still reaches the agent's env — a later cut can route inference through the same proxy via `ANTHROPIC_BASE_URL`.

## Key files

- `interactive/proxy/github_auth.py` — the mitmproxy addon and its exact-host injection allowlist (the credential boundary).
- `interactive/proxy/setup-sandbox.sh` — runner-side: create the user, neutralize the persisted git credential, hand over the checkout, start the proxy, system-trust its CA.
- `interactive/action.yaml` — wires the sandbox setup, toolchain handoff, and the user-dropped agent launch into the harness.
- `interactive/proxy/test_github_auth.py` — addon tests (incl. the Host-spoof regression), wired into `ci.yaml` as a standalone `test-proxy` job.

## Validation

`interactive-smoke` runs against the production shape (`persist-credentials: true`) and is green: a dummy-token sandbox agent authenticated as the bot (`gh api user` → `tend-agent`) and ran `git ls-remote origin` successfully, proving the credential strip neither leaks the PAT nor breaks git.

## Known gaps / follow-ups

- The Claude OAuth/API token still reaches the agent's env (phase 2).
- `*.githubusercontent.com` / git-LFS aren't in the injection allowlist (fine for the common gh/git/push path; private raw/asset fetches would fail).
- Under `persist-credentials: true`, chowning `.git` makes `actions/checkout`'s post-cleanup warn (non-fatal).
- The toolchain handoff copies ~200MB with `cp -a` every run; installing as the sandbox user would avoid it, but `mv` breaks the binary's absolute-path refs, so it's a larger refactor.

> _This was written by Claude Code on behalf of max_
