### PR TITLE
refactor(report-failure): render every outage entry as one table

### DIFF
--- a/shared/steps/report-failure.sh
+++ b/shared/steps/report-failure.sh
@@ -30,13 +30,15 @@ fi
 
 TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-gh label create "$LABEL" --description "Tracks bot outage incidents" --color "d93f0b" 2>/dev/null || true
-printf '%s\n\n%s\n%s\n%s\n\n%s\n' \
-  "The bot failed to process a request. This issue tracks failures until the underlying cause is resolved." \
+# One row per failure, in the same table format whether it seeds the issue
+# body (first failure) or is appended as a comment (every later failure), so
+# both render identically.
+TABLE=$(printf '%s\n%s\n%s' \
   "| When | Run | Trigger |" \
   "|------|-----|---------|" \
-  "| ${TIMESTAMP} | [workflow run](${RUN_URL}) | ${REF:-N/A} |" \
-  "This issue was created automatically. Close it once the outage is resolved." > /tmp/body.md
+  "| ${TIMESTAMP} | [workflow run](${RUN_URL}) | ${REF:-N/A} |")
+
+gh label create "$LABEL" --description "Tracks bot outage incidents" --color "d93f0b" 2>/dev/null || true
 
 # Jittered backoff before the check-then-act narrows the race window
 # when a matrix workflow's legs fail at near-identical times (e.g.
@@ -47,9 +49,12 @@ sleep $((RANDOM % 30))
 EXISTING=$(gh issue list --label "$LABEL" --state open --json number --jq '.[0].number // empty')
 
 if [ -n "$EXISTING" ]; then
-  printf 'Failed run at %s: [workflow run](%s)%s\n' \
-    "$TIMESTAMP" "$RUN_URL" "${REF:+ (triggered by ${REF})}" > /tmp/comment.md
+  printf '%s\n' "$TABLE" > /tmp/comment.md
   gh issue comment "$EXISTING" -F /tmp/comment.md
 else
+  printf '%s\n\n%s\n\n%s\n' \
+    "The bot failed to process a request. This issue tracks failures until the underlying cause is resolved." \
+    "$TABLE" \
+    "This issue was created automatically. Close it once the outage is resolved." > /tmp/body.md
   gh issue create --title "$TITLE" --label "$LABEL" -F /tmp/body.md
 fi


### PR DESCRIPTION
The `tend-outage` failure reporter (`shared/steps/report-failure.sh`) used two different shapes for the same information: the first failure created the issue with a `When | Run | Trigger` table body, while every subsequent failure appended a bespoke `Failed run at … (triggered by …)` one-liner comment. So a single outage issue mixed one table and N one-liners (e.g. max-sixty/worktrunk#3260).

This unifies both paths on the table format — the row is factored into one `TABLE` var that the create and comment branches share, and the trigger always lands in the Trigger column (`N/A` when absent). Each failure now renders as the same one-row table whether it seeds the body or arrives as a comment. The body still gets the surrounding intro/footer prose; comments are just the table.

Nothing consumed the old one-liner: the only reader is the nightly enrichment (`enrich-tend-outage-issues.sh`), which scans for the `/actions/runs/<id>` URL — present in the table row too — so it's unaffected. shellcheck and pre-commit pass, and I rendered all three cases (body, comment-with-ref, comment-without-ref) to confirm they're valid GitHub tables.

> _This was written by Claude Code on behalf of max_
