### PR TITLE
chore(review-reviewers): bump action pin to interactive@0.1.5

### DIFF
--- a/.github/workflows/review-reviewers.yaml
+++ b/.github/workflows/review-reviewers.yaml
@@ -68,7 +68,7 @@ jobs:
           fetch-tags: true
           token: ${{ secrets.TEND_BOT_TOKEN }}
 
-      - uses: max-sixty/tend/interactive@0.1.4
+      - uses: max-sixty/tend/interactive@0.1.5
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
review-reviewers is hand-maintained (not produced by `init`), so the 0.1.5 regen in #701 left it on `interactive@0.1.4`. That pin's claude binary (`claude_version` 2.1.150) predates Opus 4.8, so it resolved `--model opus` to 4.7 — the same drift that prompted this whole pass. Bumping to `@0.1.5` (claude_version 2.1.179) moves it to Opus 4.8 while keeping the interactive harness.

> _This was written by Claude Code on behalf of max_