### PR TITLE
skills: replace duplicated guidance with running-in-ci references

### DIFF
--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -212,12 +212,7 @@ Improvements target **repo-local** files by default:
 
 **Prefer PRs over issues.** A PR with a clear description is immediately actionable.
 
-The checkout's `.claude/` directory is bind-mounted read-only under the sandbox (protecting bots from modifying their own skills in place), so edits to `.claude/skills/` files fail with `OSError: [Errno 30] Read-only file system`. Do the edit, commit, and push from a git worktree under `/tmp`, which is writable. (Don't write `$TMPDIR/...` — GitHub Actions runners leave `$TMPDIR` unset, so the path expands to `/review-runs-fix`, which the runner user can't create.)
-
-Claude Code's harness adds a second restriction on top of the read-only mount: `Edit`, `Write`, and Bash commands with `.claude/skills/` as a write-target argument are denied regardless of filesystem permissions ([anthropics/claude-code#37157](https://github.com/anthropics/claude-code/issues/37157)). The guard checks argument text, so `Write(/tmp/…)` and `Bash(mv /tmp/… SKILL.md)` both pass — the second because `SKILL.md` is a bare filename inside the `cd`'d directory.
-
-<!-- TODO(anthropics/claude-code#37157): once the harness exempts .claude/skills/
-     as documented, replace the /tmp-then-mv dance below with direct `Write` to the worktree path. -->
+Editing `.claude/skills/` requires the read-only-mount workaround (bind-mounted read-only, plus a harness write-guard on `.claude/skills/` paths) — see **Learning from Feedback** in `/tend-ci-runner:running-in-ci`. Adapted for review-runs (base on `HEAD` since this runs on a schedule, not a PR checkout; move each edited file into place):
 
 
 ```bash

--- a/plugins/tend-ci-runner/skills/triage/SKILL.md
+++ b/plugins/tend-ci-runner/skills/triage/SKILL.md
@@ -152,13 +152,7 @@ Note the PR number for the comment.
 
 ## Step 7: Comment on the issue
 
-**Recheck before posting.** Triage can take several minutes. Before posting, re-fetch the conversation to check for new comments:
-
-```bash
-gh issue view $ARGUMENTS --json comments --jq '.comments | length'
-```
-
-If new comments appeared since you first read the issue, read them and adjust your response — someone may have answered, provided more context, or closed the issue. If your comment is now redundant, skip it.
+**Recheck before posting** per **Recheck Before Posting** in `/tend-ci-runner:running-in-ci` — triage can take minutes, so re-fetch the issue and skip any point a new human comment or a sibling tend workflow already covered.
 
 Always comment via `gh issue comment`. Keep it brief, polite, and specific. A maintainer will always review — never claim the issue is fully resolved by automation alone.
 


### PR DESCRIPTION
Follow-up to #700. A duplication audit across the bundled skills found two cases where guidance owned by `running-in-ci` was restated elsewhere rather than referenced. Both are replaced with pointers to the canonical sections.

- **`triage` step 7** — "Recheck before posting" restated the recheck guidance but only covered the "new human comment arrived" path, silently omitting the sibling-workflow dedup path that `Recheck Before Posting` in `running-in-ci` emphasizes. The reference both dedups and closes that gap.
- **`review-runs`** — the read-only-mount workaround was two word-for-word-identical paragraphs (bind-mount explanation + harness write-guard + the same TODO) copied from `Learning from Feedback` in `running-in-ci`. Now a one-line reference, keeping only review-runs' task-specific worktree commands (it bases on `HEAD`, not `origin/<default>`).

Three other candidates the audit flagged were left as-is: `ci-fix` step 1 (genuinely failure-shape-specific), `notifications` author-association (already pulls in shared `@author-association.md`), and the CI-polling / line-link / self-authored-PR references (already correct).

> _This was written by Claude Code on behalf of max_
