### PR TITLE
skills(running-tend): baseline integration-test run polling to avoid stale-run false fails

### DIFF
--- a/.claude/skills/running-tend/references/integration-test.md
+++ b/.claude/skills/running-tend/references/integration-test.md
@@ -165,6 +165,11 @@ assert the bot commented.
 
 ```bash
 TS=$(date -u +%Y%m%d-%H%M%S)
+# Baseline the latest existing run BEFORE the trigger so a prior
+# week's run is never mistaken for this one (mirrors §1).
+PREV_RUN=$(gh run list --repo tend-agent/tend-integration \
+  --workflow tend-triage --limit 1 \
+  --json databaseId --jq '.[0].databaseId // empty')
 ISSUE_URL=$(gh issue create --repo tend-agent/tend-integration \
   --title "integration-test triage $TS" \
   --body "Automated weekly integration test. The bot's reply confirms tend-triage is working; the reset step will close this.")
@@ -175,10 +180,11 @@ for _ in $(seq 1 24); do
   RUN_ID=$(gh run list --repo tend-agent/tend-integration \
     --workflow tend-triage --limit 1 \
     --json databaseId --jq '.[0].databaseId // empty')
-  [ -n "$RUN_ID" ] && break
+  [ -n "$RUN_ID" ] && [ "$RUN_ID" != "$PREV_RUN" ] && break
   sleep 5
 done
-[ -n "$RUN_ID" ] || { echo "tend-triage: workflow run never registered"; exit 1; }
+{ [ -n "$RUN_ID" ] && [ "$RUN_ID" != "$PREV_RUN" ]; } \
+  || { echo "tend-triage: workflow run never registered"; exit 1; }
 
 for _ in $(seq 1 60); do
   read -r status conclusion < <(gh run view "$RUN_ID" \
@@ -224,6 +230,11 @@ git commit -m "chore: integration-test trivial edit"
 gh auth setup-git
 git push -u origin "$BRANCH"
 
+# Baseline the latest existing run BEFORE the trigger so a prior
+# week's run is never mistaken for this one (mirrors §1).
+PREV_RUN=$(gh run list --repo tend-agent/tend-integration \
+  --workflow tend-review --limit 1 \
+  --json databaseId --jq '.[0].databaseId // empty')
 PR_URL=$(gh pr create --repo tend-agent/tend-integration \
   --title "integration-test review $TS" \
   --body "Automated weekly integration test. The bot's review confirms tend-review is working; the reset step will close this." \
@@ -235,10 +246,11 @@ for _ in $(seq 1 24); do
   RUN_ID=$(gh run list --repo tend-agent/tend-integration \
     --workflow tend-review --limit 1 \
     --json databaseId --jq '.[0].databaseId // empty')
-  [ -n "$RUN_ID" ] && break
+  [ -n "$RUN_ID" ] && [ "$RUN_ID" != "$PREV_RUN" ] && break
   sleep 5
 done
-[ -n "$RUN_ID" ] || { echo "tend-review: workflow run never registered"; exit 1; }
+{ [ -n "$RUN_ID" ] && [ "$RUN_ID" != "$PREV_RUN" ]; } \
+  || { echo "tend-review: workflow run never registered"; exit 1; }
 
 for _ in $(seq 1 60); do
   read -r status conclusion < <(gh run view "$RUN_ID" \


### PR DESCRIPTION
## What

The weekly integration-test recipe's §3 (triage) and §4 (review) verification steps poll for the freshly-triggered workflow run with `gh run list --workflow tend-{triage,review} --limit 1` but **never baseline against the run that already existed**. So on any week where a prior run is present (i.e. every week after the first), the register-wait loop matches last week's completed run instead of this week's, treats it as "registered and successful" instantly, and then fails the downstream assertion — a false negative.

§1 (the `integration-secrets` reseed) already does this correctly: it captures `PREV_ID` before dispatch and loops until a run with a *different* id appears. §3 and §4 just never got the same treatment.

## Symptom this caught

A weekly run reported `FAIL at §3 — no bot comment on issue #N`. Reconstructed from run ids and timestamps:

- §3 grabbed a `tend-triage` run from the prior week (a much smaller run id than the just-dispatched secrets run), already `completed/success`, so it skipped the wait entirely.
- The comment assertion then ran against the brand-new issue before any triage had happened → false fail.
- The false fail short-circuited to §6 reset, which **closed the test issue** at the same second the real `tend-triage` run was only just registering (`in_progress`). So even the real run ended up acting on an already-closed issue.

`tend-triage` itself was healthy the whole time — the real run triggered correctly. The bug is purely in the test harness's run-matching.

## Fix

Apply §1's baseline-and-compare pattern to §3 and §4: capture the latest existing run id before the trigger, and require the polled run id to differ from it before treating it as this run.

```bash
PREV_RUN=$(gh run list ... --workflow tend-triage --limit 1 --json databaseId --jq '.[0].databaseId // empty')
# ... open the issue ...
[ -n "$RUN_ID" ] && [ "$RUN_ID" != "$PREV_RUN" ] && break
```

Doc-only change to `.claude/skills/running-tend/references/integration-test.md`; no workflow or generator code touched.
