### PR TITLE
chore: bump claude_version to 2.1.201

### DIFF
--- a/claude-interactive/action.yaml
+++ b/claude-interactive/action.yaml
@@ -50,7 +50,7 @@ inputs:
     default: "true"
     description: Include the full Claude transcript in the workflow step summary.
   claude_version:
-    default: "2.1.195"
+    default: "2.1.201"
     description: >-
       Version of the `claude` binary to install via
       `https://claude.ai/install.sh`, pinned to a specific

--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -52,7 +52,7 @@ inputs:
     default: "true"
     description: Include the rendered Claude transcript in the workflow step summary.
   claude_version:
-    default: "2.1.195"
+    default: "2.1.201"
     description: >-
       Version of the `claude` binary to install via
       `https://claude.ai/install.sh`, pinned to a specific


### PR DESCRIPTION
Weekly bump of the pinned `claude` binary: `2.1.195` → `2.1.201`. Bumped in both `claude/action.yaml` (headless `claude -p`) and `claude-interactive/action.yaml` (PTY) to keep the two Claude pins in step. Stale pins map `--model opus`/`sonnet` aliases to a superseded binary, so this keeps alias resolution current.

Skim of the claude-code CHANGELOG between the two versions for anything touching the agent paths:

- **2.1.197** — Introduces a new default model with native 1M-token context. Our actions pass `--model` explicitly, so the default doesn't apply, but the newer binary is what resolves the `opus`/`sonnet` aliases we do pass.
- **2.1.198** — Subagents now run in the background by default, with `agent_needs_input` / `agent_completed` Notification hook events. Doesn't affect our headless `-p` exit-code completion or the interactive Stop-hook sentinel.
- **2.1.200** — Background-session fixes (cancelled-turn respawn, daemon handover) and a permission-mode label rename (`default` → `manual`, both accepted). No impact on our invocation.

Nothing in the range touches headless `-p` result events or Stop-hook semantics that the harnesses depend on.
