### PR TITLE
fix: verify the bot cannot bypass the merge restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,12 @@ layers:
 
 **Merge restriction** is the primary boundary. A GitHub ruleset prevents the
 bot from merging to protected branches — bot-authored PRs require human
-approval. `tend check` verifies this; `tend check --fix` creates the ruleset.
+approval. The bot proves this against itself on every run: preflight asks
+GitHub whether the bot's own credentials can bypass any ruleset covering the
+default branch (`current_user_can_bypass` — GitHub's evaluation, so teams,
+custom roles, and org-level rulesets are all accounted for) and refuses to
+start unless the answer is no. `tend check` verifies the setup;
+`tend check --fix` creates the ruleset.
 
 **Credential isolation** — the Claude harness runs the agent as a separate
 non-sudo user and keeps the bot token and Anthropic credential in a local

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -50,8 +50,11 @@ There are two load-bearing boundaries, one per path code can take.
 **Merge restriction** covers code that reaches the default branch through a
 merge. A GitHub ruleset (or branch protection) prevents the bot from merging
 to protected branches (the default branch plus any in `protected_branches`)
-regardless of review status, and the composite action refuses to start if the
-default branch isn't protected.
+regardless of review status. The composite action's preflight verifies this
+as the bot itself: `current_user_can_bypass` on each applying ruleset is
+GitHub's own evaluation of the bot's standing — teams, custom roles, and
+org-level rulesets included — and the run aborts if the bot can bypass every
+restrict-updates ruleset, or if the branch is unprotected entirely.
 
 **Environment-protected secrets** (below) covers code that runs *without* a
 merge: a tag push, a release, a manual or chained dispatch. The merge

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -123,11 +123,12 @@ signing keys) live in GitHub Environments whose `deployment_branch_policy`
 lists only admin-gated refs: the default branch (merge restriction) and
 all tags (a sibling tag-target ruleset that gates `creation` and `update`
 with admin-only bypass; `update` is what force-push of an existing tag
-fires, so it must be blocked alongside `creation`). The bot has write
-but not admin, so it cannot push to the default branch and cannot push
-any tag, and therefore cannot reach any environment pinned to those
-refs. The chain holds for workflows whose only path to invocation is
-updating one of those refs: trigger on `push: tags:` (release) or
+fires, so it must be blocked alongside `creation`). The bot has write,
+which is below every role that can bypass, so it cannot push to the
+default branch and cannot push any tag, and therefore cannot reach any
+environment pinned to those refs. The chain holds for workflows whose
+only path to invocation is updating one of those refs: trigger on
+`push: tags:` (release) or
 `push: branches: [main]` (continuous deploy). Other triggers
 (`workflow_dispatch`, `release: published`, `deployment`, `schedule`,
 chained dispatches) can be initiated by a write-scoped bot against an
@@ -135,8 +136,9 @@ allowed ref, so the env policy alone does not gate them; workflows
 keeping those triggers need trigger-specific containment (typically
 required reviewers on the Environment) before release or deploy secrets
 are migrated there. The chain inherits the merge restriction's
-assumption that the bot has write, not admin; an admin session voids
-both the same way.
+assumption that the bot holds no role that can bypass; an admin session
+voids both the same way. `tend check` verifies both halves: the bot's
+role, and that every bypass actor on the merge ruleset outranks write.
 
 OIDC-to-cloud deploys have no GitHub-stored secret to gate; there, the
 Environment plus the cloud provider's trust policy is the only control.

--- a/generator/src/tend/checks.py
+++ b/generator/src/tend/checks.py
@@ -193,26 +193,6 @@ def check_branch_protection(repo: str, branch: str, bot_name: str) -> CheckResul
     )
 
 
-def _ruleset_endpoint(rule: dict) -> str | None:
-    """The API path for the ruleset a branch rule came from.
-
-    A rule carries the ruleset's id and where it lives, and org rulesets are
-    readable only under `/orgs`. Returns None when the ruleset can't be
-    addressed — an Enterprise ruleset has no endpoint a repo-scoped token can
-    reach — which the caller treats as unverifiable.
-    """
-    source = rule.get("ruleset_source")
-    ruleset_id = rule.get("ruleset_id")
-    if not source or ruleset_id is None:
-        return None
-    source_type = rule.get("ruleset_source_type")
-    if source_type == "Repository":
-        return f"repos/{source}/rulesets/{ruleset_id}"
-    if source_type == "Organization":
-        return f"orgs/{source}/rulesets/{ruleset_id}"
-    return None
-
-
 def _user_id(login: str) -> int | None:
     """The numeric GitHub user id for a login, which is how a `User` bypass
     actor names its principal."""
@@ -225,14 +205,19 @@ def _user_id(login: str) -> int | None:
         return None
 
 
-def _ruleset_blocks_bot(endpoint: str, bot_name: str) -> bool | None:
+def _ruleset_blocks_bot(repo: str, ruleset_id: int, bot_name: str) -> bool | None:
     """Whether a ruleset's bypass list keeps a write-access bot out.
+
+    The repo-scoped endpoint serves organization- and enterprise-sourced
+    rulesets too, so any applying ruleset can be fetched here.
 
     Returns True if every bypass actor outranks the bot, False if one of them
     is the bot itself or a role at write or below, None if the ruleset can't be
-    read or names a principal this can't resolve (a team, app, or deploy key).
+    verified: unreadable, a bypass list GitHub withholds (only ruleset admins
+    see `bypass_actors`), or a principal this can't resolve (a team, app, or
+    deploy key).
     """
-    result = _gh("api", endpoint)
+    result = _gh("api", f"repos/{repo}/rulesets/{ruleset_id}")
     if result is None or result.returncode != 0:
         return None
     try:
@@ -242,7 +227,9 @@ def _ruleset_blocks_bot(endpoint: str, bot_name: str) -> bool | None:
     if not isinstance(data, dict):
         return None
 
-    actors = data.get("bypass_actors") or []
+    actors = data.get("bypass_actors")
+    if actors is None:
+        return None
     # A user exemption is decidable: the bot's login resolves to the id the
     # actor names. Naming the bot is the worst case — an explicit grant of the
     # merge the restriction exists to deny.
@@ -298,8 +285,12 @@ def _has_restrict_updates_ruleset(repo: str, branch: str, bot_name: str) -> bool
     # ruleset is unverified, not absent.
     unresolved = False
     for rule in update_rules:
-        endpoint = _ruleset_endpoint(rule)
-        verdict = _ruleset_blocks_bot(endpoint, bot_name) if endpoint else None
+        ruleset_id = rule.get("ruleset_id")
+        verdict = (
+            _ruleset_blocks_bot(repo, ruleset_id, bot_name)
+            if ruleset_id is not None
+            else None
+        )
         if verdict is True:
             return True
         unresolved = unresolved or verdict is None

--- a/generator/src/tend/checks.py
+++ b/generator/src/tend/checks.py
@@ -31,12 +31,9 @@ ROLE_ID_MAINTAIN = 2
 ROLE_ID_WRITE = 4
 ROLE_ID_ADMIN = 5
 
-# The roles above the bot's write access, so the only ones that can bypass a
-# ruleset. The bot must hold none of them, and a merge restriction may grant no
-# others. Keyed by name for the collaborators endpoint, valued by ID for
-# `bypass_actors` — the two APIs name the same role differently.
-BYPASS_ROLES = {"maintain": ROLE_ID_MAINTAIN, "admin": ROLE_ID_ADMIN}
-BYPASS_ROLE_IDS = frozenset(BYPASS_ROLES.values())
+# The roles above the bot's write access, so the only ones a merge
+# restriction's `bypass_actors` may grant.
+BYPASS_ROLE_IDS = frozenset({ROLE_ID_MAINTAIN, ROLE_ID_ADMIN})
 
 # Non-role bypass actors that also unambiguously outrank a write-access bot. A
 # `User` actor is resolved against the bot's own id; the rest (Team,
@@ -245,17 +242,21 @@ def _ruleset_blocks_bot(endpoint: str, bot_name: str) -> bool | None:
     if not isinstance(data, dict):
         return None
 
+    actors = data.get("bypass_actors") or []
+    # A user exemption is decidable: the bot's login resolves to the id the
+    # actor names. Naming the bot is the worst case — an explicit grant of the
+    # merge the restriction exists to deny.
+    bot_id = None
+    if any(a.get("actor_type") == "User" for a in actors):
+        bot_id = _user_id(bot_name)
+
     unresolved = False
-    for actor in data.get("bypass_actors") or []:
+    for actor in actors:
         actor_type = actor.get("actor_type")
         if actor_type == "RepositoryRole":
             if actor.get("actor_id") not in BYPASS_ROLE_IDS:
                 return False
         elif actor_type == "User":
-            # A user exemption is decidable: the bot's login resolves to the id
-            # the actor names. Naming the bot is the worst case — an explicit
-            # grant of the merge the restriction exists to deny.
-            bot_id = _user_id(bot_name)
             if bot_id is None:
                 unresolved = True
             elif actor.get("actor_id") == bot_id:
@@ -306,18 +307,16 @@ def _has_restrict_updates_ruleset(repo: str, branch: str, bot_name: str) -> bool
 
 
 def check_bot_permission(repo: str, bot_name: str) -> CheckResult:
-    """Check the bot's role (should be write or below, so it can't bypass).
+    """Check the bot's effective access stays at write or below.
 
-    Reads `.role_name`, not `.permission`: the latter is the legacy
-    admin/write/read/none field, which reports a maintain-role collaborator as
-    "write" — and maintain bypasses the merge restriction.
+    Reads the `permissions` booleans: they report effective capabilities, so a
+    custom role built on maintain or admin fails the same as the base role.
+    Neither string field works — the legacy `.permission` reports a
+    maintain-role collaborator as "write" (and maintain bypasses the merge
+    restriction), while matching `.role_name` against base-role names would
+    pass any custom role whatever it grants.
     """
-    result = _gh(
-        "api",
-        f"repos/{repo}/collaborators/{bot_name}/permission",
-        "--jq",
-        ".role_name",
-    )
+    result = _gh("api", f"repos/{repo}/collaborators/{bot_name}/permission")
     if result is None:
         return CheckResult("bot-permission", None, "gh CLI not found")
     if result.returncode != 0:
@@ -332,8 +331,16 @@ def check_bot_permission(repo: str, bot_name: str) -> CheckResult:
             "bot-permission", None, "Could not check (may require admin access to read)"
         )
 
-    role = result.stdout.strip()
-    if role in BYPASS_ROLES:
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return CheckResult(
+            "bot-permission", None, "Could not parse permission response"
+        )
+
+    perms = data["user"]["permissions"]
+    role = data["role_name"]
+    if perms["admin"] or perms["maintain"]:
         return CheckResult(
             "bot-permission",
             False,

--- a/generator/src/tend/checks.py
+++ b/generator/src/tend/checks.py
@@ -18,6 +18,33 @@ from dataclasses import dataclass
 from tend.config import CLAUDE_FAMILY_HARNESSES, Config
 
 
+# GitHub's base repository role IDs, as they appear in a ruleset's
+# `bypass_actors`. The IDs are not ordered by privilege — maintain (2) sits
+# below write (4) — so the plausible guess for "maintain" is in fact the bot's
+# own role, and guessing it into a bypass list hands the bot the merge. The API
+# reports only the number; GraphQL names it, so verify against a live ruleset:
+#
+#   gh api graphql -f query='{repository(owner:"OWNER", name:"REPO")
+#     {rulesets(first:10){nodes{name bypassActors(first:10)
+#     {nodes{repositoryRoleDatabaseId repositoryRoleName}}}}}}'
+ROLE_ID_MAINTAIN = 2
+ROLE_ID_WRITE = 4
+ROLE_ID_ADMIN = 5
+
+# The roles above the bot's write access, so the only ones that can bypass a
+# ruleset. The bot must hold none of them, and a merge restriction may grant no
+# others. Keyed by name for the collaborators endpoint, valued by ID for
+# `bypass_actors` — the two APIs name the same role differently.
+BYPASS_ROLES = {"maintain": ROLE_ID_MAINTAIN, "admin": ROLE_ID_ADMIN}
+BYPASS_ROLE_IDS = frozenset(BYPASS_ROLES.values())
+
+# Non-role bypass actors that also unambiguously outrank a write-access bot. A
+# `User` actor is resolved against the bot's own id; the rest (Team,
+# Integration, DeployKey) name a principal whose membership isn't visible from
+# the ruleset, so the bot can't be ruled out.
+BYPASS_ACTOR_TYPES_ABOVE_BOT = frozenset({"OrganizationAdmin", "EnterpriseOwner"})
+
+
 @dataclass
 class CheckResult:
     name: str
@@ -91,7 +118,7 @@ def detect_default_branch(repo: str) -> str | None:
     return None
 
 
-def check_branch_protection(repo: str, branch: str) -> CheckResult:
+def check_branch_protection(repo: str, branch: str, bot_name: str) -> CheckResult:
     """Check if a branch is protected against bot merges.
 
     Checks both that the branch is protected and that the protection actually
@@ -116,7 +143,7 @@ def check_branch_protection(repo: str, branch: str) -> CheckResult:
 
     # Branch is protected — now check if the bot can still merge.
     # A restrict-updates ruleset is sufficient (and preferred).
-    ruleset = _has_restrict_updates_ruleset(repo, branch)
+    ruleset = _has_restrict_updates_ruleset(repo, branch, bot_name)
     if ruleset is True:
         return CheckResult(
             name,
@@ -152,24 +179,101 @@ def check_branch_protection(repo: str, branch: str) -> CheckResult:
         return CheckResult(
             name,
             None,
-            f"Branch '{branch}' is protected but could not verify rulesets "
-            "(insufficient API permissions). Check rulesets manually.",
+            f"Branch '{branch}' is protected but could not verify that the bot "
+            "cannot bypass its rulesets — either they aren't readable with this "
+            "token, or a bypass actor names a team, app, or deploy key whose "
+            "membership isn't resolvable here. Check the bypass list manually.",
         )
 
     return CheckResult(
         name,
         False,
         f"Branch '{branch}' is protected but the bot can still merge PRs "
-        f"(required_approving_review_count is 0 and no restrict-updates ruleset found). "
-        "Either require at least 1 approving review, or add a 'Restrict updates' "
-        "ruleset with only admins bypassing. See docs/security-model.md.",
+        "(required_approving_review_count is 0, and no restrict-updates ruleset "
+        "the bot cannot bypass). Either require at least 1 approving review, or "
+        "add a 'Restrict updates' ruleset whose bypass actors are all above write. "
+        "See docs/security-model.md.",
     )
 
 
-def _has_restrict_updates_ruleset(repo: str, branch: str) -> bool | None:
-    """Check if any active ruleset restricts updates to the branch.
+def _ruleset_endpoint(rule: dict) -> str | None:
+    """The API path for the ruleset a branch rule came from.
 
-    Returns True if found, False if confirmed absent, None if unable to check.
+    A rule carries the ruleset's id and where it lives, and org rulesets are
+    readable only under `/orgs`. Returns None when the ruleset can't be
+    addressed — an Enterprise ruleset has no endpoint a repo-scoped token can
+    reach — which the caller treats as unverifiable.
+    """
+    source = rule.get("ruleset_source")
+    ruleset_id = rule.get("ruleset_id")
+    if not source or ruleset_id is None:
+        return None
+    source_type = rule.get("ruleset_source_type")
+    if source_type == "Repository":
+        return f"repos/{source}/rulesets/{ruleset_id}"
+    if source_type == "Organization":
+        return f"orgs/{source}/rulesets/{ruleset_id}"
+    return None
+
+
+def _user_id(login: str) -> int | None:
+    """The numeric GitHub user id for a login, which is how a `User` bypass
+    actor names its principal."""
+    result = _gh("api", f"users/{login}", "--jq", ".id")
+    if result is None or result.returncode != 0:
+        return None
+    try:
+        return int(result.stdout.strip())
+    except ValueError:
+        return None
+
+
+def _ruleset_blocks_bot(endpoint: str, bot_name: str) -> bool | None:
+    """Whether a ruleset's bypass list keeps a write-access bot out.
+
+    Returns True if every bypass actor outranks the bot, False if one of them
+    is the bot itself or a role at write or below, None if the ruleset can't be
+    read or names a principal this can't resolve (a team, app, or deploy key).
+    """
+    result = _gh("api", endpoint)
+    if result is None or result.returncode != 0:
+        return None
+    try:
+        data = json.loads(result.stdout)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+
+    unresolved = False
+    for actor in data.get("bypass_actors") or []:
+        actor_type = actor.get("actor_type")
+        if actor_type == "RepositoryRole":
+            if actor.get("actor_id") not in BYPASS_ROLE_IDS:
+                return False
+        elif actor_type == "User":
+            # A user exemption is decidable: the bot's login resolves to the id
+            # the actor names. Naming the bot is the worst case — an explicit
+            # grant of the merge the restriction exists to deny.
+            bot_id = _user_id(bot_name)
+            if bot_id is None:
+                unresolved = True
+            elif actor.get("actor_id") == bot_id:
+                return False
+        elif actor_type not in BYPASS_ACTOR_TYPES_ABOVE_BOT:
+            unresolved = True
+    return None if unresolved else True
+
+
+def _has_restrict_updates_ruleset(repo: str, branch: str, bot_name: str) -> bool | None:
+    """Check if an active ruleset stops the bot updating the branch.
+
+    An `update` rule alone isn't enough — a bypass actor at write or below
+    defeats it, and write is exactly what the bot holds. So each update rule is
+    followed back to its ruleset and its bypass list checked.
+
+    Returns True if found, False if confirmed absent or bypassable, None if
+    unable to check.
 
     Uses the per-branch rules endpoint which resolves patterns like
     ~DEFAULT_BRANCH.
@@ -183,16 +287,36 @@ def _has_restrict_updates_ruleset(repo: str, branch: str) -> bool | None:
         return None
     if not isinstance(rules, list):
         return None
-    return any(r.get("type") == "update" for r in rules)
+
+    update_rules = [r for r in rules if r.get("type") == "update"]
+    if not update_rules:
+        return False
+
+    # Several rulesets can contribute an update rule; one the bot can't bypass
+    # is enough to protect the branch. A rule we can't trace back to its
+    # ruleset is unverified, not absent.
+    unresolved = False
+    for rule in update_rules:
+        endpoint = _ruleset_endpoint(rule)
+        verdict = _ruleset_blocks_bot(endpoint, bot_name) if endpoint else None
+        if verdict is True:
+            return True
+        unresolved = unresolved or verdict is None
+    return None if unresolved else False
 
 
 def check_bot_permission(repo: str, bot_name: str) -> CheckResult:
-    """Check the bot's permission level (should be write, not admin)."""
+    """Check the bot's role (should be write or below, so it can't bypass).
+
+    Reads `.role_name`, not `.permission`: the latter is the legacy
+    admin/write/read/none field, which reports a maintain-role collaborator as
+    "write" — and maintain bypasses the merge restriction.
+    """
     result = _gh(
         "api",
         f"repos/{repo}/collaborators/{bot_name}/permission",
         "--jq",
-        ".permission",
+        ".role_name",
     )
     if result is None:
         return CheckResult("bot-permission", None, "gh CLI not found")
@@ -208,16 +332,16 @@ def check_bot_permission(repo: str, bot_name: str) -> CheckResult:
             "bot-permission", None, "Could not check (may require admin access to read)"
         )
 
-    perm = result.stdout.strip()
-    if perm == "admin":
+    role = result.stdout.strip()
+    if role in BYPASS_ROLES:
         return CheckResult(
             "bot-permission",
             False,
-            f"Bot '{bot_name}' has admin permission — it can bypass branch protection. "
+            f"Bot '{bot_name}' has {role} permission — it can bypass branch protection. "
             "Downgrade to write access.",
         )
     return CheckResult(
-        "bot-permission", True, f"Bot '{bot_name}' has '{perm}' permission"
+        "bot-permission", True, f"Bot '{bot_name}' has '{role}' permission"
     )
 
 
@@ -367,7 +491,7 @@ def _restrict_updates_ruleset(extra_branches: list[str]) -> str:
             "rules": [{"type": "update"}],
             "bypass_actors": [
                 {
-                    "actor_id": 5,
+                    "actor_id": ROLE_ID_ADMIN,
                     "actor_type": "RepositoryRole",
                     "bypass_mode": "exempt",
                 }
@@ -384,7 +508,7 @@ def fix_branch_protection(
     """Create a restrict-updates ruleset covering protected branches.
 
     Always covers the default branch. Extra branches from config are included
-    in the same ruleset. Only admins (actor_id 5) can bypass.
+    in the same ruleset. Only admins can bypass.
     """
     extra = [b for b in (extra_branches or []) if b != default_branch]
     body = _restrict_updates_ruleset(extra)
@@ -459,10 +583,10 @@ def run_all_checks(cfg: Config, repo: str | None = None) -> list[CheckResult]:
         cfg.allowed_repo_secrets
     )
 
-    results = [check_branch_protection(repo, default_branch)]
+    results = [check_branch_protection(repo, default_branch, cfg.bot_name)]
     for branch in cfg.protected_branches:
         if branch != default_branch:
-            results.append(check_branch_protection(repo, branch))
+            results.append(check_branch_protection(repo, branch, cfg.bot_name))
     results.append(check_bot_permission(repo, cfg.bot_name))
     results.append(check_secrets(repo, required_secrets))
     if cfg.harness in CLAUDE_FAMILY_HARNESSES:

--- a/generator/tests/test_checks.py
+++ b/generator/tests/test_checks.py
@@ -101,11 +101,12 @@ def _gh_ruleset(
     rules: str,
     bypass_actors: list[dict[str, object]] | None,
     user_id: int | None = None,
+    ruleset_json: str | None = None,
 ) -> object:
     """Build a `_gh` fake serving the calls `_has_restrict_updates_ruleset` makes:
     `/rules/branches/<branch>` returns `rules`; `/rulesets/<id>` returns a ruleset
-    with `bypass_actors` (or returncode=1 if None); `users/<login>` returns
-    `user_id` (or returncode=1 if None)."""
+    with `bypass_actors` (or `ruleset_json` verbatim if given, or returncode=1 if
+    both are None); `users/<login>` returns `user_id` (or returncode=1 if None)."""
 
     def fake(*args: str, **kwargs: object) -> subprocess.CompletedProcess[str] | None:
         if "/rules/branches/" in args[1]:
@@ -114,6 +115,8 @@ def _gh_ruleset(
             if user_id is None:
                 return _make_completed(returncode=1)
             return _make_completed(f"{user_id}\n")
+        if ruleset_json is not None:
+            return _make_completed(ruleset_json)
         if bypass_actors is None:
             return _make_completed(returncode=1)
         return _make_completed(json.dumps({"bypass_actors": bypass_actors}))
@@ -306,22 +309,27 @@ def test_update_rule_present() -> None:
     assert gh.call_args.args[-1] == "repos/owner/repo/rulesets/1"
 
 
-def test_org_ruleset_read_from_orgs_endpoint() -> None:
-    """An org-level ruleset is readable only under /orgs, not /repos."""
+def test_org_ruleset_read_via_repo_endpoint() -> None:
+    """The repo-scoped endpoint serves org-sourced rulesets too."""
     fake = _gh_ruleset(
         _make_branch_rules("update", source_type="Organization", source="owner"),
         [_role_actor(ROLE_ID_ADMIN)],
     )
     with patch("tend.checks._gh", side_effect=fake) as gh:
         assert _has_restrict_updates_ruleset("owner/repo", "main", "my-bot") is True
-    assert gh.call_args.args[-1] == "orgs/owner/rulesets/1"
+    assert gh.call_args.args[-1] == "repos/owner/repo/rulesets/1"
 
 
-def test_enterprise_ruleset_unverifiable() -> None:
-    """An enterprise ruleset has no endpoint a repo-scoped token can read → None."""
+def test_ruleset_bypass_list_not_visible() -> None:
+    """GitHub omits `bypass_actors` below ruleset-admin → unverifiable, not empty.
+
+    Reading the missing key as an empty list would report "nobody bypasses" —
+    a false pass for exactly the caller who can't see the danger.
+    """
     fake = _gh_ruleset(
-        _make_branch_rules("update", source_type="Enterprise", source="acme"),
-        [_role_actor(ROLE_ID_ADMIN)],
+        _make_branch_rules("update"),
+        None,
+        ruleset_json=json.dumps({"current_user_can_bypass": "never"}),
     )
     with patch("tend.checks._gh", side_effect=fake):
         assert _has_restrict_updates_ruleset("owner/repo", "main", "my-bot") is None

--- a/generator/tests/test_checks.py
+++ b/generator/tests/test_checks.py
@@ -503,15 +503,32 @@ def test_ruleset_with_extra_branches() -> None:
 # ---------------------------------------------------------------------------
 
 
+def _permission_response(
+    role_name: str, *, admin: bool = False, maintain: bool = False
+) -> str:
+    """The /collaborators/{user}/permission response, trimmed to what's read."""
+    return json.dumps(
+        {
+            "permission": "admin" if admin else "write",
+            "role_name": role_name,
+            "user": {
+                "permissions": {"admin": admin, "maintain": maintain, "push": True}
+            },
+        }
+    )
+
+
 def test_bot_write_permission() -> None:
-    with patch("tend.checks._gh", return_value=_make_completed("write\n")):
+    resp = _permission_response("write")
+    with patch("tend.checks._gh", return_value=_make_completed(resp)):
         result = check_bot_permission("owner/repo", "my-bot")
     assert result.passed is True
     assert "write" in result.message
 
 
 def test_bot_admin_permission() -> None:
-    with patch("tend.checks._gh", return_value=_make_completed("admin\n")):
+    resp = _permission_response("admin", admin=True, maintain=True)
+    with patch("tend.checks._gh", return_value=_make_completed(resp)):
         result = check_bot_permission("owner/repo", "my-bot")
     assert result.passed is False
     assert "admin" in result.message
@@ -522,20 +539,27 @@ def test_bot_maintain_permission() -> None:
     """Maintain bypasses the merge restriction, so the bot must not hold it.
 
     The legacy `.permission` field reports a maintain collaborator as "write",
-    which is why the check reads `.role_name`.
+    which is why the check reads the `permissions` booleans instead.
     """
-    with patch("tend.checks._gh", return_value=_make_completed("maintain\n")):
+    resp = _permission_response("maintain", maintain=True)
+    with patch("tend.checks._gh", return_value=_make_completed(resp)):
         result = check_bot_permission("owner/repo", "my-bot")
     assert result.passed is False
     assert "maintain" in result.message
     assert "bypass" in result.message
 
 
-def test_bot_permission_reads_role_name() -> None:
-    """The check must query `.role_name`, not the legacy `.permission` field."""
-    with patch("tend.checks._gh", return_value=_make_completed("write\n")) as gh:
-        check_bot_permission("owner/repo", "my-bot")
-    assert gh.call_args.args[-1] == ".role_name"
+def test_bot_custom_role_with_maintain_fails() -> None:
+    """A custom role is judged by its capabilities, not its name.
+
+    Its `role_name` matches no base role, so only the `permissions` booleans
+    reveal that it can bypass.
+    """
+    resp = _permission_response("release-manager", maintain=True)
+    with patch("tend.checks._gh", return_value=_make_completed(resp)):
+        result = check_bot_permission("owner/repo", "my-bot")
+    assert result.passed is False
+    assert "release-manager" in result.message
 
 
 def test_bot_permission_403() -> None:
@@ -806,10 +830,14 @@ def _fake_gh_all_pass(*args, **kwargs) -> subprocess.CompletedProcess[str]:
         return _make_completed("main\n")
     if "rules/branches" in url:
         return _make_completed(_BRANCH_HAS_UPDATE_RULE)
+    if "/rulesets/" in url:
+        return _make_completed(
+            json.dumps({"bypass_actors": [_role_actor(ROLE_ID_ADMIN)]})
+        )
     if "branches" in url:
         return _make_completed("true\n")
     if "collaborators" in url:
-        return _make_completed("write\n")
+        return _make_completed(_permission_response("write"))
     if "secrets" in url:
         return _make_completed('["T1","T2"]\n')
     return _make_completed(returncode=1)
@@ -846,10 +874,14 @@ def test_run_all_checks_allowlist_catches_unexpected() -> None:
             return _make_completed("main\n")
         if "rules/branches" in url:
             return _make_completed(_BRANCH_HAS_UPDATE_RULE)
+        if "/rulesets/" in url:
+            return _make_completed(
+                json.dumps({"bypass_actors": [_role_actor(ROLE_ID_ADMIN)]})
+            )
         if "branches" in url:
             return _make_completed("true\n")
         if "collaborators" in url:
-            return _make_completed("write\n")
+            return _make_completed(_permission_response("write"))
         if "secrets" in url:
             return _make_completed('["T1","T2","PYPI_TOKEN"]\n')
         return _make_completed(returncode=1)

--- a/generator/tests/test_checks.py
+++ b/generator/tests/test_checks.py
@@ -11,6 +11,9 @@ import pytest
 from click.testing import CliRunner
 
 from tend.checks import (
+    ROLE_ID_ADMIN,
+    ROLE_ID_MAINTAIN,
+    ROLE_ID_WRITE,
     CheckResult,
     _has_restrict_updates_ruleset,
     _restrict_updates_ruleset,
@@ -68,9 +71,54 @@ def _write_config(tmp_path: Path, content: str = "bot_name: test-bot") -> Path:
     return cfg
 
 
-def _make_branch_rules(*rule_types: str) -> str:
+def _make_branch_rules(
+    *rule_types: str,
+    ruleset_id: int | None = 1,
+    source_type: str = "Repository",
+    source: str = "owner/repo",
+) -> str:
     """Build a JSON array of branch rules (as returned by /rules/branches/{branch})."""
-    return json.dumps([{"type": t} for t in rule_types])
+    rule: dict[str, object]
+    rules = []
+    for t in rule_types:
+        rule = {"type": t, "ruleset_source_type": source_type, "ruleset_source": source}
+        if ruleset_id is not None:
+            rule["ruleset_id"] = ruleset_id
+        rules.append(rule)
+    return json.dumps(rules)
+
+
+def _role_actor(actor_id: int) -> dict[str, object]:
+    """A `bypass_actors` entry granting a base repository role."""
+    return {
+        "actor_id": actor_id,
+        "actor_type": "RepositoryRole",
+        "bypass_mode": "exempt",
+    }
+
+
+def _gh_ruleset(
+    rules: str,
+    bypass_actors: list[dict[str, object]] | None,
+    user_id: int | None = None,
+) -> object:
+    """Build a `_gh` fake serving the calls `_has_restrict_updates_ruleset` makes:
+    `/rules/branches/<branch>` returns `rules`; `/rulesets/<id>` returns a ruleset
+    with `bypass_actors` (or returncode=1 if None); `users/<login>` returns
+    `user_id` (or returncode=1 if None)."""
+
+    def fake(*args: str, **kwargs: object) -> subprocess.CompletedProcess[str] | None:
+        if "/rules/branches/" in args[1]:
+            return _make_completed(rules)
+        if args[1].startswith("users/"):
+            if user_id is None:
+                return _make_completed(returncode=1)
+            return _make_completed(f"{user_id}\n")
+        if bypass_actors is None:
+            return _make_completed(returncode=1)
+        return _make_completed(json.dumps({"bypass_actors": bypass_actors}))
+
+    return fake
 
 
 # ---------------------------------------------------------------------------
@@ -167,23 +215,27 @@ def test_detect_canonical_owner_api_failure_returns_none() -> None:
 
 
 def test_branch_protected() -> None:
+    """Protected via a restrict-updates ruleset the bot can't bypass."""
     branch_rules = _make_branch_rules("update")
+    ruleset = json.dumps({"bypass_actors": [_role_actor(ROLE_ID_ADMIN)]})
 
     def fake_gh(*args, **kwargs):
         url = args[1]
         if "rules/branches" in url:
             return _make_completed(branch_rules)
+        if "/rulesets/" in url:
+            return _make_completed(ruleset)
         return _make_completed("true\n")
 
     with patch("tend.checks._gh", side_effect=fake_gh):
-        result = check_branch_protection("owner/repo", "main")
+        result = check_branch_protection("owner/repo", "main", "my-bot")
     assert result.passed is True
-    assert "protected" in result.message
+    assert "restrict-updates ruleset" in result.message
 
 
 def test_branch_not_protected() -> None:
     with patch("tend.checks._gh", return_value=_make_completed("false\n")):
-        result = check_branch_protection("owner/repo", "main")
+        result = check_branch_protection("owner/repo", "main", "my-bot")
     assert result.passed is False
     assert "NOT protected" in result.message
 
@@ -193,14 +245,14 @@ def test_branch_protection_api_error() -> None:
         "tend.checks._gh",
         return_value=_make_completed(returncode=1, stderr="Not Found"),
     ):
-        result = check_branch_protection("owner/repo", "main")
+        result = check_branch_protection("owner/repo", "main", "my-bot")
     assert result.passed is None
     assert "API error" in result.message
 
 
 def test_branch_protection_no_gh() -> None:
     with patch("tend.checks._gh", return_value=None):
-        result = check_branch_protection("owner/repo", "main")
+        result = check_branch_protection("owner/repo", "main", "my-bot")
     assert result.passed is None
 
 
@@ -221,16 +273,16 @@ def test_branch_protected_ruleset_inconclusive_skips() -> None:
         return _make_completed(returncode=1)
 
     with patch("tend.checks._gh", side_effect=fake_gh):
-        result = check_branch_protection("owner/repo", "main")
+        result = check_branch_protection("owner/repo", "main", "my-bot")
     assert result.passed is None
-    assert "could not verify rulesets" in result.message
+    assert "could not verify that the bot cannot bypass" in result.message
 
 
 def test_branch_protection_result_name_includes_branch() -> None:
     """Each branch gets a distinct check name for identification."""
     with patch("tend.checks._gh", return_value=_make_completed("false\n")):
-        main_result = check_branch_protection("owner/repo", "main")
-        v1_result = check_branch_protection("owner/repo", "v1")
+        main_result = check_branch_protection("owner/repo", "main", "my-bot")
+        v1_result = check_branch_protection("owner/repo", "v1", "my-bot")
     assert main_result.name == "branch-protection:main"
     assert v1_result.name == "branch-protection:v1"
 
@@ -243,28 +295,162 @@ def test_branch_protection_result_name_includes_branch() -> None:
 def test_no_rules_for_branch() -> None:
     """No rules at all for this branch → False."""
     with patch("tend.checks._gh", return_value=_make_completed("[]\n")):
-        assert _has_restrict_updates_ruleset("owner/repo", "main") is False
+        assert _has_restrict_updates_ruleset("owner/repo", "main", "my-bot") is False
 
 
 def test_update_rule_present() -> None:
-    """Branch rules include an update rule → True."""
-    data = _make_branch_rules("update")
-    with patch("tend.checks._gh", return_value=_make_completed(data)):
-        assert _has_restrict_updates_ruleset("owner/repo", "main") is True
+    """Update rule whose ruleset only admins bypass → True."""
+    fake = _gh_ruleset(_make_branch_rules("update"), [_role_actor(ROLE_ID_ADMIN)])
+    with patch("tend.checks._gh", side_effect=fake) as gh:
+        assert _has_restrict_updates_ruleset("owner/repo", "main", "my-bot") is True
+    assert gh.call_args.args[-1] == "repos/owner/repo/rulesets/1"
+
+
+def test_org_ruleset_read_from_orgs_endpoint() -> None:
+    """An org-level ruleset is readable only under /orgs, not /repos."""
+    fake = _gh_ruleset(
+        _make_branch_rules("update", source_type="Organization", source="owner"),
+        [_role_actor(ROLE_ID_ADMIN)],
+    )
+    with patch("tend.checks._gh", side_effect=fake) as gh:
+        assert _has_restrict_updates_ruleset("owner/repo", "main", "my-bot") is True
+    assert gh.call_args.args[-1] == "orgs/owner/rulesets/1"
+
+
+def test_enterprise_ruleset_unverifiable() -> None:
+    """An enterprise ruleset has no endpoint a repo-scoped token can read → None."""
+    fake = _gh_ruleset(
+        _make_branch_rules("update", source_type="Enterprise", source="acme"),
+        [_role_actor(ROLE_ID_ADMIN)],
+    )
+    with patch("tend.checks._gh", side_effect=fake):
+        assert _has_restrict_updates_ruleset("owner/repo", "main", "my-bot") is None
 
 
 def test_only_non_update_rules() -> None:
     """Branch has rules but none are update → False."""
     data = _make_branch_rules("deletion", "required_linear_history")
     with patch("tend.checks._gh", return_value=_make_completed(data)):
-        assert _has_restrict_updates_ruleset("owner/repo", "main") is False
+        assert _has_restrict_updates_ruleset("owner/repo", "main", "my-bot") is False
 
 
 def test_update_rule_among_others() -> None:
     """Update rule mixed with other rules → True."""
-    data = _make_branch_rules("deletion", "update", "required_signatures")
-    with patch("tend.checks._gh", return_value=_make_completed(data)):
-        assert _has_restrict_updates_ruleset("owner/repo", "main") is True
+    fake = _gh_ruleset(
+        _make_branch_rules("deletion", "update", "required_signatures"),
+        [_role_actor(ROLE_ID_ADMIN)],
+    )
+    with patch("tend.checks._gh", side_effect=fake):
+        assert _has_restrict_updates_ruleset("owner/repo", "main", "my-bot") is True
+
+
+def test_update_rule_bypassed_by_write() -> None:
+    """A write-role bypass defeats the update rule — the bot holds write.
+
+    This is the hole the check missed: the rule is present and the branch looks
+    protected, but the bot can merge anyway.
+    """
+    fake = _gh_ruleset(_make_branch_rules("update"), [_role_actor(ROLE_ID_WRITE)])
+    with patch("tend.checks._gh", side_effect=fake):
+        assert _has_restrict_updates_ruleset("owner/repo", "main", "my-bot") is False
+
+
+def test_update_rule_maintain_bypass_ok() -> None:
+    """Maintain outranks the bot's write, so a maintain bypass still protects."""
+    fake = _gh_ruleset(
+        _make_branch_rules("update"),
+        [_role_actor(ROLE_ID_ADMIN), _role_actor(ROLE_ID_MAINTAIN)],
+    )
+    with patch("tend.checks._gh", side_effect=fake):
+        assert _has_restrict_updates_ruleset("owner/repo", "main", "my-bot") is True
+
+
+def test_update_rule_org_admin_bypass_ok() -> None:
+    """OrganizationAdmin isn't a repository role but still outranks the bot."""
+    fake = _gh_ruleset(
+        _make_branch_rules("update"),
+        [{"actor_type": "OrganizationAdmin", "actor_id": None}],
+    )
+    with patch("tend.checks._gh", side_effect=fake):
+        assert _has_restrict_updates_ruleset("owner/repo", "main", "my-bot") is True
+
+
+def test_update_rule_bot_user_bypass() -> None:
+    """A user exemption naming the bot is an explicit grant of the merge.
+
+    Without resolving the bot's login to its id this reads as unverifiable, and
+    an unverifiable check exits 0 — so the misconfiguration would pass.
+    """
+    fake = _gh_ruleset(
+        _make_branch_rules("update"),
+        [{"actor_type": "User", "actor_id": 999}],
+        user_id=999,
+    )
+    with patch("tend.checks._gh", side_effect=fake):
+        assert _has_restrict_updates_ruleset("owner/repo", "main", "my-bot") is False
+
+
+def test_update_rule_other_user_bypass_ok() -> None:
+    """A user exemption naming someone else doesn't let the bot through."""
+    fake = _gh_ruleset(
+        _make_branch_rules("update"),
+        [{"actor_type": "User", "actor_id": 12345}],
+        user_id=999,
+    )
+    with patch("tend.checks._gh", side_effect=fake):
+        assert _has_restrict_updates_ruleset("owner/repo", "main", "my-bot") is True
+
+
+def test_update_rule_user_bypass_unresolvable_login() -> None:
+    """If the bot's login won't resolve, a user exemption stays unverifiable."""
+    fake = _gh_ruleset(
+        _make_branch_rules("update"),
+        [{"actor_type": "User", "actor_id": 999}],
+        user_id=None,
+    )
+    with patch("tend.checks._gh", side_effect=fake):
+        assert _has_restrict_updates_ruleset("owner/repo", "main", "my-bot") is None
+
+
+def test_update_rule_team_bypass_unresolved() -> None:
+    """A team bypass could contain the bot; membership isn't visible → None."""
+    fake = _gh_ruleset(
+        _make_branch_rules("update"),
+        [{"actor_type": "Team", "actor_id": 42}],
+    )
+    with patch("tend.checks._gh", side_effect=fake):
+        assert _has_restrict_updates_ruleset("owner/repo", "main", "my-bot") is None
+
+
+def test_update_rule_write_bypass_beats_unresolved() -> None:
+    """A definite write bypass outweighs an unresolvable actor in the same list."""
+    fake = _gh_ruleset(
+        _make_branch_rules("update"),
+        [{"actor_type": "Team", "actor_id": 42}, _role_actor(ROLE_ID_WRITE)],
+    )
+    with patch("tend.checks._gh", side_effect=fake):
+        assert _has_restrict_updates_ruleset("owner/repo", "main", "my-bot") is False
+
+
+def test_update_rule_no_bypass_actors() -> None:
+    """An empty bypass list means nobody bypasses → protected."""
+    fake = _gh_ruleset(_make_branch_rules("update"), [])
+    with patch("tend.checks._gh", side_effect=fake):
+        assert _has_restrict_updates_ruleset("owner/repo", "main", "my-bot") is True
+
+
+def test_update_rule_ruleset_unreadable() -> None:
+    """Update rule present but its ruleset can't be read → None, not a pass."""
+    fake = _gh_ruleset(_make_branch_rules("update"), None)
+    with patch("tend.checks._gh", side_effect=fake):
+        assert _has_restrict_updates_ruleset("owner/repo", "main", "my-bot") is None
+
+
+def test_update_rule_without_ruleset_id() -> None:
+    """An update rule we can't trace to a ruleset is unverified, not absent."""
+    fake = _gh_ruleset(_make_branch_rules("update", ruleset_id=None), None)
+    with patch("tend.checks._gh", side_effect=fake):
+        assert _has_restrict_updates_ruleset("owner/repo", "main", "my-bot") is None
 
 
 def test_branch_rules_api_error() -> None:
@@ -273,13 +459,13 @@ def test_branch_rules_api_error() -> None:
         "tend.checks._gh",
         return_value=_make_completed(returncode=1, stderr="Not Found"),
     ):
-        assert _has_restrict_updates_ruleset("owner/repo", "main") is None
+        assert _has_restrict_updates_ruleset("owner/repo", "main", "my-bot") is None
 
 
 def test_branch_rules_no_gh() -> None:
     """gh CLI not found → None (can't check either endpoint)."""
     with patch("tend.checks._gh", return_value=None):
-        assert _has_restrict_updates_ruleset("owner/repo", "main") is None
+        assert _has_restrict_updates_ruleset("owner/repo", "main", "my-bot") is None
 
 
 def test_branch_rules_non_list_response() -> None:
@@ -288,7 +474,7 @@ def test_branch_rules_non_list_response() -> None:
         "tend.checks._gh",
         return_value=_make_completed('{"message": "Not Found"}'),
     ):
-        assert _has_restrict_updates_ruleset("owner/repo", "main") is None
+        assert _has_restrict_updates_ruleset("owner/repo", "main", "my-bot") is None
 
 
 # ---------------------------------------------------------------------------
@@ -330,6 +516,26 @@ def test_bot_admin_permission() -> None:
     assert result.passed is False
     assert "admin" in result.message
     assert "bypass" in result.message
+
+
+def test_bot_maintain_permission() -> None:
+    """Maintain bypasses the merge restriction, so the bot must not hold it.
+
+    The legacy `.permission` field reports a maintain collaborator as "write",
+    which is why the check reads `.role_name`.
+    """
+    with patch("tend.checks._gh", return_value=_make_completed("maintain\n")):
+        result = check_bot_permission("owner/repo", "my-bot")
+    assert result.passed is False
+    assert "maintain" in result.message
+    assert "bypass" in result.message
+
+
+def test_bot_permission_reads_role_name() -> None:
+    """The check must query `.role_name`, not the legacy `.permission` field."""
+    with patch("tend.checks._gh", return_value=_make_completed("write\n")) as gh:
+        check_bot_permission("owner/repo", "my-bot")
+    assert gh.call_args.args[-1] == ".role_name"
 
 
 def test_bot_permission_403() -> None:

--- a/generator/tests/test_integration.py
+++ b/generator/tests/test_integration.py
@@ -297,11 +297,47 @@ def _fake_gh_all_pass(*args: str, **kwargs: str) -> subprocess.CompletedProcess[
     if url == "repos/owner/repo" and ".default_branch" in args:
         return _make_completed("main\n")
     if "rules/branches" in url:
-        return _make_completed(json.dumps([{"type": "update"}]))
+        return _make_completed(
+            json.dumps(
+                [
+                    {
+                        "type": "update",
+                        "ruleset_id": 1,
+                        "ruleset_source_type": "Repository",
+                        "ruleset_source": "owner/repo",
+                    }
+                ]
+            )
+        )
+    if "/rulesets/" in url:
+        # Admin-only bypass — the shape `tend check --fix` creates.
+        return _make_completed(
+            json.dumps(
+                {
+                    "bypass_actors": [
+                        {
+                            "actor_id": 5,
+                            "actor_type": "RepositoryRole",
+                            "bypass_mode": "exempt",
+                        }
+                    ]
+                }
+            )
+        )
     if "branches" in url:
         return _make_completed("true\n")
     if "collaborators" in url:
-        return _make_completed("write\n")
+        return _make_completed(
+            json.dumps(
+                {
+                    "permission": "write",
+                    "role_name": "write",
+                    "user": {
+                        "permissions": {"admin": False, "maintain": False, "push": True}
+                    },
+                }
+            )
+        )
     if "secrets" in url:
         return _make_completed('["TEND_BOT_TOKEN","CLAUDE_CODE_OAUTH_TOKEN"]\n')
     return _make_completed(returncode=1)

--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -272,8 +272,8 @@ user that team members should @-mention the bot account instead of `@claude`.
 Two ref classes can land code that reaches a deploy or publish workflow:
 the default branch (via merge) and tags (via tag push). Restrict both to
 admin-only operations so every privileged code path chains back to an
-admin action. The bot has write, not admin, so it satisfies neither
-bypass.
+admin action. The bot has write, which is below every role that can
+bypass, so it satisfies neither.
 
 Survey existing rulesets; skip any slot already covered:
 
@@ -300,6 +300,17 @@ gh api "repos/$REPO/rulesets" --method POST --input - << 'EOF'
   }]
 }
 EOF
+```
+
+`actor_id: 5` is the admin role. The base role IDs run maintain 2, write 4,
+admin 5 — not ordered by privilege, so the plausible guess for maintain is in
+fact write, the bot's own role, and granting it hands the bot the merge. Before
+adding any bypass actor, read back what the ruleset actually granted:
+
+```bash
+gh api graphql -f query='{repository(owner:"OWNER", name:"REPO")
+  {rulesets(first:10){nodes{name bypassActors(first:10)
+  {nodes{repositoryRoleDatabaseId repositoryRoleName}}}}}}'
 ```
 
 **Tag operations.** Same shape, applied to all tags. Pushing a new tag or

--- a/plugins/install-tend/skills/install-tend/references/security-model.md
+++ b/plugins/install-tend/skills/install-tend/references/security-model.md
@@ -10,7 +10,8 @@ the subset an installing agent needs.
 
 Tend runs an agent with write access on attacker-controlled input. The
 boundary is structural: every code path into a privileged workflow chains
-back to an admin-controlled operation, and the bot has write, not admin.
+back to an admin-controlled operation, and the bot has write, which is below
+every role that can bypass a ruleset.
 
 The two admin-gated operations are:
 

--- a/plugins/install-tend/skills/install-tend/references/security-model.md
+++ b/plugins/install-tend/skills/install-tend/references/security-model.md
@@ -11,7 +11,12 @@ the subset an installing agent needs.
 Tend runs an agent with write access on attacker-controlled input. The
 boundary is structural: every code path into a privileged workflow chains
 back to an admin-controlled operation, and the bot has write, which is below
-every role that can bypass a ruleset.
+every role that can bypass a ruleset. The merge half is re-proven on every
+run: preflight, holding the bot's own token, reads `current_user_can_bypass`
+on each ruleset covering the default branch — GitHub's evaluation of the
+bot's standing, teams and custom roles included — and aborts unless some
+restrict-updates ruleset answers `never` or the branch is otherwise
+protected.
 
 The two admin-gated operations are:
 

--- a/shared/steps/security-preflight.sh
+++ b/shared/steps/security-preflight.sh
@@ -1,13 +1,50 @@
 #!/usr/bin/env bash
-# Shared preflight: refuse to run unless the default branch is protected.
-# Without branch protection the bot could merge its own PRs — the primary
-# security boundary (see docs/security-model.md). Shared verbatim by all three
-# harness actions (claude/, claude-interactive/, codex/).
+# Shared preflight: refuse to run unless the default branch is protected
+# against the bot itself. Shared verbatim by all three harness actions
+# (claude/, claude-interactive/, codex/).
 #
-# Inputs (env): GITHUB_TOKEN (for gh), GITHUB_REPOSITORY (from Actions).
+# Runs with the bot's own token, so `current_user_can_bypass` on each
+# applying ruleset is GitHub's answer to "can this bot bypass?" — teams,
+# custom roles, and org/enterprise-sourced rulesets all evaluated
+# server-side. One update rule the bot cannot bypass proves the bot cannot
+# update the branch. If update rules exist but the bot can bypass every
+# one, the merge restriction provably does not restrict the bot and the
+# run aborts. Repos protected by required reviews alone have no update
+# rule and fall back to the `.protected` floor, as before.
+#
+# Inputs (env): GITHUB_TOKEN (the bot's token, for gh), GITHUB_REPOSITORY
+# (from Actions).
 set -eo pipefail
 
 DEFAULT_BRANCH=$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.default_branch')
+
+RULESET_IDS=$(gh api "repos/${GITHUB_REPOSITORY}/rules/branches/${DEFAULT_BRANCH}" \
+  --jq '[.[] | select(.type == "update") | .ruleset_id] | unique | .[]' || true)
+
+VERDICT="no-update-rules" # or: blocked | bypassable
+while IFS= read -r id; do
+  [ -n "$id" ] || continue
+  CAN_BYPASS=$(gh api "repos/${GITHUB_REPOSITORY}/rulesets/${id}" \
+    --jq '.current_user_can_bypass' || echo "unreadable")
+  if [ "$CAN_BYPASS" = "never" ]; then
+    VERDICT="blocked"
+    break
+  elif [ "$CAN_BYPASS" != "unreadable" ]; then
+    VERDICT="bypassable"
+  fi
+done <<<"$RULESET_IDS"
+
+if [ "$VERDICT" = "blocked" ]; then
+  echo "Security preflight passed: bot cannot bypass the restrict-updates ruleset on '${DEFAULT_BRANCH}'"
+  exit 0
+fi
+if [ "$VERDICT" = "bypassable" ]; then
+  echo "::error::The bot can bypass every restrict-updates ruleset on '${DEFAULT_BRANCH}' (current_user_can_bypass != never), so the merge restriction does not restrict the bot. Remove the bot — or any team, role, or user exemption covering it — from the rulesets' bypass actors. See docs/security-model.md in the Tend repo."
+  exit 1
+fi
+
+# No update rules apply (or none were readable): fall back to requiring
+# that the branch is protected at all, e.g. by required reviews.
 PROTECTED=$(gh api "repos/${GITHUB_REPOSITORY}/branches/${DEFAULT_BRANCH}" --jq '.protected')
 if [ "$PROTECTED" != "true" ]; then
   echo "::error::Default branch '${DEFAULT_BRANCH}' is NOT protected. Without branch protection, the bot can merge PRs without review. Add a branch protection rule or ruleset before using Tend. See docs/security-model.md in the Tend repo."

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -149,7 +149,7 @@ claude /install-tend</code></pre>
     <div class="marginalia">
       <div class="margin-note">model</div>
       <div class="body">
-        <p>Tend gives Claude write access to your repo, but not the merge. A GitHub ruleset blocks the bot from merging to protected branches — whoever opened the PR, however it's been reviewed — so every change lands through a human; tend's setup verifies the ruleset and (if you ask) creates it for you. Around that sit config-pinning, rate limits, and a fixed prompt and Skill set.</p>
+        <p>Tend gives Claude write access to your repo, but not the merge. A GitHub ruleset blocks the bot from merging to protected branches — whoever opened the PR, however it's been reviewed — so every change lands through a human. The bot proves this against itself on every run: before starting, it asks GitHub whether its own credentials could bypass the ruleset, and refuses to run if the answer is yes. Tend's setup verifies the ruleset and (if you ask) creates it for you; around that sit config-pinning, rate limits, and a fixed prompt and Skill set.</p>
         <p><a href="https://github.com/max-sixty/tend/blob/main/docs/security-model.md">Read the full threat model →</a></p>
       </div>
     </div>


### PR DESCRIPTION
`tend check` asserted its central claim — the bot cannot merge to the default branch — without reading the two fields that decide it. It passed whenever an `update` rule covered the branch, never looking at the ruleset's `bypass_actors`: a bypass entry at Write (exactly what the bot holds) defeated the rule while the check reported the repo protected. And it read the bot's role from the legacy `.permission` field, which reports a maintain-role collaborator as `"write"` — maintain bypasses too. Found on a live repo where widening merge access nearly granted the bot the merge: the base role IDs run maintain **2**, write **4**, admin **5** — not ordered by privilege — so the plausible guess for "maintain" is in fact write.

Three layers land here, strongest last:

- **`tend check` verifies the bypass list.** Each `update` rule is traced to its ruleset and every bypass actor must outrank write: roles are allowlisted ({maintain, admin} — unknown IDs fail closed), a `User` exemption is resolved against the bot's own id (naming the bot there is an explicit grant of the merge), and `OrganizationAdmin`/`EnterpriseOwner` pass. A team, app, or deploy key can't be resolved from the ruleset, and a `bypass_actors` list GitHub withholds (only ruleset admins see it) is unverifiable, not empty — both report as skips with instructions, never as passes.
- **`tend check` judges the bot by capabilities, not names.** The `permissions` booleans replace string matching, so a custom role built on maintain or admin fails the same as the base role.
- **Preflight re-proves the restriction as the bot itself, every run.** `current_user_can_bypass` on each applying ruleset is GitHub's own evaluation of the caller's standing — teams, custom roles, and org/enterprise-sourced rulesets included, none of which the local check can resolve. One update rule answering `never` proves the bot cannot update the branch; if the bot can bypass every one, the run aborts. Repos protected by required reviews alone have no update rule and keep the `.protected` floor.

The docs feature the run-time self-test (README, site, security model, install recipe), and `checks.py` records the verified role-ID mapping with the GraphQL query that reads names back, since REST returns only the numbers.

Testing: 291 generator tests (+15) cover the bypass matrix — write/maintain/admin/OrgAdmin/Team/User bypasses, withheld lists, org/enterprise sources, untraceable rules. Verified live: `tend check` against a real repo passes through the new paths (API calls traced); the preflight's three verdicts each exercised against real repos — an identity that *can* bypass aborts, a non-collaborator passes via `never`, a reviews-only repo falls through to the floor. Endpoint behaviors the code relies on (org/enterprise rulesets served by the repo-scoped endpoint; `bypass_actors` withheld below ruleset-admin) were confirmed empirically, not just from docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> _This was written by Claude Code on behalf of max_
