### PR TITLE
docs(action): drop disproved "scrub hid model auth" claim from #637 quote

### DIFF
--- a/claude-interactive/action.yaml
+++ b/claude-interactive/action.yaml
@@ -274,12 +274,14 @@ runs:
         # skipDangerousModePermissionPrompt in settings.local.json). The
         # proxy injects the real credentials per-host.
         # Mirrors action.yaml: the Linux bwrap wrapping path corrupts `!`
-        # to `\!` in Bash commands, so the sandbox stays off (`0`). bwrap's
-        # value was hiding the model auth from the agent; that is now moot —
-        # the agent's env holds only dummy GitHub + Anthropic secrets, so
-        # there is nothing sensitive left for SUBPROCESS_ENV_SCRUB to hide.
+        # to `\!` in Bash commands, so the subprocess sandbox stays off (`0`).
         # Reproduced through claude 2.1.159; anthropics/claude-code#64301,
-        # write-up in #639.
+        # write-up in #639. Turning it off costs no credential hiding: the
+        # agent's env holds only dummy GitHub + Anthropic secrets (the proxy
+        # injects the real ones per-host), so SUBPROCESS_ENV_SCRUB has nothing
+        # sensitive to scrub. #637 separately found the model auth already
+        # absent from Bash-tool subprocesses with the scrub off, so the strip
+        # never depended on it.
         CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "0"
         BOT_NAME: ${{ inputs.bot_name }}
         BOT_ID: ${{ steps.bot.outputs.id }}

--- a/claude-interactive/action.yaml
+++ b/claude-interactive/action.yaml
@@ -276,12 +276,8 @@ runs:
         # Mirrors action.yaml: the Linux bwrap wrapping path corrupts `!`
         # to `\!` in Bash commands, so the subprocess sandbox stays off (`0`).
         # Reproduced through claude 2.1.159; anthropics/claude-code#64301,
-        # write-up in #639. Turning it off costs no credential hiding: the
-        # agent's env holds only dummy GitHub + Anthropic secrets (the proxy
-        # injects the real ones per-host), so SUBPROCESS_ENV_SCRUB has nothing
-        # sensitive to scrub. #637 separately found the model auth already
-        # absent from Bash-tool subprocesses with the scrub off, so the strip
-        # never depended on it.
+        # write-up in #639. Off leaks nothing: the agent's env holds only
+        # dummy secrets, and the proxy injects the real ones per-host.
         CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "0"
         BOT_NAME: ${{ inputs.bot_name }}
         BOT_ID: ${{ steps.bot.outputs.id }}

--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -234,12 +234,9 @@ runs:
         # injects the real credentials per-host.
         # The Linux bwrap wrapping path corrupts `!` to `\!` in Bash commands,
         # so the subprocess sandbox stays off (`0`). Reproduced through claude
-        # 2.1.159; anthropics/claude-code#64301, write-up in #639.
-        # Turning it off costs no credential hiding: the agent's env holds only
-        # dummy GitHub + Anthropic secrets (the proxy injects the real ones
-        # per-host), so SUBPROCESS_ENV_SCRUB has nothing sensitive to scrub.
-        # #637 separately found the model auth already absent from Bash-tool
-        # subprocesses with the scrub off, so the strip never depended on it.
+        # 2.1.159; anthropics/claude-code#64301, write-up in #639. Off leaks
+        # nothing: the agent's env holds only dummy secrets, and the proxy
+        # injects the real ones per-host.
         CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "0"
         BOT_NAME: ${{ inputs.bot_name }}
         BOT_ID: ${{ steps.bot.outputs.id }}

--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -233,11 +233,13 @@ runs:
         # CLAUDE_CODE_REMOTE for remote/non-interactive context). The proxy
         # injects the real credentials per-host.
         # The Linux bwrap wrapping path corrupts `!` to `\!` in Bash commands,
-        # so the sandbox stays off (`0`). bwrap's value was hiding the model
-        # auth from the agent; that is now moot — the agent's env holds only
-        # dummy GitHub + Anthropic secrets, so there is nothing sensitive left
-        # for SUBPROCESS_ENV_SCRUB to hide. Reproduced through claude 2.1.159;
-        # anthropics/claude-code#64301, write-up in #639.
+        # so the subprocess sandbox stays off (`0`). Reproduced through claude
+        # 2.1.159; anthropics/claude-code#64301, write-up in #639.
+        # Turning it off costs no credential hiding: the agent's env holds only
+        # dummy GitHub + Anthropic secrets (the proxy injects the real ones
+        # per-host), so SUBPROCESS_ENV_SCRUB has nothing sensitive to scrub.
+        # #637 separately found the model auth already absent from Bash-tool
+        # subprocesses with the scrub off, so the strip never depended on it.
         CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "0"
         BOT_NAME: ${{ inputs.bot_name }}
         BOT_ID: ${{ steps.bot.outputs.id }}


### PR DESCRIPTION
Follow-up to #637, addressing @max-sixty's "but how about the originally quoted section?"

My earlier sweep claimed the whole originally-quoted `env:` block was gone. That was imprecise: three of its four lines (the `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` vars and their "Expose the harness auth…" comment) were removed by the proxy refactor (#704), but `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "0"` survived — and its comment still carried the one claim #637 actually disproved.

The surviving comment asserted bubblewrap / `SUBPROCESS_ENV_SCRUB` "was hiding the model auth from the agent." #637's evidence was the opposite: the OAuth token was absent from the Bash-tool subprocess **with the scrub already off** (`0`), so the scrub was never the gate — Claude Code strips its own Anthropic credentials from bash subprocesses independent of this knob. The refactor reframed the claim as "moot" but kept its disproved premise intact.

This reword keeps the two true facts and drops the false one:

- The scrub stays `0` for the unrelated Linux bwrap `!`→`\!` corruption bug (anthropics/claude-code#64301, write-up in #639).
- Credential hiding is moot regardless, because the agent's env now holds only dummy secrets and the proxy injects the real ones per-host.
- It no longer claims the scrub ever hid model auth from bash; per #637 the strip never depended on it.

Applied to both Claude harness actions. Comment-only — no behavior change.

<details><summary>Before / after</summary>

Before (`claude/action.yaml`):

```
# so the sandbox stays off (`0`). bwrap's value was hiding the model
# auth from the agent; that is now moot — the agent's env holds only
# dummy GitHub + Anthropic secrets, so there is nothing sensitive left
# for SUBPROCESS_ENV_SCRUB to hide.
```

After:

```
# so the subprocess sandbox stays off (`0`). [...]
# Turning it off costs no credential hiding: the agent's env holds only
# dummy GitHub + Anthropic secrets (the proxy injects the real ones
# per-host), so SUBPROCESS_ENV_SCRUB has nothing sensitive to scrub.
# #637 separately found the model auth already absent from Bash-tool
# subprocesses with the scrub off, so the strip never depended on it.
```

</details>
