### PR TITLE
fix(running-in-ci): surface scope blockers instead of silently routing around them

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -119,7 +119,7 @@ Surface the blocker on the triggering thread and offer the maintainer both:
 1. **Take the upstream action on approval** — file a fresh issue, or note evidence on the existing thread.
 2. **Relax the rule going forward** — via the consuming repo's `running-tend` overlay.
 
-Record their choice per **Learning from Feedback** below. Applies to any negotiable, blocking restriction, not just scope.
+Record their choice per **Learning from Feedback** below.
 
 ## PR Creation
 

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -75,7 +75,7 @@ If a linked PR merged (or the triggering PR itself merged) **after the triggerin
 
 - **Secrets**: Never run commands that introspect the process env (`env`, `printenv`, `set`, `export`) or `cat`/`echo` credential files. The rule is absolute — name-stripping filters like `env | cut -d= -f1` do not make these commands safe: the harness may place credential-bearing values in the environment (the Codex harness passes the PAT and model auth directly to the agent), and a single unfiltered `env` or `printenv FOO` prints the value verbatim into the session log, which is uploaded as an artifact. Never include tokens or credentials in responses or comments.
 - **Merging**: Never merge PRs or enable auto-merge (`gh pr merge`, `gh pr merge --auto`). PRs are proposals — a maintainer decides when to merge.
-- **Scope**: PRs, pushes, and comments on existing threads in other repos are off-limits. Filing fresh issues in other repos follows **Filing Issues in Other Repos** below. When such a rule is the only thing standing between you and the correct action, don't quietly route around it — surface it per **When a scope rule blocks the right action** below.
+- **Scope**: PRs, pushes, and comments on existing threads in other repos are off-limits. Filing fresh issues in other repos follows **Filing Issues in Other Repos** below. When such a rule blocks the right action, surface it per **When a scope rule blocks the right action** below rather than routing around it.
 - **Hanging commands**: Never use `gh run watch` or `gh pr checks --watch` — both hang indefinitely. Poll with `gh pr checks` in a loop instead.
 
 ## End the turn only when work is shipped
@@ -112,14 +112,14 @@ Whether filed direct or post-approval, the issue body includes:
 
 ### When a scope rule blocks the right action
 
-Sometimes a **Scope** restriction is itself the only thing between you and the correct move — e.g. the relevant upstream artifact already exists and the right step is to add evidence to that existing thread, which the scope rule bars. When a restriction is the blocker, do **not** silently substitute a second-best workaround (a consuming-repo override, a narrower local patch) and report success. That hides the wall: the session ships *a* deliverable, reports `success`, and never signals it routed around a restriction — a maintainer only catches it by reading the rationale.
+When a **Scope** restriction is the only thing between you and the correct move (e.g. the right step is to add evidence to an existing upstream thread, which the rule bars), don't silently substitute a workaround and report success — that hides the wall.
 
-Instead, surface the blocker on the triggering thread and ask the maintainer, offering both:
+Surface the blocker on the triggering thread and offer the maintainer both:
 
-1. **Take the upstream action on approval** — file a fresh issue (per the rule above), or, where the upstream artifact already exists, note the evidence on that existing thread.
-2. **Relax the rule going forward** — adjust the consuming repo's `running-tend` overlay to permit the action in future.
+1. **Take the upstream action on approval** — file a fresh issue, or note evidence on the existing thread.
+2. **Relax the rule going forward** — via the consuming repo's `running-tend` overlay.
 
-Record whichever they choose per **Learning from Feedback** below. This applies to any restriction that turns out to be negotiable and blocking, not just the other-repo scope rule.
+Record their choice per **Learning from Feedback** below. Applies to any negotiable, blocking restriction, not just scope.
 
 ## PR Creation
 

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -75,7 +75,7 @@ If a linked PR merged (or the triggering PR itself merged) **after the triggerin
 
 - **Secrets**: Never run commands that introspect the process env (`env`, `printenv`, `set`, `export`) or `cat`/`echo` credential files. The rule is absolute — name-stripping filters like `env | cut -d= -f1` do not make these commands safe: the harness may place credential-bearing values in the environment (the Codex harness passes the PAT and model auth directly to the agent), and a single unfiltered `env` or `printenv FOO` prints the value verbatim into the session log, which is uploaded as an artifact. Never include tokens or credentials in responses or comments.
 - **Merging**: Never merge PRs or enable auto-merge (`gh pr merge`, `gh pr merge --auto`). PRs are proposals — a maintainer decides when to merge.
-- **Scope**: PRs, pushes, and comments on existing threads in other repos are off-limits. Filing fresh issues in other repos follows **Filing Issues in Other Repos** below.
+- **Scope**: PRs, pushes, and comments on existing threads in other repos are off-limits. Filing fresh issues in other repos follows **Filing Issues in Other Repos** below. When such a rule is the only thing standing between you and the correct action, don't quietly route around it — surface it per **When a scope rule blocks the right action** below.
 - **Hanging commands**: Never use `gh run watch` or `gh pr checks --watch` — both hang indefinitely. Poll with `gh pr checks` in a loop instead.
 
 ## End the turn only when work is shipped
@@ -109,6 +109,17 @@ Whether filed direct or post-approval, the issue body includes:
 - Problem statement: what fires, where, under what conditions.
 - Evidence: run links; cost/duration if relevant.
 - Proposed fix with code snippets a maintainer would otherwise re-derive.
+
+### When a scope rule blocks the right action
+
+Sometimes a **Scope** restriction is itself the only thing between you and the correct move — e.g. the relevant upstream artifact already exists and the right step is to add evidence to that existing thread, which the scope rule bars. When a restriction is the blocker, do **not** silently substitute a second-best workaround (a consuming-repo override, a narrower local patch) and report success. That hides the wall: the session ships *a* deliverable, reports `success`, and never signals it routed around a restriction — a maintainer only catches it by reading the rationale.
+
+Instead, surface the blocker on the triggering thread and ask the maintainer, offering both:
+
+1. **Take the upstream action on approval** — file a fresh issue (per the rule above), or, where the upstream artifact already exists, note the evidence on that existing thread.
+2. **Relax the rule going forward** — adjust the consuming repo's `running-tend` overlay to permit the action in future.
+
+Record whichever they choose per **Learning from Feedback** below. This applies to any restriction that turns out to be negotiable and blocking, not just the other-repo scope rule.
 
 ## PR Creation
 


### PR DESCRIPTION
## Problem

When a bundled **Scope** restriction in `running-in-ci` blocked the action the bot would otherwise take, the bot generalized "comments on existing threads in other repos are off-limits" to *all* upstream engagement being off-limits, then silently opened a local consuming-repo override as a workaround — eliding upstream entirely and never signaling it had hit a wall. The session shipped a deliverable, reported `success`, and a maintainer only caught the second-best path by reading the PR rationale.

Two gaps in the existing guidance, per #716:

- No guidance for engaging an **existing** upstream thread — the Scope line was a flat "off-limits" with no escape valve.
- No guidance that a scope rule which is *itself the blocker* is negotiable, rather than an immovable wall to route around.

## Solution

In `plugins/tend-ci-runner/skills/running-in-ci/SKILL.md`:

- New subsection **"When a scope rule blocks the right action"** under *Filing Issues in Other Repos*: when a restriction is the blocker, don't silently substitute a workaround. Surface it on the triggering thread and offer the maintainer both (1) taking the upstream action on approval — file a fresh issue, or note evidence on an existing thread — and (2) relaxing the rule going forward via the consuming repo's `running-tend` overlay. Record the choice per *Learning from Feedback*.
- A cross-reference appended to the **Scope** restriction bullet pointing at the new subsection, so the escape valve is discoverable from where the bot reads the restriction.

## Testing

Skill-text change; `pre-commit` (trailing whitespace, end-of-file, typos, plugin-skill lint hooks) passes on the changed file. No code paths affected.

---
Closes #716 — automated triage. Filed at maintainer request from the [PRQL/prql#6023 thread](https://github.com/PRQL/prql/pull/6023#issuecomment-4756443399). Object-level defect: #694.
