### PR TITLE
chore: bump claude_version to 2.1.220

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ https://github.com/max-sixty/tend/compare for their history.
 
 ### Internal
 
+- Bumped pinned `claude_version` to 2.1.220 in both Claude harnesses. ([#794](https://github.com/max-sixty/tend/pull/794))
 - Bumped pinned `claude_version` to 2.1.215. ([#782](https://github.com/max-sixty/tend/pull/782))
 
 ## 0.1.11

--- a/claude-interactive/action.yaml
+++ b/claude-interactive/action.yaml
@@ -50,7 +50,7 @@ inputs:
     default: "true"
     description: Include the full Claude transcript in the workflow step summary.
   claude_version:
-    default: "2.1.215"
+    default: "2.1.220"
     description: >-
       Version of the `claude` binary to install via
       `https://claude.ai/install.sh`, pinned to a specific

--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -52,7 +52,7 @@ inputs:
     default: "true"
     description: Include the rendered Claude transcript in the workflow step summary.
   claude_version:
-    default: "2.1.215"
+    default: "2.1.220"
     description: >-
       Version of the `claude` binary to install via
       `https://claude.ai/install.sh`, pinned to a specific


### PR DESCRIPTION
Weekly pin bump. `@anthropic-ai/claude-code` `dist-tags.latest` is now `2.1.220`; both Claude harness actions were pinned at `2.1.215`. Bumps the `claude_version` default in `claude/action.yaml` (headless `claude -p`) and `claude-interactive/action.yaml` (PTY) together, keeping the two Claude pins in step.

The Codex pin is left untouched — it tracks a prerelease deliberately and is only bumped to a release confirmed to run under `codex exec`.

Skimmed the claude-code CHANGELOG between `2.1.215` and `2.1.220` for anything touching the agent paths we drive; two entries are relevant to the headless harness:

- **2.1.219** makes `claude-opus-5` the default Opus model (1M context). Our headless invocation resolves `--model opus` against the pinned binary, so after this bump `opus` maps to Opus 5 rather than the older alias target — the intended effect of keeping the pin current.
- **2.1.219** fixes `claude -p` dropping already-produced text output when a turn dies on a mid-stream API error — directly on the headless result path.

Nothing in the range touched Stop-hook behavior (the sentinel `claude-interactive` relies on) or first-run onboarding.

The bump reaches adopters at the next tend release, since their workflows pin `max-sixty/tend@X.Y.Z`; tend's own workflows pick it up the same way.
