### PR TITLE
chore: roll back to the default claude harness; demote claude-interactive

### DIFF
--- a/.config/tend.yaml
+++ b/.config/tend.yaml
@@ -1,5 +1,4 @@
 bot_name: tend-agent
-harness: claude-interactive
 
 setup:
   - uses: astral-sh/setup-uv@v6

--- a/.github/workflows/tend-ci-fix.yaml
+++ b/.github/workflows/tend-ci-fix.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@v6
 
-      - uses: max-sixty/tend/interactive@0.1.4
+      - uses: max-sixty/tend@0.1.4
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tend-mention.yaml
+++ b/.github/workflows/tend-mention.yaml
@@ -209,7 +209,7 @@ jobs:
         env:
           EVENT_TS: ${{ github.event.comment.updated_at || github.event.review.submitted_at || github.event.issue.updated_at }}
 
-      - uses: max-sixty/tend/interactive@0.1.4
+      - uses: max-sixty/tend@0.1.4
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tend-nightly.yaml
+++ b/.github/workflows/tend-nightly.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@v6
 
-      - uses: max-sixty/tend/interactive@0.1.4
+      - uses: max-sixty/tend@0.1.4
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tend-notifications.yaml
+++ b/.github/workflows/tend-notifications.yaml
@@ -99,7 +99,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@v6
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'
-      - uses: max-sixty/tend/interactive@0.1.4
+      - uses: max-sixty/tend@0.1.4
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}

--- a/.github/workflows/tend-review-runs.yaml
+++ b/.github/workflows/tend-review-runs.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@v6
 
-      - uses: max-sixty/tend/interactive@0.1.4
+      - uses: max-sixty/tend@0.1.4
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tend-review.yaml
+++ b/.github/workflows/tend-review.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@v6
 
-      - uses: max-sixty/tend/interactive@0.1.4
+      - uses: max-sixty/tend@0.1.4
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tend-triage.yaml
+++ b/.github/workflows/tend-triage.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@v6
 
-      - uses: max-sixty/tend/interactive@0.1.4
+      - uses: max-sixty/tend@0.1.4
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tend-weekly.yaml
+++ b/.github/workflows/tend-weekly.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@v6
 
-      - uses: max-sixty/tend/interactive@0.1.4
+      - uses: max-sixty/tend@0.1.4
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -61,11 +61,6 @@ file](docs/tend.example.yaml) and a repo-local `/running-tend` skill.
   - Maintainers of sizeable OSS projects [get a 20x Claude Max subscription
     for free from
     Anthropic](https://claude.com/contact-sales/claude-for-oss).
-  - From 2026-06-15, subscription-funded `claude-code-action` runs draw
-    from a separate monthly Agent SDK credit on eligible plans (Pro $20,
-    Max 5x $100, Max 20x $200, Team Standard $20, Team Premium $100,
-    Enterprise usage-based $20, Enterprise seat-based Premium $200;
-    seat-based Enterprise Standard seats are not eligible).
 - While it's built to protect important secrets, a determined attacker can
   get a) the bot's token and b) the harness auth credential (Claude OAuth
   token, OpenAI API key, or ChatGPT auth.json). They can't do that much
@@ -145,26 +140,23 @@ Full threat model: [docs/security-model.md](docs/security-model.md).
 ## Configuration
 
 `.config/tend.yaml` — only `bot_name` is required. The default harness wraps
-`claude-code-action`; `harness: codex` selects OpenAI Codex, and
-`harness: claude-interactive` runs the official `claude` CLI under a PTY
-(see [Harnesses](#harnesses) below for when each fits).
+`claude-code-action`; `harness: codex` selects OpenAI Codex (see
+[Harnesses](#harnesses) below).[^interactive]
 
 ```yaml
 bot_name: my-project-bot
 
 # Optional — defaults to "claude"
 # harness: codex
-# harness: claude-interactive
 # effort: medium   # codex only: minimal | low | medium | high
 ```
 
 Repo secrets depend on the harness:
 
-| Harness               | Required secrets                                                                                                        |
-| --------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `claude`              | `TEND_BOT_TOKEN` + one of `CLAUDE_CODE_OAUTH_TOKEN` (subscription, see caveat below) or `ANTHROPIC_API_KEY` (API-billed) |
-| `claude-interactive`  | Same as `claude`.                                                                                                       |
-| `codex`               | `TEND_BOT_TOKEN` + `OPENAI_API_KEY` (pay-per-token).                                                                    |
+| Harness    | Required secrets                                                                                                         |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `claude`   | `TEND_BOT_TOKEN` + one of `CLAUDE_CODE_OAUTH_TOKEN` (subscription) or `ANTHROPIC_API_KEY` (API-billed)                   |
+| `codex`    | `TEND_BOT_TOKEN` + `OPENAI_API_KEY` (pay-per-token).                                                                    |
 
 `TEND_BOT_TOKEN` is the bot account's PAT — see
 [example config](docs/tend.example.yaml) for scopes.
@@ -190,9 +182,9 @@ workflow names `tend-ci-fix` watches, PR title conventions, label policies.
 
 ## Harnesses
 
-Tend supports three harnesses. Pick whichever fits the credentials and
-billing path that already work for you; all three run the same workflows
-and skills.
+Tend supports two harnesses. Pick whichever fits the credentials and
+billing path that already work for you; both run the same workflows and
+skills.[^interactive]
 
 ### Claude (default)
 
@@ -202,10 +194,8 @@ Anthropic's official GitHub Action for running Claude Code in CI. Two
 auth modes:
 
 - **`CLAUDE_CODE_OAUTH_TOKEN`** (recommended with an eligible Claude
-  subscription) — Claude Code OAuth token from `claude setup-token`.
-  Funded by the subscription; from 2026-06-15 eligible-plan runs draw
-  from a separate monthly Agent SDK credit — see caveat below for the
-  per-plan breakdown and the seat-based Enterprise Standard exclusion.
+  subscription) — Claude Code OAuth token from `claude setup-token`,
+  funded by the subscription's usage limits.
 - **`ANTHROPIC_API_KEY`** — standard API key from console.anthropic.com,
   billed per token against the Console org. Pick this when there's no
   Claude subscription, when the bot should bill against a dedicated
@@ -214,34 +204,6 @@ auth modes:
 Whichever you set is used exactly as it would be in any
 claude-code-action workflow — tend adds the framework (workflows, skills,
 prompts) around it but never sees the token itself.
-
-Caveat: starting **2026-06-15**, subscription-funded `claude-code-action`
-runs draw from a separate monthly Agent SDK credit rather than the plan's
-interactive usage limits. The credit is a one-time opt-in through the
-user's Claude account and then refreshes automatically each billing
-cycle; once exhausted, runs stop unless "extra usage" is enabled (in
-which case overage bills at API rates). OAuth tokens continue to
-authenticate; billing just shifts buckets. See Anthropic's
-[authentication page](https://code.claude.com/docs/en/authentication)
-and the
-[Agent SDK plan article](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan)
-for the canonical statements.
-
-### Claude (interactive)
-
-Runs the official `claude` CLI inside a PTY (via `script(1)`) instead of
-through `claude-code-action`. End-of-turn detection comes from a `Stop`
-hook that writes a sentinel file the supervisor polls for.
-
-Auth matches the default Claude harness (`CLAUDE_CODE_OAUTH_TOKEN` or
-`ANTHROPIC_API_KEY`).
-
-From 2026-06-15, subscription-funded `claude-code-action` runs draw from
-the separate metered Agent SDK credit pool described in the caveat above;
-the interactive `claude` CLI continues to draw from the flat Pro/Max
-subscription.
-
-Opt-in: `harness: claude-interactive`.
 
 ### Codex (alternative)
 
@@ -273,3 +235,9 @@ The install-tend skill offers to add this automatically during setup.
 ## License
 
 MIT
+
+[^interactive]:
+    A third harness, `claude-interactive`, runs the official `claude` CLI
+    under a PTY supervisor (`script(1)` with a `Stop`-hook sentinel) instead
+    of `claude-code-action`. Auth matches the default Claude harness. Opt in
+    with `harness: claude-interactive`.

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Wraps
 Anthropic's official GitHub Action for running Claude Code in CI. Two
 auth modes:
 
-- **`CLAUDE_CODE_OAUTH_TOKEN`** (recommended with an eligible Claude
+- **`CLAUDE_CODE_OAUTH_TOKEN`** (recommended with a Claude
   subscription) — Claude Code OAuth token from `claude setup-token`,
   funded by the subscription's usage limits.
 - **`ANTHROPIC_API_KEY`** — standard API key from console.anthropic.com,

--- a/README.md
+++ b/README.md
@@ -236,8 +236,7 @@ The install-tend skill offers to add this automatically during setup.
 
 MIT
 
-[^interactive]:
-    A third harness, `claude-interactive`, runs the official `claude` CLI
-    under a PTY supervisor (`script(1)` with a `Stop`-hook sentinel) instead
-    of `claude-code-action`. Auth matches the default Claude harness. Opt in
-    with `harness: claude-interactive`.
+[^interactive]: A third harness, `claude-interactive`, runs the official
+    `claude` CLI under a PTY supervisor (`script(1)` with a `Stop`-hook
+    sentinel) instead of `claude-code-action`. Auth matches the default
+    Claude harness. Opt in with `harness: claude-interactive`.

--- a/docs/tend.example.yaml
+++ b/docs/tend.example.yaml
@@ -14,21 +14,18 @@ bot_name: my-project-bot
 # ## Harness
 #
 # Which agent runtime to use. Defaults to "claude" (wraps
-# anthropics/claude-code-action). Alternatives: "codex" runs OpenAI
-# Codex via `codex exec`; "claude-interactive" runs the official `claude`
-# CLI under a PTY (opt-in, see README "Harnesses" for the billing-path
-# motivation).
+# anthropics/claude-code-action). "codex" runs OpenAI Codex via
+# `codex exec`. (A third harness, "claude-interactive", runs the official
+# `claude` CLI under a PTY; see README "Harnesses".)
 #
 # harness: codex
-# harness: claude-interactive
 
 # ## Model
 #
 # Model to use for all workflows. Valid values depend on the harness:
 #
-# - harness: claude              — opus (default), sonnet, haiku
-# - harness: claude-interactive  — opus (default), sonnet, haiku
-# - harness: codex               — gpt-5.5 (default); any string Codex CLI accepts
+# - harness: claude  — opus (default), sonnet, haiku
+# - harness: codex   — gpt-5.5 (default); any string Codex CLI accepts
 #
 # model: opus
 
@@ -52,11 +49,10 @@ bot_name: my-project-bot
 #
 # Repo secrets, by harness:
 #
-# | Harness               | Required                                                                  |
-# |-----------------------|---------------------------------------------------------------------------|
-# | `claude`              | `TEND_BOT_TOKEN` + one of `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` |
-# | `claude-interactive`  | Same as `claude`.                                                          |
-# | `codex`               | `TEND_BOT_TOKEN` + `OPENAI_API_KEY`                                        |
+# | Harness    | Required                                                                  |
+# |------------|---------------------------------------------------------------------------|
+# | `claude`   | `TEND_BOT_TOKEN` + one of `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` |
+# | `codex`    | `TEND_BOT_TOKEN` + `OPENAI_API_KEY`                                        |
 #
 # `TEND_BOT_TOKEN` is the bot account's PAT (scopes below).
 # `CLAUDE_CODE_OAUTH_TOKEN` is from `claude setup-token` (PKCE).
@@ -86,8 +82,8 @@ bot_name: my-project-bot
 #
 # secrets:
 #   bot_token: MY_BOT_PAT
-#   claude_token: MY_CLAUDE_TOKEN        # claude / claude-interactive (OAuth)
-#   anthropic_api_key: MY_ANTHROPIC_KEY  # claude / claude-interactive (API key)
+#   claude_token: MY_CLAUDE_TOKEN        # claude (OAuth)
+#   anthropic_api_key: MY_ANTHROPIC_KEY  # claude (API key)
 #   openai_key: MY_OPENAI_KEY            # codex
 #
 # `tend check` flags repo-level secrets not in an explicit allowlist. Repos with

--- a/interactive/action.yaml
+++ b/interactive/action.yaml
@@ -4,9 +4,7 @@ description: >-
   inside a PTY (via `script(1)`) instead of going through
   `claude-code-action` / `@anthropic-ai/claude-agent-sdk`. A Stop hook
   writes a sentinel file the supervisor watches for; on fire, the session
-  is terminated cleanly. Motivation: Anthropic's June 15 2026 billing
-  split puts the Agent SDK on a metered Agent-SDK credit pool, while
-  interactive Claude Code stays on the flat Pro/Max subscription. Inputs
+  is terminated cleanly. Inputs
   overlap with `action.yaml`'s for the common ones (auth, prompt, model,
   bot_name, allowed_tools, system_prompt_append, show_full_output); inputs
   that only existed for the Agent-SDK harness (`use_sticky_comment`,

--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -27,16 +27,10 @@ Before running step 1, choose the harness and lay out the plan:
 
 - Ask via `AskUserQuestion` which harness to use:
   - **Claude (Anthropic)** — uses a Claude Code OAuth token (recommended
-    for adopters with an eligible Claude subscription) or a
-    console.anthropic.com API key. Starting 2026-06-15, eligible-plan
-    `claude-code-action` runs draw from a separate monthly Agent SDK
-    credit (one-time opt-in then auto-refresh); using OAuth puts that
-    bundled allowance to work. Enable "extra usage" in the Console so
-    credit exhaustion overflows to API rates instead of hard-stopping
-    CI. API key is the alternative when the user is on an ineligible
-    plan (e.g. seat-based Enterprise Standard), has no subscription to
-    draw on, or wants a dedicated billing surface and per-key
-    revocation.
+    for adopters with a Claude subscription) or a console.anthropic.com
+    API key. OAuth draws from the subscription's usage limits; the API
+    key bills per token, which fits when the user has no subscription to
+    draw on or wants a dedicated billing surface and per-key revocation.
   - **Codex (OpenAI)** — uses an OpenAI API key (pay-per-token). The
     `auth.json` subscription path is incompatible with tend's
     concurrent workflows (per-call refresh-token invalidation) and is
@@ -78,18 +72,14 @@ as the bot, verify the logged-in user via the avatar menu.
 ## 1. Create config
 
 Create `.config/tend.yaml` with at minimum `bot_name`, plus `harness` if
-the user chose Codex or the interactive Claude harness (the default
-Claude harness via `claude-code-action` can be omitted). See README.md
-"Harnesses" for the comparison.
+the user chose Codex (the default Claude harness via `claude-code-action`
+can be omitted). See README.md "Harnesses" for the comparison.
 
 ```yaml
 bot_name: <bot-name>
 # For Codex, also:
 # harness: codex
 # effort: medium   # optional: minimal | low | medium | high
-# For the interactive Claude harness (PTY-supervised `claude` CLI;
-# opt-in, see README "Harnesses"):
-# harness: claude-interactive
 ```
 
 Check whether the repo already has a bot token secret under a non-default name:
@@ -479,14 +469,9 @@ gh secret list --repo "$REPO" --json name --jq '.[].name' \
 
 If not set, ask via `AskUserQuestion` which auth mode to use:
 
-- **OAuth token (recommended for eligible Claude subscribers)** —
-  `sk-ant-oat01-…` from `claude setup-token`. Funded by eligible
-  subscriptions; from 2026-06-15 these runs draw from a separate monthly
-  Agent SDK credit. Have the user opt in to the credit through
-  their Claude account once (Anthropic emails instructions; it
-  auto-refreshes each cycle after that), and enable "extra usage" in the
-  Console if they want credit exhaustion to overflow to API rates
-  instead of stopping CI. Token is advertised as 1-year.
+- **OAuth token (recommended for Claude subscribers)** —
+  `sk-ant-oat01-…` from `claude setup-token`. Draws from the
+  subscription's usage limits. Token is advertised as 1-year.
 - **API key** — `sk-ant-…` from
   `https://console.anthropic.com/settings/keys`. Billed per token against
   the Console org. Pick this when there's no Claude subscription, when

--- a/plugins/install-tend/skills/install-tend/references/tend.example.yaml
+++ b/plugins/install-tend/skills/install-tend/references/tend.example.yaml
@@ -14,21 +14,18 @@ bot_name: my-project-bot
 # ## Harness
 #
 # Which agent runtime to use. Defaults to "claude" (wraps
-# anthropics/claude-code-action). Alternatives: "codex" runs OpenAI
-# Codex via `codex exec`; "claude-interactive" runs the official `claude`
-# CLI under a PTY (opt-in, see README "Harnesses" for the billing-path
-# motivation).
+# anthropics/claude-code-action). "codex" runs OpenAI Codex via
+# `codex exec`. (A third harness, "claude-interactive", runs the official
+# `claude` CLI under a PTY; see README "Harnesses".)
 #
 # harness: codex
-# harness: claude-interactive
 
 # ## Model
 #
 # Model to use for all workflows. Valid values depend on the harness:
 #
-# - harness: claude              — opus (default), sonnet, haiku
-# - harness: claude-interactive  — opus (default), sonnet, haiku
-# - harness: codex               — gpt-5.5 (default); any string Codex CLI accepts
+# - harness: claude  — opus (default), sonnet, haiku
+# - harness: codex   — gpt-5.5 (default); any string Codex CLI accepts
 #
 # model: opus
 
@@ -52,11 +49,10 @@ bot_name: my-project-bot
 #
 # Repo secrets, by harness:
 #
-# | Harness               | Required                                                                  |
-# |-----------------------|---------------------------------------------------------------------------|
-# | `claude`              | `TEND_BOT_TOKEN` + one of `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` |
-# | `claude-interactive`  | Same as `claude`.                                                          |
-# | `codex`               | `TEND_BOT_TOKEN` + `OPENAI_API_KEY`                                        |
+# | Harness    | Required                                                                  |
+# |------------|---------------------------------------------------------------------------|
+# | `claude`   | `TEND_BOT_TOKEN` + one of `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` |
+# | `codex`    | `TEND_BOT_TOKEN` + `OPENAI_API_KEY`                                        |
 #
 # `TEND_BOT_TOKEN` is the bot account's PAT (scopes below).
 # `CLAUDE_CODE_OAUTH_TOKEN` is from `claude setup-token` (PKCE).
@@ -86,8 +82,8 @@ bot_name: my-project-bot
 #
 # secrets:
 #   bot_token: MY_BOT_PAT
-#   claude_token: MY_CLAUDE_TOKEN        # claude / claude-interactive (OAuth)
-#   anthropic_api_key: MY_ANTHROPIC_KEY  # claude / claude-interactive (API key)
+#   claude_token: MY_CLAUDE_TOKEN        # claude (OAuth)
+#   anthropic_api_key: MY_ANTHROPIC_KEY  # claude (API key)
 #   openai_key: MY_OPENAI_KEY            # codex
 #
 # `tend check` flags repo-level secrets not in an explicit allowlist. Repos with


### PR DESCRIPTION
Anthropic [paused](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan) the 2026-06-15 Agent SDK credit metering (the `-p` billing change), so subscription `claude-code-action` runs again draw from the plan's usage limits. That removes the billing motivation for the `claude-interactive` harness.

This reverts tend's own dogfooding to the default `claude` harness, demotes `claude-interactive` to a footnote in the docs, and scrubs the now-stale billing caveat.

## Changes

- `.config/tend.yaml`: drop `harness: claude-interactive` (the default is `claude`).
- Regenerate `tend-*.yaml` via `uvx tend@latest init`: the action ref goes from `max-sixty/tend/interactive@0.1.4` to `max-sixty/tend@0.1.4` across all eight workflows.
- README, `docs/tend.example.yaml` (and its synced install-tend mirror), and the install-tend skill: `claude-interactive` is now a single `[^interactive]` footnote; the secrets table and harness list show `claude` + `codex` only.
- README and install-tend skill: remove the metered Agent SDK credit caveat, which Anthropic's help center now lists as paused.

The `claude-interactive` harness still ships and works; it is just no longer the recommended path. The composite action, generator support, and session-log handling are untouched.

> _This was written by Claude Code on behalf of max_
