### PR TITLE
fix(site): self-schedule liveData polling so ticks can't overlap

### DIFF
--- a/site/src/lib/api.ts
+++ b/site/src/lib/api.ts
@@ -43,7 +43,14 @@ export async function liveData<T>(
     el.dataset.state = shown ? "loaded" : "hidden";
   };
   await tick();
+  // Self-schedule so the next tick can't start before the previous one
+  // resolves — otherwise a slow fetch overlapping a fast one can land
+  // out of order and overwrite `dataset.state` with stale data.
   if (intervalMs && intervalMs > 0) {
-    setInterval(tick, intervalMs);
+    const loop = async () => {
+      await tick();
+      setTimeout(loop, intervalMs);
+    };
+    setTimeout(loop, intervalMs);
   }
 }


### PR DESCRIPTION
## Summary

`liveData` polls a live-data Worker endpoint and reflects the result on the page. The polling loop currently uses `setInterval(tick, intervalMs)`:

```ts
await tick();
if (intervalMs && intervalMs > 0) {
  setInterval(tick, intervalMs);
}
```

`setInterval` fires by wall-clock interval regardless of whether the previous async `tick` has resolved. If a fetch takes longer than `intervalMs` (slow network, backgrounded tab unfreezing), two ticks run concurrently and their `render` results can land out of order — a stale response can overwrite `dataset.state` after a fresher one.

The fix is a self-scheduling chain: queue the next tick only after the previous tick's `render` resolves. Completion order then matches scheduling order by construction.

## Test plan

- [ ] `site/` has no test infrastructure (only `astro dev|build|preview` in `package.json`). The change is a mechanical scheduling refactor self-contained to one helper; no regression test added. Manual check: home page's live activity strip still updates while the tab is open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)