### PR TITLE
skills(review-reviewers): keep audit trail on empty-window cycles

### DIFF
--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -209,7 +209,7 @@ TARGET_REPO=$ARGUMENTS ${CLAUDE_PLUGIN_ROOT}/scripts/list-recent-runs.sh
 
 The script discovers `tend-*` workflows by default. Pass additional prefixes as arguments to include other workflows (e.g., `review-reviewers` when analyzing tend itself).
 
-If empty, report "no runs to review" and exit.
+If empty, **still append a `## Run <RUN_ID>` heading to the gist** with an all-clear body (per "Recording below-threshold findings" above) before exiting — the audit-trail entry is what later cycles read to count occurrences and confirm which hours were analyzed. Skipping the append on empty-window cycles silently widens the next cycle's recovery window and breaks Gate 1's occurrence counting. After PATCHing the gist, skip Steps 2–5 and proceed directly to Step 6 (summary).
 
 ## Step 2: Survey outcomes via cheap subagent
 

--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -209,7 +209,7 @@ TARGET_REPO=$ARGUMENTS ${CLAUDE_PLUGIN_ROOT}/scripts/list-recent-runs.sh
 
 The script discovers `tend-*` workflows by default. Pass additional prefixes as arguments to include other workflows (e.g., `review-reviewers` when analyzing tend itself).
 
-If empty, **still append a `## Run <RUN_ID>` heading to the gist** with an all-clear body (per "Recording below-threshold findings" above) before exiting — the audit-trail entry is what later cycles read to count occurrences and confirm which hours were analyzed. Skipping the append on empty-window cycles silently widens the next cycle's recovery window and breaks Gate 1's occurrence counting. After PATCHing the gist, skip Steps 2–5 and proceed directly to Step 6 (summary).
+If empty, record the run as all-clear per "Recording below-threshold findings" above, then skip to Step 6.
 
 ## Step 2: Survey outcomes via cheap subagent
 


### PR DESCRIPTION
## Problem

Step 1 of `review-reviewers/SKILL.md` says *"If empty, report 'no runs to review' and exit"* when `list-recent-runs.sh` returns an empty array. The later "Recording below-threshold findings" section (and `@review-gates.md`) explicitly require *"Append a `## Run <RUN_ID>` heading every run"* — including all-clear hours. The agent reads Step 1 first and follows the literal "exit", bypassing the gist-PATCH. The result: empty-window cycles leave silent gaps in the audit trail.

## Evidence

Confirmed structural pattern, 2 cumulative occurrences:

1. Cycle [27156076875](https://github.com/max-sixty/tend/actions/runs/27156076875) — original observation, cause hypothesized but not confirmed.
2. Cycle [27192476671](https://github.com/max-sixty/tend/actions/runs/27192476671) (numbagg leg, job [80275809460](https://github.com/max-sixty/tend/actions/runs/27192476671/job/80275809460)) — confirmed via session log `claude-interactive-session-logs-48942fc7`. Last assistant text: *"No runs to review on numbagg/numbagg this hour. The script's 1-hour completion window returned [] … Exiting per the skill's 'no runs to review' rule."* The gist read at session start was never PATCH-written back; no `## Run 27192476671` heading exists in the audit trail.

## Why it matters

- Missing entries widen the next cycle's recovery window. This cycle ([27198789108](https://github.com/max-sixty/tend/actions/runs/27198789108)) had to extend its window back to 06:12:28Z — 3h 51m instead of the nominal 1h — to recover the 08:03 cycle's gap.
- Gate 1's occurrence counting breaks for findings that only appear in skipped cycles: they never accumulate toward threshold.
- Two adjacent skipped cycles would leave a gap a single review cycle can't reconstruct in detail (`list-recent-runs.sh`'s `--created '>=3h ago'` floor is only 3h).

## Fix

One-line edit to Step 1: route empty-window cycles through the same all-clear gist-PATCH path that "Recording below-threshold findings" already defines, then skip Steps 2–5 and jump to the summary.

## Gate assessment

- **Confidence**: High — structural (same conditions always produce this failure), 2 confirmed occurrences (Gate 1 High threshold = 2–3). ✓
- **Magnitude**: Targeted text fix (1 line). Normal threshold. ✓

## Evidence gist

https://gist.github.com/39936af3c6f4ba8f6f107fb94b6a9f20 (search for *"empty-window early-exit"* in the latest `## Run 27198789108` block).
