### PR TITLE
skills(running-in-ci): recheck guard catches new directives, not just dupes

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -391,6 +391,8 @@ If any prior entry — from a human or another tend workflow — already address
 
 If the author resolved the issue, acknowledge it rather than post stale analysis. If new information contradicts the findings, update before posting.
 
+**A new entry may be a directive, not a duplicate.** The re-fetch above guards against redundant posts, but a comment that arrived while you worked can also be a maintainer follow-up that *changes the work* — a second instruction, a correction, a narrowed scope. The window is widest after a long edit→commit→push sequence: minutes pass between the session-start read and the post, and that gap is exactly when a maintainer adds to the thread. So the re-fetch isn't only a dedup check — read what landed, and if it's a new directive, fold it into the same run rather than shipping a reply (or a commit) against the stale instruction. Treating the task as done is itself a kind of post: re-fetch before ending the turn, not only before commenting.
+
 ### Dedup check for inline review comment replies
 
 A single PR review can fire both `pull_request_review` and `pull_request_review_comment` events, triggering separate workflow runs (serialized by the concurrency group, not truly concurrent). Before replying to an inline review comment, check whether the bot already replied:


### PR DESCRIPTION
## What

Tightens the **Recheck Before Posting** guard in the bundled `running-in-ci` skill so the pre-post re-fetch is understood as catching *new maintainer directives*, not only duplicate posts.

## Why

On [PR #735](https://github.com/max-sixty/tend/pull/735) a maintainer posted a follow-up comment 47s after the agent's only read of the thread, then spent ~4 minutes on an edit→commit→push cycle and posted its reply straight from the context loaded before that follow-up existed — shipping an incomplete change against the stale instruction. The maintainer caught it ([#issuecomment-4814004450](https://github.com/max-sixty/tend/pull/735#issuecomment-4814004450), "note the comment I followed up with please") and later [asked the bot to log the root cause](https://github.com/max-sixty/tend/pull/735#issuecomment-4814604743).

The bot's [own diagnosis](https://github.com/max-sixty/tend/pull/735#issuecomment-4814613127) (run `28244362446`): the existing **Recheck Before Posting** guard is meant to catch exactly this — "new entries arrived during the session" — but the section is framed entirely around *dedup* ("check whether the response would **duplicate** something already there", "if the response is now entirely redundant, don't post it"). A re-fetch read through that lens checks for duplicate posts; it doesn't prompt the agent to notice that a new entry is a *directive that changes the work*. The miss wasn't a redundant post — it was a missed instruction.

This is a structural gap (the window is widest precisely when there's a long edit→push gap, which is when a maintainer is most likely to add a follow-up) with an invisible failure mode (a missed comment never surfaces as a CI failure). It applies to every consumer, so the fix belongs in the bundled skill.

## Change

One paragraph added to the section: a new entry may be a directive, not a duplicate; the gap after edit→commit→push is the high-risk window; the re-fetch should pick up new directives and fold them into the same run; and "treating the task as done" counts as a post — re-fetch before ending the turn, not only before commenting.

Prose-only addition to an existing guard; no behavior change to any action or generator.

<details><summary>Window context</summary>

From the 2026-06-27 `review-runs` analysis (run `28284127572`). ~50 substantive runs, 0 failed jobs (two `cancelled` `tend-mention` runs were concurrency-cancellation siblings, each paired with a successful run). The #735 follow-up miss was the only finding to pass the confidence/magnitude gates this window.

</details>
