### PR TITLE
skills(review): peek check rollup before APPROVE so visible FAILUREs aren't rubber-stamped

### DIFF
--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -202,6 +202,21 @@ ALREADY_POSTED=$(gh api "repos/$REPO/pulls/<number>/reviews" \
 
 The state check matters because the maintainer may close (or another path may merge) the PR while a review is in flight — `pull_request_target` reviews routinely run for 5–10 minutes between fetching `HEAD_SHA` and posting the verdict, and HEAD doesn't move when the PR is closed. Approving a CLOSED or MERGED PR creates a confusing artifact (an approval timestamped after the close).
 
+**Before APPROVE specifically**, also peek the current check rollup on `HEAD_SHA`. If any check has reached terminal `FAILURE`, do not emit an empty-body APPROVE — the close-out reads as the bot rubber-stamping over the visibly red signal:
+
+```bash
+FAILED=$(gh pr view <number> --json statusCheckRollup \
+  --jq '[.statusCheckRollup[]
+         | select(((.status // "") == "COMPLETED") and ((.conclusion // .state) == "FAILURE"))
+         | .name // .context // "unknown"] | join(", ")')
+if [ -n "$FAILED" ]; then
+  echo "Skipping APPROVE — failing checks present on $HEAD_SHA: $FAILED"
+  exit 0
+fi
+```
+
+Step 6's "approve, monitor CI in background, dismiss if a check fails" pattern only recovers when the agent is still alive when the failure notification arrives. Sessions routinely end within minutes of the foreground `gh pr review --approve`, leaving any post-approve failure undismissed and the PR carrying a misleading APPROVED state. A synchronous pre-APPROVE peek catches the case where the failure is already in the rollup — including non-required checks like `codecov/patch` that an overlay treats as a merge gate. If a failure is present, skip the close-out entirely; any earlier substantive bot review (e.g. a COMMENT with inline suggestions) remains the active verdict until the author addresses it.
+
 Post at most one review per run. Give a verdict (**approve** or **comment**, never "request changes") when this run has something to say: a new diff-grounded finding, or an approval because the last open concern is now resolved. If the dedup rule above left nothing new and a prior unresolved bot thread still stands, post nothing; the earlier review remains the active verdict. Use `gh pr review` for reviews, not `gh pr comment`. Note: `--comment` requires a non-empty body — if there's nothing to say and no prior concern stands, use the approve-with-empty-body pattern.
 
 **Inline suggestions are mandatory for concrete fixes.** Whenever there's a concrete fix (typos, doc updates, naming, missing imports, minor refactors, test additions), post it as an inline suggestion on the exact line — never as a code block in the review body. Inline suggestions let the author apply with one click; code blocks force them to find the line and copy-paste manually.

--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -207,7 +207,7 @@ The state check matters because the maintainer may close (or another path may me
 ```bash
 FAILED=$(gh pr view <number> --json statusCheckRollup \
   --jq '[.statusCheckRollup[]
-         | select(((.status // "") == "COMPLETED") and ((.conclusion // .state) == "FAILURE"))
+         | select((.conclusion // .state) == "FAILURE")
          | .name // .context // "unknown"] | join(", ")')
 if [ -n "$FAILED" ]; then
   echo "Skipping APPROVE — failing checks present on $HEAD_SHA: $FAILED"


### PR DESCRIPTION
## Summary

Add a synchronous `statusCheckRollup` peek to `plugins/tend-ci-runner/skills/review/SKILL.md` step 5 so the bot does not emit an empty-body APPROVE when a check on the head SHA has already reached terminal `FAILURE`. Step 6's "approve, then monitor CI in background, dismiss if a check fails" pattern only recovers when the agent is still alive when the failure notification arrives — sessions routinely end within minutes of the foreground `gh pr review --approve`, leaving any post-approve failure undismissed and the PR carrying a misleading APPROVED state.

## Evidence

Triggering case this hour — `max-sixty/worktrunk` PR #3015 (non-maintainer-authored, by `Xeonacid`):

- `tend-review` run [27115489508](https://github.com/max-sixty/worktrunk/actions/runs/27115489508) posted [APPROVED review 4446577248](https://github.com/max-sixty/worktrunk/pull/3015#pullrequestreview-4446577248) (empty body) at `2026-06-08T04:16:02Z` on head `338b9ec9c9661979b610668b5504280a16761707`.
- On the same head, [`codecov/patch` reached terminal `FAILURE` at `2026-06-08T04:15:23Z`](https://app.codecov.io/gh/max-sixty/worktrunk/pull/3015) — **39 s before** the APPROVE.
- worktrunk's `running-tend` overlay treats `codecov/patch` as a merge gate ("After required CI checks pass, poll `codecov/patch` — it is mandatory despite being marked non-required") and `CLAUDE.md` requires explicit user approval before merging with it failing.
- Session log: agent's pre-flight posting check verified `HEAD_SHA` + `PR_STATE` only — never queried `statusCheckRollup` — then approved. Started a background CI poll, summarized, and the session ended ~30 s later, before the background loop could surface the codecov failure for a dismissal action. The approval stands; no dismissal followed.

## Occurrences (Gate evaluation)

Cumulative across this-month and last-month evidence gists for the shape "session shorter than CI report → empty-body APPROVE → no dismissal" (or its sibling "approve while a check is already red, no synchronous peek"):

| # | PR | Run | Shape | Self-corrected? |
|---|---|---|---|---|
| 1 | worktrunk #2580 (commit `46ce764`) | 25307086342 | session ended before `codecov/patch` FAILURE reported | no |
| 2 | worktrunk #2580 (commit `e8c82f8`) | 25308416268 | session ended before `codecov/patch` FAILURE reported | no |
| 3 | worktrunk #2951 (commit `88ec5980`) | 26738271932 | APPROVE 2 m 18 s after `lint` already FAILURE | yes (self-dismissed) |
| 4 | worktrunk #3015 (commit `338b9ec9`) | 27115489508 | APPROVE 39 s after `codecov/patch` already FAILURE | no |

- **Evidence level**: High — 4 occurrences across 3 PRs and multiple sessions, including one (#3015) by a non-maintainer author where the bot's gating role is load-bearing.
- **Classification**: Structural — deterministic relationship between session length and check-report latency. Same conditions reproduce the same failure mode regardless of model run.
- **Magnitude**: Targeted fix — adds 11 lines to the existing posting-mechanics block of the same step. No new control flow, no new dependencies, no overlay churn required (the universal pre-APPROVE peek covers required checks like `lint` and `test (linux)` directly, and overlays that mark non-required checks as gates — like worktrunk's `codecov/patch` — are caught because the rollup surfaces every check regardless of required status).
- **Gate 1**: passes (High ≥ 2–3 occurrences).
- **Gate 2**: passes (targeted fix at "Normal" bar).

The escalation criterion the prior carry pinned ("escalate to a fix-PR if the same shape recurs on a *different* PR, OR appears on a non-`max-sixty`-authored PR") materialized this run on both axes simultaneously.

## Evidence gist

[`review-reviewers evidence: max-sixty/worktrunk 2026-06`](https://gist.github.com/15c523384cfad7449cb81933b47165ff) — see the line-212 entry (PR #2951 commit `88ec5980`) for the prior in-month observation and last-month section line 4540 for the PR #2580 occurrences.

## Test plan

- [ ] Maintainer reviews the wording — the new block lives inside `#### Posting mechanics`, between the close/MERGED guard and the "Post at most one review per run" paragraph.
- [ ] Next `tend-review` run that encounters a head with a `FAILURE`-state check should print the new `Skipping APPROVE — failing checks present on …` line and exit without approving.
- [ ] No regression on the common path (all checks `SUCCESS` or `IN_PROGRESS` on APPROVE) — the new guard short-circuits only when at least one check is `COMPLETED` + `FAILURE`.
