### PR TITLE
chore: bump harness timeout default to 3 hours

### DIFF
--- a/claude-interactive/action.yaml
+++ b/claude-interactive/action.yaml
@@ -56,11 +56,12 @@ inputs:
       `https://claude.ai/install.sh`, pinned to a specific
       claude-code release.
   timeout_seconds:
-    default: "3600"
+    default: "10800"
     description: >-
       Maximum time the supervised Claude session is allowed to run before
-      the supervisor kills it. Defaults to 60 minutes — well above any
-      single-turn skill we have today.
+      the supervisor kills it. Defaults to 3 hours — long-running sessions
+      (e.g. ci-fix stress-testing a flaky failure) routinely need more
+      than an hour, and short tasks finish well before the cap regardless.
   mitmproxy_version:
     default: "12.2.1"
     description: >-

--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -58,11 +58,12 @@ inputs:
       `https://claude.ai/install.sh`, pinned to a specific
       claude-code release. Kept in step with the interactive harness's pin.
   timeout_seconds:
-    default: "3600"
+    default: "10800"
     description: >-
       Maximum time the headless Claude run is allowed to take before the
-      supervisor kills it. Defaults to 60 minutes — well above any single
-      turn we have today.
+      supervisor kills it. Defaults to 3 hours — long-running sessions
+      (e.g. ci-fix stress-testing a flaky failure) routinely need more
+      than an hour, and short tasks finish well before the cap regardless.
   mitmproxy_version:
     default: "12.2.1"
     description: >-


### PR DESCRIPTION
Bumps the default `timeout_seconds` from `3600` (60 min) to `10800` (3 hours) in both Claude harness actions (`claude/action.yaml` headless, `claude-interactive/action.yaml` PTY). Codex has no harness-level timeout (it relies on the GitHub job cap), so nothing changes there.

Requested by a maintainer in [max-sixty/worktrunk#3260](https://github.com/max-sixty/worktrunk/issues/3260): worktrunk's nightly `tend-ci-fix` was repeatedly hitting the 60-minute cap while stress-testing a flaky, timing-sensitive integration test, surfacing as recurring "Bot temporarily unavailable" outages. The sessions weren't stuck — they were genuinely longer than the cap. Raising the ceiling lets these long sessions finish; short tasks finish well before the cap regardless, so the only cost is that a genuinely runaway session now burns up to 3 hours of subscription compute before the supervisor kills it.

The bump reaches adopters at the next tend release, since their workflows pin `max-sixty/tend/<harness>@X.Y.Z`; tend's own workflows pick it up the same way.

Note: this overlaps with #736, which caps the `tend-ci-fix` *job* at `timeout-minutes: 120`. With a 3-hour harness timeout, that 120-minute GitHub job cap would kill `tend-ci-fix` at 2 hours — before the harness timeout fires — which undercuts the increase for the exact workflow that motivated it. Worth reconciling: either close #736, or raise its cap to ≥180 min so the harness timeout is the effective gate. Your call.

<details><summary>Diff summary</summary>

- `claude/action.yaml`: `timeout_seconds` default `3600` → `10800`, description updated.
- `claude-interactive/action.yaml`: same (kept in step with the headless pin).

Generator tests (255) pass — the action defaults aren't consumed by workflow generation, so there's no rendered-output change.

</details>
