### PR TITLE
docs(tend.example): weekly approves, not auto-merges, dep PRs

### DIFF
--- a/docs/tend.example.yaml
+++ b/docs/tend.example.yaml
@@ -256,8 +256,8 @@ bot_name: my-project-bot
 
 # ### weekly
 #
-# Weekly (default Sunday 09:17 UTC). Reviews dependency PRs, auto-merges safe
-# patch and minor updates.
+# Weekly (default Sunday 09:17 UTC). Reviews dependency PRs, approves safe
+# patch and minor updates (a maintainer merges — the bot never merges).
 #
 # workflows:
 #   weekly:

--- a/plugins/install-tend/skills/install-tend/references/tend.example.yaml
+++ b/plugins/install-tend/skills/install-tend/references/tend.example.yaml
@@ -256,8 +256,8 @@ bot_name: my-project-bot
 
 # ### weekly
 #
-# Weekly (default Sunday 09:17 UTC). Reviews dependency PRs, auto-merges safe
-# patch and minor updates.
+# Weekly (default Sunday 09:17 UTC). Reviews dependency PRs, approves safe
+# patch and minor updates (a maintainer merges — the bot never merges).
 #
 # workflows:
 #   weekly:


### PR DESCRIPTION
The example config's `weekly` workflow description claimed the workflow "auto-merges safe patch and minor updates". That's inaccurate and contradicts a safety-critical policy:

- The bundled `weekly` skill **approves** safe dependency PRs (`gh pr review --approve`) — it never merges them.
- tend's core rule (`running-in-ci`) is explicit: the bot never merges PRs or enables auto-merge; a maintainer decides when to merge.

Since `tend.example.yaml` is what adopters read while installing, the stale line sets the wrong expectation about a security boundary — implying the bot will land dependency updates unattended. Corrected to "approves safe patch and minor updates (a maintainer merges — the bot never merges)."

Documentation-only change to a comment, so no regression test is feasible.

Found during the nightly rolling survey.
