### PR TITLE
fix: attribute bot commits and PRs solely to the tend bot

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,1 +1,0 @@
-{"permissions":{"defaultMode":"bypassPermissions","allow":["Bash","Edit","Read","Write","Glob","Grep","WebSearch","WebFetch","Task","Skill"]},"skipDangerousModePermissionPrompt":true}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,1 @@
+{"permissions":{"defaultMode":"bypassPermissions","allow":["Bash","Edit","Read","Write","Glob","Grep","WebSearch","WebFetch","Task","Skill"]},"skipDangerousModePermissionPrompt":true}

--- a/claude-interactive/action.yaml
+++ b/claude-interactive/action.yaml
@@ -325,6 +325,7 @@ runs:
           '{
             permissions: {defaultMode: "bypassPermissions", allow: $allow},
             skipDangerousModePermissionPrompt: true,
+            attribution: {commit: "", pr: ""},
             hooks: {
               Stop:        [{matcher: "", hooks: [{type: "command", command: ("touch " + ($ok   | @sh))}]}],
               StopFailure: [{matcher: "", hooks: [{type: "command", command: ("touch " + ($fail | @sh))}]}]

--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -273,10 +273,15 @@ runs:
         # the settings key the dialog's accept button writes, read from any
         # settings layer. No Stop/StopFailure hooks — headless detects
         # completion from the process exit plus the result-event verdict below.
+        # attribution: {commit: "", pr: ""} empties Claude Code's auto-added
+        # `Co-Authored-By: Claude` commit trailer and `Generated with Claude
+        # Code` PR footer, so bot commits and PRs are attributed solely to the
+        # tend bot. (`attribution` supersedes the deprecated `includeCoAuthoredBy`.)
         jq -nc --argjson allow "$ALLOW_JSON" \
           '{
             permissions: {defaultMode: "bypassPermissions", allow: $allow},
-            skipDangerousModePermissionPrompt: true
+            skipDangerousModePermissionPrompt: true,
+            attribution: {commit: "", pr: ""}
           }' > "$RUNNER_TEMP/tend-settings.json"
         sudo -u "$SANDBOX" mkdir -p "$GITHUB_WORKSPACE/.claude"
         sudo -u "$SANDBOX" tee "$GITHUB_WORKSPACE/.claude/settings.local.json" \

--- a/plugins/tend-ci-runner/skills/ci-fix/SKILL.md
+++ b/plugins/tend-ci-runner/skills/ci-fix/SKILL.md
@@ -54,9 +54,7 @@ Re-check for existing fix PRs (one may have been created while you worked).
 ```bash
 git checkout -b fix/ci-<run-id>
 git add <files>
-git commit -m "fix: <description>
-
-Co-Authored-By: Claude <noreply@anthropic.com>"
+git commit -m "fix: <description>"
 git push -u origin fix/ci-<run-id>
 ```
 

--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -403,8 +403,6 @@ Outdated comments (null line) are best-effort — skip if the original context c
 ```bash
 gh pr checkout <number>
 git add <files>
-git commit -m "fix: <description>
-
-Co-Authored-By: Claude <noreply@anthropic.com>"
+git commit -m "fix: <description>"
 git push
 ```

--- a/plugins/tend-ci-runner/skills/triage/SKILL.md
+++ b/plugins/tend-ci-runner/skills/triage/SKILL.md
@@ -112,9 +112,7 @@ Step 3's duplicate check catches identical fixes. It misses the *same root cause
    git add -A
    git commit -m "fix: <description>
 
-   Closes #$ARGUMENTS
-
-   Co-Authored-By: Claude <noreply@anthropic.com>"
+   Closes #$ARGUMENTS"
    git push -u origin fix/issue-$ARGUMENTS
    gh pr create --title "fix: <description>" --body "## Problem
    [What the issue reported and the root cause]
@@ -137,9 +135,7 @@ Commit just the failing test on a reproduction branch and open a PR:
 ```bash
 git checkout -b repro/issue-$ARGUMENTS
 git add -A
-git commit -m "test: add reproduction for #$ARGUMENTS
-
-Co-Authored-By: Claude <noreply@anthropic.com>"
+git commit -m "test: add reproduction for #$ARGUMENTS"
 git push -u origin repro/issue-$ARGUMENTS
 gh pr create --title "test: reproduction for #$ARGUMENTS" --body "## Context
 Adds a failing test that reproduces #$ARGUMENTS. The fix is not yet included — this PR captures the reproduction so a maintainer can investigate.


### PR DESCRIPTION
## Problem

Bot commits carry a `Co-Authored-By: Claude <noreply@anthropic.com>` trailer and bot PRs carry a `🤖 Generated with [Claude Code](https://claude.com/claude-code)` footer (example: max-sixty/worktrunk#3393). The ask in #759 is to drop both so the sole author is the tend bot.

These come from two sources:

1. **Claude Code auto-attribution.** The `claude` binary injects a commit trailer and a PR footer. In v2.1.195 this is controlled by the `attribution` settings key (`{commit, pr}`), which supersedes the now-deprecated `includeCoAuthoredBy` boolean. Confirmed against the installed binary's own logic: `attribution.commit`/`attribution.pr` override the defaults, and setting either to `""` empties it.
2. **Hard-coded skill templates.** The triage, ci-fix, and review commit-message templates literally spell out `Co-Authored-By: Claude …`, so they'd persist even with auto-attribution off.

## Solution

- Add `attribution: {commit: "", pr: ""}` to the `settings.local.json` that both Claude harness actions (`claude/action.yaml` headless and `claude-interactive/action.yaml` PTY) write. This empties the auto-added commit trailer and PR footer.
- Remove the hard-coded `Co-Authored-By` lines from the triage, ci-fix, and review commit templates.

Commit authorship is unchanged — it already resolves to the bot via the git identity configured in `running-in-ci` (`user.name`/`user.email` = the bot account).

The Codex harness is unaffected (no Claude Code attribution); it's out of scope for this issue.

## Testing

- Verified the `attribution` key and its precedence over `includeCoAuthoredBy` directly against the installed `claude` v2.1.195 binary strings, not just the docs.
- Confirmed both actions' `jq` invocations still emit valid `settings.local.json` with the new key.
- Grepped the plugins/shared/action trees to confirm no `Co-Authored-By` occurrences remain outside the explanatory comment.

The `attribution` change reaches adopters at the next tend release (their workflows pin `max-sixty/tend/<harness>@X.Y.Z`); the skill-template change reaches them via the marketplace plugin on the next run.

---
Closes #759 — automated triage
