### PR TITLE
skills(triage): drop "run full suite" — defer to PR CI per "ship before end_turn"

### DIFF
--- a/plugins/tend-ci-runner/skills/triage/SKILL.md
+++ b/plugins/tend-ci-runner/skills/triage/SKILL.md
@@ -105,9 +105,8 @@ Step 3's duplicate check catches identical fixes. It misses the *same root cause
 ### If fixing
 
 1. Fix the root cause (not just the symptom)
-2. Confirm the test now passes
-3. Run the full test suite and lints (use project test commands from CLAUDE.md)
-4. Create branch, commit, push, and create PR:
+2. Confirm the reproduction test now passes — that targeted pass plus a clean compile is enough local confidence to ship. Leave the comprehensive suite to PR CI per `/tend-ci-runner:running-in-ci`'s "End the turn only when work is shipped"; backgrounding a long suite before push pushes the agent into mid-wait `end_turn` and the deliverable never ships.
+3. Create branch, commit, push, and create PR:
    ```bash
    git checkout -b fix/issue-$ARGUMENTS
    git add -A
@@ -129,7 +128,7 @@ Step 3's duplicate check catches identical fixes. It misses the *same root cause
    ---
    Closes #<issue-number> — automated triage"
    ```
-5. Monitor CI using the approach from /tend-ci-runner:running-in-ci.
+4. Monitor CI using the approach from /tend-ci-runner:running-in-ci.
 
 ### If reproduction test works but fix is not confident
 


### PR DESCRIPTION
## Problem

`tend-triage`'s Step 6 "If fixing" tells the bot to "Run the full test suite and lints" before commit/push. That directly conflicts with [`running-in-ci`'s "End the turn only when work is shipped"](https://github.com/max-sixty/tend/blob/main/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md#end-the-turn-only-when-work-is-shipped) (added in #661), which forbids backgrounding pre-push work the deliverable depends on.

Today on `PRQL/prql`, run [27149177431](https://github.com/PRQL/prql/actions/runs/27149177431) (`tend-triage` on issue #5988, "Compiler crash when joining a zero-row relation"):

- Bot reproduced the panic, applied the fix, added a snapshot test, ran it green — all locally.
- Following Step 6.3 ("Run the full test suite and lints"), kicked off `task prqlc:pull-request` (~7 min suite) with `run_in_background: true`.
- Used `Monitor` (`timeout_ms: 420000`) and `ScheduleWakeup` (`delaySeconds: 180`) to wait for the suite, then emitted `end_turn`.
- Session terminated — no commit, no push, no PR, no comment on the issue. 14 minutes of agent time on a real user bug, zero maintainer-visible output.

Last assistant text: *"I've scheduled a fallback check. Waiting for the test suite to finish."*

This is the second occurrence of "agent calls `ScheduleWakeup`/`Monitor` in CI expecting resumption and the deliverable never ships" — the first was `tend-mention` run 26347739838 (May 24, fix attempt closed as #593, gate-tightening followed in #602, and the root-cause guidance shipped in #661 — but the triage skill never picked up the alignment). PRQL is still pinned to `max-sixty/tend@0.1.2`, predating #661, so the conflicting Step 6.3 won. Even once consumers bump past #661, an agent reading both skills will see Step 6.3's explicit instruction and a generic principle in `running-in-ci`; the explicit instruction tends to win.

## Solution

Rewrite triage Step 6.3 so the two skills agree: the targeted reproduction test plus a clean compile is sufficient confidence; the comprehensive suite is PR CI's job. Renumber the following two steps (4 → 3, 5 → 4) since "Confirm the test passes" merges naturally into Step 2.

## Gate assessment

- **Evidence level**: High — 2 occurrences of "agent uses async-resume tool in CI then `end_turn` leaves deliverable unshipped" across `tend-mention` and `tend-triage`. Both fully diagnosed from session logs.
- **Structural vs stochastic**: Structural. Two skills' instructions conflict on whether to run the comprehensive suite before push; the more specific (triage Step 6.3) wins. Same conditions reproduce reliably.
- **Change type**: Removal / simplification — drop the conflicting "Run the full test suite and lints" line, fold "Confirm the test passes" into the same step, renumber. Per Gate 2, Low evidence bar (1 occurrence enough).
- **Both gates**: Pass.

Evidence gist (full per-run history): https://gist.github.com/a017dd295de05dc44af4479748ffe636

<details><summary>Sources and notes</summary>

- Today's triage session: [PRQL/prql Run 27149177431](https://github.com/PRQL/prql/actions/runs/27149177431), issue [PRQL/prql#5988](https://github.com/PRQL/prql/issues/5988) (reporter `kgutwin`, non-maintainer).
- Session JSONL tool sequence: `Bash(task prqlc:pull-request, timeout 420000)` → `Bash(until... done, run_in_background: true, timeout 420000)` → `Monitor(timeout_ms: 420000, persistent: false)` → `Write(/tmp/pr-body.md)` → `Read(.../tasks/...output)` (×3) → `ScheduleWakeup(delaySeconds: 180, prompt: "Check the prqlc:pull-request test output ... and continue triage of issue 5988")`. Stop reason: `end_turn`. No `git commit` / `git push` / `gh pr create` / `gh issue comment` in the session.
- Prior `tend-mention` occurrence: [PRQL/prql Run 26347739838](https://github.com/PRQL/prql/actions/runs/26347739838), terminated at 6h cap; documented in the 2026-05 evidence gist under "Acted on (High evidence, structural): `tend-mention` 6h-cap idle after `ScheduleWakeup` in CI".
- Earlier closed PR: #593 (`forbid ScheduleWakeup and fire-and-forget background bash in CI`) — closed at 1 occurrence pre-gate-tightening. Comment: *"no! we need to change our criteria; this is structural and it's not critical"*. Gates were tightened in #602, then #661 added the more nuanced framing — this PR completes the picture by removing the triage-side conflict.
- `running-in-ci`'s rule (post-#661): *"A targeted compile plus the tests directly exercising the change is enough local confidence to ship — leave the comprehensive matrix to CI."*

</details>
