### PR TITLE
docs: correct stale claude-code-action attributions

### DIFF
--- a/.claude/skills/running-tend/references/integration-test.md
+++ b/.claude/skills/running-tend/references/integration-test.md
@@ -211,7 +211,7 @@ self-authored, trivial PRs (GitHub blocks self-approval; the skill keeps
 quiet when there are no concerns). So an "is there a bot review on the
 PR?" assertion can't distinguish "the action never ran" from "the action
 ran and stayed silent by design" — both produce zero reviews. Asserting
-on the session-log artifact, which `claude-code-action` uploads
+on the session-log artifact, which the tend harness action uploads
 unconditionally on every invocation, distinguishes the two.
 
 ```bash
@@ -261,7 +261,7 @@ for _ in $(seq 1 60); do
 done
 [ "$conclusion" = "success" ] || { echo "tend-review: $status/$conclusion"; exit 1; }
 
-# Session-log artifact presence proves claude-code-action invoked the
+# Session-log artifact presence proves the tend harness action invoked the
 # Claude session. The skill may then post a review, post nothing, or
 # anything in between — that's a separate concern from "did tend-review
 # fire end-to-end?".

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -473,7 +473,7 @@ Always use markdown links for files, issues, PRs, and docs. **Any link containin
 - **Issues/PRs**: `#123` shorthand
 - **External**: `[text](url)` format
 
-Don't add job links, footers, or authorship sign-offs (e.g. `> _Written by Claude Code on behalf of @maintainer_`) — the bot account already conveys authorship, and `claude-code-action` adds any needed footer automatically. This covers PR and issue bodies too, not just comments.
+Don't add job links, footers, or authorship sign-offs (e.g. `> _Written by Claude Code on behalf of @maintainer_`) — the bot account already conveys authorship, and the harness suppresses the default Claude Code footer. This covers PR and issue bodies too, not just comments.
 
 ## Keeping PR Titles and Descriptions Current
 


### PR DESCRIPTION
Nightly survey turned up documentation that still credits `claude-code-action` with runtime behavior, even though tend migrated off it to running the `claude` binary directly behind the credential proxy. These spots imply the wrapper is still in the loop; the behavior they describe is now handled by tend's own composite action or config.

- **`.claude/skills/running-tend/references/integration-test.md`** — the §4 assertion prose (and its inline comment) said `claude-code-action` uploads the session-log artifact "unconditionally on every invocation". The artifact is actually uploaded by the harness action's own `Upload session logs` step (`if: always()`, `claude/action.yaml`), and the `claude-session-logs*` name the assertion matches on is unchanged — so the check still works; only the attribution was wrong.
- **`plugins/tend-ci-runner/skills/running-in-ci/SKILL.md`** — the "don't add footers" rule was justified by "`claude-code-action` adds any needed footer automatically". The current harness instead *suppresses* the default Claude Code footer via `attribution: {commit: "", pr: ""}` in `claude/action.yaml`. Reworded to match; the rule itself is unchanged.

Left untouched: the legitimate references that cite claude-code-action as the upstream project tend mirrors or replaces (e.g. `restore-sensitive-config.sh`, `install-tend`'s "delete workflows using `anthropics/claude-code-action`", the agent-equipped-target signal).

Docs-only; no code change, so no test.
