### PR TITLE
fix(notifications): tolerate transient non-JSON gh api responses

### DIFF
--- a/generator/src/tend/templates/notifications.yaml.j2
+++ b/generator/src/tend/templates/notifications.yaml.j2
@@ -30,7 +30,14 @@ jobs:
           done
           if [ -z "$NOTIFS" ]; then
             echo "count=0" >> "$GITHUB_OUTPUT"
-            echo "notifications fetch failed transiently — skipping this cycle"
+            echo "notifications fetch failed after retries — skipping this cycle"
+            # Surface the HTTP status + body head so a *persistent* failure
+            # (a real problem, not a transient blip) stays diagnosable instead
+            # of being silently swallowed. `gh api -i` prepends the status line
+            # and headers; on an error status it exits non-zero, hence `|| true`.
+            echo "--- last response (status + body head) ---"
+            gh api notifications -i 2>&1 | head -c 800 || true
+            echo
             exit 0
           fi
 

--- a/generator/src/tend/templates/notifications.yaml.j2
+++ b/generator/src/tend/templates/notifications.yaml.j2
@@ -14,7 +14,27 @@ jobs:
       - name: Check for unread notifications
         id: check
         run: |
-          COUNT=$(gh api notifications --jq 'length')
+          # Fetch notifications once, tolerating transient non-JSON responses.
+          # GitHub occasionally returns an HTML error page (even with a 200)
+          # during a brief API blip; under `bash -e` an untolerated `gh api`
+          # failure would abort the whole step red. A failed fetch just means
+          # this cycle can't enumerate — the next scheduled cycle picks up
+          # anything missed — so retry briefly, then skip cleanly.
+          NOTIFS=""
+          for attempt in 1 2 3; do
+            if NOTIFS=$(gh api notifications 2>/dev/null) && echo "$NOTIFS" | jq -e . >/dev/null 2>&1; then
+              break
+            fi
+            NOTIFS=""
+            [ "$attempt" -lt 3 ] && sleep "$attempt"
+          done
+          if [ -z "$NOTIFS" ]; then
+            echo "count=0" >> "$GITHUB_OUTPUT"
+            echo "notifications fetch failed transiently — skipping this cycle"
+            exit 0
+          fi
+
+          COUNT=$(echo "$NOTIFS" | jq 'length')
           if [ "$COUNT" = "0" ]; then
             echo "count=0" >> "$GITHUB_OUTPUT"
             echo "No unread notifications — skipping"
@@ -30,7 +50,6 @@ jobs:
           RECENT_PRS=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs?created=>=$SINCE&per_page=50" --jq '[.workflow_runs[] | select(.name | test("^(tend-review|tend-mention|tend-triage|tend-ci-fix)$")) | .pull_requests[]?.number] | unique | .[]' || true)
 
           if [ -n "$RECENT_PRS" ]; then
-            NOTIFS=$(gh api notifications)
             for pr in $RECENT_PRS; do
               echo "$NOTIFS" | jq -r --arg repo "$GITHUB_REPOSITORY" --arg pr "$pr" '.[] | select(.subject.url == "https://api.github.com/repos/" + $repo + "/pulls/" + $pr or .subject.url == "https://api.github.com/repos/" + $repo + "/issues/" + $pr) | .id' | while read -r tid; do
                 [ -n "$tid" ] || continue
@@ -42,7 +61,8 @@ jobs:
           # --- Layer C: drop notifications on bot-authored closed PRs ---
           # The bot auto-subscribes to its own PRs. After merge/close, leftover
           # subscription notifications are pure noise — no action needed.
-          NOTIFS=$(gh api notifications)
+          # Reuses the snapshot fetched above; marking a thread read is
+          # idempotent, so a stale snapshot at worst re-PATCHes a read thread.
           echo "$NOTIFS" | jq -r --arg repo "$GITHUB_REPOSITORY" '.[] | select(.repository.full_name == $repo and .subject.type == "PullRequest") | .id' | while read -r tid; do
             [ -n "$tid" ] || continue
             PR_NUM=$(echo "$NOTIFS" | jq -r --arg tid "$tid" '.[] | select(.id == $tid) | .subject.url | split("/") | last')
@@ -61,7 +81,12 @@ jobs:
           # Processing them now risks duplicating work. Cross-repo notifications
           # are exempt — no dedicated workflow handles them.
           CUTOFF=$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
-          REMAINING=$(gh api notifications)
+          # Re-fetch so the count reflects threads marked read in Layers B/C.
+          # Tolerate a transient failure by falling back to the pre-mutation
+          # snapshot — an over-count at worst spends one agent run, never fails.
+          if ! REMAINING=$(gh api notifications 2>/dev/null) || ! echo "$REMAINING" | jq -e . >/dev/null 2>&1; then
+            REMAINING="$NOTIFS"
+          fi
           COUNT=$(echo "$REMAINING" | jq --arg repo "$GITHUB_REPOSITORY" --arg cutoff "$CUTOFF" '[.[] | select(.repository.full_name != $repo or .updated_at <= $cutoff)] | length')
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
           if [ "$COUNT" = "0" ]; then

--- a/generator/src/tend/templates/notifications.yaml.j2
+++ b/generator/src/tend/templates/notifications.yaml.j2
@@ -20,24 +20,29 @@ jobs:
           # failure would abort the whole step red. A failed fetch just means
           # this cycle can't enumerate — the next scheduled cycle picks up
           # anything missed — so retry briefly, then skip cleanly.
+          #
+          # On every failed attempt, log what actually came back: the plain
+          # fetch hides the body behind `2>/dev/null`, and a transient blip
+          # that recovers on retry would otherwise leave no trace of the bad
+          # response. `gh api -i` re-fetches with the HTTP status line +
+          # headers ahead of the body, so a recurring failure shows the real
+          # status code and body — not just jq's parse complaint. It exits
+          # non-zero on an error status, hence `|| true`. The extra call runs
+          # only on the (rare) failing attempt; the happy path is one fetch.
           NOTIFS=""
           for attempt in 1 2 3; do
             if NOTIFS=$(gh api notifications 2>/dev/null) && echo "$NOTIFS" | jq -e . >/dev/null 2>&1; then
               break
             fi
             NOTIFS=""
+            echo "--- notifications fetch attempt $attempt failed; actual response (status + body head) ---"
+            gh api notifications -i 2>&1 | head -c 1000 || true
+            echo
             [ "$attempt" -lt 3 ] && sleep "$attempt"
           done
           if [ -z "$NOTIFS" ]; then
             echo "count=0" >> "$GITHUB_OUTPUT"
             echo "notifications fetch failed after retries — skipping this cycle"
-            # Surface the HTTP status + body head so a *persistent* failure
-            # (a real problem, not a transient blip) stays diagnosable instead
-            # of being silently swallowed. `gh api -i` prepends the status line
-            # and headers; on an error status it exits non-zero, hence `|| true`.
-            echo "--- last response (status + body head) ---"
-            gh api notifications -i 2>&1 | head -c 800 || true
-            echo
             exit 0
           fi
 

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
@@ -42,7 +42,14 @@ jobs:
           done
           if [ -z "$NOTIFS" ]; then
             echo "count=0" >> "$GITHUB_OUTPUT"
-            echo "notifications fetch failed transiently ? skipping this cycle"
+            echo "notifications fetch failed after retries ? skipping this cycle"
+            # Surface the HTTP status + body head so a *persistent* failure
+            # (a real problem, not a transient blip) stays diagnosable instead
+            # of being silently swallowed. `gh api -i` prepends the status line
+            # and headers; on an error status it exits non-zero, hence `|| true`.
+            echo "--- last response (status + body head) ---"
+            gh api notifications -i 2>&1 | head -c 800 || true
+            echo
             exit 0
           fi
 

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
@@ -32,24 +32,29 @@ jobs:
           # failure would abort the whole step red. A failed fetch just means
           # this cycle can't enumerate ? the next scheduled cycle picks up
           # anything missed ? so retry briefly, then skip cleanly.
+          #
+          # On every failed attempt, log what actually came back: the plain
+          # fetch hides the body behind `2>/dev/null`, and a transient blip
+          # that recovers on retry would otherwise leave no trace of the bad
+          # response. `gh api -i` re-fetches with the HTTP status line +
+          # headers ahead of the body, so a recurring failure shows the real
+          # status code and body ? not just jq's parse complaint. It exits
+          # non-zero on an error status, hence `|| true`. The extra call runs
+          # only on the (rare) failing attempt; the happy path is one fetch.
           NOTIFS=""
           for attempt in 1 2 3; do
             if NOTIFS=$(gh api notifications 2>/dev/null) && echo "$NOTIFS" | jq -e . >/dev/null 2>&1; then
               break
             fi
             NOTIFS=""
+            echo "--- notifications fetch attempt $attempt failed; actual response (status + body head) ---"
+            gh api notifications -i 2>&1 | head -c 1000 || true
+            echo
             [ "$attempt" -lt 3 ] && sleep "$attempt"
           done
           if [ -z "$NOTIFS" ]; then
             echo "count=0" >> "$GITHUB_OUTPUT"
             echo "notifications fetch failed after retries ? skipping this cycle"
-            # Surface the HTTP status + body head so a *persistent* failure
-            # (a real problem, not a transient blip) stays diagnosable instead
-            # of being silently swallowed. `gh api -i` prepends the status line
-            # and headers; on an error status it exits non-zero, hence `|| true`.
-            echo "--- last response (status + body head) ---"
-            gh api notifications -i 2>&1 | head -c 800 || true
-            echo
             exit 0
           fi
 

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
@@ -26,7 +26,27 @@ jobs:
       - name: Check for unread notifications
         id: check
         run: |
-          COUNT=$(gh api notifications --jq 'length')
+          # Fetch notifications once, tolerating transient non-JSON responses.
+          # GitHub occasionally returns an HTML error page (even with a 200)
+          # during a brief API blip; under `bash -e` an untolerated `gh api`
+          # failure would abort the whole step red. A failed fetch just means
+          # this cycle can't enumerate ? the next scheduled cycle picks up
+          # anything missed ? so retry briefly, then skip cleanly.
+          NOTIFS=""
+          for attempt in 1 2 3; do
+            if NOTIFS=$(gh api notifications 2>/dev/null) && echo "$NOTIFS" | jq -e . >/dev/null 2>&1; then
+              break
+            fi
+            NOTIFS=""
+            [ "$attempt" -lt 3 ] && sleep "$attempt"
+          done
+          if [ -z "$NOTIFS" ]; then
+            echo "count=0" >> "$GITHUB_OUTPUT"
+            echo "notifications fetch failed transiently ? skipping this cycle"
+            exit 0
+          fi
+
+          COUNT=$(echo "$NOTIFS" | jq 'length')
           if [ "$COUNT" = "0" ]; then
             echo "count=0" >> "$GITHUB_OUTPUT"
             echo "No unread notifications ? skipping"
@@ -42,7 +62,6 @@ jobs:
           RECENT_PRS=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs?created=>=$SINCE&per_page=50" --jq '[.workflow_runs[] | select(.name | test("^(tend-review|tend-mention|tend-triage|tend-ci-fix)$")) | .pull_requests[]?.number] | unique | .[]' || true)
 
           if [ -n "$RECENT_PRS" ]; then
-            NOTIFS=$(gh api notifications)
             for pr in $RECENT_PRS; do
               echo "$NOTIFS" | jq -r --arg repo "$GITHUB_REPOSITORY" --arg pr "$pr" '.[] | select(.subject.url == "https://api.github.com/repos/" + $repo + "/pulls/" + $pr or .subject.url == "https://api.github.com/repos/" + $repo + "/issues/" + $pr) | .id' | while read -r tid; do
                 [ -n "$tid" ] || continue
@@ -54,7 +73,8 @@ jobs:
           # --- Layer C: drop notifications on bot-authored closed PRs ---
           # The bot auto-subscribes to its own PRs. After merge/close, leftover
           # subscription notifications are pure noise ? no action needed.
-          NOTIFS=$(gh api notifications)
+          # Reuses the snapshot fetched above; marking a thread read is
+          # idempotent, so a stale snapshot at worst re-PATCHes a read thread.
           echo "$NOTIFS" | jq -r --arg repo "$GITHUB_REPOSITORY" '.[] | select(.repository.full_name == $repo and .subject.type == "PullRequest") | .id' | while read -r tid; do
             [ -n "$tid" ] || continue
             PR_NUM=$(echo "$NOTIFS" | jq -r --arg tid "$tid" '.[] | select(.id == $tid) | .subject.url | split("/") | last')
@@ -73,7 +93,12 @@ jobs:
           # Processing them now risks duplicating work. Cross-repo notifications
           # are exempt ? no dedicated workflow handles them.
           CUTOFF=$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
-          REMAINING=$(gh api notifications)
+          # Re-fetch so the count reflects threads marked read in Layers B/C.
+          # Tolerate a transient failure by falling back to the pre-mutation
+          # snapshot ? an over-count at worst spends one agent run, never fails.
+          if ! REMAINING=$(gh api notifications 2>/dev/null) || ! echo "$REMAINING" | jq -e . >/dev/null 2>&1; then
+            REMAINING="$NOTIFS"
+          fi
           COUNT=$(echo "$REMAINING" | jq --arg repo "$GITHUB_REPOSITORY" --arg cutoff "$CUTOFF" '[.[] | select(.repository.full_name != $repo or .updated_at <= $cutoff)] | length')
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
           if [ "$COUNT" = "0" ]; then

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[notifications].out
@@ -31,24 +31,29 @@ jobs:
           # failure would abort the whole step red. A failed fetch just means
           # this cycle can't enumerate ? the next scheduled cycle picks up
           # anything missed ? so retry briefly, then skip cleanly.
+          #
+          # On every failed attempt, log what actually came back: the plain
+          # fetch hides the body behind `2>/dev/null`, and a transient blip
+          # that recovers on retry would otherwise leave no trace of the bad
+          # response. `gh api -i` re-fetches with the HTTP status line +
+          # headers ahead of the body, so a recurring failure shows the real
+          # status code and body ? not just jq's parse complaint. It exits
+          # non-zero on an error status, hence `|| true`. The extra call runs
+          # only on the (rare) failing attempt; the happy path is one fetch.
           NOTIFS=""
           for attempt in 1 2 3; do
             if NOTIFS=$(gh api notifications 2>/dev/null) && echo "$NOTIFS" | jq -e . >/dev/null 2>&1; then
               break
             fi
             NOTIFS=""
+            echo "--- notifications fetch attempt $attempt failed; actual response (status + body head) ---"
+            gh api notifications -i 2>&1 | head -c 1000 || true
+            echo
             [ "$attempt" -lt 3 ] && sleep "$attempt"
           done
           if [ -z "$NOTIFS" ]; then
             echo "count=0" >> "$GITHUB_OUTPUT"
             echo "notifications fetch failed after retries ? skipping this cycle"
-            # Surface the HTTP status + body head so a *persistent* failure
-            # (a real problem, not a transient blip) stays diagnosable instead
-            # of being silently swallowed. `gh api -i` prepends the status line
-            # and headers; on an error status it exits non-zero, hence `|| true`.
-            echo "--- last response (status + body head) ---"
-            gh api notifications -i 2>&1 | head -c 800 || true
-            echo
             exit 0
           fi
 

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[notifications].out
@@ -41,7 +41,14 @@ jobs:
           done
           if [ -z "$NOTIFS" ]; then
             echo "count=0" >> "$GITHUB_OUTPUT"
-            echo "notifications fetch failed transiently ? skipping this cycle"
+            echo "notifications fetch failed after retries ? skipping this cycle"
+            # Surface the HTTP status + body head so a *persistent* failure
+            # (a real problem, not a transient blip) stays diagnosable instead
+            # of being silently swallowed. `gh api -i` prepends the status line
+            # and headers; on an error status it exits non-zero, hence `|| true`.
+            echo "--- last response (status + body head) ---"
+            gh api notifications -i 2>&1 | head -c 800 || true
+            echo
             exit 0
           fi
 

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[notifications].out
@@ -25,7 +25,27 @@ jobs:
       - name: Check for unread notifications
         id: check
         run: |
-          COUNT=$(gh api notifications --jq 'length')
+          # Fetch notifications once, tolerating transient non-JSON responses.
+          # GitHub occasionally returns an HTML error page (even with a 200)
+          # during a brief API blip; under `bash -e` an untolerated `gh api`
+          # failure would abort the whole step red. A failed fetch just means
+          # this cycle can't enumerate ? the next scheduled cycle picks up
+          # anything missed ? so retry briefly, then skip cleanly.
+          NOTIFS=""
+          for attempt in 1 2 3; do
+            if NOTIFS=$(gh api notifications 2>/dev/null) && echo "$NOTIFS" | jq -e . >/dev/null 2>&1; then
+              break
+            fi
+            NOTIFS=""
+            [ "$attempt" -lt 3 ] && sleep "$attempt"
+          done
+          if [ -z "$NOTIFS" ]; then
+            echo "count=0" >> "$GITHUB_OUTPUT"
+            echo "notifications fetch failed transiently ? skipping this cycle"
+            exit 0
+          fi
+
+          COUNT=$(echo "$NOTIFS" | jq 'length')
           if [ "$COUNT" = "0" ]; then
             echo "count=0" >> "$GITHUB_OUTPUT"
             echo "No unread notifications ? skipping"
@@ -41,7 +61,6 @@ jobs:
           RECENT_PRS=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs?created=>=$SINCE&per_page=50" --jq '[.workflow_runs[] | select(.name | test("^(tend-review|tend-mention|tend-triage|tend-ci-fix)$")) | .pull_requests[]?.number] | unique | .[]' || true)
 
           if [ -n "$RECENT_PRS" ]; then
-            NOTIFS=$(gh api notifications)
             for pr in $RECENT_PRS; do
               echo "$NOTIFS" | jq -r --arg repo "$GITHUB_REPOSITORY" --arg pr "$pr" '.[] | select(.subject.url == "https://api.github.com/repos/" + $repo + "/pulls/" + $pr or .subject.url == "https://api.github.com/repos/" + $repo + "/issues/" + $pr) | .id' | while read -r tid; do
                 [ -n "$tid" ] || continue
@@ -53,7 +72,8 @@ jobs:
           # --- Layer C: drop notifications on bot-authored closed PRs ---
           # The bot auto-subscribes to its own PRs. After merge/close, leftover
           # subscription notifications are pure noise ? no action needed.
-          NOTIFS=$(gh api notifications)
+          # Reuses the snapshot fetched above; marking a thread read is
+          # idempotent, so a stale snapshot at worst re-PATCHes a read thread.
           echo "$NOTIFS" | jq -r --arg repo "$GITHUB_REPOSITORY" '.[] | select(.repository.full_name == $repo and .subject.type == "PullRequest") | .id' | while read -r tid; do
             [ -n "$tid" ] || continue
             PR_NUM=$(echo "$NOTIFS" | jq -r --arg tid "$tid" '.[] | select(.id == $tid) | .subject.url | split("/") | last')
@@ -72,7 +92,12 @@ jobs:
           # Processing them now risks duplicating work. Cross-repo notifications
           # are exempt ? no dedicated workflow handles them.
           CUTOFF=$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
-          REMAINING=$(gh api notifications)
+          # Re-fetch so the count reflects threads marked read in Layers B/C.
+          # Tolerate a transient failure by falling back to the pre-mutation
+          # snapshot ? an over-count at worst spends one agent run, never fails.
+          if ! REMAINING=$(gh api notifications 2>/dev/null) || ! echo "$REMAINING" | jq -e . >/dev/null 2>&1; then
+            REMAINING="$NOTIFS"
+          fi
           COUNT=$(echo "$REMAINING" | jq --arg repo "$GITHUB_REPOSITORY" --arg cutoff "$CUTOFF" '[.[] | select(.repository.full_name != $repo or .updated_at <= $cutoff)] | length')
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
           if [ "$COUNT" = "0" ]; then

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
@@ -31,24 +31,29 @@ jobs:
           # failure would abort the whole step red. A failed fetch just means
           # this cycle can't enumerate ? the next scheduled cycle picks up
           # anything missed ? so retry briefly, then skip cleanly.
+          #
+          # On every failed attempt, log what actually came back: the plain
+          # fetch hides the body behind `2>/dev/null`, and a transient blip
+          # that recovers on retry would otherwise leave no trace of the bad
+          # response. `gh api -i` re-fetches with the HTTP status line +
+          # headers ahead of the body, so a recurring failure shows the real
+          # status code and body ? not just jq's parse complaint. It exits
+          # non-zero on an error status, hence `|| true`. The extra call runs
+          # only on the (rare) failing attempt; the happy path is one fetch.
           NOTIFS=""
           for attempt in 1 2 3; do
             if NOTIFS=$(gh api notifications 2>/dev/null) && echo "$NOTIFS" | jq -e . >/dev/null 2>&1; then
               break
             fi
             NOTIFS=""
+            echo "--- notifications fetch attempt $attempt failed; actual response (status + body head) ---"
+            gh api notifications -i 2>&1 | head -c 1000 || true
+            echo
             [ "$attempt" -lt 3 ] && sleep "$attempt"
           done
           if [ -z "$NOTIFS" ]; then
             echo "count=0" >> "$GITHUB_OUTPUT"
             echo "notifications fetch failed after retries ? skipping this cycle"
-            # Surface the HTTP status + body head so a *persistent* failure
-            # (a real problem, not a transient blip) stays diagnosable instead
-            # of being silently swallowed. `gh api -i` prepends the status line
-            # and headers; on an error status it exits non-zero, hence `|| true`.
-            echo "--- last response (status + body head) ---"
-            gh api notifications -i 2>&1 | head -c 800 || true
-            echo
             exit 0
           fi
 

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
@@ -41,7 +41,14 @@ jobs:
           done
           if [ -z "$NOTIFS" ]; then
             echo "count=0" >> "$GITHUB_OUTPUT"
-            echo "notifications fetch failed transiently ? skipping this cycle"
+            echo "notifications fetch failed after retries ? skipping this cycle"
+            # Surface the HTTP status + body head so a *persistent* failure
+            # (a real problem, not a transient blip) stays diagnosable instead
+            # of being silently swallowed. `gh api -i` prepends the status line
+            # and headers; on an error status it exits non-zero, hence `|| true`.
+            echo "--- last response (status + body head) ---"
+            gh api notifications -i 2>&1 | head -c 800 || true
+            echo
             exit 0
           fi
 

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
@@ -25,7 +25,27 @@ jobs:
       - name: Check for unread notifications
         id: check
         run: |
-          COUNT=$(gh api notifications --jq 'length')
+          # Fetch notifications once, tolerating transient non-JSON responses.
+          # GitHub occasionally returns an HTML error page (even with a 200)
+          # during a brief API blip; under `bash -e` an untolerated `gh api`
+          # failure would abort the whole step red. A failed fetch just means
+          # this cycle can't enumerate ? the next scheduled cycle picks up
+          # anything missed ? so retry briefly, then skip cleanly.
+          NOTIFS=""
+          for attempt in 1 2 3; do
+            if NOTIFS=$(gh api notifications 2>/dev/null) && echo "$NOTIFS" | jq -e . >/dev/null 2>&1; then
+              break
+            fi
+            NOTIFS=""
+            [ "$attempt" -lt 3 ] && sleep "$attempt"
+          done
+          if [ -z "$NOTIFS" ]; then
+            echo "count=0" >> "$GITHUB_OUTPUT"
+            echo "notifications fetch failed transiently ? skipping this cycle"
+            exit 0
+          fi
+
+          COUNT=$(echo "$NOTIFS" | jq 'length')
           if [ "$COUNT" = "0" ]; then
             echo "count=0" >> "$GITHUB_OUTPUT"
             echo "No unread notifications ? skipping"
@@ -41,7 +61,6 @@ jobs:
           RECENT_PRS=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs?created=>=$SINCE&per_page=50" --jq '[.workflow_runs[] | select(.name | test("^(tend-review|tend-mention|tend-triage|tend-ci-fix)$")) | .pull_requests[]?.number] | unique | .[]' || true)
 
           if [ -n "$RECENT_PRS" ]; then
-            NOTIFS=$(gh api notifications)
             for pr in $RECENT_PRS; do
               echo "$NOTIFS" | jq -r --arg repo "$GITHUB_REPOSITORY" --arg pr "$pr" '.[] | select(.subject.url == "https://api.github.com/repos/" + $repo + "/pulls/" + $pr or .subject.url == "https://api.github.com/repos/" + $repo + "/issues/" + $pr) | .id' | while read -r tid; do
                 [ -n "$tid" ] || continue
@@ -53,7 +72,8 @@ jobs:
           # --- Layer C: drop notifications on bot-authored closed PRs ---
           # The bot auto-subscribes to its own PRs. After merge/close, leftover
           # subscription notifications are pure noise ? no action needed.
-          NOTIFS=$(gh api notifications)
+          # Reuses the snapshot fetched above; marking a thread read is
+          # idempotent, so a stale snapshot at worst re-PATCHes a read thread.
           echo "$NOTIFS" | jq -r --arg repo "$GITHUB_REPOSITORY" '.[] | select(.repository.full_name == $repo and .subject.type == "PullRequest") | .id' | while read -r tid; do
             [ -n "$tid" ] || continue
             PR_NUM=$(echo "$NOTIFS" | jq -r --arg tid "$tid" '.[] | select(.id == $tid) | .subject.url | split("/") | last')
@@ -72,7 +92,12 @@ jobs:
           # Processing them now risks duplicating work. Cross-repo notifications
           # are exempt ? no dedicated workflow handles them.
           CUTOFF=$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
-          REMAINING=$(gh api notifications)
+          # Re-fetch so the count reflects threads marked read in Layers B/C.
+          # Tolerate a transient failure by falling back to the pre-mutation
+          # snapshot ? an over-count at worst spends one agent run, never fails.
+          if ! REMAINING=$(gh api notifications 2>/dev/null) || ! echo "$REMAINING" | jq -e . >/dev/null 2>&1; then
+            REMAINING="$NOTIFS"
+          fi
           COUNT=$(echo "$REMAINING" | jq --arg repo "$GITHUB_REPOSITORY" --arg cutoff "$CUTOFF" '[.[] | select(.repository.full_name != $repo or .updated_at <= $cutoff)] | length')
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
           if [ "$COUNT" = "0" ]; then

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
@@ -31,24 +31,29 @@ jobs:
           # failure would abort the whole step red. A failed fetch just means
           # this cycle can't enumerate ? the next scheduled cycle picks up
           # anything missed ? so retry briefly, then skip cleanly.
+          #
+          # On every failed attempt, log what actually came back: the plain
+          # fetch hides the body behind `2>/dev/null`, and a transient blip
+          # that recovers on retry would otherwise leave no trace of the bad
+          # response. `gh api -i` re-fetches with the HTTP status line +
+          # headers ahead of the body, so a recurring failure shows the real
+          # status code and body ? not just jq's parse complaint. It exits
+          # non-zero on an error status, hence `|| true`. The extra call runs
+          # only on the (rare) failing attempt; the happy path is one fetch.
           NOTIFS=""
           for attempt in 1 2 3; do
             if NOTIFS=$(gh api notifications 2>/dev/null) && echo "$NOTIFS" | jq -e . >/dev/null 2>&1; then
               break
             fi
             NOTIFS=""
+            echo "--- notifications fetch attempt $attempt failed; actual response (status + body head) ---"
+            gh api notifications -i 2>&1 | head -c 1000 || true
+            echo
             [ "$attempt" -lt 3 ] && sleep "$attempt"
           done
           if [ -z "$NOTIFS" ]; then
             echo "count=0" >> "$GITHUB_OUTPUT"
             echo "notifications fetch failed after retries ? skipping this cycle"
-            # Surface the HTTP status + body head so a *persistent* failure
-            # (a real problem, not a transient blip) stays diagnosable instead
-            # of being silently swallowed. `gh api -i` prepends the status line
-            # and headers; on an error status it exits non-zero, hence `|| true`.
-            echo "--- last response (status + body head) ---"
-            gh api notifications -i 2>&1 | head -c 800 || true
-            echo
             exit 0
           fi
 

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
@@ -41,7 +41,14 @@ jobs:
           done
           if [ -z "$NOTIFS" ]; then
             echo "count=0" >> "$GITHUB_OUTPUT"
-            echo "notifications fetch failed transiently ? skipping this cycle"
+            echo "notifications fetch failed after retries ? skipping this cycle"
+            # Surface the HTTP status + body head so a *persistent* failure
+            # (a real problem, not a transient blip) stays diagnosable instead
+            # of being silently swallowed. `gh api -i` prepends the status line
+            # and headers; on an error status it exits non-zero, hence `|| true`.
+            echo "--- last response (status + body head) ---"
+            gh api notifications -i 2>&1 | head -c 800 || true
+            echo
             exit 0
           fi
 

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
@@ -25,7 +25,27 @@ jobs:
       - name: Check for unread notifications
         id: check
         run: |
-          COUNT=$(gh api notifications --jq 'length')
+          # Fetch notifications once, tolerating transient non-JSON responses.
+          # GitHub occasionally returns an HTML error page (even with a 200)
+          # during a brief API blip; under `bash -e` an untolerated `gh api`
+          # failure would abort the whole step red. A failed fetch just means
+          # this cycle can't enumerate ? the next scheduled cycle picks up
+          # anything missed ? so retry briefly, then skip cleanly.
+          NOTIFS=""
+          for attempt in 1 2 3; do
+            if NOTIFS=$(gh api notifications 2>/dev/null) && echo "$NOTIFS" | jq -e . >/dev/null 2>&1; then
+              break
+            fi
+            NOTIFS=""
+            [ "$attempt" -lt 3 ] && sleep "$attempt"
+          done
+          if [ -z "$NOTIFS" ]; then
+            echo "count=0" >> "$GITHUB_OUTPUT"
+            echo "notifications fetch failed transiently ? skipping this cycle"
+            exit 0
+          fi
+
+          COUNT=$(echo "$NOTIFS" | jq 'length')
           if [ "$COUNT" = "0" ]; then
             echo "count=0" >> "$GITHUB_OUTPUT"
             echo "No unread notifications ? skipping"
@@ -41,7 +61,6 @@ jobs:
           RECENT_PRS=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs?created=>=$SINCE&per_page=50" --jq '[.workflow_runs[] | select(.name | test("^(tend-review|tend-mention|tend-triage|tend-ci-fix)$")) | .pull_requests[]?.number] | unique | .[]' || true)
 
           if [ -n "$RECENT_PRS" ]; then
-            NOTIFS=$(gh api notifications)
             for pr in $RECENT_PRS; do
               echo "$NOTIFS" | jq -r --arg repo "$GITHUB_REPOSITORY" --arg pr "$pr" '.[] | select(.subject.url == "https://api.github.com/repos/" + $repo + "/pulls/" + $pr or .subject.url == "https://api.github.com/repos/" + $repo + "/issues/" + $pr) | .id' | while read -r tid; do
                 [ -n "$tid" ] || continue
@@ -53,7 +72,8 @@ jobs:
           # --- Layer C: drop notifications on bot-authored closed PRs ---
           # The bot auto-subscribes to its own PRs. After merge/close, leftover
           # subscription notifications are pure noise ? no action needed.
-          NOTIFS=$(gh api notifications)
+          # Reuses the snapshot fetched above; marking a thread read is
+          # idempotent, so a stale snapshot at worst re-PATCHes a read thread.
           echo "$NOTIFS" | jq -r --arg repo "$GITHUB_REPOSITORY" '.[] | select(.repository.full_name == $repo and .subject.type == "PullRequest") | .id' | while read -r tid; do
             [ -n "$tid" ] || continue
             PR_NUM=$(echo "$NOTIFS" | jq -r --arg tid "$tid" '.[] | select(.id == $tid) | .subject.url | split("/") | last')
@@ -72,7 +92,12 @@ jobs:
           # Processing them now risks duplicating work. Cross-repo notifications
           # are exempt ? no dedicated workflow handles them.
           CUTOFF=$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
-          REMAINING=$(gh api notifications)
+          # Re-fetch so the count reflects threads marked read in Layers B/C.
+          # Tolerate a transient failure by falling back to the pre-mutation
+          # snapshot ? an over-count at worst spends one agent run, never fails.
+          if ! REMAINING=$(gh api notifications 2>/dev/null) || ! echo "$REMAINING" | jq -e . >/dev/null 2>&1; then
+            REMAINING="$NOTIFS"
+          fi
           COUNT=$(echo "$REMAINING" | jq --arg repo "$GITHUB_REPOSITORY" --arg cutoff "$CUTOFF" '[.[] | select(.repository.full_name != $repo or .updated_at <= $cutoff)] | length')
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
           if [ "$COUNT" = "0" ]; then

--- a/generator/tests/test_integration.py
+++ b/generator/tests/test_integration.py
@@ -447,6 +447,62 @@ def test_init_notifications_has_precheck(
         assert "workflow_dispatch" in step["if"]
 
 
+def test_notifications_precheck_tolerates_transient_non_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The pre-check must not fail the build when `gh api notifications`
+    transiently returns a non-JSON (HTML) body — a routine GitHub API blip.
+    The step runs under `bash -e`; an untolerated fetch aborts the whole job
+    red. The correct disposition is to skip this cycle (count=0, exit 0); the
+    next scheduled cycle picks up anything missed."""
+    _write_config(tmp_path, "bot_name: test-bot")
+    monkeypatch.chdir(tmp_path)
+    _run_init()
+
+    data = yaml.safe_load(
+        (_workflow_dir(tmp_path) / "tend-notifications.yaml").read_text()
+    )
+    script = data["jobs"]["notifications"]["steps"][0]["run"]
+
+    # Fake `gh` mimics a transient GitHub blip: bare `gh api notifications`
+    # returns a 200 with an HTML body (exit 0, non-JSON output); the same call
+    # with `--jq` fails because gh runs jq internally and jq can't parse HTML.
+    bindir = tmp_path / "fakebin"
+    bindir.mkdir()
+    gh = bindir / "gh"
+    gh.write_text(
+        "#!/usr/bin/env bash\n"
+        'for a in "$@"; do [ "$a" = "--jq" ] && exit 4; done\n'
+        'echo "<html><body>error</body></html>"\n'
+        "exit 0\n"
+    )
+    gh.chmod(0o755)
+    # No-op sleep so the retry loop's backoff doesn't slow the test.
+    sleep = bindir / "sleep"
+    sleep.write_text("#!/usr/bin/env bash\nexit 0\n")
+    sleep.chmod(0o755)
+
+    output_file = tmp_path / "gh_output"
+    output_file.write_text("")
+    env = {
+        "PATH": f"{bindir}:/usr/bin:/bin",
+        "GITHUB_OUTPUT": str(output_file),
+        "GITHUB_REPOSITORY": "owner/repo",
+    }
+    result = subprocess.run(
+        ["bash", "-e", "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, (
+        f"pre-check aborted on a transient non-JSON response "
+        f"(exit {result.returncode}); stderr:\n{result.stderr}"
+    )
+    assert "count=0" in output_file.read_text()
+
+
 # ---------------------------------------------------------------------------
 # Bot name flows into workflow content
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The generated `tend-notifications.yaml` pre-check ("Check for unread notifications") opened with `COUNT=$(gh api notifications --jq 'length')` as its first command, running under the default `bash -e`. When GitHub transiently returns an HTML error page instead of JSON — a routine minutes-long API blip, sometimes even with a 200 status — gh's internal jq fails with `invalid character '<' looking for beginning of value`, gh exits non-zero, and `set -e` aborts the whole step. A scheduled janitor cycle becomes a red build over a transient upstream blip, and that notification-sweep cycle is skipped until the next schedule interval.

The three later bare `gh api notifications` re-fetches (Layers B/C/D) were untolerated too.

## Solution

Fetch notifications once with a short retry, validate the body is JSON, and if it still fails skip the cycle cleanly (`count=0`, `exit 0`) rather than failing red — the next scheduled cycle picks up anything missed. Layers B and C now reuse that single snapshot (marking a thread read is idempotent, so a stale snapshot at worst re-PATCHes an already-read thread). Layer D keeps its re-fetch because that fetch is *semantically meaningful* — it must reflect threads marked read in B/C so the processable count is accurate — but falls back to the pre-mutation snapshot on a transient failure instead of aborting (an over-count at worst spends one agent run, never fails the build).

This is a structural fix to the generated workflow template, so it reaches every tend consumer at the next release.

## Testing

Added `test_notifications_precheck_tolerates_transient_non_json`, which extracts the rendered pre-check script and runs it under `bash -e` with a fake `gh` that mimics the transient blip (bare `gh api notifications` returns HTML with exit 0; the `--jq` form fails as gh's internal jq does). It asserts the script exits 0 and writes `count=0`. The test fails on the old template (exit 4) and passes on the fix. The 4 notifications regtest snapshots were regenerated; full suite (276 tests) green.

---
Closes #779 — automated triage
