### PR TITLE
docs: correct codex effort value list

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ bot_name: my-project-bot
 
 # Optional — defaults to "claude"
 # harness: codex
-# effort: medium   # codex only: minimal | low | medium | high
+# effort: medium   # codex only: low | medium | high | xhigh
 ```
 
 Repo secrets depend on the harness:

--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -79,7 +79,7 @@ README.md "Harnesses" for the comparison.
 bot_name: <bot-name>
 # For Codex, also:
 # harness: codex
-# effort: medium   # optional: minimal | low | medium | high
+# effort: medium   # optional: low | medium | high | xhigh
 ```
 
 Check whether the repo already has a bot token secret under a non-default name:


### PR DESCRIPTION
Nightly survey finding: two docs advertise an invalid `effort` value list.

`README.md` and the `install-tend` skill both document the Codex `effort` option as `minimal | low | medium | high`. That's wrong on both ends:

- `minimal` is **not** an accepted value. The generator validates `effort` against `KNOWN_EFFORTS = {"", "low", "medium", "high", "xhigh"}` ([`config.py`](https://github.com/max-sixty/tend/blob/main/generator/src/tend/config.py)), so `effort: minimal` fails config load with `effort 'minimal' is not recognized`.
- `xhigh` is valid but was omitted.

This aligns the two stragglers with `KNOWN_EFFORTS` — and with the two `tend.example.yaml` copies (`docs/` and the install-tend references), which already document `low, medium, high, xhigh` correctly.

Pure documentation change — no regression test (the value list is a comment, not executed code). The source of truth, `KNOWN_EFFORTS`, is already exercised by the config-validation tests.
