### PR TITLE
fix(running-in-ci): prohibit self-authored attribution sign-offs

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -473,7 +473,7 @@ Always use markdown links for files, issues, PRs, and docs. **Any link containin
 - **Issues/PRs**: `#123` shorthand
 - **External**: `[text](url)` format
 
-Don't add job links or footers — `claude-code-action` adds these automatically.
+Don't add job links, footers, or authorship sign-offs (e.g. `> _Written by Claude Code on behalf of @maintainer_`) — the bot account already conveys authorship, and `claude-code-action` adds any needed footer automatically. This covers PR and issue bodies too, not just comments.
 
 ## Keeping PR Titles and Descriptions Current
 


### PR DESCRIPTION
## Problem

The bot occasionally appended a self-authored sign-off to a PR body, e.g. `> _This was written by Claude Code on behalf of @max-sixty_` (observed on [max-sixty/worktrunk#3427](https://github.com/max-sixty/worktrunk/pull/3427)). The PR already comes from the tend bot account, so authorship is unambiguous — the line is noise, and it re-introduces exactly the "Claude" attribution that #759/#760 set out to remove, this time as prose the model writes itself rather than the harness footer those PRs fixed.

## Root cause

Not template-driven. The strings `behalf` / `written by` / `sign-off` / `attribution` appear in no tend template, skill, or harness action (confirmed by grepping `shared/`, `plugins/`, `claude/`, `claude-interactive/`, `codex/`), and #760 already emptied the harness `attribution` config. It's emergent model self-attribution — occasional, not systematic — so there's no template to edit; it needs an explicit *don't do this* instruction the model reads on every run.

## Solution

Extend the existing footer prohibition in `plugins/tend-ci-runner/skills/running-in-ci/SKILL.md` (Comment Formatting), which already governs the analogous "don't add footers" case, to also cover authorship sign-offs, and to note explicitly that it applies to PR and issue bodies, not just comments. `running-in-ci` is loaded first in every workflow, so this reaches the PR-creation path without duplicating guidance into a second file.

## Testing

Skill-text/prompt-compliance change — no code path to unit-test. The reproduction is the linked PR body; the fix is the standing instruction that prevents the model from re-emitting it.

---
Closes #772 — automated triage
