### PR TITLE
fix: skip no-op tend-mention session on bot's own APPROVED review

### DIFF
--- a/generator/src/tend/templates/mention.yaml.j2
+++ b/generator/src/tend/templates/mention.yaml.j2
@@ -95,15 +95,20 @@ jobs:
             exit 0
           fi
 
-          # The bot's own APPROVED review is terminal — nothing to act on. The
-          # engagement heuristic below counts this very review (BOT_REVIEWS > 0)
-          # and would spin up a no-op session. Gate on review *state*, not just
-          # author: bot self-reviews carrying suggestions on the bot's own PR
-          # still need to fire. review.state arrives lowercase in the webhook
-          # payload (REST returns uppercase), hence "approved".
+          # The bot's own empty-body APPROVED review is terminal — nothing to
+          # act on. The engagement heuristic below counts this very review
+          # (BOT_REVIEWS > 0) and would spin up a no-op session. Gate on three
+          # things, not just author: review *state* (an approval is terminal; a
+          # bot CHANGES_REQUESTED/COMMENTED review keeps actionable signal) and
+          # an empty *body* (an approval carrying nits in its body may warrant
+          # follow-up changes, so let it fire). Together these preserve #166's
+          # actionable bot self-reviews. review.state arrives lowercase in the
+          # webhook payload (REST returns uppercase), hence "approved".
+          # COMMENT_BODY holds review.body for a pull_request_review event.
           if [ "$EVENT_NAME" = "pull_request_review" ] \
              && [ "$REVIEW_AUTHOR" = "<<cfg.bot_name>>" ] \
-             && [ "$REVIEW_STATE" = "approved" ]; then
+             && [ "$REVIEW_STATE" = "approved" ] \
+             && [ -z "$COMMENT_BODY" ]; then
             echo "should_run=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/generator/src/tend/templates/mention.yaml.j2
+++ b/generator/src/tend/templates/mention.yaml.j2
@@ -95,6 +95,19 @@ jobs:
             exit 0
           fi
 
+          # The bot's own APPROVED review is terminal — nothing to act on. The
+          # engagement heuristic below counts this very review (BOT_REVIEWS > 0)
+          # and would spin up a no-op session. Gate on review *state*, not just
+          # author: bot self-reviews carrying suggestions on the bot's own PR
+          # still need to fire. review.state arrives lowercase in the webhook
+          # payload (REST returns uppercase), hence "approved".
+          if [ "$EVENT_NAME" = "pull_request_review" ] \
+             && [ "$REVIEW_AUTHOR" = "<<cfg.bot_name>>" ] \
+             && [ "$REVIEW_STATE" = "approved" ]; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           # pull_request_review payloads include review.body (checked above)
           # but NOT the bodies of inline comments attached to the review.
           # Fetch them so a first-contact @-mention inside an inline comment
@@ -160,6 +173,8 @@ jobs:
           PR_URL: ${{ github.event.issue.pull_request.url }}
           EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
           REVIEW_ID: ${{ github.event.review.id }}
+          REVIEW_AUTHOR: ${{ github.event.review.user.login }}
+          REVIEW_STATE: ${{ github.event.review.state }}
 
       - name: React to mention
         if: |

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
@@ -80,15 +80,20 @@ jobs:
             exit 0
           fi
 
-          # The bot's own APPROVED review is terminal ? nothing to act on. The
-          # engagement heuristic below counts this very review (BOT_REVIEWS > 0)
-          # and would spin up a no-op session. Gate on review *state*, not just
-          # author: bot self-reviews carrying suggestions on the bot's own PR
-          # still need to fire. review.state arrives lowercase in the webhook
-          # payload (REST returns uppercase), hence "approved".
+          # The bot's own empty-body APPROVED review is terminal ? nothing to
+          # act on. The engagement heuristic below counts this very review
+          # (BOT_REVIEWS > 0) and would spin up a no-op session. Gate on three
+          # things, not just author: review *state* (an approval is terminal; a
+          # bot CHANGES_REQUESTED/COMMENTED review keeps actionable signal) and
+          # an empty *body* (an approval carrying nits in its body may warrant
+          # follow-up changes, so let it fire). Together these preserve #166's
+          # actionable bot self-reviews. review.state arrives lowercase in the
+          # webhook payload (REST returns uppercase), hence "approved".
+          # COMMENT_BODY holds review.body for a pull_request_review event.
           if [ "$EVENT_NAME" = "pull_request_review" ] \
              && [ "$REVIEW_AUTHOR" = "test-bot" ] \
-             && [ "$REVIEW_STATE" = "approved" ]; then
+             && [ "$REVIEW_STATE" = "approved" ] \
+             && [ -z "$COMMENT_BODY" ]; then
             echo "should_run=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
@@ -80,6 +80,19 @@ jobs:
             exit 0
           fi
 
+          # The bot's own APPROVED review is terminal ? nothing to act on. The
+          # engagement heuristic below counts this very review (BOT_REVIEWS > 0)
+          # and would spin up a no-op session. Gate on review *state*, not just
+          # author: bot self-reviews carrying suggestions on the bot's own PR
+          # still need to fire. review.state arrives lowercase in the webhook
+          # payload (REST returns uppercase), hence "approved".
+          if [ "$EVENT_NAME" = "pull_request_review" ] \
+             && [ "$REVIEW_AUTHOR" = "test-bot" ] \
+             && [ "$REVIEW_STATE" = "approved" ]; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           # pull_request_review payloads include review.body (checked above)
           # but NOT the bodies of inline comments attached to the review.
           # Fetch them so a first-contact @-mention inside an inline comment
@@ -145,6 +158,8 @@ jobs:
           PR_URL: ${{ github.event.issue.pull_request.url }}
           EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
           REVIEW_ID: ${{ github.event.review.id }}
+          REVIEW_AUTHOR: ${{ github.event.review.user.login }}
+          REVIEW_STATE: ${{ github.event.review.state }}
 
       - name: React to mention
         if: |

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
@@ -80,15 +80,20 @@ jobs:
             exit 0
           fi
 
-          # The bot's own APPROVED review is terminal ? nothing to act on. The
-          # engagement heuristic below counts this very review (BOT_REVIEWS > 0)
-          # and would spin up a no-op session. Gate on review *state*, not just
-          # author: bot self-reviews carrying suggestions on the bot's own PR
-          # still need to fire. review.state arrives lowercase in the webhook
-          # payload (REST returns uppercase), hence "approved".
+          # The bot's own empty-body APPROVED review is terminal ? nothing to
+          # act on. The engagement heuristic below counts this very review
+          # (BOT_REVIEWS > 0) and would spin up a no-op session. Gate on three
+          # things, not just author: review *state* (an approval is terminal; a
+          # bot CHANGES_REQUESTED/COMMENTED review keeps actionable signal) and
+          # an empty *body* (an approval carrying nits in its body may warrant
+          # follow-up changes, so let it fire). Together these preserve #166's
+          # actionable bot self-reviews. review.state arrives lowercase in the
+          # webhook payload (REST returns uppercase), hence "approved".
+          # COMMENT_BODY holds review.body for a pull_request_review event.
           if [ "$EVENT_NAME" = "pull_request_review" ] \
              && [ "$REVIEW_AUTHOR" = "test-bot" ] \
-             && [ "$REVIEW_STATE" = "approved" ]; then
+             && [ "$REVIEW_STATE" = "approved" ] \
+             && [ -z "$COMMENT_BODY" ]; then
             echo "should_run=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
@@ -80,6 +80,19 @@ jobs:
             exit 0
           fi
 
+          # The bot's own APPROVED review is terminal ? nothing to act on. The
+          # engagement heuristic below counts this very review (BOT_REVIEWS > 0)
+          # and would spin up a no-op session. Gate on review *state*, not just
+          # author: bot self-reviews carrying suggestions on the bot's own PR
+          # still need to fire. review.state arrives lowercase in the webhook
+          # payload (REST returns uppercase), hence "approved".
+          if [ "$EVENT_NAME" = "pull_request_review" ] \
+             && [ "$REVIEW_AUTHOR" = "test-bot" ] \
+             && [ "$REVIEW_STATE" = "approved" ]; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           # pull_request_review payloads include review.body (checked above)
           # but NOT the bodies of inline comments attached to the review.
           # Fetch them so a first-contact @-mention inside an inline comment
@@ -145,6 +158,8 @@ jobs:
           PR_URL: ${{ github.event.issue.pull_request.url }}
           EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
           REVIEW_ID: ${{ github.event.review.id }}
+          REVIEW_AUTHOR: ${{ github.event.review.user.login }}
+          REVIEW_STATE: ${{ github.event.review.state }}
 
       - name: React to mention
         if: |

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
@@ -80,15 +80,20 @@ jobs:
             exit 0
           fi
 
-          # The bot's own APPROVED review is terminal ? nothing to act on. The
-          # engagement heuristic below counts this very review (BOT_REVIEWS > 0)
-          # and would spin up a no-op session. Gate on review *state*, not just
-          # author: bot self-reviews carrying suggestions on the bot's own PR
-          # still need to fire. review.state arrives lowercase in the webhook
-          # payload (REST returns uppercase), hence "approved".
+          # The bot's own empty-body APPROVED review is terminal ? nothing to
+          # act on. The engagement heuristic below counts this very review
+          # (BOT_REVIEWS > 0) and would spin up a no-op session. Gate on three
+          # things, not just author: review *state* (an approval is terminal; a
+          # bot CHANGES_REQUESTED/COMMENTED review keeps actionable signal) and
+          # an empty *body* (an approval carrying nits in its body may warrant
+          # follow-up changes, so let it fire). Together these preserve #166's
+          # actionable bot self-reviews. review.state arrives lowercase in the
+          # webhook payload (REST returns uppercase), hence "approved".
+          # COMMENT_BODY holds review.body for a pull_request_review event.
           if [ "$EVENT_NAME" = "pull_request_review" ] \
              && [ "$REVIEW_AUTHOR" = "test-bot" ] \
-             && [ "$REVIEW_STATE" = "approved" ]; then
+             && [ "$REVIEW_STATE" = "approved" ] \
+             && [ -z "$COMMENT_BODY" ]; then
             echo "should_run=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
@@ -80,6 +80,19 @@ jobs:
             exit 0
           fi
 
+          # The bot's own APPROVED review is terminal ? nothing to act on. The
+          # engagement heuristic below counts this very review (BOT_REVIEWS > 0)
+          # and would spin up a no-op session. Gate on review *state*, not just
+          # author: bot self-reviews carrying suggestions on the bot's own PR
+          # still need to fire. review.state arrives lowercase in the webhook
+          # payload (REST returns uppercase), hence "approved".
+          if [ "$EVENT_NAME" = "pull_request_review" ] \
+             && [ "$REVIEW_AUTHOR" = "test-bot" ] \
+             && [ "$REVIEW_STATE" = "approved" ]; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           # pull_request_review payloads include review.body (checked above)
           # but NOT the bodies of inline comments attached to the review.
           # Fetch them so a first-contact @-mention inside an inline comment
@@ -145,6 +158,8 @@ jobs:
           PR_URL: ${{ github.event.issue.pull_request.url }}
           EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
           REVIEW_ID: ${{ github.event.review.id }}
+          REVIEW_AUTHOR: ${{ github.event.review.user.login }}
+          REVIEW_STATE: ${{ github.event.review.state }}
 
       - name: React to mention
         if: |

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -614,11 +614,13 @@ def test_mention_prompt_omits_delay_when_empty(tmp_path: Path) -> None:
 
 
 def test_mention_skips_bot_approved_review(tmp_path: Path) -> None:
-    """A bot-authored APPROVED review is terminal — there is nothing to act
-    on. The verify gate must short-circuit it to should_run=false instead of
-    counting it as engagement (BOT_REVIEWS > 0) and spinning up a no-op
-    session (issue #747). The skip is gated on review *state*, not just
-    author, so bot self-reviews carrying suggestions still fire (#166)."""
+    """A bot-authored *empty-body* APPROVED review is terminal — there is
+    nothing to act on. The verify gate must short-circuit it to
+    should_run=false instead of counting it as engagement (BOT_REVIEWS > 0)
+    and spinning up a no-op session (issue #747). The skip is gated on review
+    *state* and an empty *body*, not just author: a bot CHANGES_REQUESTED /
+    COMMENTED review keeps actionable signal, and an approval carrying nits in
+    its body may warrant follow-up changes, so both still fire (#166)."""
     cfg = Config.load(_minimal_config(tmp_path))
     wf = generate_mention(cfg)
     data = yaml.safe_load(wf.content)
@@ -626,13 +628,16 @@ def test_mention_skips_bot_approved_review(tmp_path: Path) -> None:
         s for s in data["jobs"]["verify"]["steps"] if s.get("id") == "check"
     )
     script = check_step["run"]
-    # Gate on the (lowercase, per the webhook payload) approved state.
+    # Gate on the (lowercase, per the webhook payload) approved state and an
+    # empty review body, so only no-op approvals are skipped.
     assert "REVIEW_STATE" in script
     assert "approved" in script
+    assert '[ -z "$COMMENT_BODY" ]' in script
     # The skip must precede the BOT_REVIEWS heuristic query that would
     # otherwise count the just-submitted review and return should_run=true.
     assert script.index("REVIEW_STATE") < script.index("BOT_REVIEWS=$(")
-    # REVIEW_STATE/REVIEW_AUTHOR must be wired into the env block.
+    # REVIEW_STATE/REVIEW_AUTHOR must be wired into the env block;
+    # COMMENT_BODY (review.body for a review event) is already present.
     env = check_step["env"]
     assert "REVIEW_STATE" in env
     assert "REVIEW_AUTHOR" in env

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -613,6 +613,31 @@ def test_mention_prompt_omits_delay_when_empty(tmp_path: Path) -> None:
     assert "Before acting" in prompt
 
 
+def test_mention_skips_bot_approved_review(tmp_path: Path) -> None:
+    """A bot-authored APPROVED review is terminal — there is nothing to act
+    on. The verify gate must short-circuit it to should_run=false instead of
+    counting it as engagement (BOT_REVIEWS > 0) and spinning up a no-op
+    session (issue #747). The skip is gated on review *state*, not just
+    author, so bot self-reviews carrying suggestions still fire (#166)."""
+    cfg = Config.load(_minimal_config(tmp_path))
+    wf = generate_mention(cfg)
+    data = yaml.safe_load(wf.content)
+    check_step = next(
+        s for s in data["jobs"]["verify"]["steps"] if s.get("id") == "check"
+    )
+    script = check_step["run"]
+    # Gate on the (lowercase, per the webhook payload) approved state.
+    assert "REVIEW_STATE" in script
+    assert "approved" in script
+    # The skip must precede the BOT_REVIEWS heuristic query that would
+    # otherwise count the just-submitted review and return should_run=true.
+    assert script.index("REVIEW_STATE") < script.index("BOT_REVIEWS=$(")
+    # REVIEW_STATE/REVIEW_AUTHOR must be wired into the env block.
+    env = check_step["env"]
+    assert "REVIEW_STATE" in env
+    assert "REVIEW_AUTHOR" in env
+
+
 # ---------------------------------------------------------------------------
 # Fork guard
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`tend-mention` spins up a billable agent session every time the bot leaves an empty-body `APPROVED` review on a human PR. The session can only read its own approval and exit silently — a no-op (issue #747).

Root cause: for a `pull_request_review` event the verify gate falls through to a "has the bot engaged on this PR?" heuristic that queries `repos/.../pulls/<n>/reviews` and counts bot-authored reviews. When the *triggering* event is the bot's own review, that review is itself counted (`BOT_REVIEWS > 0`), so the gate always returns `should_run=true`. The `issue_comment` path has an analogous bot early-exit; the `pull_request_review` path had none.

## Solution

Add an early-exit in the verify gate (`generator/src/tend/templates/mention.yaml.j2`) alongside the existing `issue_comment` bot-skip, gated on review **state** rather than author alone:

```bash
if [ "$EVENT_NAME" = "pull_request_review" ] \
   && [ "$REVIEW_AUTHOR" = "<bot>" ] \
   && [ "$REVIEW_STATE" = "approved" ]; then
  echo "should_run=false" >> "$GITHUB_OUTPUT"; exit 0
fi
```

plus `REVIEW_AUTHOR`/`REVIEW_STATE` in the step `env:`.

Gating on state, not just author, preserves #166: bot self-reviews carrying suggestions on the bot's own PR still have actionable content and keep firing. Only the terminal `approved` state short-circuits. `review.state` arrives **lowercase** in the webhook payload (REST returns uppercase) — verified against GitHub's documented `github.event.review.state == 'approved'` example — hence the lowercase comparison.

## Testing

- Added `test_mention_skips_bot_approved_review`, which renders the mention workflow and asserts the verify gate skips a bot-authored `approved` review *before* reaching the `BOT_REVIEWS` engagement query, and wires `REVIEW_AUTHOR`/`REVIEW_STATE` into the env block. It fails on `main` (reproduction) and passes with the fix.
- Updated the three `mention` regtest snapshots.
- Full generator suite green (256 passed).

---
Closes #747 — automated triage
