### PR TITLE
skills: soften over-stringent guidance into examples and open frames

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,6 +270,13 @@ When adding to or editing files in `plugins/tend-ci-runner/skills/` or
   expected to drift can be dated; a one-shot incident citation should not be.
 - **Prefer recipe over narrative.** A code block plus a one-sentence framing
   beats a multi-paragraph explanation.
+- **Examples over templates; open frames over closed menus.** For text the
+  agent *produces* (comments, PR bodies, summaries), give an example labeled
+  as such rather than verbatim wording to paste — canned phrasing reproduced
+  literally reads awkwardly off-situation. For choices the agent *makes* (when
+  to respond, which cases to check), frame the goal and give examples rather
+  than a list it will read as exhaustive. Reserve mandatory exact wording for
+  fragile mechanics: dedup keys, commands, API formats.
 
 ## Agent-driven vs deterministic steps
 

--- a/plugins/tend-ci-runner/skills/ci-fix/SKILL.md
+++ b/plugins/tend-ci-runner/skills/ci-fix/SKILL.md
@@ -88,10 +88,7 @@ gh issue create --title "ci-fix: transient failure on <run-id>" --label tend-out
 gh issue close <issue-number> --reason "not planned" --comment "Transient — closing as diagnosed."
 ```
 
-Use this path when:
-- The same code path succeeded on the most recent 5 prior runs with no relevant changes between runs
-- The failure shape is filesystem/network-level, not anything the project's code does
-- An upstream status incident matches the timing and components
+Use this path only when the evidence points to ephemeral infrastructure, not anything the project's code does. Signals (examples, not a checklist): the same code path passed on recent prior runs with no relevant change; the failure shape is filesystem/network-level; an upstream status incident matches the timing and components. Weigh the evidence rather than matching the list.
 
 #### Repeat-occurrence escalation
 

--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -263,7 +263,7 @@ echo "OLD=$OLD_VER NEW=$NEW_VER  compare: https://github.com/max-sixty/tend/comp
 
 Compose the PR body with the Write tool at `/tmp/tend-update-body.md` — describe the upgrade, **don't paste a file list** (the diff is just mechanical action-ref bumps):
 
-- Open with `Automated nightly regeneration of tend workflow files.`
+- Open by noting this is the automated nightly regeneration of tend's workflow files — phrase it per-run, or fold it into the version summary.
 - **Version bumped**: add a `**tend version:** OLD → NEW` line, then a short **Notable changes** list — 3–5 bullets summarizing the entries in `/tmp/tend-upstream-commits.txt`. Rewrite each `(#NNN)` ref as `max-sixty/tend#NNN` — a bare `#NNN` auto-links to this repo's own issues, not tend's. Filter to **consumer-relevant** changes only — harness/action behavior, skill updates (review, ci-fix, triage, nightly, etc.), generator output that changes the adopter's workflow files, CI-monitoring guidance. **Exclude** pure mechanics (`chore: regenerate workflows`, `chore: release`, action-pin and lockfile bumps) and **tend-internal items** that affect only tend's own development or release (e.g. release-publishing workflow, marketing site, integration-test fixtures, internal refactors with no adopter-visible effect). Close with the compare link printed above. If the commits file is empty (the compare call failed), keep just the version line and the compare link.
 - **No version bump** (same-version regen): one sentence on what the regen changed (a generator template tweak the committed workflows were lagging). No version line, no commit list.
 

--- a/plugins/tend-ci-runner/skills/notifications/SKILL.md
+++ b/plugins/tend-ci-runner/skills/notifications/SKILL.md
@@ -121,9 +121,9 @@ gh api notifications/threads/{thread_id} -X PATCH
 
 Cross-repo notifications skip dedup (no good signal for "already handled" across repos) — go straight to step 4b. Stop the check here: no author-association lookups, no workflow-run queries.
 
-### 4b. Respond to notifications only this skill covers
+### 4b. Respond to notifications no dedicated workflow covered
 
-The notifications skill is the **sole handler** for these categories — respond to them:
+This skill is the fallback: handle any notification no dedicated workflow picked up, subject to the Step 3 scope and security rules and the Step 4a freshness/dedup. Common cases:
 
 - **Fork PR inline comments** — `pull_request_review_comment` events don't fire for the bot on fork PRs, so no other workflow picks these up. Read the comment, the diff hunk, and respond in context.
 
@@ -135,6 +135,8 @@ The notifications skill is the **sole handler** for these categories — respond
   - For mentions/comments: read context and respond helpfully.
 
 - **`subscribed`/`comment`** on threads the bot participates in (same-repo), where the comment is directed at the bot and no dedicated workflow handled it — respond if the comment asks a question, requests changes, or replies to a concern the bot raised. If the conversation is between humans, do not respond.
+
+Shapes not listed here — a fork PR's top-level comment, a discussion thread — are what this fallback exists for; use judgment, applying the same scope and freshness rules.
 
 ### 4c. Mark as read
 

--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -232,7 +232,7 @@ Use a cheap subagent (e.g. Haiku / gpt-mini) and a prompt like:
 > - `tend-mention`: map run to issue/PR from triggering comment, check for bot replies
 > - `tend-ci-fix`: map run → PR via `headBranch`, check for bot commits
 >
-> **Negative outcome signals** (report these):
+> **Negative outcome signals** — report any sign the bot's output was rejected, corrected, or ignored. Common shapes (use judgment for signals not listed):
 > - Human reviewer posted CHANGES_REQUESTED after bot approved
 > - PR closed without merge shortly after bot approved
 > - Bot posted no review despite a `tend-review` run completing on an open PR

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -173,12 +173,14 @@ Skip runs without artifacts. Trace decision chains: what did tend decide, what e
 
 ## Step 4: Cross-check outcomes
 
-For each analyzed run, compare what the bot did against what happened next:
+For each analyzed run, compare what the bot did against what happened next. The same "did it stick?" question applies to every tend workflow — ask it of whatever ran. For example:
 
-- **Review runs**: Did subsequent commits undo something the bot approved? Did human reviewers flag issues the bot missed?
-- **Triage runs**: Was the bot's classification correct? Did the issue get relabeled?
-- **Nightly runs**: Did the bot's PRs get merged, or were they closed as unhelpful?
-- **CI-fix runs**: Did the fix actually resolve the CI failure?
+- **Review**: did subsequent commits undo something the bot approved? Did human reviewers flag issues it missed?
+- **Triage**: was the classification correct? Did the issue get relabeled?
+- **Nightly**: did the bot's PRs merge, or get closed as unhelpful?
+- **CI-fix**: did the fix actually resolve the failure?
+
+mention, notifications, weekly, and review-reviewers runs get the same treatment: find the bot's output and check whether it was accepted.
 
 ```bash
 # Example: check if a bot PR was merged or closed

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -100,9 +100,7 @@ The adopter's `running-tend` overlay may grant a standing exception for **agent-
 
 Two or three convergent signals are enough; borderline cases revert to the default. Without an explicit opt-in in `running-tend`, the default also applies.
 
-When asking permission (the default path), close with a short offer so the user can record a preference for future asks:
-
-> By default I ask before filing upstream issues. If you'd prefer I file without asking, let me know and I'll add a standing exception to my guidance. If you'd rather keep approving each one but stop seeing this offer, also let me know.
+When asking permission (the default path), close with a short offer so the user can record a preference for future asks. The offer should let them pick either outcome: have the bot file without asking next time, or keep approving each one but stop seeing the offer. Phrase it to fit the thread.
 
 Either reply gets codified in the consumer repo's `running-tend` overlay per **Learning from Feedback** below — opt-in adds the target (or "all agent-equipped targets") to the exceptions list; suppress adds a one-line rule telling the bot to skip the offer for future asks.
 
@@ -533,7 +531,7 @@ If you can't find source evidence for a specific detail, say so ("I'm not sure o
 
 **`--jq` projections must include the ID when downstream URLs cite individual items.** Composing `actions/runs/<id>`, `#issuecomment-<id>`, or `pull/<n>` URLs from `gh run list` / `gh api .../comments` / `gh pr list` results requires the ID field in the projection (`databaseId` for runs, `id` for comments, `number` for PRs/issues). If the projection kept only timestamps, titles, or bodies, the bot composes the URL from what it has and fabricates the missing ID — the link 404s. Re-query with the ID field rather than guessing.
 
-**"Likely" is a stop-sign.** If a draft contains "likely works", "probably parses as", "should behave like", or "I think" in a user-facing claim, you have two options: verify and replace the hedge with the answer, or hedge explicitly ("I haven't tested this — would appreciate if you can confirm") and don't dress up the guess as analysis. Posting an unverified guess as confident-sounding analysis is the hallucination shape that erodes trust the fastest.
+**"Likely" is a stop-sign.** A hedge in a user-facing claim — "likely works", "probably parses as", "should behave like", "I think" — means it rests on an unverified guess. Two options: verify and replace the hedge with the answer, or hedge explicitly ("I haven't tested this — would appreciate if you can confirm") and don't dress up the guess as analysis. The shape is the tell, not the exact words: posting an unverified guess as confident-sounding analysis is the hallucination that erodes trust the fastest.
 
 **Never ship literal placeholders in user-visible content.** Strings like `<PLACEHOLDER>`, `PR #PLACEHOLDER`, `<SHA>`, `TBD`, `XXX`, or `<TODO(fill)>` in an issue body, PR body, or comment are corruption: a deferred substitution that never ran. They survive into the rendered output and read as broken. When a multi-step ask references an artifact that doesn't yet exist ("file an issue that references the PR I'm about to file"), sequence the work so the referenced artifact exists before the referencing body is composed: create the PR → read its number → compose the issue with the number filled in → file the issue. If the cross-reference can't be resolved before posting (e.g. the artifact is out of scope or deferred), omit it or rephrase ("a follow-up PR will…") rather than emit a placeholder. Before any `gh issue create`, `gh pr create`, or `gh ... comment --body-file`, grep the body file for `PLACEHOLDER`, `<SHA>`, `<TODO`, `TBD`, `XXX` and refuse to post if any match. A session that times out mid-sequence leaves an unsubstituted placeholder permanently visible — pre-substitute, don't post-substitute.
 

--- a/plugins/tend-ci-runner/skills/weekly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/weekly/SKILL.md
@@ -34,7 +34,7 @@ If no dependency PRs are open, note "0 dependency PRs to process" and continue t
    if [ "$LAST_APPROVAL_SHA" = "$HEAD_SHA" ]; then
      echo "Already approved on this commit; skipping."
    else
-     gh pr review <number> --approve --body "Automated dependency update — CI passing, no breaking changes."
+     gh pr review <number> --approve --body "<one line: package, bump type, CI status — what you checked>"
    fi
    ```
 4. If CI is failing, comment with the failure summary and skip

--- a/plugins/tend-ci-runner/skills/weekly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/weekly/SKILL.md
@@ -34,7 +34,9 @@ If no dependency PRs are open, note "0 dependency PRs to process" and continue t
    if [ "$LAST_APPROVAL_SHA" = "$HEAD_SHA" ]; then
      echo "Already approved on this commit; skipping."
    else
-     gh pr review <number> --approve --body "<one line: package, bump type, CI status — what you checked>"
+     # Compose a one-line review body naming the package, bump type, and what you
+     # checked — e.g. "ruff 0.13 → 0.14 (patch), CI green, no API changes".
+     gh pr review <number> --approve --body "$REVIEW_BODY"
    fi
    ```
 4. If CI is failing, comment with the failure summary and skip


### PR DESCRIPTION
Follow-up to the triage reply-templates change (#692). A fan-out audit of tend's bot guidance — 16 skill/prompt files, each finding adversarially verified — found that the triage-template problem was systemic. Two anti-patterns recur across the skills, both giving a good median output but an awkward or incomplete tail:

- **Verbatim templates** the bot reproduces literally (canned comment/PR-body wording).
- **Closed enumerated lists** the bot reads as exhaustive ("respond to these categories", "cross-check these workflows").

This applies the 8 high/medium-value softenings the audit surfaced, and codifies the underlying principle in `CLAUDE.md` → "Authoring skills" so new skills don't reintroduce the pattern.

## What changed

- **`review-runs` Step 4** — cross-check applies to every tend workflow, not just the four listed. This was a real coverage gap: the bot could skip checking mention/notifications/weekly/review-reviewers.
- **`ci-fix` 3a** — transient-failure signals presented as examples to weigh, not a checklist to satisfy (the conservative default-to-durable backstop and repeat-occurrence escalation are unchanged).
- **`notifications` 4b** — framed as the fallback for any notification no dedicated workflow covered, not a closed category list (Step 3 scope/security and Step 4a freshness/dedup guards unchanged).
- **`review-reviewers` Step 2** — rejection signals are examples; every bullet and the corruption-scan recipe are kept verbatim.
- **`running-in-ci`** — the upstream-issue permission offer and the "'Likely' is a stop-sign" rule reframed around intent and semantic shape rather than fixed wording.
- **`nightly` Step 7, `weekly` Step 2** — canned PR-body strings become goal-stated summaries the model writes per-situation.

## Safety

Each site keeps its load-bearing guard; only the wording loosens. Safety/correctness gates (reproduce-before-fix), security rules, branch-protection, and exact commands were deliberately left rigid — the audit's verification pass dropped any finding that touched them. An independent review confirmed no guard was weakened and no cross-reference broken.

The audit's low-tier findings (17 more of the same two patterns, lower value) are a candidate fast-follow.

> _This was written by Claude Code on behalf of max_
