### PR TITLE
skills(running-in-ci): split CI Monitoring into gated/ungated cases

### DIFF
--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -215,7 +215,7 @@ if [ -n "$FAILED" ]; then
 fi
 ```
 
-Step 6's "approve, monitor CI in background, dismiss if a check fails" pattern only recovers when the agent is still alive when the failure notification arrives. Sessions routinely end within minutes of the foreground `gh pr review --approve`, leaving any post-approve failure undismissed and the PR carrying a misleading APPROVED state. A synchronous pre-APPROVE peek catches the case where the failure is already in the rollup — including non-required checks like `codecov/patch` that an overlay treats as a merge gate. If a failure is present, skip the close-out entirely; any earlier substantive bot review (e.g. a COMMENT with inline suggestions) remains the active verdict until the author addresses it.
+Step 6's "approve, foreground-poll CI, dismiss if a check fails" pattern only recovers while the session is still alive — the job timeout or a poll cap can leave a post-approve failure undismissed and the PR carrying a misleading APPROVED state. A synchronous pre-APPROVE peek catches the case where the failure is already in the rollup — including non-required checks like `codecov/patch` that an overlay treats as a merge gate. If a failure is present, skip the close-out entirely; any earlier substantive bot review (e.g. a COMMENT with inline suggestions) remains the active verdict until the author addresses it.
 
 Post at most one review per run. Give a verdict (**approve** or **comment**, never "request changes") when this run has something to say: a new diff-grounded finding, or an approval because the last open concern is now resolved. If the dedup rule above left nothing new and a prior unresolved bot thread still stands, post nothing; the earlier review remains the active verdict. Use `gh pr review` for reviews, not `gh pr comment`. Note: `--comment` requires a non-empty body — if there's nothing to say and no prior concern stands, use the approve-with-empty-body pattern.
 
@@ -292,7 +292,9 @@ Prevention: before writing any inline comment, verify the target line falls insi
 
 ### 6. Monitor CI
 
-After approving or staying silent, poll CI using the polling loop in `/tend-ci-runner:running-in-ci` under "CI Monitoring". Run it with the Bash tool's `run_in_background: true`.
+If you **stayed silent** (no review posted, nothing to dismiss), end the session — there's no follow-up gated on the CI result. Don't background-poll: per `/tend-ci-runner:running-in-ci` under "End the turn only when work is shipped", the completion notification isn't reliably delivered to a CI session.
+
+If you **approved**, the dismissal-on-failure is a gated follow-up. Foreground-poll using the recipe in `/tend-ci-runner:running-in-ci` under "CI Monitoring" (don't use `run_in_background`).
 
 Then handle the outcome:
 

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -86,7 +86,7 @@ The session is live until the deliverable is **maintainer-visible**: pushed, pos
 
 Corollary: don't background anything whose output gates the deliverable. If a full test suite or comprehensive lint needs to run before push, run it synchronously and accept the time cost; if it's too slow for the session budget, push first and let CI re-run it. A session that shipped a partial result is recoverable; a session that ended mid-wait with the deliverable on a local branch is not. A targeted compile plus the tests directly exercising the change is enough local confidence to ship — leave the comprehensive matrix to CI.
 
-The `run_in_background: true` recipe under **CI Monitoring** is safe because it runs *after* push: the deliverable is already shipped, so the worst case is a missed CI-result follow-up, not a lost PR. Pre-push has no such fallback.
+After push, match the polling shape to whether a follow-up is gated on the CI result — see **CI Monitoring**. When nothing is gated, end the session; the deliverable is shipped and the harness can't deliver a background-poll notification reliably enough to keep an "I'll report the result" promise. When a follow-up *is* gated (fix-on-failure, dismiss your own approval), foreground-poll synchronously so the wait and the follow-up share the same session.
 
 ## Filing Issues in Other Repos
 
@@ -182,12 +182,14 @@ When asked to merge the default branch into a PR branch:
 
 ## CI Monitoring
 
-After pushing, wait for CI before reporting completion.
+After pushing, decide based on whether a concrete follow-up is gated on the CI result.
 
-**Use `run_in_background: true`** for the polling loop so it does not block the session. When the background task completes you will be notified — check the result and take any follow-up action (dismiss approval, post analysis) at that point.
+**Nothing is gated on the result** — the common case after a nightly pushes a PR or a self-authored PR is reviewed silently: state CI is in flight in your final message and **end the session**. Don't foreground-wait, and don't start a background poll — its completion notification isn't reliably delivered to a CI session, so any "I'll report the result" promise won't fire. The deliverable is already shipped; the worst case is a missed follow-up, not lost work.
+
+**A follow-up is gated on the result** — fix-on-failure, dismiss your own approval, post failure analysis: poll **synchronously in the foreground** (don't use `run_in_background`) and accept the time cost. The follow-up has to run in the same session as the wait.
 
 ```bash
-# Run with Bash tool's run_in_background: true.
+# Foreground poll — invoke Bash without run_in_background.
 #
 # Poll statusCheckRollup — every check-run + status context on the commit.
 # Exit when all non-own items are terminal.
@@ -252,7 +254,7 @@ exit 1
 
 1. Poll every 60 seconds (up to ~15 minutes) until all non-own check-runs on the commit are terminal. **Filter out the current run's URL (`/runs/$GITHUB_RUN_ID/`)** — the current workflow's own check is always pending while polling and must be excluded to avoid a deadlock. **Also filter same-workflow check runs (`$GITHUB_WORKFLOW`)** — sibling runs of the same workflow on the same PR are subject to concurrency rules (queueing or cancel-in-progress) and don't represent independent CI signals. The 30s grace re-check catches late-registering omnibus checks.
 2. If a required check fails, diagnose with `gh run view <run-id> --log-failed`, fix, commit, push, repeat.
-3. Report completion only after all required checks pass.
+3. Once checks are terminal, perform the gated follow-up.
 
 Before dismissing local test failures as "pre-existing", check main branch CI:
 


### PR DESCRIPTION
## Problem

Two sections of `running-in-ci` pulled opposite ways when a session's only remaining work was awaiting CI:

- **CI Monitoring** told the bot to `run_in_background: true` the polling loop and "Report completion only after all required checks pass" — implying the bot would be notified when checks finished.
- **End the turn only when work is shipped** said `end_turn` ends the CI session and the harness does not reliably resume from a background-task completion.

For sessions whose deliverable is already shipped and whose only remaining step is awaiting CI (silent self-review, nightly that pushed a PR), the bot resolved the tension by foreground-waiting — `sleep`, re-check, "I'll wait for the monitor", repeat — burning turns and tokens before `end_turn`-ing anyway with an unfulfilled "I'll report the result" promise.

## Solution

Split CI Monitoring into two cases, matching #668's proposal:

- **A concrete follow-up is gated on the CI result** (fix-on-failure, dismiss own approval, post failure analysis): poll **synchronously in the foreground** and accept the time cost — don't background it, because the notification that would resume the session isn't reliable in CI.
- **Nothing is gated on the result** (deliverable already shipped): state CI is in flight and **end the session**. Don't foreground-wait, and don't start a background poll either.

Also updates the cross-reference in **End the turn only when work is shipped** to remove the stale "background-poll after push is safe" framing.

`review` skill step 6 (Monitor CI) is updated alongside since it was the most common trigger: it told the bot to background-poll after **approving or staying silent**, but the staying-silent case has nothing gated and should just end the session.

## Testing

This is a skill-text change with no executable behavior — no unit test to add. The structural rule resolves a real contradiction visible in evidence cited in #668 (three occurrences in cargo-affected nightly + review runs over two days, all sessions whose only remaining action was awaiting CI).

---
Closes #668 — automated triage
