### PR TITLE
fix(list-recent-runs): recover dropped cron ticks via previous-run anchor

### DIFF
--- a/plugins/tend-ci-runner/scripts/list-recent-runs.sh
+++ b/plugins/tend-ci-runner/scripts/list-recent-runs.sh
@@ -13,8 +13,11 @@
 # exactly: [intended-1h, intended], then [intended, intended+1h]. Without
 # this, GHA scheduler delay (20-40 min during peak hours) shifts each
 # cycle's window relative to actual start time and drops runs that finished
-# in the slack between consecutive actual starts. For non-schedule events
-# or non-hourly crons, falls back to a now-anchored 1h window.
+# in the slack between consecutive actual starts. When GHA *drops* a tick
+# entirely (not just delays it), the window's floor is instead pulled back to
+# the previous actual run's intended tick so the orphaned hour still gets
+# analyzed. For non-schedule events or non-hourly crons, falls back to a
+# now-anchored 1h window.
 #
 # Environment variables:
 #   TARGET_REPO - Query a different repo (default: current repo)
@@ -63,8 +66,43 @@ if [ -n "$cron_minute" ]; then
   else
     intended=$this_hour_tick
   fi
+  # Default floor: one cron period back. Consecutive ticks tile exactly.
   COMPLETED_AFTER=$((intended - 3600))
-  CREATED_SINCE=$(date -u -d "@$((intended - 10800))" +%Y-%m-%dT%H:%M:%S)
+
+  # Dropped-tick recovery. GHA doesn't only *delay* scheduled ticks, it also
+  # *drops* them: a tick that fires zero times leaves that hour's completions
+  # in the gap between the previous and next cycle's windows (the skipped-tick
+  # case #526 deferred as acceptable). Rather than assume the previous tick
+  # fired, resume from where the previous *actual* completed run of this
+  # workflow left off: recover that run's intended tick and floor the window
+  # there. When every tick fires, the previous run's intended tick == the
+  # default (intended - 3600), so this is a byte-identical no-op — still no
+  # overlap between consecutive cycles. When a tick was dropped, it reaches
+  # back to cover the orphaned hour. Capped at 6h so a sustained outage can't
+  # create an unbounded window. The analyzing workflow runs on the current
+  # repo, so this query omits TARGET_REPO's -R.
+  if [ -n "${GITHUB_WORKFLOW:-}" ]; then
+    prev_start=$(gh run list --workflow "$GITHUB_WORKFLOW" --status completed \
+      --limit 10 --json databaseId,createdAt \
+      --jq "[.[] | select(.databaseId != (${GITHUB_RUN_ID:-0}))] | .[0].createdAt // empty" \
+      2>/dev/null || true)
+    if [ -n "$prev_start" ]; then
+      prev_ts=$(date -u -d "$prev_start" +%s 2>/dev/null || echo "")
+      if [ -n "$prev_ts" ]; then
+        prev_hour_tick=$(date -u -d "$(date -u -d "@$prev_ts" +%Y-%m-%dT%H:00:00) $cron_minute minutes" +%s)
+        if [ "$prev_ts" -ge "$prev_hour_tick" ]; then
+          prev_intended=$prev_hour_tick
+        else
+          prev_intended=$((prev_hour_tick - 3600))
+        fi
+        floor_cap=$((intended - 21600))   # never reach back more than 6h
+        [ "$prev_intended" -lt "$floor_cap" ] && prev_intended=$floor_cap
+        [ "$prev_intended" -lt "$COMPLETED_AFTER" ] && COMPLETED_AFTER=$prev_intended
+      fi
+    fi
+  fi
+
+  CREATED_SINCE=$(date -u -d "@$((COMPLETED_AFTER - 7200))" +%Y-%m-%dT%H:%M:%S)
 else
   CREATED_SINCE=$(date -d '3 hours ago' +%Y-%m-%dT%H:%M:%S)
   COMPLETED_AFTER=$(date -d '1 hour ago' +%s)


### PR DESCRIPTION
## Problem

`list-recent-runs.sh` anchors its completion window to the most recent intended cron tick and floors it at `intended - 3600`. This tiles exactly — `[intended-1h, intended]` then `[intended, intended+1h]` — **only when consecutive cron ticks actually fire.** GHA doesn't just *delay* scheduled ticks (which the tick-anchoring in #526 handles well); it *drops* them. A dropped tick leaves that hour's completions in the gap between the previous and next cycle's windows, and no run ever analyzes them.

[#526](https://github.com/max-sixty/tend/pull/526) named this exact "skipped-tick edge case" and deferred it as "rare under sustained outage," because the only fix on the table then was the 2h-overlap approach the maintainer had rejected for re-analyzing runs. This run is direct evidence it is **not** rare and the miss is **invisible** — a dropped tick produces no error, so the skipped outcomes just never get audited.

## Evidence (this run)

Analyzing `max-sixty/worktrunk`, `review-reviewers` fired at `07:50Z` (07:47 tick) then `09:46Z` (09:47 tick) — **GHA dropped the 08:47 tick.** The window for the 09:47 cycle floored at `08:47`, leaving `[07:47, 08:47]` covered by no cycle. `list-recent-runs.sh` returned **3** of the **10** tend-* runs actually in `[07:47, 09:47]`. The orphaned hour contained real, substantive bot output:

- **[worktrunk#3355](https://github.com/max-sixty/worktrunk/issues/3355)** — a well-sourced answer on Windows Defender code-signing (comment `4874219842`, `08:16Z`).
- **[worktrunk#3357](https://github.com/max-sixty/worktrunk/pull/3357)** — a full review cycle: `COMMENTED` flagging `codecov/patch`, author pushed coverage, bot `APPROVED` on the fixed commit (`08:15Z`–`08:23Z`).

Both were healthy outcomes this time — but had either gone wrong, no `review-reviewers` cycle would have caught it. (I covered the gap manually for this run's audit; the gist records the full window.)

## Fix

Floor the window at the previous **actual** completed run's intended tick instead of assuming the previous tick fired. #526's discussion weighed only two options — the *intended* fire time (not exposed by GHA) vs 2h overlap (rejected) — and missed a third: the previous run's own start time **is** queryable, and rounding it down to its cron tick recovers exactly where the last cycle's window ended.

- **Every tick fires** → previous intended tick `== intended - 3600` → byte-identical to today's behavior, **no overlap** (the constraint #526 set).
- **A tick was dropped** → floor reaches back to the last actual run's tick, covering the orphaned hour with no double-analysis.
- Capped at **6h** reach-back so a sustained outage can't create an unbounded window. Falls back cleanly (`gh` failure, no `GITHUB_WORKFLOW`) to the current floor.

Verified in this CI session: the patched script returns all **10** in-window runs (was 3); with consecutive ticks it resolves the floor to `intended - 3600` unchanged.

## Gate assessment

- **Type:** targeted fix to one branch of the window logic (not a structural rewrite).
- **Classification:** structural + deterministic — a dropped tick *always* produces the gap; not a stochastic model lapse.
- **Occurrences:** 1 confirmed gap-with-missed-outcomes this run. Below the normal 2–3 bar, but acted on because the failure mode is **self-concealing**: future cycles use the same window and won't re-detect the gap, so evidence cannot accumulate — "wait for occurrence 2" would sit at 1 while silently under-covering. This is tend's own audit tooling, the fix reduces to a no-op in the common case, and human review is the backstop.

Evidence log: https://gist.github.com/b923bbc52f3c6606931d59abdae616a3
