### PR TITLE
fix(running-in-ci): don't ask outsiders to do work the bot can't do itself

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -608,7 +608,7 @@ Two paths, in order of preference:
 1. **Run the tool.** If it's installable in this environment, install it and invoke the specific command or flag in question. Link the output in your reply.
 2. **Read the source.** Tend can clone any public repo. `gh repo clone <owner>/<repo>` then grep for the flag or behavior. Source doesn't lag itself, and a flag that isn't defined in the parser doesn't exist.
 
-If both paths fail (GUI-only tool, private repo, environment-specific behavior), cite what you found, name the remaining gap, and ask a human with the tool installed to confirm before shipping a dependent change.
+If both paths fail (GUI-only tool, private repo, environment-specific behavior), cite what you found, name the remaining gap honestly, and follow **Who to ask when you can't do it yourself** below — don't hand the verification to an outside party, least of all an upstream maintainer reviewing your change.
 
 <example>
 <bad reason="Trusted upstream docs for a fast-moving external CLI and shipped a broken recipe">
@@ -619,6 +619,30 @@ Bad: Review asked whether `cmux list-workspaces` had structured output. Read a m
 <good reason="Cloned the upstream source and verified the flag before shipping">
 
 Good: Same question. Cloned cmux's source repo → grepped the CLI parser for `list-workspaces` → saw no `--json` flag defined → replied with the source link and proposed an alternative that matched the actual CLI surface.
+
+</good>
+</example>
+
+### Who to ask when you can't do it yourself
+
+Some checks need hardware or an environment CI doesn't have (Windows, a GPU, a physical terminal). When you can't complete or verify something directly, escalate in this order and stop at the first rung that works:
+
+1. **Do it yourself.** Exhaust what's reachable from CI first — install the tool, clone and read the source, stand up the missing surface in a container.
+2. **Make it doable yourself.** Add the capability to *your own* repo so no future run needs a favor — e.g. add a Windows CI job that exercises the path, rather than asking a person to run it once by hand.
+3. **Ask a contributor of your own repo**, and only for something that's a logical consequence of what they're already doing (a PR author testing their own change).
+4. **Escalate to your own repo's maintainer** that you're blocked and need help.
+
+Never route the ask *outward* — least of all to the maintainer of another repo who is reviewing or merging your change as a favor. State the gap honestly and take rung 2 back home instead of handing them work.
+
+<example>
+<bad reason="Asked an upstream maintainer, mid-review of the bot's own PR, to run a verification the bot couldn't do">
+
+Bad: Bot upstreams a fix to a dependency; the fix touches a Windows-only code path the bot verified by source inspection. In the PR thread it closes with "If you can confirm on a real Windows terminal I'd appreciate it" — handing work to the maintainer who's doing the bot a favor by reviewing the change.
+
+</bad>
+<good reason="Stated the gap honestly and fixed it back home instead of asking the upstream maintainer">
+
+Good: Same fix. Bot writes "I verified the Windows path by source inspection, not on hardware" and stops — no ask to the upstream maintainer. Back in its own repo it opens a follow-up to add a Windows CI job that exercises the path, so the gap closes without anyone's favor.
 
 </good>
 </example>


### PR DESCRIPTION
## Problem

A tend consumer's bot, after upstreaming a fix to another repo, closed its PR comment with *"If you can confirm on a real Windows terminal I'd appreciate it"* — handing verification work to the maintainer of another repo who was doing the bot a favor by reviewing and merging the change. #788 flags this as out of bounds and gives the intended hierarchy: do the task itself → offer to make changes so it *can* do the task itself (e.g. add a Windows CI job) → ask a contributor of its own repo → escalate to its own maintainer; it shouldn't ask outsiders.

Root cause is a bundled-skill gap. The `running-in-ci` **Verifying external-tool behavior** section ends with a generic escape hatch — *"ask a human with the tool installed to confirm."* In an upstream thread the nearest "human with the tool installed" is the reviewing maintainer, so the guidance actively steers the bot toward the behavior #788 objects to. Nothing in the bundled skills established who is and isn't appropriate to ask.

## Solution

In `plugins/tend-ci-runner/skills/running-in-ci/SKILL.md`:

- Add a **Who to ask when you can't do it yourself** subsection encoding the maintainer's hierarchy: (1) do it yourself, (2) make it doable yourself in your own repo, (3) ask a contributor of your own repo, (4) escalate to your own maintainer — with an explicit "never route the ask outward, least of all to a maintainer merging your change as a favor." Includes a bad/good example modeled on the Windows-verification case, stated structurally (no case links).
- Redirect the **Verifying external-tool behavior** escape hatch away from the bare "ask a human with the tool installed" and toward the new hierarchy, so the gap gets stated honestly and closed back home rather than pushed onto an outside party.

This is a bundled default, so it reaches every tend consumer at the next release. It's complementary to #770 (permit maintainer-invited upstream contributions): #770 says the bot *may* contribute upstream when invited; this says that while doing so it still owns its own verification and doesn't offload it onto the host maintainer.

## Testing

Skill-text change (no code path to unit-test). Reproduction is the linked real-world comment; the fix removes the guidance that steered toward it and states the correct hierarchy. Verified no duplication of this rule exists in the shared system prompt or co-loaded skills before adding it.

---
Closes #788 — automated triage
