### PR TITLE
chore: bump harness timeout default to 5h50m

### DIFF
--- a/claude-interactive/action.yaml
+++ b/claude-interactive/action.yaml
@@ -56,12 +56,17 @@ inputs:
       `https://claude.ai/install.sh`, pinned to a specific
       claude-code release.
   timeout_seconds:
-    default: "10800"
+    default: "21000"
     description: >-
       Maximum time the supervised Claude session is allowed to run before
-      the supervisor kills it. Defaults to 3 hours — long-running sessions
-      (e.g. ci-fix stress-testing a flaky failure) routinely need more
-      than an hour, and short tasks finish well before the cap regardless.
+      the supervisor kills it. Defaults to 5h50m — GitHub Actions hard-caps
+      hosted-runner job execution at 6 hours, counting the whole job
+      (checkout, setup, this run, and the reporting/log-upload steps after
+      it), not just the supervised run; a 10-minute buffer covers that
+      overhead (observed ~2 minutes) with margin, so a session that fills
+      its budget still gets the supervisor's clean kill and failure report
+      instead of GitHub's own silent one. Short tasks finish well before
+      the cap regardless.
   mitmproxy_version:
     default: "12.2.1"
     description: >-

--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -58,12 +58,17 @@ inputs:
       `https://claude.ai/install.sh`, pinned to a specific
       claude-code release. Kept in step with the interactive harness's pin.
   timeout_seconds:
-    default: "10800"
+    default: "21000"
     description: >-
       Maximum time the headless Claude run is allowed to take before the
-      supervisor kills it. Defaults to 3 hours — long-running sessions
-      (e.g. ci-fix stress-testing a flaky failure) routinely need more
-      than an hour, and short tasks finish well before the cap regardless.
+      supervisor kills it. Defaults to 5h50m — GitHub Actions hard-caps
+      hosted-runner job execution at 6 hours, counting the whole job
+      (checkout, setup, this run, and the reporting/log-upload steps after
+      it), not just the supervised run; a 10-minute buffer covers that
+      overhead (observed ~2 minutes) with margin, so a run that fills its
+      budget still gets the supervisor's clean kill and failure report
+      instead of GitHub's own silent one. Short tasks finish well before
+      the cap regardless.
   mitmproxy_version:
     default: "12.2.1"
     description: >-


### PR DESCRIPTION
Raises the default harness timeout from 3 hours (10800s, set in #739) to 5h50m (21000s) in both Claude harnesses (`claude/action.yaml` headless, `claude-interactive/action.yaml` PTY).

GitHub Actions hard-caps hosted-runner job execution at 6 hours with no override — confirmed against GitHub's own Actions limits docs, not configurable higher even by support. That cap counts the whole job (checkout, setup, the supervised Claude run, and the reporting/log-upload steps after it), not just the run itself, so `timeout_seconds` can't simply match GitHub's ceiling exactly: a session that fills its full budget would then get killed uncleanly by GitHub mid-teardown, before the harness's own SIGTERM-and-report path can run — the same opaque "$0.00, 0 tokens" failure mode #739 was fixing in the first place, just moved from 1 hour to 6.

21000s leaves a 10-minute buffer under the 6-hour ceiling. Pulled real step-timing data from two worktrunk `tend-nightly` runs (a normal one and the one that originally hit the 3600s cap) — actual overhead outside the supervised run (checkout, `claude-setup`, and the composite action's own internal setup/report steps) is ~2 minutes, so 10 minutes covers it with margin for a slower run (cache miss, network variance) while staying close to GitHub's ceiling.

Codex has no harness-level timeout (relies on the GitHub job cap directly), so it's unaffected.

Verified: full generator test suite (275 tests) and `pre-commit run --all-files` pass, including the check that keeps the two harnesses' input defaults in sync.

> _This was written by Claude Code on behalf of max_
