### PR TITLE
chore: bump claude_version to 2.1.195

### DIFF
--- a/claude-interactive/action.yaml
+++ b/claude-interactive/action.yaml
@@ -50,7 +50,7 @@ inputs:
     default: "true"
     description: Include the full Claude transcript in the workflow step summary.
   claude_version:
-    default: "2.1.185"
+    default: "2.1.195"
     description: >-
       Version of the `claude` binary to install via
       `https://claude.ai/install.sh`, pinned to a specific

--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -52,7 +52,7 @@ inputs:
     default: "true"
     description: Include the rendered Claude transcript in the workflow step summary.
   claude_version:
-    default: "2.1.185"
+    default: "2.1.195"
     description: >-
       Version of the `claude` binary to install via
       `https://claude.ai/install.sh`, pinned to a specific


### PR DESCRIPTION
Bumps the pinned `claude_version` from `2.1.185` to `2.1.195` (current npm `dist-tags.latest`) in both Claude harness actions, keeping the headless (`claude/action.yaml`) and PTY (`claude-interactive/action.yaml`) pins in step. A stale pin resolves `--model opus`/`sonnet` against an old alias target.

Notable changes between the two versions touching the agent paths:

- **2.1.195** — Hook matchers with hyphenated identifiers now exact-match instead of substring-matching. The interactive harness's Stop-hook sentinel uses the plain `Stop` matcher, so it is unaffected, but worth noting for the PTY path.
- **2.1.187** — Fixed `--resume` failing with "No conversation found" when the original `-p` run produced no model turns (headless path). Also added a `sandbox.credentials` setting to block sandboxed commands from reading credential files and secret env vars — relevant to the credential-injecting proxy/sandbox model, though not enabled here.
- **2.1.187** — Fixed `--json-schema` / workflow `agent({schema})` structured output so the model can't re-call `StructuredOutput` indefinitely and follow-up turns reliably return structured output.

No changes observed to first-run onboarding or headless `-p` result-event formats that would require action-side adjustments.

The bump reaches adopters at the next tend release, since their workflows pin `max-sixty/tend@X.Y.Z`; tend's own workflows pick it up the same way.
