### PR TITLE
fix: configure git identity before bundled-skill worktree commits

### DIFF
--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -109,6 +109,14 @@ Do not check out or rebase manually — the bot owns the branch and will overwri
 
 ### Bot-authored PRs: resolve manually
 
+Set the git identity once in the main session **before dispatching** — the subagents below `git commit --no-edit` in fresh worktrees, and as separate invocations they don't reliably load `running-in-ci`. `--global` writes to the runner's shared `~/.gitconfig`, so the subagents inherit it and don't fail with `Author identity unknown`. See "Configure git identity before the first commit" in `/tend-ci-runner:running-in-ci`.
+
+```bash
+BOT_LOGIN=$(gh api user --jq '.login'); BOT_ID=$(gh api user --jq '.id')
+git config --global user.name "$BOT_LOGIN"
+git config --global user.email "${BOT_ID}+${BOT_LOGIN}@users.noreply.github.com"
+```
+
 For each conflicted PR authored by `$BOT_LOGIN`, dispatch a subagent to:
 
 1. Check out the PR: `gh pr checkout <number>`

--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -284,6 +284,12 @@ Then ship it:
 ```bash
 TITLE=$(cat "/tmp/tend-pr-title")
 git add -A .github/workflows .config
+# A fresh /tmp worktree has no git identity; without this the commit fails with
+# `Author identity unknown` and an empty branch gets pushed. Idempotent — see
+# "Configure git identity before the first commit" in /tend-ci-runner:running-in-ci.
+BOT_LOGIN=$(gh api user --jq '.login'); BOT_ID=$(gh api user --jq '.id')
+git config --global user.name "$BOT_LOGIN"
+git config --global user.email "${BOT_ID}+${BOT_LOGIN}@users.noreply.github.com"
 git commit -m "$TITLE"
 git push -u origin tend/update-workflows
 gh pr create --title "$TITLE" --body-file "/tmp/tend-update-body.md"

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -225,6 +225,9 @@ cd "/tmp/review-runs-fix/.claude/skills/running-tend" && mv /tmp/running-tend.md
 
 cd "/tmp/review-runs-fix"
 git add .claude/skills/
+# Set git identity first if not already done this session — a fresh worktree has
+# none and the commit fails with `Author identity unknown`. See "Configure git
+# identity before the first commit" in /tend-ci-runner:running-in-ci.
 git commit -m "skills(running-tend): ..."
 git push -u origin daily/review-runs-$GITHUB_RUN_ID
 gh pr create --title "..." --body-file /tmp/pr-body.md --head daily/review-runs-$GITHUB_RUN_ID

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -134,6 +134,19 @@ git branch -r --list 'origin/fix/*'
 
 If an existing PR addresses the same problem, work on that PR instead.
 
+### Configure git identity before the first commit
+
+Runners don't always pre-seed a git identity, and a fresh `git worktree` never inherits one. Without it `git commit` fails with `Author identity unknown`, the branch gets pushed with **no commit**, and `gh pr create` then fails with `No commits between main and <branch>`. Set it once before your first commit — `--global` covers the main checkout and every `/tmp` worktree in one shot, and it's idempotent, so re-running is safe:
+
+```bash
+BOT_LOGIN=$(gh api user --jq '.login')
+BOT_ID=$(gh api user --jq '.id')
+git config --global user.name "$BOT_LOGIN"
+git config --global user.email "${BOT_ID}+${BOT_LOGIN}@users.noreply.github.com"
+```
+
+The noreply form (`<id>+<login>@users.noreply.github.com`) keeps commits attributed to the bot account and passes `verified`-email push rules.
+
 ### Dedup recheck immediately before `gh pr create`
 
 A separate mention on a different issue/PR can trigger a concurrent run asking for the same fix. Those runs are not serialized — each has its own concurrency group — so both may read an empty `gh pr list` at session start and then each open their own PR minutes later, producing near-duplicates. A long workflow queue (`tend-mention` can wait hours) also lets a sibling run open *and merge* a PR before this run starts — already-merged duplicates need to be in scope too. Re-run the check **as the last step before `gh pr create`**, with `--state all` so closed and merged siblings show up:
@@ -687,6 +700,9 @@ When the correction identifies a gap or bug in a **bundled** skill — the same 
 
    cd "/tmp/skill-fix"
    git add .claude/skills/
+   # Set git identity first if you haven't already this session — see
+   # "Configure git identity before the first commit" above. A fresh worktree
+   # has no identity and the commit below fails with `Author identity unknown`.
    git commit -m "skills(running-tend): ..."
    git push -u origin skills/<topic>-$GITHUB_RUN_ID
    gh pr create --title "..." --body-file /tmp/pr-body.md --head skills/<topic>-$GITHUB_RUN_ID


### PR DESCRIPTION
## Problem

Bundled skills that commit in a fresh `/tmp` `git worktree` (and in the main checkout) run `git commit` without first configuring a git identity. On runners where the harness doesn't pre-seed one, the first commit fails with `Author identity unknown`, the branch gets pushed with no commit, and `gh pr create` then fails with `No commits between main and <branch>`. Sessions self-correct by setting an identity and recommitting, but they burn turns and momentarily push an empty branch. Per #729 this has fired on consecutive committing nightlies, making it structural rather than a one-off.

The gap is systemic — the same `git commit`-without-identity shape exists across `nightly`, `review-runs`, `running-in-ci`, `triage`, `review`, and `ci-fix`.

## Solution

Fix it once at the root and reinforce at the documented failure sites:

- **`running-in-ci/SKILL.md`** — new `### Configure git identity before the first commit` subsection under PR Creation. Every skill loads `running-in-ci` first, so this is the canonical rule for all of them. Uses `git config --global` (covers the main checkout and every worktree in one shot) with the GitHub noreply email form (`<id>+<login>@users.noreply.github.com`) so commits stay attributed to the bot and pass `verified`-email push rules. Also annotated the Learning-from-Feedback worktree block to point at it.
- **`nightly/SKILL.md`** — inlined the identity config into the Step 7 verbatim ship block (the failure site in #729). Shell state doesn't persist between bash calls, so it's self-contained there.
- **`review-runs/SKILL.md`** — annotated its worktree-commit block to set identity first.

## Testing

Skill-text fix — no generator unit test applies. Reproduced the mechanism locally: `git commit` with no configured identity fails with `Author identity unknown` both in a fresh repo and a fresh worktree; setting `git config --global user.name`/`user.email` lets the same commit succeed. `pre-commit` (trailing-whitespace, typos, bang-backtick guard, install-tend sync) passes on all three changed files.

---
Closes #729 — automated triage
