### PR TITLE
skills(nightly): skip action-ref downgrade regen PRs

### DIFF
--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -231,8 +231,10 @@ NON_STAMP_DIFF=$(git diff --no-color .github/workflows .config \
   | wc -l)
 ```
 
-If `git status` shows no changes, or `NON_STAMP_DIFF` is `0`, clean up
-and skip the PR:
+**Action-ref downgrade skip.** Dependabot may bump an action ref inside the committed `tend-*.yaml` files (e.g. `actions/checkout@v6` → `@v7`) between tend releases, leaving them ahead of what the generator emits. Regen then produces a diff that *downgrades* the ref back to tend's pin, and `NON_STAMP_DIFF` counts it as substantive. If the only non-stamp diff is such downgrades — the regenerated (`+`) ref is older than the committed (`-`) ref — skip the PR: it would revert a maintainer-merged dependency bump, and tend catches up to the newer ref in a later release. Direction matters: a diff where the regenerated ref is *newer* than committed is a real upgrade tend is shipping — open the PR normally.
+
+If `git status` shows no changes, or `NON_STAMP_DIFF` is `0` (or the only
+remaining diff is action-ref downgrades, per above), clean up and skip the PR:
 
 ```bash
 cd -


### PR DESCRIPTION
## Problem

When Dependabot bumps an action ref inside a consumer's committed `tend-*.yaml` files (e.g. `actions/checkout@v6` → `@v7`) between tend releases, the committed workflows run *ahead* of what tend's generator emits. The nightly "Update tend workflows" step then regenerates the files, producing a diff that **downgrades** the ref back to tend's pin — reverting the maintainer-merged Dependabot bump.

The `NON_STAMP_DIFF` guard added in #689 only strips the `# Generated by tend X.Y.Z` header, so these action-ref downgrades count as substantive diff and the skill would open a revert PR — recurring nightly until tend's generator catches up.

## Solution

Extend the stamp-only skip in `plugins/tend-ci-runner/skills/nightly/SKILL.md` with a direction-aware rule: when the only non-stamp diff is action-ref *downgrades* (the regenerated `+` ref is older than the committed `-` ref), skip the PR — it would revert a maintainer-merged bump, and tend catches up to the newer ref in a later release. Direction is the discriminator: a diff where the regenerated ref is *newer* than committed is a real upgrade tend is shipping, and still opens a PR normally.

This is prose guidance rather than a version-comparison bash extension by design: the agent already drives this judgment (the run that filed #714 reasoned its way to skipping the PR), and a brittle downgrade-detector would have to special-case direction to avoid suppressing legitimate upgrades. Codifying the rule makes the existing reasoning reliable without embedding fragile bash.

## Testing

Skill-text change — no code path. Verified the guidance isn't duplicated in the co-loaded nightly skill (the existing `NON_STAMP_DIFF` block covers stamp-only, not action-ref direction) and that the placement reads naturally alongside the stamp-only skip it extends.

---
Closes #714 — automated triage
