### PR TITLE
fix(running-in-ci): trim CI-poll loops to fit Bash tool's 10-min cap

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -296,6 +296,8 @@ for i in $(seq 1 9); do
 done
 ```
 
+As with the CI Monitoring loop above, invoke this Bash call with `timeout: 600000` (10 min) — the default 2-min Bash timeout would kill the loop early, and the 9-iteration cap is sized to fit inside the harness's 10-min Bash maximum.
+
 ## Replying to Comments
 
 Reply in context rather than creating new top-level comments:

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -220,7 +220,7 @@ After pushing, decide based on whether a concrete follow-up is gated on the CI r
 # tend-mention's `tend-mention-handle-{PR#}` group), the sibling's handle job
 # queues behind the current one — its CheckRun shows PENDING in the rollup
 # but it can't start until the current run exits. Polling for it deadlocks
-# until the 15-min cap breaks it. For workflows
+# until the loop cap breaks it. For workflows
 # with `cancel-in-progress: true`, the older sibling is cancelled and
 # wouldn't gate polling anyway, so this filter is a no-op there.
 #
@@ -238,7 +238,7 @@ pending() {
        | select(. == "IN_PROGRESS" or . == "QUEUED" or . == "PENDING" or . == "WAITING" or . == "REQUESTED" or . == "EXPECTED")
       ] | length'
 }
-for i in $(seq 1 15); do
+for i in $(seq 1 9); do
   sleep 60
   [ "$(pending)" -gt 0 ] && continue
   sleep 30
@@ -246,11 +246,13 @@ for i in $(seq 1 15); do
   gh pr checks <number>
   exit 0
 done
-echo "CI still running after 15 minutes"
+echo "CI still running after 9 minutes"
 exit 1
 ```
 
-1. Poll every 60 seconds (up to ~15 minutes) until all non-own check-runs on the commit are terminal. **Filter out the current run's URL (`/runs/$GITHUB_RUN_ID/`)** — the current workflow's own check is always pending while polling and must be excluded to avoid a deadlock. **Also filter same-workflow check runs (`$GITHUB_WORKFLOW`)** — sibling runs of the same workflow on the same PR are subject to concurrency rules (queueing or cancel-in-progress) and don't represent independent CI signals. The 30s grace re-check catches late-registering omnibus checks.
+Invoke this Bash call with `timeout: 600000` (10 min). The default 2-min Bash timeout would kill the loop early; the 9-iteration cap is sized to fit inside the harness's 10-min Bash maximum, so a longer loop would auto-background and the gated follow-up wouldn't fire.
+
+1. Poll every 60 seconds (up to ~9 minutes) until all non-own check-runs on the commit are terminal. **Filter out the current run's URL (`/runs/$GITHUB_RUN_ID/`)** — the current workflow's own check is always pending while polling and must be excluded to avoid a deadlock. **Also filter same-workflow check runs (`$GITHUB_WORKFLOW`)** — sibling runs of the same workflow on the same PR are subject to concurrency rules (queueing or cancel-in-progress) and don't represent independent CI signals. The 30s grace re-check catches late-registering omnibus checks.
 2. If a required check fails, diagnose with `gh run view <run-id> --log-failed`, fix, commit, push, repeat.
 3. Once checks are terminal, perform the gated follow-up.
 
@@ -288,7 +290,7 @@ pending_jobs() {
   done
   echo "$n"
 }
-for i in $(seq 1 15); do
+for i in $(seq 1 9); do
   [ "$(pending_jobs)" -eq 0 ] && break
   sleep 60
 done


### PR DESCRIPTION
## Problem

The bundled `running-in-ci` skill's foreground CI-poll recipe (and the structurally-identical `gh run rerun --failed` rollup loop) iterated `for i in $(seq 1 15); do sleep 60; ...; done` — a ≥15-minute wall clock if CI didn't finish early. The Claude Code Bash tool's max configurable timeout is 600000 ms (10 min); past that the harness auto-backgrounds the call. The skill's own policy says background-completion notifications are not reliably delivered to a CI session, so the gated follow-up (dismiss approval on failure, post failure analysis) can't fire — and the bot's `sleep` workarounds get blocked by the harness's anti-polling guards, ending the session before the dismissal runs.

#694 documents six occurrences in a single 24h window on `max-sixty/worktrunk` (six of ~20 token-bearing `tend-review` runs — ~30%). All six PRs merged cleanly so the loss-of-dismissal path was not exercised, but the failure mode is structural and would fail open on a future red-CI run.

This is the same root-cause class as #674 (triage's full-suite gate exceeding the 10-min cap) but in a different code path — the gated CI dismissal path on review.

## Solution

Trim both loops from `seq 1 15` to `seq 1 9`. With 60s sleeps per iteration plus the at-most-once 30s grace re-check, the worst case sits comfortably inside the 600000 ms Bash cap so the loop runs to completion and the gated follow-up fires.

Also added a one-line note that callers must invoke Bash with `timeout: 600000` — the default 2-min Bash timeout would kill even the trimmed loop early.

Updated the inline references that cited the old 15-minute figure (`"Polling for it deadlocks until the 15-min cap breaks it"` → `"loop cap"`, `"CI still running after 15 minutes"` → `"9 minutes"`, `"up to ~15 minutes"` → `"up to ~9 minutes"`).

## Testing

Skill text fix — no automated test. Verified by reading the recipe end-to-end: 9 iterations × 60s + one 30s grace + small `gh`/`jq` overhead per iteration stays under 600s. The reporter's evidence (six session log traces showing the auto-background sequence) is the reproduction.

---
Closes #694 — automated triage
