### PR TITLE
chore: release 0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ published verbatim as that version's GitHub Release notes
 0.1.1 predate this changelog; see the compare views at
 https://github.com/max-sixty/tend/compare for their history.
 
+## 0.1.8
+
+### Fixed
+
+- **Bundled skills configure a git identity before committing in fresh worktrees.** The `nightly`, `running-in-ci`, and `review-runs` skills now set `git config --global user.name/email` (to the bot's noreply identity) before the bot's first commit. A `/tmp` worktree inherits no identity, so `git commit` previously failed with `Author identity unknown`, pushed an empty branch, and left `gh pr create` to error with `No commits between main and <branch>`. ([#730](https://github.com/max-sixty/tend/pull/730))
+
 ## 0.1.7
 
 ### Improved

--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "tend"
-version = "0.1.7"
+version = "0.1.8"
 description = "An autonomous junior maintainer for GitHub repos, powered by Claude or OpenAI Codex — reviews PRs, triages issues, fixes CI"
 license = "MIT"
 requires-python = ">=3.11"

--- a/generator/uv.lock
+++ b/generator/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "tend"
-version = "0.1.7"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Release 0.1.8.

Bumps the generator to 0.1.8, syncs the lockfile, and adds the `## 0.1.8` CHANGELOG section (published verbatim as the GitHub Release notes).

### Fixed
- **Bundled skills configure a git identity before committing in fresh worktrees.** The `nightly`, `running-in-ci`, and `review-runs` skills now set `git config --global user.name/email` before the bot's first commit, so a `/tmp` worktree (which inherits no identity) no longer fails with `Author identity unknown`, push an empty branch, and break `gh pr create`. ([#730](https://github.com/max-sixty/tend/pull/730))

#728 (release-skill docs) and #727 (workflow regen) are internal and omitted from adopter-facing notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)