### PR TITLE
docs(README): weekly approves dep PRs, doesn't auto-merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ file](docs/tend.example.yaml) and a repo-local `/running-tend` skill.
 | **triage**        | Issue opened               | Classifies the issue, checks for duplicates, reproduces bugs, attempts conservative fixes.                                                                  |
 | **ci-fix**        | CI fails on default branch | Reads failure logs, identifies root cause, searches for the same pattern elsewhere, opens a fix PR.                                                         |
 | **nightly**       | Daily                      | Resolves conflicts on open PRs, reviews recent commits, surveys ~10 files for bugs and stale docs, closes resolved issues, regenerates tend workflow files. |
-| **weekly**        | Weekly                     | Reviews dependency PRs, auto-merges safe patch and minor updates.                                                                                           |
+| **weekly**        | Weekly                     | Reviews dependency PRs, approves safe patch and minor updates (the bot never merges — a merge restriction is the security boundary).                        |
 | **notifications** | Every 15 minutes           | Polls GitHub notifications, responds to unhandled mentions, marks handled threads as read.                                                                  |
 | **review-runs**   | Daily                      | Reviews recent CI runs for behavioral problems and proposes skill/config improvements.                                                                      |
 


### PR DESCRIPTION
## Summary

The README's workflow table describes the `weekly` workflow as "auto-merges safe patch and minor updates." The weekly skill ([`plugins/tend-ci-runner/skills/weekly/SKILL.md`](https://github.com/max-sixty/tend/blob/e77bda81fe811cca72d1d92e596f33932dda7af9/plugins/tend-ci-runner/skills/weekly/SKILL.md)) only **approves** dependency PRs — it never invokes `gh pr merge`. The bot is explicitly prohibited from merging or enabling auto-merge in [`plugins/tend-ci-runner/skills/running-in-ci/SKILL.md`](https://github.com/max-sixty/tend/blob/e77bda81fe811cca72d1d92e596f33932dda7af9/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md) ("Merging: Never merge PRs or enable auto-merge"). The merge restriction is in fact the primary security boundary documented in `docs/security-model.md`.

Update the table to say "approves" instead of "auto-merges" and note that the bot can't merge.

## Test plan

- [x] Inspection: weekly skill source confirmed — no merge call exists.
- [x] No code change; doc-only update.
