### PR TITLE
skills(ci-fix): label transient-tracker issues tend-outage to suppress no-op cascade

### DIFF
--- a/plugins/tend-ci-runner/skills/ci-fix/SKILL.md
+++ b/plugins/tend-ci-runner/skills/ci-fix/SKILL.md
@@ -80,10 +80,11 @@ Automated fix for [failed run](run-url)
 
 If the diagnosis identifies the failure as transient — runner-disk corruption, an isolated network blip, an upstream incident that has since resolved — there is no fix PR to create. Don't post the diagnosis as a commit comment (it surfaces on whatever commit triggered CI, including release commits where it's visibly off-topic).
 
-Instead, open an issue with the diagnosis and close it immediately. The closure records "diagnosed, no further action" while keeping the analysis discoverable and off the commit timeline:
+Instead, open an issue with the diagnosis and close it immediately. The closure records "diagnosed, no further action" while keeping the analysis discoverable and off the commit timeline. Apply the `tend-outage` label — the workflow-level `if:` in `tend-triage` and `tend-mention` skip labelled issues, suppressing the no-op cascade runs (`opened` → silent-exit; `closed`-comment → silent-exit) that would otherwise fire on every transient tracker:
 
 ```bash
-gh issue create --title "ci-fix: transient failure on <run-id>" --body-file /tmp/diagnosis.md
+gh label create tend-outage --description "Tracks bot outage incidents" --color "d93f0b" 2>/dev/null || true
+gh issue create --title "ci-fix: transient failure on <run-id>" --label tend-outage --body-file /tmp/diagnosis.md
 gh issue close <issue-number> --reason "not planned" --comment "Transient — closing as diagnosed."
 ```
 


### PR DESCRIPTION
Closes the no-op cascade where every `tend-ci-fix` transient-tracker issue triggers a silent-exit `tend-triage` run (on `issues.opened`) and a silent-exit `tend-mention` run (on the bot's own close comment). The fix labels the tracker issue with `tend-outage` so the existing workflow-level `if:` skips in [`triage.yaml.j2`](https://github.com/max-sixty/tend/blob/6a90890d256d4bf8b1f191fae0c4a2c2ad24e90c/generator/src/tend/templates/triage.yaml.j2) and [`mention.yaml.j2`](https://github.com/max-sixty/tend/blob/6a90890d256d4bf8b1f191fae0c4a2c2ad24e90c/generator/src/tend/templates/mention.yaml.j2) filter the cascade before any agent boots. `tend-outage` is already the canonical "skip cascade workflows on this bookkeeping issue" label — the action's "Report failure" step uses it the same way, and the `review-reviewers` skill's Non-issues section names it explicitly as the accepted shape for loop-prevention.

## Evidence

19 `ci-fix: transient …` issues opened-and-closed within 1–5 seconds by `worktrunk-bot` since 2026-05-11, all unlabeled, each firing the two-workflow cascade:

| # | Created | Closed | Title prefix |
|---|---|---|---|
| [#3018](https://github.com/max-sixty/worktrunk/issues/3018) | 2026-06-08T09:56:35Z | +1s | transient 504 gateway-timeout wave on 27122253273 |
| [#3017](https://github.com/max-sixty/worktrunk/issues/3017) | 2026-06-08T08:23:57Z | +1s | transient setup-nu 504 on 27121352081 |
| [#2996](https://github.com/max-sixty/worktrunk/issues/2996) | 2026-06-06T23:09:43Z | +1s | transient codecov uploader GPG signature failure on 27073218369 |
| [#2993](https://github.com/max-sixty/worktrunk/issues/2993) | 2026-06-06T21:35:04Z | +1s | transient codecov uploader GPG signature failure on 27072336952 |
| [#2974](https://github.com/max-sixty/worktrunk/issues/2974) | 2026-06-03T16:49:06Z | +1s | transient Windows DLL-init failure (0xc0000142) on 26888924959 |
| [#2963](https://github.com/max-sixty/worktrunk/issues/2963) | 2026-06-02T15:49:23Z | +4s | transient lychee 503 on 26825478066 |
| [#2958](https://github.com/max-sixty/worktrunk/issues/2958) | 2026-06-01T19:26:05Z | +1s | transient macOS profraw cleanup ENOTEMPTY on 26769127359 |
| [#2957](https://github.com/max-sixty/worktrunk/issues/2957) | 2026-06-01T17:47:24Z | +5s | transient runner disk-full on 26767318774 |
| …11 more in May | | | |

This run's occurrence ([#3018](https://github.com/max-sixty/worktrunk/issues/3018)) fired two visible cascade runs:

- **`tend-triage` [27129923256](https://github.com/max-sixty/worktrunk/actions/runs/27129923256)** — silent-exit via `running-in-ci`'s "Triggering issue/PR already closed" rule (issue was closed 5 s before the triage run started).
- **`tend-mention` [27129923378](https://github.com/max-sixty/worktrunk/actions/runs/27129923378)** — silent-exit via the prompt's self-conversation guard (trigger was the bot's own close-out comment).

Per-occurrence cost is ~94 s of `tend-mention` agent context-load + ~90 s of `tend-triage` agent context-load — ~3 minutes wasted on every transient. At the observed rate (~4 / week), that's ~12 min/week of cascade no-op cost, growing as CI-flake density grows.

## Gate evaluation

- **Evidence level**: High — consistent pattern across 19 sessions over 5 weeks, every occurrence reproduces the same cascade. Gate 1 High threshold is 2–3; pass with margin.
- **Classification**: Structural — no decision point. Every unlabeled bot-opened-and-closed `ci-fix: transient` issue produces the same two cascade runs; the agent's silent-exit guards fire correctly each time but only after context-load.
- **Change type**: Targeted fix — one `gh label create … || true` line plus `--label tend-outage` on the existing `gh issue create`, mirroring the action's own `Report failure` pattern. Gate 2 Normal threshold = Gate 1 High = 2–3; pass.
- **Both gates pass**: act.

## Why `tend-outage` (not a new label)

- Already exists in every consumer repo — the action's `Report failure` step creates it idempotently (`gh label create tend-outage … 2>/dev/null || true`) and applies it to outage-tracker issues. No generator change, no new label to provision.
- Workflow-level skip is already wired: [`triage.yaml.j2:13`](https://github.com/max-sixty/tend/blob/6a90890d256d4bf8b1f191fae0c4a2c2ad24e90c/generator/src/tend/templates/triage.yaml.j2#L13) and [`mention.yaml.j2:52-62`](https://github.com/max-sixty/tend/blob/6a90890d256d4bf8b1f191fae0c4a2c2ad24e90c/generator/src/tend/templates/mention.yaml.j2#L52-L62) already filter `tend-outage`-labeled issues. The cascade simply doesn't run.
- The `review-reviewers` Non-issues list names `tend-outage` as the canonical example of label-based loop-prevention.
- Semantically: both shapes (Anthropic action outage, project CI transient) are bot-bookkeeping records of a transient external incident — the nightly `enrich-tend-outage-issues.sh` only touches **open** outage issues, so closed transient trackers don't enter that path.

## Evidence gist

Full per-run accumulation in the [review-reviewers evidence gist for `max-sixty/worktrunk` 2026-06](https://gist.github.com/15c523384cfad7449cb81933b47165ff).

This run: [27130895184](https://github.com/max-sixty/tend/actions/runs/27130895184).
