### PR TITLE
docs: record env-gating rejection analysis; restructure CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,24 +1,22 @@
 # Development
 
+Tend is an autonomous CI maintainer for GitHub repos: it reviews PRs, triages
+issues, and fixes CI, powered by Claude or Codex. This repo ships the generator
+(`uvx tend@latest`) that stamps each adopter's workflow files, plus the plugins
+and composite actions those workflows run.
+
 No backward compatibility. When a config format or API changes, cut over
 completely — old formats should fail with a clear error, not silently parse.
 
 ## Commands
 
 ```bash
-wt test                                               # run pytest in generator/
-wt list statusline --format json | jq -r '.[].url'    # this worktree's dev server URL
-uvx tend@latest init                                  # regenerate workflows from .config/tend.yaml
-uvx tend@latest init --dry-run                        # preview without writing
-uvx tend@latest check                                 # verify branch protection, secrets, bot access
+wt test                            # run pytest in generator/
+uvx tend@latest init               # regenerate workflows from .config/tend.yaml
+uvx tend@latest init --dry-run     # preview without writing
+uvx tend@latest check              # verify branch protection, secrets, bot access
+pre-commit run --all-files         # lint: ruff, typos, actionlint, uv-lock
 ```
-
-The Astro dev server starts automatically per worktree via a `wt`
-post-start hook (`.config/wt.toml`) on a deterministic port derived from
-the branch name. Get the URL from
-`wt list statusline --format json | jq -r '.[].url'`; logs land in
-`.git/wt/logs/`. Do not run `npm run dev` — it duplicates the existing
-server on a different port.
 
 ## Architecture
 
@@ -117,8 +115,6 @@ tag that does not exist yet, and the workflow's `uses:` fails to resolve.
 Between a generator commit and the next release the committed workflows lag
 the in-tree generator; that is expected, and the gap closes at the next
 release (which tags `X.Y.Z` before regenerating, so the pin always resolves).
-
-Linting: `pre-commit run --all-files` (ruff, typos, actionlint, uv-lock).
 
 ## Generator vs adopter ownership
 
@@ -292,3 +288,25 @@ Codex). When adding new capability, split work along this line:
 
 Don't build deterministic YAML steps for work that happens *inside* an
 agent run. Extend the skill instead.
+
+## Live testing against real GitHub
+
+For live experiments against real GitHub behavior (environments, branch
+protection, workflow triggers, secret release), `tend-agent/tend-integration`
+is a persistent public repo we own, admin via the `tend-agent` account
+(`gh auth token --user tend-agent`). Its `main` is branch-protected with
+`enforce_admins: false`, so the owner can push directly and reset in place.
+The weekly integration test (`.claude/skills/running-tend/references/integration-test.md`)
+also drives it, so clean up any probe artifacts (extra workflows, branches,
+environments, dummy secrets) when done.
+
+## Site and worker
+
+`site/` is the Astro marketing site (tend-src.com); `worker/` is the
+Cloudflare Worker that serves its two data streams from `data/consumers.json`.
+
+The site's dev server starts automatically per worktree via a `wt` post-start
+hook (`.config/wt.toml`) on a deterministic port derived from the branch name.
+Get the URL with `wt list statusline --format json | jq -r '.[].url'`; logs
+land in `.git/wt/logs/`. Don't run `npm run dev`; it duplicates the running
+server on a different port.

--- a/TODO.md
+++ b/TODO.md
@@ -126,6 +126,47 @@ Limitations: triage-level approvals don't satisfy required-review policies,
 and triage can't push to human PR branches — the bot posts review
 suggestions instead.
 
+## Environment-gating operational secrets: considered, rejected
+
+Moving `TEND_BOT_TOKEN` and the harness token into a `tend` GitHub Environment
+gated to the default branch was evaluated as a way to close the no-merge exfil
+path: a write-scoped actor (a hijacked session, attacker code in the sandbox, a
+leaked PAT) pushes `.github/workflows/exfil.yml` to a branch, or opens a
+same-repo `pull_request`, and reads the repo-level secret from that run without
+ever touching the proxy. It does not work, because GitHub evaluates an
+Environment's deployment branch policy against `GITHUB_REF`, and `tend-mention`'s
+legitimate review paths share their ref with the attack.
+
+Probe on `tend-agent/tend-integration` (current GitHub behavior, 2026-06), a job
+bound to an environment whose policy admits only the default branch:
+
+| Trigger | `GITHUB_REF` | Gate |
+|---|---|---|
+| `pull_request_target` | `refs/heads/main` | passes, `HAS_SECRET` |
+| `issue_comment`, `issues`, `schedule`, `workflow_run` | `refs/heads/main` | passes |
+| `push` to a feature branch | `refs/heads/<branch>` | blocked, 0 steps |
+| same-repo `pull_request` | `refs/pull/N/merge` | blocked |
+| `pull_request_review`, `pull_request_review_comment` | `refs/pull/N/merge` | **blocked, 0 steps** |
+
+(`pull_request_target`, `issue_comment`, both review events, and `push` were
+observed directly; the rest follow from the same default-ref vs merge-ref
+families.)
+
+The gate blocks the same-repo-PR exfil attempt, but also blocks mention's
+review-submission and inline-review-comment handling: those carry the same
+`refs/pull/N/merge` ref and a ref policy cannot tell them apart. There is no ref
+pattern that admits the review events without also admitting the attack. The
+"runs in the context of the default branch" docs sentence for review events
+refers to which workflow *file* runs, not `GITHUB_REF`.
+
+The precise gate keys on the workflow file's source ref, not the execution ref.
+That value exists as the OIDC `job_workflow_ref` claim, but no native mechanism
+releases a secret on it; it needs a token-minting service. That is the GitHub
+App route above, which also retires the durable-PAT-leak risk. Until then the
+operational tokens stay repo-level and `docs/security-model.md` records the
+accepted risk: repo write access implies secret access, as with any GitHub
+secret.
+
 ## Security hardening — deferred
 
 From the old `docs/security-model.md` "what we could do but don't" — none

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -163,6 +163,23 @@ on the standard runner image anyway. The boundaries that are load-bearing
 (merge restriction, scope-limited credentials) sit outside the harness's
 local-exec sandbox regardless.
 
+**Repo write access implies secret access.** The bot PAT and the harness
+token are repo-level secrets, readable by any workflow the repo runs; unlike
+the release secrets above, they are not environment-gated. Like any GitHub
+Actions secret, a write-scoped actor (a leaked PAT, or a hijacked session that
+can push a branch) can commit a workflow that prints them and read them from
+its own run. Branch protection bounds what gets *merged*; it does not bound
+what a write-scoped run can *read*, and the merge restriction does not apply
+because nothing is merged. Forks cannot reach them: GitHub withholds secrets from
+fork-PR workflows, and the secret-bearing events (`pull_request_target`, the
+review events, `schedule`) run only the default branch's reviewed workflow
+files. Pinning these secrets to the default-branch ref with a GitHub
+Environment does not close the gap: the policy keys on `GITHUB_REF`, which
+cannot tell a legitimate `tend-mention` review event (carrying
+`refs/pull/N/merge`) from a same-repo-PR exfiltration on the same ref, so it
+would break mention's review-comment paths without gaining protection; the full
+analysis is in `TODO.md`.
+
 **Token exfiltration via side channels.** Log masking only catches exact
 string matches in stdout. An attacker who gets code execution can exfiltrate
 tokens via DNS queries, HTTP requests to an external server, or encoding


### PR DESCRIPTION
Records the outcome of investigating environment-gating tend's operational secrets (`TEND_BOT_TOKEN` + harness token), and restructures CLAUDE.md.

**Why no code ships:** gating those secrets to a default-branch-only GitHub Environment was designed and probe-validated, then rejected. The deployment branch policy evaluates `GITHUB_REF`, and `tend-mention`'s legitimate `pull_request_review` / `pull_request_review_comment` events carry `refs/pull/N/merge` — the same ref as the same-repo-PR exfil run the gate must keep blocking. No ref pattern admits one without the other, so the gate would break mention's review-comment paths without gaining protection. Verified empirically on `tend-agent/tend-integration` (review events blocked at the gate with zero steps; `pull_request_target` and `issue_comment` pass with the secret).

- `docs/security-model.md`: new remaining-risk entry stating the accepted property — repo write access implies secret access, as with any GitHub Actions secret — and why the environment gate doesn't close it.
- `TODO.md`: the analysis with the per-trigger `GITHUB_REF` probe table, replacing the prior build plan.
- `CLAUDE.md`: orientation intro (what tend is), slimmer Commands, the Astro dev server demoted to a new "Site and worker" section, and a "Live testing against real GitHub" section documenting the `tend-integration` probe repo.

> _This was written by Claude Code on behalf of max_
