### PR TITLE
fix(nightly): base workflow-regen worktree on open PR, not branch ref

### DIFF
--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -193,12 +193,24 @@ Used by both Step 4 (applied to recent diffs) and Step 6 (applied to full files)
 Regenerate the tend workflow files and open a PR if anything changed. The checkout's `.github/` directory may be mounted read-only under the sandbox (protecting bots from modifying their own workflows in place), so do the regeneration in a git worktree under `/tmp`, which is writable. Use the literal path `/tmp/tend-update-workflows` — GitHub Actions runners leave `$TMPDIR` unset, so a `$TMPDIR/...` path expands to an unwritable root path.
 
 ```bash
-# Base the worktree on the open update-workflows PR if one exists, so the
-# regen produces only the incremental delta. Falls back to HEAD when no PR
-# is open (first regen, or after the prior PR merged). `-B` resets a stale
-# local branch from a prior failed attempt rather than rejecting it.
+# Base the worktree on the update-workflows branch only when an **open PR**
+# rides it, so the regen produces only the incremental delta. Otherwise base
+# on HEAD. Gate on the open PR, not on branch-ref existence: a PR closed without
+# merge leaves the branch behind, and basing on that stale branch carries the
+# closed PR's content on top of main — inflating the diff and producing an
+# inaccurate PR body, and defeating the no-value skip below (its "only
+# non-stamp diff" test only holds when the diff is computed against the
+# true base, not a stale branch's accumulated content).
+# When no open PR exists, drop any leftover remote branch so the push starts
+# fresh from HEAD. `-B` resets a stale local branch from a prior failed
+# attempt rather than rejecting it.
 git fetch origin tend/update-workflows 2>/dev/null || true
-BASE=$(git rev-parse --verify origin/tend/update-workflows 2>/dev/null || git rev-parse HEAD)
+if gh pr list --head tend/update-workflows --state open --json number --jq '.[0].number' | grep -q .; then
+  BASE=$(git rev-parse origin/tend/update-workflows)
+else
+  git push origin --delete tend/update-workflows 2>/dev/null || true
+  BASE=$(git rev-parse HEAD)
+fi
 git worktree add "/tmp/tend-update-workflows" -B tend/update-workflows "$BASE"
 cd "/tmp/tend-update-workflows"
 


### PR DESCRIPTION
## Problem

The nightly "Step 7: Update tend workflows" picks the worktree base with:

```bash
BASE=$(git rev-parse --verify origin/tend/update-workflows 2>/dev/null || git rev-parse HEAD)
```

This keys on whether the **branch ref exists**, but the step's own comment states the intent is to base on the branch only when an **open PR** rides it ("Base the worktree on the open update-workflows PR if one exists … Falls back to HEAD when no PR is open"). A PR closed without merge leaves the branch behind, so the next regen bases on that stale branch — which carries the closed PR's content on top of `main`. Two consequences:

1. **Inflated diff / inaccurate PR body.** The PR opens against `main`, so it displays the stale branch's accumulated content as if it were new, and the generated "Notable changes" body lists upstream changes that are already on `main`.
2. **Defeats the no-value skip.** The stamp-only skip (and the action-ref-downgrade skip in #715) decide "no value" from `git diff … <base>`. Against a stale base that test sees the accumulated content, not the true `main`→regen delta, so it fails to fire and a no-value PR is opened anyway.

## Evidence — recurring on `numbagg/numbagg`

Three `tend/update-workflows` PRs were opened and **closed unmerged** in ~10 days: [#644](https://github.com/numbagg/numbagg/pull/644), [#646](https://github.com/numbagg/numbagg/pull/646), [#662](https://github.com/numbagg/numbagg/pull/662). The most recent, [#662](https://github.com/numbagg/numbagg/pull/662) (nightly run [27952551358](https://github.com/numbagg/numbagg/actions/runs/27952551358), 2026-06-22), was self-closed by the bot, whose closing comment names this exact failure:

> The diff shown on this PR looked larger because the branch was accidentally based on the stale closed-PR branch rather than `main`; regenerating against `main` shows the true picture above.

The PR body listed a full "Notable changes" set (harness rollback, skill updates) for `0.1.4 → 0.1.6` — all already on `main` — because the stale base inflated the diff. The bot recovered manually (regenerated against `main`, then closed), but a run that doesn't catch the pattern ships the inaccurate PR.

## Fix

Gate `BASE` on an **open** PR, matching the documented intent. When none exists, drop any leftover remote branch so the push starts fresh from `HEAD`:

```bash
if gh pr list --head tend/update-workflows --state open --json number --jq '.[0].number' | grep -q .; then
  BASE=$(git rev-parse origin/tend/update-workflows)
else
  git push origin --delete tend/update-workflows 2>/dev/null || true
  BASE=$(git rev-parse HEAD)
fi
```

The remote-branch delete is safe — with no open PR nothing references the branch — and lets the existing non-force `git push -u` create it fresh.

## Relationship to #714 / #715

[#715](https://github.com/max-sixty/tend/pull/715) adds the action-ref-downgrade *skip* but computes direction from the regen diff. That detection only holds when the diff is taken against the true base; a stale closed-PR branch makes the diff "more than just a downgrade," so #715's guard would not fire and the PR would still open. This change is the prerequisite that keeps #715's guard (and the stamp-only skip) reliable. The two are complementary — neither supersedes the other.

## Gate assessment

- **Evidence level**: High — structural (the BASE selection is deterministic code that diverges from its own documented intent; the same stale-branch condition reproduces the failure every time). Recurring theme: 3 no-value `update-workflows` PRs closed unmerged in ~10 days (#644, #646, #662), with #662 explicitly attributed to this base-selection bug.
- **Change type**: targeted fix (Normal bar) — a few lines of bundled-skill guidance, no new section.
- Passes both gates.

Evidence log: https://gist.github.com/39936af3c6f4ba8f6f107fb94b6a9f20
