### PR TITLE
fix(list-recent-runs): fail loud on transient gh errors instead of a false all-clear

### DIFF
--- a/plugins/tend-ci-runner/scripts/list-recent-runs.sh
+++ b/plugins/tend-ci-runner/scripts/list-recent-runs.sh
@@ -44,7 +44,10 @@ gh_retry() {
       printf '%s' "$out"
       return 0
     fi
-    sleep $((attempt * 3))
+    # Don't sleep after the final attempt — the whole point of this script is
+    # to fail loud and fast during an incident, so a trailing backoff before
+    # the caller's `exit 1` is wasted delay.
+    [ "$attempt" -lt 3 ] && sleep $((attempt * 3))
   done
   return 1
 }

--- a/plugins/tend-ci-runner/scripts/list-recent-runs.sh
+++ b/plugins/tend-ci-runner/scripts/list-recent-runs.sh
@@ -29,6 +29,26 @@ set -euo pipefail
 # Prevent gh from emitting ANSI color codes in non-TTY contexts.
 export NO_COLOR=1
 
+# Retry a command up to 3 times on failure, echoing its stdout on success.
+# Transient GitHub API errors (e.g. HTTP 503 during an Actions incident) would
+# otherwise slip past `set -euo pipefail` at the call sites below — a process
+# substitution's failure is invisible to `set -e`, and a `|| echo "[]"` fallback
+# silently turns an errored fetch into an empty result. Either way the script
+# would report zero runs when runs exist, and the calling skill records a false
+# "all-clear" that permanently skips that window. Retry here, and let the caller
+# fail loud if every attempt fails rather than swallow the error.
+gh_retry() {
+  local out attempt
+  for attempt in 1 2 3; do
+    if out=$("$@" 2>/dev/null); then
+      printf '%s' "$out"
+      return 0
+    fi
+    sleep $((attempt * 3))
+  done
+  return 1
+}
+
 repo_args=()
 if [ -n "${TARGET_REPO:-}" ]; then
   repo_args=(-R "$TARGET_REPO")
@@ -42,9 +62,14 @@ else
   PREFIXES=("$@")
 fi
 
+if ! wf_json=$(gh_retry gh workflow list "${repo_args[@]}" --json name); then
+  echo "ERROR: 'gh workflow list' failed after retries (transient API error?) — refusing to report an empty run list that would read as a false all-clear" >&2
+  exit 1
+fi
+
 WORKFLOWS=()
 for prefix in "${PREFIXES[@]}"; do
-  mapfile -t matches < <(gh workflow list "${repo_args[@]}" --json name --jq ".[].name | select(startswith(\"$prefix\"))")
+  mapfile -t matches < <(printf '%s' "$wf_json" | jq -r ".[].name | select(startswith(\"$prefix\"))")
   WORKFLOWS+=("${matches[@]}")
 done
 
@@ -111,12 +136,15 @@ fi
 all_runs="[]"
 
 for wf in "${WORKFLOWS[@]}"; do
-  runs=$(gh run list \
+  if ! runs=$(gh_retry gh run list \
     "${repo_args[@]}" \
     --workflow "${wf}" \
     --created ">=${CREATED_SINCE}" \
     --json databaseId,conclusion,createdAt,updatedAt \
-    --limit 50 2>/dev/null || echo "[]")
+    --limit 50); then
+    echo "ERROR: 'gh run list' for workflow '$wf' failed after retries — refusing to report a partial run list" >&2
+    exit 1
+  fi
   all_runs=$(echo "$all_runs" "$runs" | jq -s 'add')
 done
 


### PR DESCRIPTION
## Problem

`list-recent-runs.sh` silently returns an empty (or partial) run list when a `gh` API call fails transiently, causing `review-reviewers` / `review-runs` to record a false **all-clear** and permanently skip that window's runs.

Directly reproduced this run (review-reviewers leg [`29710673739`](https://github.com/max-sixty/tend/actions/runs/29710673739)) during the active GitHub Actions incident (critical, started 2026-07-19T23:34Z, affecting API Requests / Issues / Actions / Pages). The workflow-discovery fetch hit an HTTP 503:

```
+ mapfile -t matches < <(gh workflow list -R max-sixty/cargo-affected --json name --jq ...)
could not get workflows: HTTP 503: No server is currently available to service your request.
+ WORKFLOWS+=("${matches[@]}")   # empty
...
+ echo '[]'                      # <- reported zero runs
```

At that moment three `tend-notifications` runs (`29708109161`, `29708916955`, `29710166166`) existed in the window. Had the leg trusted the script's output, it would have recorded an all-clear and never analyzed them.

## Root cause

Two call sites swallow `gh` failures, both of which escape `set -euo pipefail`:

- `mapfile -t matches < <(gh workflow list ...)` — a process substitution's exit status is invisible to `set -e`, and `mapfile` itself succeeds on empty input. A single 503 here zeros out `WORKFLOWS` → no runs are queried → `[]`.
- `runs=$(gh run list ... || echo "[]")` — the `|| echo "[]"` fallback turns a per-workflow fetch error into an empty result, silently dropping that workflow's runs.

Either way the script emits fewer runs than exist with a `0` exit code, and the calling skill treats it as "nothing happened this hour." The failure is invisible: a false all-clear produces no CI failure, and each leg only ever sees its own one-hour window, so a skipped hour is never re-analyzed.

## Fix

A small `gh_retry` helper retries transient failures (3 attempts, linear backoff). Both fetch sites now use it and **fail loud** (`exit 1`) if every attempt fails, so the caller errors instead of reporting a bogus empty window. A genuinely empty result (successful fetch, repo has no matching workflows) still returns `[]` as before — only *fetch failures* now abort.

## Verification

- `bash -n` + `shellcheck`: clean.
- Failure path (mocked `gh` that always 503s): exits `1` with `refusing to report an empty run list`, instead of printing `[]`.
- Success path (live): returns the two in-window runs (`29710166166`, `29708916955`) rather than `[]`.

## Gate assessment

- **Evidence**: directly reproduced this run — clearly-wrong outcome (analysis tooling reports zero runs while runs exist → missed detection that never resurfaces).
- **Structural**: yes — any transient fetch failure deterministically produces the empty/partial result; not a stochastic model lapse.
- **Invisible failure mode**: yes — a false all-clear surfaces no CI failure and the skipped window is never re-analyzed, so it wouldn't be caught next time without this fix.
- **Change type**: targeted fix (retry helper + fail-loud at two call sites), proportionate.

Evidence log: https://gist.github.com/8518c95fe85c0e52a3b5f26695187382
