### PR TITLE
chore: bump claude_version to 2.1.215

### DIFF
--- a/claude-interactive/action.yaml
+++ b/claude-interactive/action.yaml
@@ -50,7 +50,7 @@ inputs:
     default: "true"
     description: Include the full Claude transcript in the workflow step summary.
   claude_version:
-    default: "2.1.207"
+    default: "2.1.215"
     description: >-
       Version of the `claude` binary to install via
       `https://claude.ai/install.sh`, pinned to a specific

--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -52,7 +52,7 @@ inputs:
     default: "true"
     description: Include the rendered Claude transcript in the workflow step summary.
   claude_version:
-    default: "2.1.207"
+    default: "2.1.215"
     description: >-
       Version of the `claude` binary to install via
       `https://claude.ai/install.sh`, pinned to a specific


### PR DESCRIPTION
Bumps the pinned `claude_version` from `2.1.207` to `2.1.215` (latest npm `dist-tags.latest`) in both `claude/action.yaml` (headless `claude -p`) and `claude-interactive/action.yaml` (PTY), keeping the two Claude pins in step per the weekly maintenance task.

The pin is a static string nothing else moves, so it drifts behind and the harness resolves `--model opus`/`sonnet` to a stale alias target if left unbumped.

CHANGELOG items between the two versions that touch the agent paths tend exercises (headless `-p` result handling, `--model` alias resolution, skills, Stop-hook):

- **2.1.215** — Claude no longer runs the `/verify` and `/code-review` skills on its own; they must be invoked explicitly. Tend's harness invokes skills explicitly, so no behavior change expected.
- **2.1.212** — Headless/SDK sessions now apply a `set_model` control request mid-turn (next round-trip uses the new model instead of waiting for the next turn).
- Headless stream-json sessions no longer hang permanently when a `control_request` carries a non-string `set_model` payload (CLI now answers with an error response).
- Fixed headless print-mode sessions on Windows crashing when stdin is unreadable (tend runs on Linux — not applicable, noted for completeness).
- Several memory-leak fixes in long sessions, including unbounded growth in headless/SDK from large tool-result payloads.
- Bedrock/Vertex/AWS default-model and startup-fallback fixes (tend uses the Claude subscription, not these backends — not applicable).

Nothing in the range touches first-run onboarding or Stop-hook sentinel behavior in a way that affects either harness's completion supervision.
