### PR TITLE
skills(running-in-ci): carve out bot-authored machine-report issues

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -330,6 +330,8 @@ If a maintainer has already addressed the point, exit silently unless you can ad
 
 If you are responding to your own prior comment or review (not a human's reply to it), only respond if there is a distinct role boundary (e.g., you are the reviewer on your own PR and need to address review feedback). If there is no such role distinction, exit silently to avoid self-conversation loops.
 
+**Exception — bot-authored issues with no prior bot comments.** A freshly-opened issue the bot authored (nightly failure, CI report, code-quality finding) is a report to act on, not a self-conversation. Triage it normally. The Recheck Before Posting guard below still prevents duplicate triage comments if a sibling run fires on the same issue.
+
 ## Recheck Before Posting
 
 **Before posting any comment, review, or inline reply**, re-fetch the conversation and check whether the response would duplicate something already there. Two duplication paths:


### PR DESCRIPTION
## Problem

The Self-conversation Guard in `tend-ci-runner/skills/running-in-ci/SKILL.md` over-applies to bot-authored machine-report issues. When a consumer's bot opens a "nightly tests failed" issue, `tend-triage` fires within seconds but reads the issue as a self-conversation and exits silently. The failure then sits untriaged until a human @-mentions the bot.

## Solution

Adds a one-sentence exception to the guard: a freshly-opened issue the bot authored is a report to act on, not a self-conversation. The Recheck Before Posting guard immediately below already prevents duplicate triage comments if a sibling run fires on the same issue, so loop risk stays covered.

## Testing

Skill-text change; no automated test. The guard's intent (loop prevention on comment/review threads where replying recurses) is preserved verbatim — the carve-out only covers issue *bodies* the bot authored with no prior bot comments, which can't recurse.

---
Closes #665 — automated triage
