### PR TITLE
fix(actions): self-heal duplicate tend-outage issues from concurrent leg failures

### DIFF
--- a/shared/steps/report-failure.sh
+++ b/shared/steps/report-failure.sh
@@ -52,4 +52,21 @@ if [ -n "$EXISTING" ]; then
   gh issue comment "$EXISTING" -F /tmp/comment.md
 else
   gh issue create --title "$TITLE" --label "$LABEL" -F /tmp/body.md
+
+  # The jitter above only narrows the create-create race; it can't close it.
+  # Two legs can still both read $EXISTING empty (jitter collision within the
+  # few-second window the list index takes to reflect a fresh create), so each
+  # files its own issue. Reconcile after creating: settle for the index, list
+  # every open tend-outage issue, keep the lowest-numbered, and close the rest
+  # as duplicates. Idempotent and convergent — every racing leg computes the
+  # same keeper, so a second leg closing an already-closed dup is a no-op.
+  sleep 5
+  OPEN=$(gh issue list --label "$LABEL" --state open --json number --jq 'sort_by(.number) | .[].number')
+  KEEP=$(echo "$OPEN" | head -1)
+  echo "$OPEN" | tail -n +2 | while read -r DUP; do
+    [ -z "$DUP" ] && continue
+    gh issue close "$DUP" \
+      --comment "Duplicate of #${KEEP} (concurrent matrix-leg failure); consolidating outage tracking there." \
+      2>/dev/null || true
+  done
 fi


### PR DESCRIPTION
## Problem

The outage-tracker dedup in `shared/steps/report-failure.sh` is racy, and the jitter added in #586 to fix it has now been proven insufficient in production.

When several matrix legs fail within a few seconds of each other (the common case for an upstream model-API 5xx/overload incident, which hits every leg at once), each leg runs the check-then-create dedup. The `sleep $((RANDOM % 30))` jitter only *narrows* the create-create window — it can't close it. Two legs can still both read `EXISTING` as empty: jitter collisions are likely with several legs drawing from a 30-slot range (birthday problem), and GitHub's issue-list index takes a few seconds to reflect a freshly-created issue, so even a staggered second leg can miss the first's issue.

## Evidence

- **2026-05-22**: four duplicate `tend-outage` issues (#575, #576, #577, #578) created within 4 seconds. This prompted #586 (jitter).
- **2026-06-29**: the jitter mitigation failed — an all-five-legs `review-reviewers` failure ([run 28352782724](https://github.com/max-sixty/tend/actions/runs/28352782724), transient `529 Overloaded`/StopFailure) produced **two** duplicate trackers #742 and #743, created within 1 second (06:23:30 and 06:23:31), both referencing the same run.

Every prior incident with only 1–2 failing legs produced a single tracker, so the failure mode scales with the number of simultaneously-failing legs. Impact is low (both dupes were auto-closed by nightly ~2h later when the outage resolved), but it's a recurring structural failure of a deployed fix, and it generates duplicate "Bot temporarily unavailable" notifications during every wide outage.

## Fix

Keep the jitter (it still reduces contention and the number of dupes created) and add a self-healing reconciliation to the create path: after `gh issue create`, settle briefly for the list index, then list every open `tend-outage` issue, keep the lowest-numbered, and close the rest as duplicates. It is idempotent and convergent — every racing leg computes the same keeper, so a second leg closing an already-closed dup is a no-op.

This is shared verbatim by all three harness actions, so it reaches every consumer at the next release.

<details><summary>Verification</summary>

- `shellcheck shared/steps/report-failure.sh` passes.
- Logic unit-tested against today's numbers: `[{742},{743}]` → keep #742, close #743; single-issue input closes nothing.
- Index-lag safety: the 5s settle plus the convergent keep-lowest rule means even if leg B's first re-list misses leg A's issue, both legs eventually compute the same keeper and the loser is closed.

</details>

Found by `review-runs` analyzing [run 28361647677](https://github.com/max-sixty/tend/actions/runs/28361647677).
