### PR TITLE
feat(worker): share /activity payload across colos via a KV tier

### DIFF
--- a/worker/README.md
+++ b/worker/README.md
@@ -57,9 +57,12 @@ Recent things tend has done, in primitive buckets — one Search query per
 bucket per bot (`sort=updated`): the page yields both the `recent` items and
 the lifetime `count` (`total_count`); `count_this_week` is counted off the
 page, so it saturates around one page (~100) per bot per bucket — fine for a
-headline number. The fanout is 4·N concurrent Search requests, which stays
-under the 30 req/min cap up to ~7 bots; past that, the per-bot calls would
-need staggering or a scheduled refresh (see the Phase-2 note).
+headline number. The fanout is 4·N concurrent Search requests against the
+30 req/min Search cap, so a single fanout stays clear up to ~7 bots. The KV
+sharing tier (see [Caching](#caching)) bounds how often a fanout fires by the
+freshness budget network-wide rather than letting it scale with colo count or
+traffic, so near-simultaneous fanouts that would stack against the cap stay
+rare.
 
 ```jsonc
 {
@@ -129,28 +132,43 @@ the hour.
 
 ## Caching
 
-Responses are served **stale-while-revalidate** from the colo cache
-(`caches.default`). A request is always answered from cache — no waiting on
-the GitHub fanout. When the cached entry is past its freshness budget
-(30 s / 5 min), the hit also kicks off a background refresh via
-`ctx.waitUntil` so the next viewer sees fresher data. An entry stays
-serveable for ten freshness budgets — 5 min on `/currently-tending`, 50 min
-on `/activity` — before the cache drops it, so a viewer never sees data
-older than that and an ordinarily-trafficked site never goes cold.
+Two tiers. The **colo cache** (`caches.default`) is the hot, per-data-center
+tier: every request is answered from it, never waiting on the GitHub fanout.
+Past its freshness budget (30 s / 5 min) a hit also kicks off a background
+refresh via `ctx.waitUntil`, so the next viewer sees fresher data. An entry
+stays serveable for ten freshness budgets (5 min on `/currently-tending`,
+50 min on `/activity`) before the cache drops it.
 
-Still demand-driven: a background refresh only fires when a request comes
-in, so a no-traffic day costs zero GitHub calls. The cost is one cold start
-— a fresh deploy, or a gap longer than 10 freshness budgets, makes that one
-request wait on the fanout. A cron-triggered prewarm would close even that
-gap but would trade away the zero-when-idle property; not worth it at this
-scale.
+The colo cache is per-colo, so each Cloudflare data center would otherwise fan
+out to GitHub on its own. `/activity` adds a **KV tier** (`activity:v1`)
+behind the hot tier: a refresh publishes its rendered payload to KV, a global
+store, so a refresh in one colo serves every other colo. The GitHub fanout
+then fires about once per freshness budget across the whole network instead of
+once per colo. That keeps the 4·N Search burst clear of the 30 req/min cap
+whatever the colo count. KV survives deploys and outlives the colo cache, so a
+viewer waits on the fanout only when colo cache and KV are both empty: the
+first request ever, or after an idle longer than KV's retention.
+`/currently-tending` skips KV; its 30 s budget is under KV's 60 s floor, and
+its fanout is cheap core REST, not the Search quota the sharing protects.
 
-When a refresh throws (GitHub outage) with no prior entry to serve, the Worker
-returns a 503 rather than a 200 all-zero payload, so the site renders nothing
-for that section instead of fabricated zeros. The 503 is negative-cached at the
-short **fallback budget** (5 s / 30 s) so the next request retries soon. On a
-warm cache a failed background refresh keeps the last good entry instead, so an
-outage never overwrites good data with zeros.
+Still demand-driven: a refresh fires only on a request (foreground on a true
+cold start, background otherwise), so a no-traffic day costs zero GitHub
+calls. The KV coordination is best-effort, not a global lock: colos going
+stale at the same instant can still race within KV's write-propagation window
+(up to ~60 s) before the first write is visible, after which later arrivals
+read the fresh entry and skip the fanout. A cron-driven single refresher would
+make that a hard guarantee but trade away the zero-when-idle property; not
+worth it at this scale.
+
+When a refresh throws (GitHub outage) on a warm colo cache, the bumped stale
+entry is kept, so an outage never overwrites good data with zeros. On a cold
+colo cache, `/activity` serves a prior KV entry (stale if need be) and
+revalidates in the background, so even a cold start during an outage shows the
+last-known data. Only when colo cache and KV are both empty does a thrown
+refresh return a 503 rather than a 200 all-zero payload, so the site renders
+nothing for that section instead of fabricated zeros. The 503 is
+negative-cached at the short **fallback budget** (5 s / 30 s) so the next
+request retries soon.
 
 ## Topology
 
@@ -164,7 +182,8 @@ data/consumers.json on main
 Cloudflare Worker (tend-website)
   ├─ reads data/consumers.json via raw URL (KV-cached 1 h)
   ├─ /currently-tending: fans out actions/runs per repo (in-progress, tend-*)
-  ├─ /activity:          fans out one Search query per bucket per bot
+  ├─ /activity:          fans out one Search query per bucket per bot,
+  │                      payload shared across colos via KV (activity:v1)
   └─ each route stale-while-revalidate from the colo cache, served at api.tend-src.com
 ```
 
@@ -213,22 +232,29 @@ Then `curl http://localhost:8787/activity` etc. `wrangler dev` reads the same
   response tells `serveCached` when to background-refresh a hit. A missing
   or garbled stamp counts as stale, so the first hit self-heals an entry
   written by code predating this scheme.
-- `CACHE` KV namespace, key `repos:v1`, TTL 1 h — the `consumers.json`
-  content. Decouples `running-tend`'s weekly refresh from Worker deploys. KV
-  is appropriate here because the 1 h TTL is above KV's 60 s minimum and we
-  want cross-isolate sharing.
+- `CACHE` KV namespace, two keys. `repos:v1` (TTL 1 h) holds the
+  `consumers.json` content, decoupling `running-tend`'s weekly refresh from
+  Worker deploys. `activity:v1` (TTL = 10 freshness budgets) holds the rendered
+  `/activity` payload plus its `staleAt`, the shared tier that lets one colo's
+  refresh serve the others. KV suits both: the TTLs clear its 60 s minimum, and
+  the whole point is cross-isolate, cross-colo sharing.
 
-Concurrent stale-hits are coalesced: the first request pushes the
+Concurrent stale-hits are coalesced within a colo: the first request pushes the
 cached entry's `x-tend-stale-at` forward by a short grace window
 (`REFRESH_GRACE_MS`, currently 30 s) and starts the background refresh;
 viewers arriving within that window read the bumped entry as fresh and
 skip starting their own refresh. One refresh per stale window per colo,
-not one per viewer — keeps the Search-API fanout bounded under bursts.
+not one per viewer. `refreshShared` extends this across colos: a refresh
+(cold or background) returns a sibling colo's still-fresh `activity:v1` entry
+instead of fanning out, and publishes its own result there when it does fan
+out.
 
-A cold cache miss costs the route's full fanout (N actions/runs calls for
-`/currently-tending`, 4·N Search calls for `/activity`). The freshness
-budget bounds how often that happens: at most one cold refresh per budget
-per colo, under any traffic level.
+For `/currently-tending` a cold colo cache costs the full N actions/runs
+fanout, bounded to one cold refresh per budget per colo. For `/activity` the
+KV tier collapses that to roughly one 4·N Search fanout per budget across the
+whole network: a cold or stale colo reads `activity:v1` first and fans out only
+when KV is stale too, so neither colo count nor traffic multiplies the GitHub
+load.
 
 The zone's **Browser Cache TTL** must be set to "Respect Existing Headers"
 (value `0`). Any positive value is treated as a floor on outgoing

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -277,12 +277,22 @@ function readKvEntry<T>(env: Env, key: string): Promise<KvEntry<T> | null> {
 // GitHub fanout. Both the cold path and the background refresh funnel through
 // here, so the GitHub fanout fires at most once per freshness budget across
 // every colo except those racing within KV's write-propagation window.
-async function refreshShared<T>(env: Env, opts: CacheOpts<T>): Promise<T> {
-  if (!opts.kvKey) return opts.refresh();
+//
+// Returns the entry, not just the payload: a reused KV entry carries its
+// original stale-at, a freshly-fetched one `now + ttl.ok`. Callers stamp the
+// colo cache from that, so a colo inherits the shared clock instead of
+// resetting it (see entryResponse).
+async function refreshShared<T>(env: Env, opts: CacheOpts<T>): Promise<KvEntry<T>> {
+  // staleAt is read after the fanout resolves (property order), so a slow
+  // fanout doesn't shorten the published freshness window.
+  const mint = async (): Promise<KvEntry<T>> => ({
+    payload: await opts.refresh(),
+    staleAt: Date.now() + opts.ttl.ok * 1000,
+  });
+  if (!opts.kvKey) return mint();
   const entry = await readKvEntry<T>(env, opts.kvKey);
-  if (entry && Date.now() < entry.staleAt) return entry.payload;
-  const payload = await opts.refresh();
-  const fresh: KvEntry<T> = { payload, staleAt: Date.now() + opts.ttl.ok * 1000 };
+  if (entry && Date.now() < entry.staleAt) return entry; // sibling colo's fresh write
+  const fresh = await mint();
   await env.CACHE.put(opts.kvKey, JSON.stringify(fresh), {
     // Outlive the freshness budget by STALE_SERVE_FACTOR, matching the colo
     // cache, so a quiet stretch still leaves a (stale) entry to serve. Stays
@@ -290,7 +300,7 @@ async function refreshShared<T>(env: Env, opts: CacheOpts<T>): Promise<T> {
     // (activity's is 300s); a shorter-budget route would need its own floor.
     expirationTtl: opts.ttl.ok * STALE_SERVE_FACTOR,
   }).catch((e) => console.error(`KV put failed for ${opts.kvKey}:`, e));
-  return payload;
+  return fresh;
 }
 
 async function serveCached<T>(
@@ -358,7 +368,7 @@ async function refreshAndCache<T>(
   if (opts.kvKey) {
     const entry = await readKvEntry<T>(env, opts.kvKey);
     if (entry) {
-      const response = kvHydratedResponse(entry, env, opts.ttl.ok);
+      const response = entryResponse(entry, env, opts.ttl.ok);
       if (Date.now() >= entry.staleAt) {
         // coalesceAndRefresh writes the colo entry (bumped, then fresh) and
         // re-checks KV, so don't also put here.
@@ -380,7 +390,7 @@ async function refreshAndCache<T>(
 
   let response: Response;
   try {
-    response = jsonResponse(await refreshShared(env, opts), env, opts.ttl.ok);
+    response = entryResponse(await refreshShared(env, opts), env, opts.ttl.ok);
   } catch (e) {
     console.error(`cold refresh failed for ${opts.cacheKeyPath}:`, e);
     response = jsonResponse(
@@ -420,7 +430,7 @@ async function coalesceAndRefresh<T>(
   bumped.headers.set(STALE_AT_HEADER, String(Date.now() + REFRESH_GRACE_MS));
   await caches.default.put(cacheKey, bumped);
   try {
-    const fresh = jsonResponse(await refreshShared(env, opts), env, opts.ttl.ok);
+    const fresh = entryResponse(await refreshShared(env, opts), env, opts.ttl.ok);
     await caches.default.put(cacheKey, fresh);
   } catch (e) {
     console.error(
@@ -824,12 +834,13 @@ function jsonResponse(
   );
 }
 
-// A payload hydrated from KV: inherit the entry's stale-at so the colo doesn't
-// reset the shared clock (an entry written 200 s ago must still go stale at its
-// original instant, not 300 s from now), while keeping the full colo-retention
-// window. max-age is the entry's remaining freshness, floored at 0 for a stale
-// entry — which serveCached then revalidates.
-function kvHydratedResponse<T>(entry: KvEntry<T>, env: Env, okTtl: number): Response {
+// A response built from a cache entry (a fresh fetch or a sibling colo's KV
+// write). It inherits the entry's stale-at, so a colo never resets the shared
+// clock: an entry written 200 s ago goes stale at its original instant, not a
+// full budget from now. max-age is the entry's remaining freshness, floored at
+// 0 for a stale entry, which serveCached then revalidates. s-maxage keeps the
+// full colo-retention window regardless.
+function entryResponse<T>(entry: KvEntry<T>, env: Env, okTtl: number): Response {
   return cacheableJson(entry.payload, env, {
     staleAtMs: entry.staleAt,
     maxAgeSeconds: Math.max(0, Math.ceil((entry.staleAt - Date.now()) / 1000)),

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -10,16 +10,25 @@
 // for an hour, and fan out to GitHub. Responses are stale-while-revalidate:
 // a request is always answered from the colo cache (no waiting on the
 // fanout) and, when the cached entry is past its budget, also kicks off a
-// background refresh so the next request sees fresher data. Only a cold
-// cache — a fresh deploy, or a quiet stretch long enough for the entry to
-// be evicted — makes a viewer wait. A background refresh only fires on a
-// request, so idle days still cost zero GitHub calls.
+// background refresh so the next request sees fresher data. A background
+// refresh only fires on a request, so idle days still cost zero GitHub calls.
+//
+// The colo cache is per-data-center, so each colo would otherwise fan out to
+// GitHub on its own. `/activity` therefore also publishes its rendered
+// payload to KV (a global store): a refresh in one colo populates KV for the
+// others, so the GitHub fanout fires roughly once per freshness budget across
+// the whole network instead of once per colo. KV survives deploys and outlives
+// the colo cache, so a viewer waits on GitHub only when colo cache and KV are
+// both empty (the first request ever, or after a long idle). `/currently-tending`
+// skips KV: its 30s budget is under KV's 60s floor, and its fanout is cheap
+// core REST, not the Search quota that the sharing protects.
 //
 // `/activity` is one Search query per bucket per bot (`sort=updated`): the
 // page yields both the recent items and the lifetime `total_count`; "this
 // week" is counted off the page, so it saturates around one page (~100) per
 // bot per bucket — fine for a headline number. The fanout is 4·N concurrent
-// Search requests, under the 30/min cap up to ~7 bots.
+// Search requests against the 30/min Search cap; KV sharing keeps how often
+// it fires independent of colo count and traffic.
 //
 // See ../README.md for architecture and the rate-limit reasoning behind
 // the budgets.
@@ -112,6 +121,9 @@ interface IssueCommentObject {
 
 const REPOS_KEY = "repos:v1";
 const REPOS_TTL_SECONDS = 3600;
+// /activity's rendered payload, shared across colos so one colo's fanout
+// spares the rest. See refreshShared.
+const ACTIVITY_KV_KEY = "activity:v1";
 const FETCH_TIMEOUT_MS = 10_000;
 const WORKFLOW_PREFIX = "tend-";
 // `actions/runs` sorts by created_at desc across ALL workflows in the
@@ -224,6 +236,7 @@ export default {
         return serveCached(url, env, ctx, {
           cacheKeyPath: "/activity",
           ttl: TTL.activity,
+          kvKey: ACTIVITY_KV_KEY,
           refresh: () => refreshActivity(env),
         });
       default:
@@ -239,6 +252,45 @@ interface CacheOpts<T> {
   cacheKeyPath: string;
   ttl: { ok: number; fallback: number };
   refresh: () => Promise<T>;
+  // When set, refreshes coordinate through this KV key (a global store) so a
+  // fanout in one colo populates KV for every other colo. Routes without it
+  // (currently-tending, whose 30s budget is under KV's 60s floor) refresh
+  // straight from GitHub on each colo.
+  kvKey?: string;
+}
+
+// A KV-stored payload plus the instant it goes stale (epoch ms). The colo
+// cache is the hot, per-colo tier; KV is the shared tier behind it, so one
+// colo's refresh serves the others.
+interface KvEntry<T> {
+  payload: T;
+  staleAt: number;
+}
+
+function readKvEntry<T>(env: Env, key: string): Promise<KvEntry<T> | null> {
+  return env.CACHE.get<KvEntry<T>>(key, "json").catch(() => null);
+}
+
+// Refresh that coordinates through KV when opts.kvKey is set: if a sibling
+// colo wrote a still-fresh entry, reuse it and skip GitHub; otherwise fan out
+// and publish the result to KV for the others. Without a kvKey it's a straight
+// GitHub fanout. Both the cold path and the background refresh funnel through
+// here, so the GitHub fanout fires at most once per freshness budget across
+// every colo except those racing within KV's write-propagation window.
+async function refreshShared<T>(env: Env, opts: CacheOpts<T>): Promise<T> {
+  if (!opts.kvKey) return opts.refresh();
+  const entry = await readKvEntry<T>(env, opts.kvKey);
+  if (entry && Date.now() < entry.staleAt) return entry.payload;
+  const payload = await opts.refresh();
+  const fresh: KvEntry<T> = { payload, staleAt: Date.now() + opts.ttl.ok * 1000 };
+  await env.CACHE.put(opts.kvKey, JSON.stringify(fresh), {
+    // Outlive the freshness budget by STALE_SERVE_FACTOR, matching the colo
+    // cache, so a quiet stretch still leaves a (stale) entry to serve. Stays
+    // above KV's 60s minimum expirationTtl for any route whose ttl.ok ≥ 6s
+    // (activity's is 300s); a shorter-budget route would need its own floor.
+    expirationTtl: opts.ttl.ok * STALE_SERVE_FACTOR,
+  }).catch((e) => console.error(`KV put failed for ${opts.kvKey}:`, e));
+  return payload;
 }
 
 async function serveCached<T>(
@@ -247,9 +299,10 @@ async function serveCached<T>(
   ctx: ExecutionContext,
   opts: CacheOpts<T>,
 ): Promise<Response> {
-  // Normalize the cache key so query strings don't fork the cache. Using
-  // the colo cache (not KV) for the response also dodges KV's 60s minimum
-  // expirationTtl — currently-tending's budget is shorter than that.
+  // Normalize the cache key so query strings don't fork the cache. The colo
+  // cache (not KV) holds the rendered Response: its sub-second granularity
+  // suits currently-tending's 30s budget, below KV's 60s floor. /activity
+  // shares its payload across colos via KV behind this hot tier (refreshShared).
   const cacheKey = new Request(`${url.origin}${opts.cacheKeyPath}`, {
     method: "GET",
   });
@@ -276,15 +329,20 @@ async function serveCached<T>(
     return cached;
   }
 
-  // Cold cache — a fresh deploy, or no traffic for STALE_SERVE_FACTOR
-  // budgets. This request pays the fanout; everyone after it is served
-  // from cache until the next cold start.
+  // Cold colo cache — a fresh isolate, or no traffic for STALE_SERVE_FACTOR
+  // budgets. refreshAndCache checks KV before paying the fanout.
   return refreshAndCache(cacheKey, env, ctx, opts);
 }
 
-// Cold-cache path: the caller is waiting on this, so we return the fresh
-// Response and let the cache put run via ctx.waitUntil. On refresh failure
-// there's no prior data to serve, so we return a 503 rather than a 200
+// Cold colo-cache path. For a KV-shared route, a sibling colo may already
+// have the data in KV: serve that (even when stale) so this viewer skips the
+// GitHub fanout, and a burst after idle doesn't make every colo fan out at
+// once. A stale KV entry is served immediately and revalidated in the
+// background, so an outage on cold start shows the last-known data rather than
+// nothing.
+//
+// Only when colo cache and KV are both empty does this request pay the fanout.
+// On failure there's then no prior data, so we return a 503 rather than a 200
 // all-zero payload: the site reads the non-OK response as "no data" and hides
 // the section instead of rendering fabricated zeros. The 503 is negative-cached
 // at the short fallback budget so a sustained outage doesn't re-fan-out on
@@ -297,9 +355,32 @@ async function refreshAndCache<T>(
   ctx: ExecutionContext,
   opts: CacheOpts<T>,
 ): Promise<Response> {
+  if (opts.kvKey) {
+    const entry = await readKvEntry<T>(env, opts.kvKey);
+    if (entry) {
+      const response = kvHydratedResponse(entry, env, opts.ttl.ok);
+      if (Date.now() >= entry.staleAt) {
+        // coalesceAndRefresh writes the colo entry (bumped, then fresh) and
+        // re-checks KV, so don't also put here.
+        ctx.waitUntil(
+          coalesceAndRefresh(cacheKey, response.clone(), env, opts).catch((e) =>
+            console.error(`background refresh failed for ${opts.cacheKeyPath}:`, e),
+          ),
+        );
+      } else {
+        ctx.waitUntil(
+          caches.default
+            .put(cacheKey, response.clone())
+            .catch((e) => console.error(`cache put failed for ${opts.cacheKeyPath}:`, e)),
+        );
+      }
+      return response;
+    }
+  }
+
   let response: Response;
   try {
-    response = jsonResponse(await opts.refresh(), env, opts.ttl.ok);
+    response = jsonResponse(await refreshShared(env, opts), env, opts.ttl.ok);
   } catch (e) {
     console.error(`cold refresh failed for ${opts.cacheKeyPath}:`, e);
     response = jsonResponse(
@@ -320,10 +401,12 @@ async function refreshAndCache<T>(
 // Stale-hit path: coalesce concurrent refreshes by bumping the cached
 // entry's stale-at forward before running the refresh. Concurrent
 // stale-hits arriving within REFRESH_GRACE_MS read the bumped entry as
-// fresh and skip starting their own refresh. On refresh failure keep the
-// bumped cached entry — a viewer keeps seeing the previous (slightly
-// stale) data instead of an empty payload overwriting it for the
-// fallback TTL, which would briefly black out every viewer.
+// fresh and skip starting their own refresh. The refresh goes through
+// refreshShared, so on a KV-shared route it pulls a sibling colo's fresh KV
+// entry instead of fanning out. On refresh failure keep the bumped cached
+// entry — a viewer keeps seeing the previous (slightly stale) data instead of
+// an empty payload overwriting it for the fallback TTL, which would briefly
+// black out every viewer.
 async function coalesceAndRefresh<T>(
   cacheKey: Request,
   cached: Response,
@@ -337,7 +420,7 @@ async function coalesceAndRefresh<T>(
   bumped.headers.set(STALE_AT_HEADER, String(Date.now() + REFRESH_GRACE_MS));
   await caches.default.put(cacheKey, bumped);
   try {
-    const fresh = jsonResponse(await opts.refresh(), env, opts.ttl.ok);
+    const fresh = jsonResponse(await refreshShared(env, opts), env, opts.ttl.ok);
     await caches.default.put(cacheKey, fresh);
   } catch (e) {
     console.error(
@@ -697,33 +780,61 @@ function withCors(resp: Response, env: Env): Response {
   return resp;
 }
 
+function cacheableJson(
+  data: unknown,
+  env: Env,
+  cache: { staleAtMs: number; maxAgeSeconds: number; sMaxAgeSeconds: number },
+  status = 200,
+): Response {
+  return withCors(
+    new Response(JSON.stringify(data), {
+      status,
+      headers: {
+        "Content-Type": "application/json",
+        // Browsers revalidate after `max-age`; the colo cache, a shared
+        // cache, keeps the entry for `s-maxage` so it stays warm for
+        // stale-while-revalidate. Requires the zone's Browser Cache TTL to be
+        // "Respect Existing Headers" — any positive value there acts as a floor
+        // on outgoing `max-age`, so a 4 h default silently inflates this header
+        // and pins browsers to whichever snapshot they fetched first.
+        "Cache-Control": `public, max-age=${cache.maxAgeSeconds}, s-maxage=${cache.sMaxAgeSeconds}`,
+        [STALE_AT_HEADER]: String(cache.staleAtMs),
+      },
+    }),
+    env,
+  );
+}
+
+// A freshly-fetched payload: the budget starts ticking now.
 function jsonResponse(
   data: unknown,
   env: Env,
   ttlSeconds: number,
   status = 200,
 ): Response {
-  const staleAtMs = Date.now() + ttlSeconds * 1000;
-  return withCors(
-    new Response(JSON.stringify(data), {
-      status,
-      headers: {
-        "Content-Type": "application/json",
-        // Browsers revalidate after the freshness budget (`max-age`); the
-        // colo cache, a shared cache, keeps the entry for STALE_SERVE_FACTOR
-        // budgets (`s-maxage`) so it stays warm for stale-while-revalidate.
-        // Requires the zone's Browser Cache TTL to be "Respect Existing
-        // Headers" — any positive value there acts as a floor on outgoing
-        // `max-age`, so a 4 h default silently inflates this header and
-        // pins browsers to whichever snapshot they fetched first.
-        "Cache-Control":
-          `public, max-age=${ttlSeconds}, ` +
-          `s-maxage=${ttlSeconds * STALE_SERVE_FACTOR}`,
-        [STALE_AT_HEADER]: String(staleAtMs),
-      },
-    }),
+  return cacheableJson(
+    data,
     env,
+    {
+      staleAtMs: Date.now() + ttlSeconds * 1000,
+      maxAgeSeconds: ttlSeconds,
+      sMaxAgeSeconds: ttlSeconds * STALE_SERVE_FACTOR,
+    },
+    status,
   );
+}
+
+// A payload hydrated from KV: inherit the entry's stale-at so the colo doesn't
+// reset the shared clock (an entry written 200 s ago must still go stale at its
+// original instant, not 300 s from now), while keeping the full colo-retention
+// window. max-age is the entry's remaining freshness, floored at 0 for a stale
+// entry — which serveCached then revalidates.
+function kvHydratedResponse<T>(entry: KvEntry<T>, env: Env, okTtl: number): Response {
+  return cacheableJson(entry.payload, env, {
+    staleAtMs: entry.staleAt,
+    maxAgeSeconds: Math.max(0, Math.ceil((entry.staleAt - Date.now()) / 1000)),
+    sMaxAgeSeconds: okTtl * STALE_SERVE_FACTOR,
+  });
 }
 
 function corsPreflight(env: Env): Response {
@@ -754,5 +865,7 @@ export const __test = {
   isStale,
   coalesceAndRefresh,
   refreshAndCache,
+  refreshShared,
+  ACTIVITY_KV_KEY,
   STALE_AT_HEADER,
 };

--- a/worker/test/worker.test.ts
+++ b/worker/test/worker.test.ts
@@ -674,6 +674,128 @@ describe("coalesceAndRefresh (background refresh on stale-hit)", () => {
     const body = JSON.parse(await entry!.text()) as { prs: { count: number } };
     expect(body.prs.count).toBe(999);
   });
+
+  it("pulls a sibling colo's fresh KV entry instead of fanning out (kvKey)", async () => {
+    const { __test } = await import("../src/index");
+    const { store, api } = fakeCache();
+    (globalThis as unknown as { caches: CacheStorage }).caches = {
+      default: api,
+    } as unknown as CacheStorage;
+
+    const kv = makeFakeKv();
+    await kv.put(
+      "activity:v1",
+      JSON.stringify({ payload: { prs: { count: 994 } }, staleAt: Date.now() + 100_000 }),
+    );
+    const cacheKey = new Request("https://api.example/activity");
+    const stale = new Response(JSON.stringify({ prs: { count: 1 } }), {
+      headers: { "Content-Type": "application/json" },
+    });
+    store.set(cacheKey.url, stale);
+
+    const env = { ALLOWED_ORIGIN: "*", CACHE: kv } as unknown as Parameters<
+      typeof __test.coalesceAndRefresh
+    >[2];
+    const refresh = vi.fn(async () => {
+      throw new Error("should not fan out — KV is fresh");
+    });
+    await __test.coalesceAndRefresh(cacheKey, stale, env, {
+      cacheKeyPath: "/activity",
+      ttl: { ok: 300, fallback: 30 },
+      kvKey: "activity:v1",
+      refresh,
+    });
+
+    expect(refresh).not.toHaveBeenCalled();
+    const entry = store.get(cacheKey.url);
+    expect(JSON.parse(await entry!.text())).toEqual({ prs: { count: 994 } });
+  });
+});
+
+describe("refreshShared (KV-coordinated refresh)", () => {
+  it("reuses a fresh KV entry instead of fanning out", async () => {
+    const { __test } = await import("../src/index");
+    const kv = makeFakeKv();
+    await kv.put(
+      "activity:v1",
+      JSON.stringify({ payload: { prs: { count: 994 } }, staleAt: Date.now() + 100_000 }),
+    );
+    const env = { CACHE: kv } as unknown as Parameters<typeof __test.refreshShared>[0];
+    const refresh = vi.fn(async () => {
+      throw new Error("should not fan out — KV is fresh");
+    });
+
+    const result = await __test.refreshShared(env, {
+      cacheKeyPath: "/activity",
+      ttl: { ok: 300, fallback: 30 },
+      kvKey: "activity:v1",
+      refresh,
+    });
+
+    expect(result).toEqual({ prs: { count: 994 } });
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("fans out and publishes the result to KV when no entry exists", async () => {
+    const { __test } = await import("../src/index");
+    const kv = makeFakeKv();
+    const env = { CACHE: kv } as unknown as Parameters<typeof __test.refreshShared>[0];
+    const refresh = vi.fn(async () => ({ prs: { count: 5 } }));
+
+    const result = await __test.refreshShared(env, {
+      cacheKeyPath: "/activity",
+      ttl: { ok: 300, fallback: 30 },
+      kvKey: "activity:v1",
+      refresh,
+    });
+
+    expect(result).toEqual({ prs: { count: 5 } });
+    expect(refresh).toHaveBeenCalledOnce();
+    const stored = (await kv.get("activity:v1", "json")) as {
+      payload: unknown;
+      staleAt: number;
+    };
+    expect(stored.payload).toEqual({ prs: { count: 5 } });
+    expect(stored.staleAt).toBeGreaterThan(Date.now()); // published fresh for siblings
+  });
+
+  it("fans out a stale KV entry rather than serving it", async () => {
+    const { __test } = await import("../src/index");
+    const kv = makeFakeKv();
+    await kv.put(
+      "activity:v1",
+      JSON.stringify({ payload: { prs: { count: 1 } }, staleAt: Date.now() - 1000 }),
+    );
+    const env = { CACHE: kv } as unknown as Parameters<typeof __test.refreshShared>[0];
+    const refresh = vi.fn(async () => ({ prs: { count: 999 } }));
+
+    const result = await __test.refreshShared(env, {
+      cacheKeyPath: "/activity",
+      ttl: { ok: 300, fallback: 30 },
+      kvKey: "activity:v1",
+      refresh,
+    });
+
+    expect(result).toEqual({ prs: { count: 999 } });
+    expect(refresh).toHaveBeenCalledOnce();
+  });
+
+  it("fans out without touching KV when no kvKey is set (currently-tending)", async () => {
+    const { __test } = await import("../src/index");
+    const kv = makeFakeKv();
+    const env = { CACHE: kv } as unknown as Parameters<typeof __test.refreshShared>[0];
+    const refresh = vi.fn(async () => ({ currently_tending: [] }));
+
+    const result = await __test.refreshShared(env, {
+      cacheKeyPath: "/currently-tending",
+      ttl: { ok: 30, fallback: 5 },
+      refresh,
+    });
+
+    expect(result).toEqual({ currently_tending: [] });
+    expect(refresh).toHaveBeenCalledOnce();
+    expect(await kv.get("activity:v1")).toBeNull();
+  });
 });
 
 describe("refreshAndCache (cold cache)", () => {
@@ -739,6 +861,101 @@ describe("refreshAndCache (cold cache)", () => {
     expect(resp.status).toBe(503);
     await Promise.all(tasks);
     expect(store.get(cacheKey.url)?.status).toBe(503); // negative-cached
+  });
+
+  it("serves a sibling colo's fresh KV entry on a cold colo cache, no fanout, inheriting its stale-at (kvKey)", async () => {
+    const { __test } = await import("../src/index");
+    const { store } = installCache();
+    const { tasks, ctx } = fakeCtx();
+    const kv = makeFakeKv();
+    // KV entry written earlier: it goes stale 100s from now, NOT a full budget
+    // (300s) from now. The colo entry must inherit this instant, otherwise the
+    // colo resets the shared clock and serves data up to a budget too long.
+    const staleAt = Date.now() + 100_000;
+    await kv.put(
+      "activity:v1",
+      JSON.stringify({ payload: { prs: { count: 994 } }, staleAt }),
+    );
+    const cacheKey = new Request("https://api.example/activity");
+    const env = { ALLOWED_ORIGIN: "*", CACHE: kv } as unknown as Parameters<
+      typeof __test.refreshAndCache
+    >[1];
+    const refresh = vi.fn(async () => {
+      throw new Error("should not fan out — KV is fresh");
+    });
+
+    const resp = await __test.refreshAndCache(cacheKey, env, ctx, {
+      cacheKeyPath: "/activity",
+      ttl: { ok: 300, fallback: 30 },
+      kvKey: "activity:v1",
+      refresh,
+    });
+
+    expect(resp.status).toBe(200);
+    expect(JSON.parse(await resp.clone().text())).toEqual({ prs: { count: 994 } });
+    expect(resp.headers.get(__test.STALE_AT_HEADER)).toBe(String(staleAt));
+    expect(refresh).not.toHaveBeenCalled();
+    await Promise.all(tasks);
+    const colo = store.get(cacheKey.url);
+    expect(colo?.status).toBe(200); // colo hydrated from KV
+    expect(colo?.headers.get(__test.STALE_AT_HEADER)).toBe(String(staleAt)); // not now+ttl.ok
+  });
+
+  it("serves a stale KV entry immediately and revalidates in the background (kvKey)", async () => {
+    const { __test } = await import("../src/index");
+    const { store } = installCache();
+    const { tasks, ctx } = fakeCtx();
+    const kv = makeFakeKv();
+    await kv.put(
+      "activity:v1",
+      JSON.stringify({ payload: { prs: { count: 1 } }, staleAt: Date.now() - 1000 }),
+    );
+    const cacheKey = new Request("https://api.example/activity");
+    const env = { ALLOWED_ORIGIN: "*", CACHE: kv } as unknown as Parameters<
+      typeof __test.refreshAndCache
+    >[1];
+    const refresh = vi.fn(async () => ({ prs: { count: 999 } }));
+
+    const resp = await __test.refreshAndCache(cacheKey, env, ctx, {
+      cacheKeyPath: "/activity",
+      ttl: { ok: 300, fallback: 30 },
+      kvKey: "activity:v1",
+      refresh,
+    });
+
+    // Served immediately = the stale payload (no waiting on the fanout).
+    expect(JSON.parse(await resp.clone().text())).toEqual({ prs: { count: 1 } });
+    await Promise.all(tasks); // run the background revalidation
+    expect(refresh).toHaveBeenCalledOnce();
+    // KV and colo cache now hold the fresh payload for the next viewers.
+    const stored = (await kv.get("activity:v1", "json")) as { payload: unknown };
+    expect(stored.payload).toEqual({ prs: { count: 999 } });
+    expect(JSON.parse(await store.get(cacheKey.url)!.text())).toEqual({ prs: { count: 999 } });
+  });
+
+  it("503s and publishes nothing when colo cache and KV are both empty and the fanout fails (kvKey)", async () => {
+    const { __test } = await import("../src/index");
+    const { store } = installCache();
+    const { tasks, ctx } = fakeCtx();
+    const kv = makeFakeKv();
+    const cacheKey = new Request("https://api.example/activity");
+    const env = { ALLOWED_ORIGIN: "*", CACHE: kv } as unknown as Parameters<
+      typeof __test.refreshAndCache
+    >[1];
+
+    const resp = await __test.refreshAndCache(cacheKey, env, ctx, {
+      cacheKeyPath: "/activity",
+      ttl: { ok: 300, fallback: 30 },
+      kvKey: "activity:v1",
+      refresh: async () => {
+        throw new Error("github down");
+      },
+    });
+
+    expect(resp.status).toBe(503);
+    await Promise.all(tasks);
+    expect(store.get(cacheKey.url)?.status).toBe(503); // negative-cached
+    expect(await kv.get("activity:v1")).toBeNull(); // nothing published on failure
   });
 });
 

--- a/worker/test/worker.test.ts
+++ b/worker/test/worker.test.ts
@@ -683,9 +683,10 @@ describe("coalesceAndRefresh (background refresh on stale-hit)", () => {
     } as unknown as CacheStorage;
 
     const kv = makeFakeKv();
+    const staleAt = Date.now() + 100_000; // fresh, but not a full budget out
     await kv.put(
       "activity:v1",
-      JSON.stringify({ payload: { prs: { count: 994 } }, staleAt: Date.now() + 100_000 }),
+      JSON.stringify({ payload: { prs: { count: 994 } }, staleAt }),
     );
     const cacheKey = new Request("https://api.example/activity");
     const stale = new Response(JSON.stringify({ prs: { count: 1 } }), {
@@ -709,17 +710,20 @@ describe("coalesceAndRefresh (background refresh on stale-hit)", () => {
     expect(refresh).not.toHaveBeenCalled();
     const entry = store.get(cacheKey.url);
     expect(JSON.parse(await entry!.text())).toEqual({ prs: { count: 994 } });
+    // The colo entry inherits KV's stale-at, not now + ttl.ok — otherwise this
+    // common warm-stale path would reset the shared clock and drift freshness.
+    expect(entry?.headers.get(__test.STALE_AT_HEADER)).toBe(String(staleAt));
   });
 });
 
 describe("refreshShared (KV-coordinated refresh)", () => {
-  it("reuses a fresh KV entry instead of fanning out", async () => {
+  it("reuses a fresh KV entry, returning its original stale-at (not a re-minted one)", async () => {
     const { __test } = await import("../src/index");
     const kv = makeFakeKv();
-    await kv.put(
-      "activity:v1",
-      JSON.stringify({ payload: { prs: { count: 994 } }, staleAt: Date.now() + 100_000 }),
-    );
+    // staleAt 100s out — NOT a full budget (300s). The reused entry must carry
+    // this instant forward so callers don't reset the shared clock.
+    const staleAt = Date.now() + 100_000;
+    await kv.put("activity:v1", JSON.stringify({ payload: { prs: { count: 994 } }, staleAt }));
     const env = { CACHE: kv } as unknown as Parameters<typeof __test.refreshShared>[0];
     const refresh = vi.fn(async () => {
       throw new Error("should not fan out — KV is fresh");
@@ -732,7 +736,8 @@ describe("refreshShared (KV-coordinated refresh)", () => {
       refresh,
     });
 
-    expect(result).toEqual({ prs: { count: 994 } });
+    expect(result.payload).toEqual({ prs: { count: 994 } });
+    expect(result.staleAt).toBe(staleAt); // inherited, not now + ttl.ok
     expect(refresh).not.toHaveBeenCalled();
   });
 
@@ -749,14 +754,14 @@ describe("refreshShared (KV-coordinated refresh)", () => {
       refresh,
     });
 
-    expect(result).toEqual({ prs: { count: 5 } });
+    expect(result.payload).toEqual({ prs: { count: 5 } });
+    expect(result.staleAt).toBeGreaterThan(Date.now()); // freshly minted
     expect(refresh).toHaveBeenCalledOnce();
     const stored = (await kv.get("activity:v1", "json")) as {
       payload: unknown;
       staleAt: number;
     };
-    expect(stored.payload).toEqual({ prs: { count: 5 } });
-    expect(stored.staleAt).toBeGreaterThan(Date.now()); // published fresh for siblings
+    expect(stored).toEqual(result); // published verbatim for siblings
   });
 
   it("fans out a stale KV entry rather than serving it", async () => {
@@ -776,7 +781,8 @@ describe("refreshShared (KV-coordinated refresh)", () => {
       refresh,
     });
 
-    expect(result).toEqual({ prs: { count: 999 } });
+    expect(result.payload).toEqual({ prs: { count: 999 } });
+    expect(result.staleAt).toBeGreaterThan(Date.now()); // re-minted, not the stale instant
     expect(refresh).toHaveBeenCalledOnce();
   });
 
@@ -792,7 +798,8 @@ describe("refreshShared (KV-coordinated refresh)", () => {
       refresh,
     });
 
-    expect(result).toEqual({ currently_tending: [] });
+    expect(result.payload).toEqual({ currently_tending: [] });
+    expect(result.staleAt).toBeGreaterThan(Date.now());
     expect(refresh).toHaveBeenCalledOnce();
     expect(await kv.get("activity:v1")).toBeNull();
   });


### PR DESCRIPTION
The colo cache (`caches.default`) is per-data-center, so each Cloudflare colo fanned out to GitHub's Search API on its own. During a traffic spike spread across colos, those 4·N concurrent Search bursts stack against the 30 req/min cap (shared per token), so the rate-limit risk grew with colo count and traffic, exactly when the data matters most.

`/activity` now publishes its rendered payload to KV (a global store) behind the hot colo cache. `refreshShared` is the single choke point both the cold path and the background refresh funnel through: it reuses a sibling colo's still-fresh KV entry instead of fanning out, and publishes its own result when it does fan out. The GitHub fanout then fires roughly once per freshness budget across the whole network instead of once per colo, independent of colo count or traffic.

On a cold colo cache a sibling's KV entry is served immediately (stale entries are served and revalidated in the background), so a burst after idle no longer makes every colo block on and dogpile the fanout. KV survives deploys and outlives the colo cache, so the cold-fanout 503 fires only when colo cache and KV are both empty, and a cold start during a GitHub outage shows last-known data rather than nothing.

`/currently-tending` is unchanged: its 30s budget is under KV's 60s floor, and its fanout is cheap core REST, not the Search quota the sharing protects.

## Trade-off

Coordination is best-effort, not a global lock: colos going stale at the same instant can still race within KV's write-propagation window (up to ~60s) before the first write is visible. The race is bounded (later arrivals read the fresh entry) and degrades gracefully (serve-stale-from-KV, never blank). A cron-driven single refresher would make it a hard guarantee but trade away the zero-when-idle property; not worth it at this scale.

## Files

- `worker/src/index.ts`: `refreshShared` (the KV choke point, returning the entry so its stale-at survives), the KV tier in `refreshAndCache`, and `entryResponse` (every data response inherits its entry's stale-at, so a colo never resets the shared clock on either the cold or the background-refresh path).
- `worker/test/worker.test.ts`: a `refreshShared` block, KV-tier cases in `refreshAndCache`, and a cross-colo case in `coalesceAndRefresh`.
- `worker/README.md`: Caching / Cache strategy rewritten for the two tiers.

> _This was written by Claude Code on behalf of max_
