### PR TITLE
docs: correct worker-deploy stream count comment

### DIFF
--- a/.github/workflows/worker-deploy.yaml
+++ b/.github/workflows/worker-deploy.yaml
@@ -1,8 +1,9 @@
 name: worker-deploy
 
 # Deploys the tend-website Cloudflare Worker on push to main that touches
-# worker/** or this workflow. The Worker serves all three live data streams
-# the site renders. One-time account setup (KV namespace, GITHUB_TOKEN
+# worker/** or this workflow. The Worker serves the two live data streams
+# the site renders (/currently-tending and /activity). One-time account
+# setup (KV namespace, GITHUB_TOKEN
 # Worker secret, CLOUDFLARE_API_TOKEN in the cloudflare-deploy environment,
 # custom domain) is documented in worker/README.md and is already done for
 # max-sixty/tend.


### PR DESCRIPTION
Nightly survey finding: a stale comment in the worker-deploy workflow.

The header comment said the Worker "serves all **three** live data streams the site renders." The Worker serves **two** routes — `/currently-tending` and `/activity` ([`worker/src/index.ts`](https://github.com/max-sixty/tend/blob/main/worker/src/index.ts): "Two routes, both CORS-enabled JSON"), and `CLAUDE.md` agrees ("serves the 2 site data streams"). The site renders three *sections* (stat strip, activity feed, currently-tending dot), but the stat strip and activity feed both come from `/activity` — so "three streams" conflated sections with routes.

Corrected to "two live data streams" and named them inline so the count is self-evidencing.

Pure comment change — no code path affected, no regression test applicable.
