### PR TITLE
fix(review-reviewers): pre-create monthly tracking issue to eliminate matrix race

### DIFF
--- a/.github/workflows/review-reviewers.yaml
+++ b/.github/workflows/review-reviewers.yaml
@@ -13,7 +13,37 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Create the monthly tracking issue before the matrix runs, so all matrix
+  # legs find an existing issue instead of racing to create one. Without this,
+  # the first cron tick of each new month produced N-1 duplicate tracking
+  # issues (one per matrix leg that lost the find-or-create race).
+  init-tracking:
+    runs-on: ubuntu-24.04
+    permissions:
+      issues: write
+    steps:
+      - env:
+          GH_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
+        run: |
+          MONTH=$(date -u +%Y-%m)
+          LABEL="review-reviewers-tracking"
+          NUM=$(gh issue list -R "$GITHUB_REPOSITORY" --state open --label "$LABEL" \
+            --json number,title \
+            --jq "[.[] | select(.title | contains(\"$MONTH\"))] | sort_by(.number) | .[0].number // empty")
+          if [ -n "$NUM" ]; then
+            echo "Tracking issue for $MONTH exists: #$NUM"
+            exit 0
+          fi
+          cat > /tmp/body.md <<'EOF'
+          Monthly tracking issue for `review-reviewers`. Per-target evidence lives in secret gists owned by the bot. A comment below is posted when each target's gist is first created.
+
+          **Do not close manually** — a new issue is created each month.
+          EOF
+          gh issue create -R "$GITHUB_REPOSITORY" \
+            --title "$LABEL: $MONTH" --label "$LABEL" -F /tmp/body.md
+
   review-reviewers:
+    needs: init-tracking
     strategy:
       fail-fast: false
       matrix:

--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -78,7 +78,7 @@ GIST_DESC="review-reviewers evidence: $TARGET $MONTH"
 
 The tracking issue lives on tend (the current repo). It indexes gists via one comment per new gist — no per-run comments, no body edits.
 
-The matrix runs three targets concurrently on the same cron tick, so the first run of a new month races: all three targets can find no tracking issue and each create one. Sorting and picking the lowest-numbered match keeps later runs deterministic — maintainers can close any duplicates. `gh issue create` prints the new issue's URL; parse the number from its basename.
+The workflow's `init-tracking` job runs before the matrix and creates the monthly tracking issue if absent, so matrix legs always find an existing one. The find-or-create logic below remains the fallback for ad-hoc invocations and as a safety net; sort lowest-numbered first in case a race ever does produce duplicates. `gh issue create` prints the new issue's URL; parse the number from its basename.
 
 ```bash
 TRACKING_NUMBER=$(gh issue list --state open --label "$TRACKING_LABEL" \


### PR DESCRIPTION
Closes the recurring "duplicate `review-reviewers-tracking` issues" pattern raised in #644.

## Root cause

The `review-reviewers` matrix runs 5 legs in parallel on the same cron tick. On the first tick of a new month, every leg queries "does a `review-reviewers-tracking: YYYY-MM` issue exist?" simultaneously — all see no, all create one. The skill's "sort, pick lowest-numbered" logic then routes future evidence comments to the canonical issue, but the duplicates remain open. 2026-06 produced #641 (canonical, 2 gist comments) plus #642, #643, #644; 2026-04 produced 5 duplicates that were closed manually.

## Fix

A new `init-tracking` job runs before the matrix, idempotently creating the tracking issue if absent. Matrix legs then always find an existing issue, so the find-or-create dance in the skill becomes a no-op in the common path. The skill's logic stays as a fallback for ad-hoc invocations (`workflow_dispatch` against a single target).

## Test plan

- [ ] First cron tick after merge creates one tracking issue, not five.
- [ ] Subsequent cron ticks no-op (issue already exists).
- [ ] Skill's find-or-create fallback still works for ad-hoc / `workflow_dispatch` invocations.
