### PR TITLE
skills(review): add /code-review pass scaled to how core the change is

### DIFF
--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -153,6 +153,17 @@ Two search strategies, both required:
 
 Flag duplicates — reuse is almost always better than a parallel implementation.
 
+**`/code-review` pass (Claude harness only):**
+
+Run a `/code-review` over the diff, a Claude Code built-in that reviews the working-tree diff (here, the PR's merged tree) for correctness bugs and cleanups. Match the effort tier to how core the change is:
+
+- Peripheral or mechanical (docs, config, dependency bumps, test-only): `/code-review low` or `medium`.
+- The project's core logic: `/code-review high` or `max`.
+
+What counts as core is repo-specific; let the project's own guidance (CLAUDE.md, a repo review skill) or your judgment decide. Skip `ultra` (the human-triggered cloud pass). Fold its findings into the review you submit next; don't pass `--comment` or `--fix`, which act outside the dedup and single-review path.
+
+Other harnesses (Codex) lack this command; skip the pass.
+
 ### 5. Submit
 
 **If there are no issues, approve with an empty body — silence means correct.**

--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -117,6 +117,13 @@ Scale depth to the change. A docs-only PR or a mechanical rename needs a skim fo
 
 Check the project's CLAUDE.md for language-specific review criteria and conventions. Load any project-specific review skill if available.
 
+Review the diff two ways at once: the manual checks below, plus a `/code-review` over it (Claude harness only; the Codex harness lacks the command, so skip it there). `/code-review` is a Claude Code built-in that reviews the working-tree diff (here, the PR's merged tree) for correctness bugs and cleanups. Scale its effort tier to how core the change is, the same way you scale the manual depth above:
+
+- Peripheral or mechanical (docs, config, dependency bumps, test-only): `/code-review low` or `medium`.
+- The project's core logic: `/code-review high` or `max`.
+
+What counts as core is repo-specific; let the project's own guidance (CLAUDE.md, a repo review skill) or your judgment decide. Skip `ultra` (the human-triggered cloud pass). Both passes feed one verdict: fold the `/code-review` findings into the review you submit in step 5, and don't pass `--comment` or `--fix`, which act outside the dedup and single-review path.
+
 **Code quality:**
 
 - Is the code clear and well-structured?
@@ -152,17 +159,6 @@ Two search strategies, both required:
 2. **Overlapping subgoals.** Identify the intermediate steps the new code performs and search for existing code that does the same sub-tasks.
 
 Flag duplicates — reuse is almost always better than a parallel implementation.
-
-**`/code-review` pass (Claude harness only):**
-
-Run a `/code-review` over the diff, a Claude Code built-in that reviews the working-tree diff (here, the PR's merged tree) for correctness bugs and cleanups. Match the effort tier to how core the change is:
-
-- Peripheral or mechanical (docs, config, dependency bumps, test-only): `/code-review low` or `medium`.
-- The project's core logic: `/code-review high` or `max`.
-
-What counts as core is repo-specific; let the project's own guidance (CLAUDE.md, a repo review skill) or your judgment decide. Skip `ultra` (the human-triggered cloud pass). Fold its findings into the review you submit next; don't pass `--comment` or `--fix`, which act outside the dedup and single-review path.
-
-Other harnesses (Codex) lack this command; skip the pass.
 
 ### 5. Submit
 


### PR DESCRIPTION
## What

PR review now runs two passes at once: its existing manual checks, plus a `/code-review` over the diff. This is framed at the top of the review step (step 4), tied to the same "scale depth to the change" principle the manual review already uses, rather than tacked on at the end as a separate afterthought. The `/code-review` effort tier is matched to how core the change is: peripheral or mechanical changes (docs, config, dependency bumps, test-only) get `low`/`medium`; changes to the project's core logic get `high`/`max`. The rule is stated generically — each adopter repo's own guidance, or the reviewer's judgment, supplies what "core" means there, so the bundled skill doesn't hardcode any one project's components.

## Why

A happy-path manual read approves code that matches its documented behavior but was never run on adversarial inputs. The motivating case: prql-bot reviewed a PR adding `append by:name` to PRQL and approved it after confirming the feature against the documented snapshot. It missed two silent data-loss bugs — `from a | select {x, x + 1} | append by:name (from b | select {x, y})` silently drops the unnamed `x + 1` column, and `from a | append by:name (from b)` over unknown schemas compiles to a plain position-based `UNION ALL`, ignoring `by:name`. A structured `/code-review` at an effort matched to the change being core compiler semantics is far more likely to surface that class of bug than a happy-path read.

## Harness scoping

`/code-review` is a Claude Code built-in — it lives in the `claude` binary, and the Codex harness doesn't have it. The review skill is loaded by both harnesses (Claude invokes it as a slash command; Codex reads it via the `$review` mention), so the guidance is gated to Claude inline in the opening sentence: "a `/code-review` over it (Claude harness only; the Codex harness lacks the command, so skip it there)." Codex self-identifies through its `Codex harness`-headed AGENTS.md, so the gate is unambiguous and Codex won't try to invoke a command it lacks.

No harness change was needed. `claude/action.yaml` already lists `Skill` in `allowed_tools`, and the review skill already loads other skills mid-session, so the pass runs inside the existing review job — this is skill text only.

The guidance also steers away from `--comment`/`--fix` (which would post or commit outside the skill's dedup and single-review path) and from the `ultra` tier (the human-triggered cloud pass, not an automated CI job).

> _This was written by Claude Code on behalf of max_
