### PR TITLE
chore: release 0.1.3

### DIFF
--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "tend"
-version = "0.1.2"
+version = "0.1.3"
 description = "An autonomous junior maintainer for GitHub repos, powered by Claude or OpenAI Codex — reviews PRs, triages issues, fixes CI"
 license = "MIT"
 requires-python = ">=3.11"

--- a/generator/uv.lock
+++ b/generator/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "tend"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Bumps generator version to `0.1.2` → `0.1.3` and syncs the lockfile.

This release ships the GitHub-PAT credential isolation in the `claude-interactive` harness (#652) — tend's production harness for its own `review`/`mention`/`triage`/`ci-fix` workflows. Until this releases and the nightly regen bumps the pinned action ref, production still runs the pre-isolation harness with the PAT in the agent's env.

### Notable changes (24 commits since 0.1.2)

- **interactive: isolate the GitHub PAT behind a credential-injecting proxy (#652)** — agent runs as a non-sudo `tend-sandbox` user; the PAT lives only in a local mitmproxy that injects it for GitHub hosts
- feat: recall prior context from past runs on an issue/PR (#649)
- feat(worker): share `/activity` payload across colos via a KV tier (#653)
- dogfood: switch tend to claude-interactive harness (#622)
- Worker reliability fixes (#650, #648, #655) and skills/docs refinements (#656, #647, #640, #638, #635, #632, #620)
- Dead-input / template cleanups (#631, #625, #623, #621)

## Test plan

- [x] `wt test` passes (254 tests)
- [x] `pre-commit run --all-files` passes
- [ ] CI green