### PR TITLE
chore(review-reviewers): bump action pin to claude-interactive@0.1.9

### DIFF
--- a/.github/workflows/review-reviewers.yaml
+++ b/.github/workflows/review-reviewers.yaml
@@ -68,7 +68,7 @@ jobs:
           fetch-tags: true
           token: ${{ secrets.TEND_BOT_TOKEN }}
 
-      - uses: max-sixty/tend/interactive@0.1.5
+      - uses: max-sixty/tend/claude-interactive@0.1.9
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
Nightly survey finding: `review-reviewers.yaml` is the only workflow in the repo still pinned to an old action ref. It uses `max-sixty/tend/interactive@0.1.5`, four releases behind the generated `tend-*` workflows (now on `max-sixty/tend/claude@0.1.9`).

Two things are stale:

- **Harness path renamed.** The `interactive` harness was split into `claude` (default, headless) and `claude-interactive` (PTY) after 0.1.5 — there is no top-level `interactive/` directory anymore. The `@0.1.5` pin is immutable and still resolves against the old tree, so the workflow isn't broken, but it runs 0.1.5-era action code and skills.
- **Version lag.** 0.1.5 → 0.1.9 misses four releases of harness/skill improvements the rest of the repo already tracks.

This bumps the pin to `max-sixty/tend/claude-interactive@0.1.9`, the interactive harness's current path and version. All of the workflow's inputs (`github_token`, `claude_code_oauth_token`, `anthropic_api_key`, `bot_name`, `model`, `prompt`) are still accepted by the current `claude-interactive/action.yaml`, so this is a path/version bump only — no input changes.

No regression test: this is a workflow-file pin bump. Confirmed `claude-interactive/action.yaml` exists at tag `0.1.9` so the new ref resolves.

This continues the file's existing bump-maintenance pattern (it was previously bumped to `0.1.2`, then `interactive@0.1.5`); the hand-maintained workflow doesn't ride `tend init`, so it lags releases until bumped manually.
