### PR TITLE
fix(review): opt into v7 fork-PR checkout so fork reviews run

### DIFF
--- a/generator/src/tend/templates/macros.yaml.j2
+++ b/generator/src/tend/templates/macros.yaml.j2
@@ -73,18 +73,27 @@
 {% if cfg.repo_owner %}github.repository_owner == '<<cfg.repo_owner|replace("'", "''")>>' && {% endif %}
 {%- endmacro %}
 
-{# Shared `actions/checkout@v6` step. `ref` defaults to the configured default
+{# Shared `actions/checkout@v7` step. `ref` defaults to the configured default
    branch; pass `None` to omit (mention reuses the runner's default checkout
    ref), or any GHA expression for review's pr_ref dispatch. `if_condition`
-   gates the step (used by notifications' skip_condition). #}
-{% macro checkout(cfg, ref=None, if_condition='') %}
-      - uses: actions/checkout@v6
+   gates the step (used by notifications' skip_condition).
+
+   `allow_unsafe_pr_checkout` opts into checkout's fork-PR guard: v7 refuses to
+   check out a fork's `refs/pull/N/{merge,head}` under `pull_request_target`
+   (the "pwn request" guard) unless this input is set. Only review feeds a fork
+   ref straight to the action, so only it sets this; mention checks out the base
+   repo then `gh pr checkout`s, never handing the action a fork ref. #}
+{% macro checkout(cfg, ref=None, if_condition='', allow_unsafe_pr_checkout=False) %}
+      - uses: actions/checkout@v7
 {% if if_condition %}
         if: <<if_condition>>
 {% endif %}
         with:
 {% if ref %}
           ref: <<ref>>
+{% endif %}
+{% if allow_unsafe_pr_checkout %}
+          allow-unsafe-pr-checkout: true
 {% endif %}
           fetch-depth: 0
           fetch-tags: true

--- a/generator/src/tend/templates/review.yaml.j2
+++ b/generator/src/tend/templates/review.yaml.j2
@@ -32,6 +32,6 @@ jobs:
             echo "ref=refs/pull/$PR/head" >> "$GITHUB_OUTPUT"
             echo "::notice::refs/pull/$PR/merge unavailable (likely merge conflict); falling back to /head"
           fi
-<<checkout(cfg, ref='${{ steps.pr_ref.outputs.ref }}')>>
+<<checkout(cfg, ref='${{ steps.pr_ref.outputs.ref }}', allow_unsafe_pr_checkout=True)>>
 <<setup>>
 <<agent_step(cfg, prompt_body)>>

--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -435,7 +435,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v6
       - name: Verify required secrets are set
         env:

--- a/generator/tests/_regtest_outputs/test_generate.test_extras_apply_path_regtest.out
+++ b/generator/tests/_regtest_outputs/test_generate.test_extras_apply_path_regtest.out
@@ -42,9 +42,10 @@ jobs:
             echo "ref=refs/pull/$PR/head" >> "$GITHUB_OUTPUT"
             echo "::notice::refs/pull/$PR/merge unavailable (likely merge conflict); falling back to /head"
           fi
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ steps.pr_ref.outputs.ref }}
+          allow-unsafe-pr-checkout: true
           fetch-depth: 0
           fetch-tags: true
           token: ${{ secrets.TEND_BOT_TOKEN }}

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-ci-fix.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-ci-fix.yaml].out
@@ -23,7 +23,7 @@ jobs:
       id-token: write
       actions: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-nightly.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-nightly.yaml].out
@@ -23,7 +23,7 @@ jobs:
       actions: read
       issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
@@ -89,7 +89,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'
         with:
           ref: main

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-review-runs.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-review-runs.yaml].out
@@ -23,7 +23,7 @@ jobs:
       actions: read
       issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-triage.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-triage.yaml].out
@@ -26,7 +26,7 @@ jobs:
       actions: read
       issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-weekly.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-weekly.yaml].out
@@ -23,7 +23,7 @@ jobs:
       actions: read
       issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0

--- a/generator/tests/_regtest_outputs/test_generate.test_install_test_workflow_regtest[claude-interactive].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_install_test_workflow_regtest[claude-interactive].out
@@ -23,7 +23,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v6
       - name: Verify required secrets are set
         env:

--- a/generator/tests/_regtest_outputs/test_generate.test_install_test_workflow_regtest[claude].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_install_test_workflow_regtest[claude].out
@@ -23,7 +23,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v6
       - name: Verify required secrets are set
         env:

--- a/generator/tests/_regtest_outputs/test_generate.test_install_test_workflow_regtest[codex].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_install_test_workflow_regtest[codex].out
@@ -23,7 +23,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v6
       - name: Verify required secrets are set
         env:

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[ci-fix].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[ci-fix].out
@@ -23,7 +23,7 @@ jobs:
       id-token: write
       actions: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
@@ -173,7 +173,7 @@ jobs:
       actions: read
       issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[nightly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[nightly].out
@@ -22,7 +22,7 @@ jobs:
       actions: read
       issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[notifications].out
@@ -88,7 +88,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'
         with:
           ref: main

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[review-runs].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[review-runs].out
@@ -22,7 +22,7 @@ jobs:
       actions: read
       issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[review].out
@@ -41,9 +41,10 @@ jobs:
             echo "ref=refs/pull/$PR/head" >> "$GITHUB_OUTPUT"
             echo "::notice::refs/pull/$PR/merge unavailable (likely merge conflict); falling back to /head"
           fi
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ steps.pr_ref.outputs.ref }}
+          allow-unsafe-pr-checkout: true
           fetch-depth: 0
           fetch-tags: true
           token: ${{ secrets.TEND_BOT_TOKEN }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[triage].out
@@ -26,7 +26,7 @@ jobs:
       actions: read
       issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[weekly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[weekly].out
@@ -22,7 +22,7 @@ jobs:
       actions: read
       issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[ci-fix].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[ci-fix].out
@@ -23,7 +23,7 @@ jobs:
       id-token: write
       actions: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
@@ -173,7 +173,7 @@ jobs:
       actions: read
       issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[nightly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[nightly].out
@@ -22,7 +22,7 @@ jobs:
       actions: read
       issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
@@ -88,7 +88,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'
         with:
           ref: main

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review-runs].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review-runs].out
@@ -22,7 +22,7 @@ jobs:
       actions: read
       issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review].out
@@ -41,9 +41,10 @@ jobs:
             echo "ref=refs/pull/$PR/head" >> "$GITHUB_OUTPUT"
             echo "::notice::refs/pull/$PR/merge unavailable (likely merge conflict); falling back to /head"
           fi
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ steps.pr_ref.outputs.ref }}
+          allow-unsafe-pr-checkout: true
           fetch-depth: 0
           fetch-tags: true
           token: ${{ secrets.TEND_BOT_TOKEN }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[triage].out
@@ -26,7 +26,7 @@ jobs:
       actions: read
       issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[weekly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[weekly].out
@@ -22,7 +22,7 @@ jobs:
       actions: read
       issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[ci-fix].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[ci-fix].out
@@ -23,7 +23,7 @@ jobs:
       id-token: write
       actions: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
@@ -173,7 +173,7 @@ jobs:
       actions: read
       issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[nightly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[nightly].out
@@ -22,7 +22,7 @@ jobs:
       actions: read
       issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
@@ -88,7 +88,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'
         with:
           ref: main

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review-runs].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review-runs].out
@@ -22,7 +22,7 @@ jobs:
       actions: read
       issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review].out
@@ -41,9 +41,10 @@ jobs:
             echo "ref=refs/pull/$PR/head" >> "$GITHUB_OUTPUT"
             echo "::notice::refs/pull/$PR/merge unavailable (likely merge conflict); falling back to /head"
           fi
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ steps.pr_ref.outputs.ref }}
+          allow-unsafe-pr-checkout: true
           fetch-depth: 0
           fetch-tags: true
           token: ${{ secrets.TEND_BOT_TOKEN }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[triage].out
@@ -26,7 +26,7 @@ jobs:
       actions: read
       issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[weekly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[weekly].out
@@ -22,7 +22,7 @@ jobs:
       actions: read
       issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -314,7 +314,7 @@ def test_review_probes_merge_ref_and_falls_back_to_head(tmp_path: Path) -> None:
     steps = data["jobs"]["review"]["steps"]
     probe_idx = next(i for i, s in enumerate(steps) if s.get("id") == "pr_ref")
     checkout_idx = next(
-        i for i, s in enumerate(steps) if s.get("uses") == "actions/checkout@v6"
+        i for i, s in enumerate(steps) if s.get("uses") == "actions/checkout@v7"
     )
     assert probe_idx < checkout_idx
     probe = steps[probe_idx]
@@ -330,7 +330,7 @@ def test_setup_after_checkout_in_review(tmp_path: Path) -> None:
     cfg = Config.load(_minimal_config(tmp_path, extra))
     workflows = {wf.filename: wf for wf in generate_all(cfg)}
     review = workflows["tend-review.yaml"]
-    checkout_idx = review.content.index("actions/checkout@v6")
+    checkout_idx = review.content.index("actions/checkout@v7")
     setup_idx = review.content.index("./.github/actions/my-setup")
     assert setup_idx > checkout_idx, "Setup must come after checkout"
 
@@ -552,7 +552,7 @@ def test_setup_before_pr_checkout_in_mention(tmp_path: Path) -> None:
     cfg = Config.load(_minimal_config(tmp_path, extra))
     workflows = {wf.filename: wf for wf in generate_all(cfg)}
     mention = workflows["tend-mention.yaml"]
-    initial_checkout_idx = mention.content.index("actions/checkout@v6")
+    initial_checkout_idx = mention.content.index("actions/checkout@v7")
     setup_idx = mention.content.index("./.github/actions/my-setup")
     pr_checkout_idx = mention.content.index("Check out PR branch")
     assert initial_checkout_idx < setup_idx < pr_checkout_idx, (

--- a/generator/tests/test_integration.py
+++ b/generator/tests/test_integration.py
@@ -622,7 +622,7 @@ def test_install_test_workflow_shape(
     assert "astral-sh/setup-uv@v6" in content
 
     # Default-branch probe: must not use `git remote set-head origin --auto`,
-    # which errors on the default shallow `actions/checkout@v6` (only the PR
+    # which errors on the default shallow `actions/checkout@v7` (only the PR
     # head ref is fetched, so `refs/remotes/origin/<default>` doesn't exist
     # locally). Query the API and fetch the default branch instead. See #582.
     assert "git remote set-head" not in content


### PR DESCRIPTION
Implements option 2 from #723 per maintainer direction (`implement (2)`).

`actions/checkout@v7` (2026-06-18) added a guard that refuses to check out a fork's `refs/pull/N/{merge,head}` under `pull_request_target` unless `allow-unsafe-pr-checkout: true` is set. `tend-review` feeds the fork ref straight to the action, so every fork PR trips the guard the moment an adopter's checkout pin drifts to v7 — the `review` check goes red before the review runs.

## Change

- Bump the shared `checkout()` macro to `actions/checkout@v7` (the `allow-unsafe-pr-checkout` input doesn't exist on v6).
- Add an `allow_unsafe_pr_checkout` parameter to the macro; `tend-review` sets it `true`, keeping the post-merge `refs/pull/N/merge` tree the review prefers.
- The opt-in renders **only** for review. `tend-mention` checks out the base repo then `gh pr checkout`s, so it never hands the action a fork ref and needs no flag — the macro default stays `false`.
- Bump the install-test workflow's checkout to v7 for consistency (same-repo only; doesn't trip the guard either way).

Rendered review step:

```yaml
      - uses: actions/checkout@v7
        with:
          ref: ${{ steps.pr_ref.outputs.ref }}
          allow-unsafe-pr-checkout: true
          fetch-depth: 0
          fetch-tags: true
          token: ${{ secrets.BOT_GITHUB_TOKEN }}
```

This keeps the same `pull_request_target` + fork-code exposure tend-review has always carried (a deliberate design choice for a workflow that must inspect the contributor's tree); it just makes the opt-in explicit so v7 stops refusing it.

## Tests

Updated the `@v6` → `@v7` assertions in `test_generate.py` and regenerated the regtest fixtures (`pytest --regtest-reset`). The flag now appears only in review fixtures; all 255 tests pass.
