### PR TITLE
docs: mention Codex in install-tend plugin descriptions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "install-tend",
-      "description": "Set up tend — an autonomous junior maintainer for your GitHub repo, powered by Claude.",
+      "description": "Set up tend — an autonomous junior maintainer for your GitHub repo, powered by Claude or OpenAI Codex.",
       "source": "./plugins/install-tend"
     },
     {

--- a/plugins/install-tend/.claude-plugin/plugin.json
+++ b/plugins/install-tend/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "install-tend",
-  "description": "Set up tend — an autonomous junior maintainer for your GitHub repo, powered by Claude.",
+  "description": "Set up tend — an autonomous junior maintainer for your GitHub repo, powered by Claude or OpenAI Codex.",
   "author": {
     "name": "Maximilian Roos",
     "url": "https://github.com/max-sixty"


### PR DESCRIPTION
## Summary

- `plugins/install-tend/.claude-plugin/plugin.json` and the install-tend entry in `.claude-plugin/marketplace.json` still said "powered by Claude" only.
- The install-tend skill provisions either a Claude OAuth token or an OpenAI Codex `auth.json` based on the `harness:` setting; the SKILL.md frontmatter already reads "powered by Claude or OpenAI Codex". These two metadata strings were the last drift.

## Test plan

- [ ] Pure documentation change (description strings, no code path affected). No test added — strings are not consumed by any runtime check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)