### PR TITLE
fix(review): leak-free incremental review (three-dot diff + git log --no-merges)

### DIFF
--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -48,11 +48,20 @@ If the bot reviewed a previous commit (`LAST_REVIEW_SHA` exists but differs from
 - The **accurate incremental** — commits authored since the last review, with per-file line counts — for the trivial-skip decision below.
 
 ```bash
-# Commits + per-file line counts authored since the last review. --no-merges
-# drops any base-merge commit, so its churn (code the PR never authored) never
-# counts — overlapping files (touched by the PR *and* a base-merge) are counted
-# correctly too. The review checkout is fetch-depth: 0, so the range is local.
-git log --no-merges --numstat --format='%h %s' "$LAST_REVIEW_SHA..$HEAD_SHA"
+# Commits + per-file line counts authored since the last review.
+#
+# --no-merges alone is NOT enough: it drops the merge *commit*, but a base
+# merge also pulls in the base branch's own non-merge commits, which are
+# reachable from $HEAD_SHA but not from $LAST_REVIEW_SHA — so they sit in the
+# A..B range and their churn gets summed as if it were the new push. Exclude
+# everything reachable from the base tip with `--not "$BASE_SHA"`: base churn
+# is always an ancestor of the base tip, while the PR's own commits are not,
+# so this isolates exactly the authored incremental (overlapping files
+# included). The review checkout is fetch-depth: 0; fetch the base tip in case
+# the /head conflict-fallback checkout didn't materialize it.
+BASE_SHA=$(gh pr view <number> --json baseRefOid --jq '.baseRefOid')
+git fetch --no-tags --quiet origin "$BASE_SHA" 2>/dev/null || true
+git log --no-merges --numstat --format='%h %s' "$LAST_REVIEW_SHA..$HEAD_SHA" --not "$BASE_SHA"
 ```
 
 If the incremental changes are trivial, skip the full review — go directly to step 7 to resolve any bot threads addressed by the new changes. After resolving threads: if the most recent bot review was a COMMENT that flagged issues, and those issues are now addressed, submit an APPROVE with an empty body so the PR isn't left in limbo. Otherwise do not submit a new review — the existing one stands. Do NOT proceed to steps 2–6. Rough heuristic: changes under ~20 added+deleted lines that don't introduce new functions, types, or control flow are typically trivial.

--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -42,16 +42,17 @@ LAST_REVIEW_SHA=$(gh pr view <number> --json reviews \
 
 If `LAST_REVIEW_SHA == HEAD_SHA`, this commit has already been reviewed — exit silently. Two exceptions: an unanswered conversation question directed at the bot (check below), or `EVENT_ACTION == "ready_for_review"` (the PR just transitioned out of draft, so any prior review was a draft-mode review and the author is now asking for a full one — proceed).
 
-If the bot reviewed a previous commit (`LAST_REVIEW_SHA` exists but differs from `HEAD_SHA`), judge what was pushed since. The diff to read is always the PR's three-dot surface — `gh pr diff <number>` (merge-base→head, the same diff step 3 uses); base-merge commits never enter it. List the commits added since the last review to see the new work:
+If the bot reviewed a previous commit (`LAST_REVIEW_SHA` exists but differs from `HEAD_SHA`), judge what was pushed since. Read two signals, both leak-free against base-merges:
+
+- The PR's three-dot diff — `gh pr diff <number>` (merge-base→head, the same diff step 3 uses) — for the current state. Base-merge commits never enter it.
+- The **accurate incremental** — commits authored since the last review, with per-file line counts — for the trivial-skip decision below.
 
 ```bash
-REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
-# List only the commits added since the last review — judge triviality from
-# these plus the three-dot `gh pr diff`. Don't read this compare's `.files`
-# totals: the `A...B` symmetric-difference range folds in any base-merge's
-# churn (code the PR never authored), which skews the line counts.
-gh api "repos/$REPO/compare/$LAST_REVIEW_SHA...$HEAD_SHA" \
-  --jq '.commits[] | "\(.sha[0:9]) \(.commit.message | split("\n")[0])"'
+# Commits + per-file line counts authored since the last review. --no-merges
+# drops any base-merge commit, so its churn (code the PR never authored) never
+# counts — overlapping files (touched by the PR *and* a base-merge) are counted
+# correctly too. The review checkout is fetch-depth: 0, so the range is local.
+git log --no-merges --numstat --format='%h %s' "$LAST_REVIEW_SHA..$HEAD_SHA"
 ```
 
 If the incremental changes are trivial, skip the full review — go directly to step 7 to resolve any bot threads addressed by the new changes. After resolving threads: if the most recent bot review was a COMMENT that flagged issues, and those issues are now addressed, submit an APPROVE with an empty body so the PR isn't left in limbo. Otherwise do not submit a new review — the existing one stands. Do NOT proceed to steps 2–6. Rough heuristic: changes under ~20 added+deleted lines that don't introduce new functions, types, or control flow are typically trivial.

--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -42,12 +42,16 @@ LAST_REVIEW_SHA=$(gh pr view <number> --json reviews \
 
 If `LAST_REVIEW_SHA == HEAD_SHA`, this commit has already been reviewed — exit silently. Two exceptions: an unanswered conversation question directed at the bot (check below), or `EVENT_ACTION == "ready_for_review"` (the PR just transitioned out of draft, so any prior review was a draft-mode review and the author is now asking for a full one — proceed).
 
-If the bot reviewed a previous commit (`LAST_REVIEW_SHA` exists but differs from `HEAD_SHA`), check the incremental changes:
+If the bot reviewed a previous commit (`LAST_REVIEW_SHA` exists but differs from `HEAD_SHA`), judge what was pushed since. The diff to read is always the PR's three-dot surface — `gh pr diff <number>` (merge-base→head, the same diff step 3 uses); base-merge commits never enter it. List the commits added since the last review to see the new work:
 
 ```bash
 REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+# List only the commits added since the last review — judge triviality from
+# these plus the three-dot `gh pr diff`. Don't read this compare's `.files`
+# totals: the `A...B` symmetric-difference range folds in any base-merge's
+# churn (code the PR never authored), which skews the line counts.
 gh api "repos/$REPO/compare/$LAST_REVIEW_SHA...$HEAD_SHA" \
-  --jq '{total: ([.files[] | .additions + .deletions] | add), files: [.files[] | "\(.filename)\t+\(.additions)/-\(.deletions)"]}'
+  --jq '.commits[] | "\(.sha[0:9]) \(.commit.message | split("\n")[0])"'
 ```
 
 If the incremental changes are trivial, skip the full review — go directly to step 7 to resolve any bot threads addressed by the new changes. After resolving threads: if the most recent bot review was a COMMENT that flagged issues, and those issues are now addressed, submit an APPROVE with an empty body so the PR isn't left in limbo. Otherwise do not submit a new review — the existing one stands. Do NOT proceed to steps 2–6. Rough heuristic: changes under ~20 added+deleted lines that don't introduce new functions, types, or control flow are typically trivial.


### PR DESCRIPTION
## Problem

The `review` skill's incremental pre-flight (step 1) computed "what changed since my last review" with a two-endpoint `gh api compare/$LAST_REVIEW_SHA...$HEAD_SHA`. The `A...B` symmetric-difference range includes every commit reachable from `B` but not `A`, so when a `Merge branch '<default>'` commit lands between the two review points, the compare drags in the **entire merged-in base delta** — none of which is the PR's own work. The incremental review then anchored its trivial-vs-substantive decision and the model's reading on that leaked diff, critiquing code the PR never authored.

Reported and maintainer-confirmed in max-sixty/worktrunk#3246.

This two-endpoint compare was the **original** form of the incremental check — it was never added to handle conflicts or any corner case. The `...` range just happens to leak base-merges.

## Solution

Keep both signals the incremental check needs, with both made leak-free against base-merges:

- **Review surface** — the PR's **three-dot** `gh pr diff` (merge-base→head), which base-merge commits never enter. This is the same diff step 3 (the full-review path) already used; step 1 now uses it too.
- **Accurate incremental** — `git log --no-merges --numstat` over `$LAST_REVIEW_SHA..$HEAD_SHA`, giving the commits and per-file line counts pushed since the last review for the trivial-skip heuristic. `--no-merges` drops any base-merge commit, so its churn never counts — and unlike the old compare's `.files` totals, files touched by both the PR and a base-merge are counted correctly. The review checkout is `fetch-depth: 0`, so the range is present locally.

This replaces the leaky two-endpoint compare (and its earlier partial file-list jq filter, which still mis-counted overlapping files) — the trivial-skip stays accurate and the review surface stays leak-free.

## Testing

No pytest harness covers skill prose; the bug was reproduced and maintainer-confirmed upstream. The change is a doc/recipe edit — the three-dot `gh pr diff` is merge-base→head by construction and `git log --no-merges` excludes the merge commit, so base-merge churn cannot enter either.

---
Closes #734 — automated triage
