### PR TITLE
chore: bump claude_version to 2.1.185

### DIFF
--- a/claude-interactive/action.yaml
+++ b/claude-interactive/action.yaml
@@ -50,7 +50,7 @@ inputs:
     default: "true"
     description: Include the full Claude transcript in the workflow step summary.
   claude_version:
-    default: "2.1.179"
+    default: "2.1.185"
     description: >-
       Version of the `claude` binary to install via
       `https://claude.ai/install.sh`, pinned to a specific

--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -52,7 +52,7 @@ inputs:
     default: "true"
     description: Include the rendered Claude transcript in the workflow step summary.
   claude_version:
-    default: "2.1.179"
+    default: "2.1.185"
     description: >-
       Version of the `claude` binary to install via
       `https://claude.ai/install.sh`, pinned to a specific


### PR DESCRIPTION
Weekly pin bump of the `claude` binary in both Claude harness actions, keeping the headless (`claude/action.yaml`) and PTY (`claude-interactive/action.yaml`) pins in step. `2.1.179` → `2.1.185` (npm `dist-tags.latest`).

Skim of the [claude-code CHANGELOG](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md) between the two pins for anything touching the agent paths tend exercises (headless `-p`, the credential-injecting proxy, Stop-hook completion):

- **2.1.181** — Fixed prompt caching not reading on a custom `ANTHROPIC_BASE_URL`. Relevant: both harnesses run behind the local proxy with a rewritten base URL, so this should restore cache reads on tend's runs.
- **2.1.183** — Fixed turns silently completing with no visible output when the model returned only a thinking block (now re-prompts once); fixed MCP auth-stub tools being exposed in headless/SDK mode; added a stderr warning in print mode (`-p`) when the requested model is deprecated or auto-updated — directly on the headless result/`-p` path.
- **2.1.185** — Stream-stall hint copy change and a 10s→20s silence threshold before the "waiting for API response" hint. Cosmetic for tend's non-interactive runs.

Nothing in the range removes or changes a flag tend passes or the `-p` exit-code / Stop-hook completion contract.

The bump reaches adopters at the next tend release (their workflows pin `max-sixty/tend@X.Y.Z`); tend's own workflows pick it up the same way.
