### PR TITLE
fix(running-in-ci): permit maintainer-invited upstream contributions

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -75,7 +75,7 @@ If a linked PR merged (or the triggering PR itself merged) **after the triggerin
 
 - **Secrets**: Never run commands that introspect the process env (`env`, `printenv`, `set`, `export`) or `cat`/`echo` credential files. The rule is absolute — name-stripping filters like `env | cut -d= -f1` do not make these commands safe: the harness may place credential-bearing values in the environment (the Codex harness passes the PAT and model auth directly to the agent), and a single unfiltered `env` or `printenv FOO` prints the value verbatim into the session log, which is uploaded as an artifact. Never include tokens or credentials in responses or comments.
 - **Merging**: Never merge PRs or enable auto-merge (`gh pr merge`, `gh pr merge --auto`). PRs are proposals — a maintainer decides when to merge.
-- **Scope**: PRs, pushes, and comments on existing threads in other repos are off-limits. Filing fresh issues in other repos follows **Filing Issues in Other Repos** below. When such a rule blocks the right action, surface it per **When a scope rule blocks the right action** below rather than routing around it.
+- **Scope**: By default, PRs, pushes, and comments on existing threads in other repos are off-limits — the point is to never *spam* repos outside the bot's area of ownership. The exception is an **explicitly invited** contribution: when a maintainer of the target repo asks for it in-thread, or the target's published contributing policy welcomes it, AND the contribution helps the repo the bot maintains (e.g. upstreaming a fix for a dependency bug the bot is working around), the bot may open a PR or comment on that thread — see **Contributing to Other Repos on Invitation** below. Filing fresh issues follows **Filing Issues in Other Repos** below. Absent an explicit invitation, the default holds — surface the blocker per **When a scope rule blocks the right action** below rather than routing around it.
 - **Hanging commands**: Never use `gh run watch` or `gh pr checks --watch` — both hang indefinitely. Poll with `gh pr checks` in a loop instead.
 
 ## End the turn only when work is shipped
@@ -109,6 +109,15 @@ Whether filed direct or post-approval, the issue body includes:
 - Problem statement: what fires, where, under what conditions.
 - Evidence: run links; cost/duration if relevant.
 - Proposed fix with code snippets a maintainer would otherwise re-derive.
+
+### Contributing to Other Repos on Invitation
+
+The Scope default bars *unsolicited* PRs/comments in other repos. It does not bar an *invited* one. When BOTH hold, the bot may open a PR or comment on an existing thread in the target repo:
+
+- **Explicit invitation** — a maintainer of the target repo asked for the contribution in-thread (e.g. "do you want to open the PR?"), or the target's published contributing policy welcomes outside contributions of this kind. Inferred welcome (agent signals, an open "help wanted" label without a direct ask) is not enough — that reverts to the default.
+- **Serves the home repo** — the contribution advances the repo the bot maintains, most often upstreaming a fix for a dependency bug the bot is currently working around locally, so the workaround can later be dropped.
+
+Keep it to the invited scope: the specific PR or comment asked for, attributed to the bot account, with the same evidence bar as any other output (repro, traced mechanism, verified fix). Don't expand into unrelated upstream work. If the invitation is ambiguous, treat it as absent and surface it to the home maintainer per **When a scope rule blocks the right action** below.
 
 ### When a scope rule blocks the right action
 


### PR DESCRIPTION
## Problem

The bundled `running-in-ci` **Scope** rule was unconditional:

> **Scope**: PRs, pushes, and comments on existing threads in other repos are off-limits.

That default correctly stops the bot spamming issues/PRs outside the repo it maintains, but it had no carve-out for the case where an upstream maintainer *explicitly invites* the contribution (or the target's published policy welcomes it) and the contribution materially helps the repo the bot maintains. In that case the rule blocked the correct move — as surfaced in #769, where an upstream maintainer asked worktrunk-bot to open a one-line fix PR and the bot couldn't respond.

The tend/worktrunk owner asked for this to become a change in tend:

> It's correct that you shouldn't *spam issues or PRs* outside your area of ownership. But if a maintainer of a different project (or the project's policy) says it's OK for you to contribute, and it's helpful for the project you maintain, then you should do this. Probably this is a change in `tend`.

Since the restriction fires for every tend consumer, this is a bundled-skill change rather than a per-repo `running-tend` overlay.

## Solution

Add a bounded exception to the Scope rule. The anti-spam default holds; an **explicitly invited** upstream contribution is permitted only when BOTH conditions hold:

- **Explicit invitation** — a target-repo maintainer asks for it in-thread, or the target's published contributing policy welcomes it. Inferred welcome (agent signals, a `help wanted` label without a direct ask) is not enough and reverts to the default.
- **Serves the home repo** — most often upstreaming a fix for a dependency bug the bot is currently working around, so the workaround can later be dropped.

This parallels the existing **agent-equipped standing exception** (which relaxes the default for *filing fresh issues*), extending the same "invited, not unsolicited" principle to PRs and comments on existing threads — but gated on an explicit invitation rather than agent signals, since acting in a human-maintained repo is higher-touch.

Two edits to `plugins/tend-ci-runner/skills/running-in-ci/SKILL.md`:

1. Rewrite the **Scope** bullet to state the anti-spam intent, name the exception, and point to the new subsection.
2. Add a **Contributing to Other Repos on Invitation** subsection spelling out the two gates, the scope limit (the specific PR/comment asked for, same evidence bar), and the ambiguity fallback.

## Testing

`pre-commit run --files …` (trailing whitespace, end-of-file, typos, bang-backtick guard, reference sync) passes. This is a skill-text/guidance change with no runtime surface — no test to add.

---
Closes #769 — automated triage
