### PR TITLE
docs(debug-tend-run): fix codex message content-item jq path

### DIFF
--- a/plugins/install-tend/skills/debug-tend-run/references/codex-logs.md
+++ b/plugins/install-tend/skills/debug-tend-run/references/codex-logs.md
@@ -8,7 +8,9 @@ Each JSONL line has a top-level `type` of `session_meta`, `turn_context`,
 `response_item.payload`, with the variant in `.payload.type`:
 
 - `message` — initial input from `user` or `developer` (system prompt,
-  AGENTS.md, skill listings); text at `.payload.content[].input_text.text`
+  AGENTS.md, skill listings); each content item is internally tagged
+  `{type: "input_text", text}`, so text is at
+  `.payload.content[] | select(.type == "input_text") | .text`
 - `agent_message` — text emitted by the model during the turn
   (`.payload.message`)
 - `function_call` — tool invocation; `.payload.name` plus


### PR DESCRIPTION
Nightly survey found an internal inconsistency in the Codex log-parsing reference: the prose description of a `message` item's text location contradicts the working `jq` recipe further down the same file.

- Line ~11 said text lives at `.payload.content[].input_text.text` — a nested `input_text` object shape.
- The recipe under "Initial prompts" uses `.payload.content[] | select(.type == "input_text") | .text` — a flat, `type`-tagged shape.

A reader who follows the prose path gets `null`. The flat shape is correct: Codex's `ContentItem` enum is internally tagged, so each content item serializes as `{"type": "input_text", "text": "…"}`.

Source: [`codex-rs/protocol/src/models.rs`](https://github.com/openai/codex/blob/main/codex-rs/protocol/src/models.rs) —

```rust
#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema, TS)]
#[serde(tag = "type", rename_all = "snake_case")]
pub enum ContentItem {
    InputText { text: String },
    ...
}
```

`#[serde(tag = "type", rename_all = "snake_case")]` produces `{"type": "input_text", "text": ...}`, not `{"input_text": {"text": ...}}`.

This fix aligns the prose with the working recipe. Pure documentation change — no test feasible.
