### PR TITLE
skills: a pushed fix waits for and owns its CI

### DIFF
--- a/plugins/tend-ci-runner/skills/ci-fix/SKILL.md
+++ b/plugins/tend-ci-runner/skills/ci-fix/SKILL.md
@@ -157,4 +157,4 @@ Skip step 4 — there's no PR to monitor.
 
 ### 4. Monitor CI
 
-Poll CI using the approach from `running-in-ci` (loaded in step 0). If CI fails, diagnose with `gh run view <run-id> --log-failed`, fix, commit, push, and repeat.
+Wait for CI and own the result, per **CI Monitoring** in `running-in-ci` (loaded in step 0). The fix PR isn't done until the required checks on its commit are terminal: foreground-poll, and on a red required check diagnose with `gh run view <run-id> --log-failed`, fix, push, and repeat. End only once they pass or you've commented the failure on the PR. Don't open the PR and exit while CI is still in flight.

--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -114,7 +114,7 @@ For each conflicted PR authored by `$BOT_LOGIN`, dispatch a subagent to:
 1. Check out the PR: `gh pr checkout <number>`
 2. Merge the default branch: `git merge origin/main`
 3. Resolve conflicts (read files, understand both sides), `git add`, `git commit --no-edit`
-4. Push and poll CI using the approach from `/tend-ci-runner:running-in-ci`
+4. Push, then wait for CI and own the result per **CI Monitoring** in `/tend-ci-runner:running-in-ci`: foreground-poll until the required checks are terminal, fix any red one and push again, and don't exit while CI is still in flight
 5. If conflicts are too complex, `git merge --abort` and comment explaining manual resolution is needed
 
 Run subagents in parallel. Each must work in isolation (`git worktree add /tmp/pr-<number>

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -86,7 +86,7 @@ The session is live until the deliverable is **maintainer-visible**: pushed, pos
 
 Corollary: don't background anything whose output gates the deliverable. If a full test suite or comprehensive lint needs to run before push, run it synchronously and accept the time cost; if it's too slow for the session budget, push first and let CI re-run it. A session that shipped a partial result is recoverable; a session that ended mid-wait with the deliverable on a local branch is not. A targeted compile plus the tests directly exercising the change is enough local confidence to ship — leave the comprehensive matrix to CI.
 
-After push, match the polling shape to whether a follow-up is gated on the CI result — see **CI Monitoring**. When nothing is gated, end the session; the deliverable is shipped and the harness can't deliver a background-poll notification reliably enough to keep an "I'll report the result" promise. When a follow-up *is* gated (fix-on-failure, dismiss your own approval), foreground-poll synchronously so the wait and the follow-up share the same session.
+After a push, whether to wait is set by whether a red CI result would create a follow-up for this session — see **CI Monitoring**. A pushed fix always creates one (fix-on-failure), so foreground-poll until the required checks on its commit are terminal, fix any red result, and end only once they pass or you've reported why they don't. When nothing this session did depends on the CI result, end once the visible work is posted. Either way, don't background the wait — a background-poll completion notification isn't reliably delivered to a CI session, so the wait and any fix must share this session.
 
 ## Filing Issues in Other Repos
 
@@ -180,11 +180,11 @@ When asked to merge the default branch into a PR branch:
 
 ## CI Monitoring
 
-After pushing, decide based on whether a concrete follow-up is gated on the CI result.
+After pushing, decide based on whether a red CI result would create a follow-up for this session.
 
-**Nothing is gated on the result** — the common case after a nightly pushes a PR or a self-authored PR is reviewed silently: state CI is in flight in your final message and **end the session**. Don't foreground-wait, and don't start a background poll — its completion notification isn't reliably delivered to a CI session, so any "I'll report the result" promise won't fire. The deliverable is already shipped; the worst case is a missed follow-up, not lost work.
+**A follow-up is gated on the result** — poll **synchronously in the foreground** (don't use `run_in_background`) until the required checks on the commit are terminal, then do it. A pushed fix is always in this case: a triage fix, a CI fix, or a code change a reviewer asked for owns its CI, because a failing required check is a fix-on-failure follow-up. Diagnose, fix, push, and repeat; if you genuinely can't fix it, comment the failure on the PR so the maintainer sees it instead of a silent red. Approving a PR is also gated — a later red result means dismissing your own approval. Don't pre-judge a fresh push as ungated: the red result *is* the follow-up, and no other tend run fixes a PR branch's CI for you (`tend-ci-fix` watches only the default branch).
 
-**A follow-up is gated on the result** — fix-on-failure, dismiss your own approval, post failure analysis: poll **synchronously in the foreground** (don't use `run_in_background`) and accept the time cost. The follow-up has to run in the same session as the wait.
+**Nothing is gated** — a review that only commented, a mention you answered without changes, a no-op: nothing this session did depends on the CI result. State anything still in flight in your final message and **end the session**. Don't start a background poll — its completion notification isn't reliably delivered to a CI session, so any "I'll report the result" promise won't fire.
 
 ```bash
 # Foreground poll — invoke Bash without run_in_background.
@@ -252,7 +252,8 @@ exit 1
 
 1. Poll every 60 seconds (up to ~15 minutes) until all non-own check-runs on the commit are terminal. **Filter out the current run's URL (`/runs/$GITHUB_RUN_ID/`)** — the current workflow's own check is always pending while polling and must be excluded to avoid a deadlock. **Also filter same-workflow check runs (`$GITHUB_WORKFLOW`)** — sibling runs of the same workflow on the same PR are subject to concurrency rules (queueing or cancel-in-progress) and don't represent independent CI signals. The 30s grace re-check catches late-registering omnibus checks.
 2. If a required check fails, diagnose with `gh run view <run-id> --log-failed`, fix, commit, push, repeat.
-3. Once checks are terminal, perform the gated follow-up.
+3. Once the required checks are terminal, perform the gated follow-up: finish a green fix, comment an unresolved failure on the PR, or dismiss your approval on red.
+4. If the poll hits its cap with required checks still running, don't treat that as done — that just relocates an unwatched red to after you've left. Comment on the PR naming the still-pending checks and that the result is unverified, so a later failure lands where the maintainer sees it, then end.
 
 Before dismissing local test failures as "pre-existing", check main branch CI:
 
@@ -678,7 +679,7 @@ When the correction identifies a gap or bug in a **bundled** skill — the same 
    git worktree remove "/tmp/skill-fix" --force
    ```
 4. **Open as a separate PR.** Follow the repo's PR title conventions (conventional commits, Jira prefix, or whatever the repo uses — check recent merged PRs or `CONTRIBUTING.md`). The body quotes the triggering feedback and links the thread (PR/issue/comment URL).
-5. **Open and exit — don't merge, don't wait.** The PR itself is the review request; a maintainer lands it (or doesn't) in their own time. Don't post a separate comment pinging for review, and don't block the session waiting.
+5. **Open and exit — don't merge, don't wait.** The PR itself is the review request; a maintainer lands it (or doesn't) in their own time. Don't post a separate comment pinging for review, and don't block the session waiting. This open-and-exit is specific to skill proposals, where a human is the gate; a code fix owns its CI and follows **CI Monitoring** instead.
 
 ## Tone
 

--- a/plugins/tend-ci-runner/skills/triage/SKILL.md
+++ b/plugins/tend-ci-runner/skills/triage/SKILL.md
@@ -128,7 +128,7 @@ Step 3's duplicate check catches identical fixes. It misses the *same root cause
    ---
    Closes #<issue-number> — automated triage"
    ```
-4. Monitor CI using the approach from /tend-ci-runner:running-in-ci.
+4. Wait for CI and own the result, per **CI Monitoring** in `/tend-ci-runner:running-in-ci`. A pushed fix isn't done until the required checks on its commit are terminal: foreground-poll, fix any red required check and push again, and end only once they pass or you've commented on the PR why they don't. Don't open the PR and exit while CI is still in flight.
 
 ### If reproduction test works but fix is not confident
 


### PR DESCRIPTION
## Problem

A tend run that pushed a fix could classify itself as "nothing gated on the CI result" and end before CI even ran, leaving a red required check that no other run picks up (`tend-ci-fix` watches only the default branch). The guidance had crystallized an "if nothing is gated, end the session" decision, and a freshly-pushed fix read as ungated.

## Change

A pushed fix is always a gated follow-up. The run foreground-polls until the required checks on its commit are terminal, fixes red or comments the failure, then ends. Hitting the poll cap with checks still running now forces an "unverified" comment instead of a silent exit, so the signal lands where a maintainer sees it. Approving a PR stays gated (dismiss on red).

`CI Monitoring` in `running-in-ci` is the single source of truth: `triage`, `ci-fix`, and `nightly` reference it rather than restating the poll/fix/comment mechanics. The skill-PR "open and exit" path is scoped so it can't cover fix PRs.

> _This was written by Claude Code on behalf of max_
