### PR TITLE
ci-fix: cap the job at a 120-minute timeout

### DIFF
--- a/generator/src/tend/templates/ci-fix.yaml.j2
+++ b/generator/src/tend/templates/ci-fix.yaml.j2
@@ -15,6 +15,7 @@ jobs:
   fix-ci:
     if: <<fork_guard_prefix(cfg)>>github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     permissions:
 <<permissions(issues=False)>>
     steps:

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-ci-fix.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-ci-fix.yaml].out
@@ -17,6 +17,7 @@ jobs:
   fix-ci:
     if: github.repository_owner == 'test-owner' && github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[ci-fix].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[ci-fix].out
@@ -17,6 +17,7 @@ jobs:
   fix-ci:
     if: github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[ci-fix].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[ci-fix].out
@@ -17,6 +17,7 @@ jobs:
   fix-ci:
     if: github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[ci-fix].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[ci-fix].out
@@ -17,6 +17,7 @@ jobs:
   fix-ci:
     if: github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     permissions:
       contents: write
       pull-requests: write

--- a/plugins/tend-ci-runner/skills/ci-fix/SKILL.md
+++ b/plugins/tend-ci-runner/skills/ci-fix/SKILL.md
@@ -47,8 +47,6 @@ gh issue list --state open --author "$BOT_LOGIN" --search "ci-fix: in:title" \
 4. Reproduce locally using test commands from the project's CLAUDE.md
 5. Fix at the right level (shared helper > per-file fix)
 
-**Budget-box local validation.** The harness kills the session at a hard timeout (~1h), and a killed session ships nothing — no PR, no issue, and any root cause you found dies with it. Validating a fix for a timing-sensitive or flaky failure means re-running the test many times under load, which drains the budget fast. If repeated stress-validation isn't converging on a green fix and you've already pinned the root cause, stop iterating and take the 3b durable-diagnosis path **while the session is still alive** — a posted diagnosis (offending commit, mechanism, candidate fix direction) that a maintainer or a later run can act on beats grinding to the timeout with nothing to show.
-
 ### 3. Create PR
 
 Re-check for existing fix PRs (one may have been created while you worked).

--- a/plugins/tend-ci-runner/skills/ci-fix/SKILL.md
+++ b/plugins/tend-ci-runner/skills/ci-fix/SKILL.md
@@ -47,6 +47,8 @@ gh issue list --state open --author "$BOT_LOGIN" --search "ci-fix: in:title" \
 4. Reproduce locally using test commands from the project's CLAUDE.md
 5. Fix at the right level (shared helper > per-file fix)
 
+**Budget-box local validation.** The harness kills the session at a hard timeout (~1h), and a killed session ships nothing — no PR, no issue, and any root cause you found dies with it. Validating a fix for a timing-sensitive or flaky failure means re-running the test many times under load, which drains the budget fast. If repeated stress-validation isn't converging on a green fix and you've already pinned the root cause, stop iterating and take the 3b durable-diagnosis path **while the session is still alive** — a posted diagnosis (offending commit, mechanism, candidate fix direction) that a maintainer or a later run can act on beats grinding to the timeout with nothing to show.
+
 ### 3. Create PR
 
 Re-check for existing fix PRs (one may have been created while you worked).


### PR DESCRIPTION
Caps the `tend-ci-fix` job at `timeout-minutes: 120` so a session that grinds on stress-validating a flaky/timing-sensitive failure is bounded by GitHub Actions rather than by self-budgeting prose in the skill.

Per [maintainer feedback](https://github.com/max-sixty/tend/pull/736#issuecomment-4816094046), this replaces the earlier budget-box paragraph in `ci-fix/SKILL.md` — the deterministic YAML timeout is the cheaper gate (it doesn't cost a skill load every session) and keeps the skill leaner.
