### PR TITLE
chore: bump claude_version to 2.1.207

### DIFF
--- a/claude-interactive/action.yaml
+++ b/claude-interactive/action.yaml
@@ -50,7 +50,7 @@ inputs:
     default: "true"
     description: Include the full Claude transcript in the workflow step summary.
   claude_version:
-    default: "2.1.201"
+    default: "2.1.207"
     description: >-
       Version of the `claude` binary to install via
       `https://claude.ai/install.sh`, pinned to a specific

--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -52,7 +52,7 @@ inputs:
     default: "true"
     description: Include the rendered Claude transcript in the workflow step summary.
   claude_version:
-    default: "2.1.201"
+    default: "2.1.207"
     description: >-
       Version of the `claude` binary to install via
       `https://claude.ai/install.sh`, pinned to a specific


### PR DESCRIPTION
Weekly bump of the pinned `claude_version` from `2.1.201` to the latest release `2.1.207`, kept in step across both Claude harnesses (`claude/action.yaml` headless and `claude-interactive/action.yaml` PTY). The pin is a static string nothing else moves, so it drifts behind and `--model opus`/`sonnet` resolves against a stale binary's alias table.

CHANGELOG items between `2.1.201` and `2.1.207` touching the harness paths (headless `-p`, hooks, model/alias, proxy base URL):

- **2.1.207** — Fixed remote managed settings from a non-interactive run (`claude -p`, the SDK) being permanently recorded as consented without ever showing the security consent dialog. Also: compound commands with `cd` no longer prompt for permission when the only output redirect was to `/dev/null`; plugin hooks reject `${user_config.*}` in shell-form commands (shell-injection fix) — use exec form or `$CLAUDE_PLUGIN_OPTION_<KEY>`.
- **2.1.204** — Fixed hook events not streaming during SessionStart hooks in headless sessions, which could idle-reap remote workers mid-hook (relevant to the interactive harness's Stop-hook supervision).
- **2.1.203** — Fixed background/agent-view sessions dropping a shell-exported `ANTHROPIC_BASE_URL`, which sent API keys to the default endpoint and 401'd. Tend's harnesses run behind the credential-injecting proxy that sets the base URL, so worth noting; the headless `-p` path we use is not the background-session path, but flagging for awareness.

No changes to `codex_version` — Codex pins a prerelease on purpose and its catalog churns, so it's bumped separately only to a release confirmed to run under `codex exec`.

Generated by the weekly maintenance workflow.
