### PR TITLE
skills(running-in-ci): end the turn only when work is shipped

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -134,6 +134,10 @@ gh pr list --state all --search "author:$BOT_LOGIN <issue-number>" \
 
 Compare by title keywords **and** the files the new PR would modify — two concurrent fixes for the same bug typically pick different branch names, so a branch-name match is not sufficient. If a sibling bot PR overlaps in scope — whether open, closed, or already merged — **do not create**: post a comment on the triggering thread linking the existing PR and exit.
 
+### Ship the deliverable before any long wait
+
+Don't gate `git push` / `gh pr create` on a multi-minute local validation — a full test suite, a comprehensive lint hook, a `Monitor`-waited background task. Session budget is finite; if the wait outlives the session the implementation is lost on a local branch the maintainer can't see, with no comment, no PR, and no signal that the work happened. Sequence the visible deliverable (commit, push, `gh pr create`) **first**; CI re-runs the same gates after push and gives the maintainer progress regardless of how long the local check would have taken. A targeted compile plus the tests directly exercising the change is enough local confidence to ship — leave the comprehensive matrix to CI. If a slow local validation is genuinely needed (rare), run it synchronously and accept the time cost, but don't background it behind a `Monitor` wait that the session may not outlast.
+
 ## Pushing to PR Branches
 
 Always use `git push` without specifying a remote — `gh pr checkout` configures tracking to the correct remote, including for fork PRs. Specifying `origin` explicitly can push to the wrong place.

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -78,6 +78,16 @@ If a linked PR merged (or the triggering PR itself merged) **after the triggerin
 - **Scope**: PRs, pushes, and comments on existing threads in other repos are off-limits. Filing fresh issues in other repos follows **Filing Issues in Other Repos** below.
 - **Hanging commands**: Never use `gh run watch` or `gh pr checks --watch` — both hang indefinitely. Poll with `gh pr checks` in a loop instead.
 
+## End the turn only when work is shipped
+
+Emitting `end_turn` ends the CI session — the runner is discarded, and the harness does not reliably resume it from a background-task completion. If you `end_turn` while a `run_in_background: true` Bash whose result was going to gate the deliverable is still running, the task either finishes invisibly or gets killed when the runner is torn down, and any staged work the maintainer was supposed to see — a committed-but-unpushed branch, a written-but-unsent `/tmp/comment-body.md` — dies with it.
+
+The session is live until the deliverable is **maintainer-visible**: pushed, posted, or opened. Local-only state — a commit nobody else can see, a comment body never sent — does not count and is not recoverable on a follow-up.
+
+Corollary: don't background anything whose output gates the deliverable. If a full test suite or comprehensive lint needs to run before push, run it synchronously and accept the time cost; if it's too slow for the session budget, push first and let CI re-run it. A session that shipped a partial result is recoverable; a session that ended mid-wait with the deliverable on a local branch is not. A targeted compile plus the tests directly exercising the change is enough local confidence to ship — leave the comprehensive matrix to CI.
+
+The `run_in_background: true` recipe under **CI Monitoring** is safe because it runs *after* push: the deliverable is already shipped, so the worst case is a missed CI-result follow-up, not a lost PR. Pre-push has no such fallback.
+
 ## Filing Issues in Other Repos
 
 Default: file an issue in the current repo asking for permission to file in the target. On maintainer approval, file in the target.
@@ -133,10 +143,6 @@ gh pr list --state all --search "author:$BOT_LOGIN <issue-number>" \
 ```
 
 Compare by title keywords **and** the files the new PR would modify — two concurrent fixes for the same bug typically pick different branch names, so a branch-name match is not sufficient. If a sibling bot PR overlaps in scope — whether open, closed, or already merged — **do not create**: post a comment on the triggering thread linking the existing PR and exit.
-
-### Ship the deliverable before any long wait
-
-Don't gate `git push` / `gh pr create` on a multi-minute local validation — a full test suite, a comprehensive lint hook, a `Monitor`-waited background task. Session budget is finite; if the wait outlives the session the implementation is lost on a local branch the maintainer can't see, with no comment, no PR, and no signal that the work happened. Sequence the visible deliverable (commit, push, `gh pr create`) **first**; CI re-runs the same gates after push and gives the maintainer progress regardless of how long the local check would have taken. A targeted compile plus the tests directly exercising the change is enough local confidence to ship — leave the comprehensive matrix to CI. If a slow local validation is genuinely needed (rare), run it synchronously and accept the time cost, but don't background it behind a `Monitor` wait that the session may not outlast.
 
 ## Pushing to PR Branches
 


### PR DESCRIPTION
Three sessions over a ~17-hour window did meaningful code work for a maintainer ask, then silently failed to ship anything because each one emitted `end_turn` while a `run_in_background: true` pre-merge gate was still pending. The harness did not resume — none of the runs ever subscribed to a `task-notification` wakeup (one didn't call `Monitor`, two more got `InputValidationError` on a deferred-tool schema race and never retried). Each occurrence leaves a visibly unanswered maintainer ask: branch never pushed, no commit, no comment, no signal the work happened.

This reframes the rule after maintainer review (https://github.com/max-sixty/tend/pull/661#issuecomment-4640896565). The first cut narrowed it to *"ship the deliverable before any long wait"* under **PR Creation**; the failure mode generalises beyond PR creation to **any case where `end_turn` fires while a maintainer-visible deliverable is staged but un-shipped** — comment posting, follow-up commits, inline replies, anywhere a `run_in_background` task gates the next step.

Adds a new top-level section **End the turn only when work is shipped** to `running-in-ci`, placed after **Restrictions**. Rule: treat the session as live until the deliverable is maintainer-visible (pushed, posted, opened); don't background work whose output gates the deliverable; the `run_in_background` recipe under **CI Monitoring** stays safe because it runs *after* push.

**Evidence**

- [`tend-mention` run 27051779110](https://github.com/max-sixty/worktrunk/actions/runs/27051779110) — backgrounded pre-merge gating a deprecation PR, session ended mid-wait, no PR shipped.
- [`tend-notifications` run 27053336290](https://github.com/max-sixty/worktrunk/actions/runs/27053336290) — picked up the deferred work, implemented cleanly on local branch `deprecate/squash-commits-var-27053336290`, ~17 min and $7.35 of session, never called `Monitor`, branch never pushed, no comment.
- [`tend-mention` run 27075856123](https://github.com/max-sixty/worktrunk/actions/runs/27075856123) — different PR (worktrunk#2991), full rework implemented, called `Monitor({})` with empty input → `InputValidationError`, loaded the schema via `ToolSearch` but never retried, `end_turn` with text "I'll be re-invoked when it finishes". It was not.

**Classification.** Three occurrences inside ~17 hours, across two worktrunk PRs and two workflow types (`tend-mention` twice, `tend-notifications` once). Gate 1 (High structural needs 2–3 occurrences). Gate 2 (targeted fix at Normal threshold).

**Evidence gist:** https://gist.github.com/15c523384cfad7449cb81933b47165ff
