### PR TITLE
skills(running-tend): install uv into sandbox before integration-test §1/§5

### DIFF
--- a/.claude/skills/running-tend/references/integration-test.md
+++ b/.claude/skills/running-tend/references/integration-test.md
@@ -41,6 +41,28 @@ in place.
 Run steps in order. If §3, §4, or §5 fails, jump to §6 (reset), then §7
 (report).
 
+## 0. Sandbox prerequisites
+
+§1 (bootstrap) and §5 (self-heal) shell out to `uvx tend@latest init`.
+The agent runs as `tend-sandbox` inside the harness sandbox, but the
+workflow's `astral-sh/setup-uv` step installs uv under the runner user's
+home, which the sandbox can't see. Without uv on the sandbox PATH §5
+silently no-ops — the missing-binary error is swallowed and an empty
+`git status` reads as "idempotent" — so install uv into the sandbox
+before continuing:
+
+```bash
+if ! command -v uvx >/dev/null 2>&1; then
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
+command -v uvx >/dev/null \
+  || { echo "uvx unavailable after install; aborting recipe"; exit 1; }
+```
+
+The installer drops uv into `$HOME/.local/bin`, which is already on the
+sandbox PATH, so no `export PATH` is needed for later sections to pick
+it up.
+
 ## 1. Bootstrap (first run only) and reseed (every run)
 
 Create the test repo if missing, with workflows installed on `main`


### PR DESCRIPTION
The weekly integration-test recipe shells out to `uvx tend@latest init` in §1 (bootstrap) and §5 (self-heal). The Claude agent runs as `tend-sandbox` inside the harness sandbox, but the workflow's `astral-sh/setup-uv` step installs uv under the runner user's `$HOME` (`/home/runner/.local/bin`), which the sandbox's PATH doesn't include. The result: §5's `uvx tend@latest init` exits non-zero with no output captured, `git status --porcelain` reports clean (nothing was regenerated, nothing was modified), and the idempotency assertion reads that as a pass.

Caught during this week's run — §5 reported PASSED while doing nothing. Manual `curl https://astral.sh/uv/install.sh | sh` into the sandbox made `uvx` reachable and §5 then exercised init for real.

Adds a §0 sandbox-prerequisites section that installs uv into the sandbox if `command -v uvx` is empty, and aborts loudly if uvx is still unreachable afterward. The installer's default destination (`$HOME/.local/bin`) is already on the sandbox PATH, so no `export PATH` is needed for later sections to inherit it.

This is an invisible-failure-mode fix: without it, §5 silently passes on every weekly run without exercising the generator.

Surfaced during the weekly integration test on [run 27495976519](https://github.com/max-sixty/tend/actions/runs/27495976519).
