### PR TITLE
interactive: bump pinned claude_version to 2.1.179

### DIFF
--- a/interactive/action.yaml
+++ b/interactive/action.yaml
@@ -323,7 +323,7 @@ runs:
     # must be installed in place — installing as runner and moving breaks it.
     # uv is the agent's own (its skills run `uvx tend@latest …`); the runner has
     # a separate uv for the proxy. Installers fetch over the direct network (no
-    # proxy env here). Same pinned claude version as claude-code-base-action.
+    # proxy env here).
     - name: Install agent toolchain (sandbox)
       shell: bash
       env:

--- a/interactive/action.yaml
+++ b/interactive/action.yaml
@@ -52,11 +52,11 @@ inputs:
     default: "true"
     description: Include the full Claude transcript in the workflow step summary.
   claude_version:
-    default: "2.1.150"
+    default: "2.1.179"
     description: >-
       Version of the `claude` binary to install via
-      `https://claude.ai/install.sh`. Matches the version
-      claude-code-base-action installs today.
+      `https://claude.ai/install.sh`, pinned to a specific
+      claude-code release.
   timeout_seconds:
     default: "3600"
     description: >-


### PR DESCRIPTION
The interactive harness installs the `claude` binary pinned to `claude_version`, which sat at `2.1.150`. That predates Opus 4.8 (which shipped in claude-code `2.1.154`), so the binary's `--model opus` alias resolved to Opus 4.7. A recent `tend-notifications` run on this harness confirmed it ran on `claude-opus-4-7`.

This bumps the pin to the current latest claude-code release (`2.1.179`) so `opus` resolves to 4.8, and drops the now-inaccurate "matches claude-code-base-action" note from the input description. The `running-tend` weekly task added in #696 keeps the pin current going forward.

> _This was written by Claude Code on behalf of max_
