### PR TITLE
fix: don't treat stale cancellation-cascade FAILURE as red in pre-APPROVE guard

### DIFF
--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -230,13 +230,19 @@ FAILED=$(gh pr view <number> --json statusCheckRollup \
   --jq '[.statusCheckRollup[]
          | select((.conclusion // .state) == "FAILURE")
          | .name // .context // "unknown"] | join(", ")')
-if [ -n "$FAILED" ]; then
-  echo "Skipping APPROVE — failing checks present on $HEAD_SHA: $FAILED"
-  exit 0
-fi
+PENDING=$(gh pr view <number> --json statusCheckRollup \
+  --jq '[.statusCheckRollup[]
+         | (.status // .state)
+         | select(IN(["IN_PROGRESS","QUEUED","PENDING","WAITING","REQUESTED","EXPECTED"][]))] | length')
 ```
 
-Step 6's "approve, foreground-poll CI, dismiss if a check fails" pattern only recovers while the session is still alive — the job timeout or a poll cap can leave a post-approve failure undismissed and the PR carrying a misleading APPROVED state. A synchronous pre-APPROVE peek catches the case where the failure is already in the rollup — including non-required checks like `codecov/patch` that an overlay treats as a merge gate. If a failure is present, skip the close-out entirely; any earlier substantive bot review (e.g. a COMMENT with inline suggestions) remains the active verdict until the author addresses it.
+**Don't treat a mid-flight rollup as settled.** A `FAILURE` co-existing with checks still in flight (`$PENDING > 0`) is often a *stale cancellation-cascade* artifact, not a real failure: when several events fire near-simultaneously (e.g. Dependabot opening a PR), the `tests` concurrency group cancels all but the latest, and a cancelled contributor makes an `if: always()` merge-gate omnibus (like PRQL's `check-ok-to-merge`) resolve to conclusion `FAILURE` — *not* `cancelled`, so it slips past the post-approve cancellation awareness below and reads as red. A fresh replacement run is already in flight and will re-register the omnibus. So decide on the **settled** rollup:
+
+- **`$FAILED` set and `$PENDING > 0`** — the rollup hasn't settled. Foreground-poll until non-own checks are terminal (the Step 6 / `running-in-ci` CI-monitoring loop), then re-peek `$FAILED`. Judge the settled state, not the mid-flight snapshot — a stale cancellation-cascade `FAILURE` clears once the replacement run's omnibus goes green.
+- **`$FAILED` set and `$PENDING == 0`** — genuine terminal red. Skip the close-out (`exit 0`). But if **no prior substantive bot review** stands on this PR, don't exit fully silent or leave only a `+1` reaction — a clean external-dependency bump then carries zero review signal. Post a brief COMMENT recording the diff assessment and why approval is held (e.g. "Diff is a correct, mechanical dependency bump; holding APPROVE because `check-ok-to-merge` is red."). Any earlier substantive review (e.g. a COMMENT with inline suggestions) already stands as the active verdict — leave it.
+- **`$FAILED` empty** — proceed with APPROVE.
+
+Step 6's "approve, foreground-poll CI, dismiss if a check fails" pattern only recovers while the session is still alive — the job timeout or a poll cap can leave a post-approve failure undismissed and the PR carrying a misleading APPROVED state. A synchronous pre-APPROVE peek catches the case where the failure is already in the rollup — including non-required checks like `codecov/patch` that an overlay treats as a merge gate. Waiting for the rollup to settle before this peek is what keeps a superseded red from being mistaken for a real one.
 
 Post at most one review per run. Give a verdict (**approve** or **comment**, never "request changes") when this run has something to say: a new diff-grounded finding, or an approval because the last open concern is now resolved. If the dedup rule above left nothing new and a prior unresolved bot thread still stands, post nothing; the earlier review remains the active verdict. Use `gh pr review` for reviews, not `gh pr comment`. Note: `--comment` requires a non-empty body — if there's nothing to say and no prior concern stands, use the approve-with-empty-body pattern.
 

--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -231,9 +231,12 @@ FAILED=$(gh pr view <number> --json statusCheckRollup \
          | select((.conclusion // .state) == "FAILURE")
          | .name // .context // "unknown"] | join(", ")')
 PENDING=$(gh pr view <number> --json statusCheckRollup \
-  --jq '[.statusCheckRollup[]
-         | (.status // .state)
-         | select(IN(["IN_PROGRESS","QUEUED","PENDING","WAITING","REQUESTED","EXPECTED"][]))] | length')
+  | jq --arg own "/runs/$GITHUB_RUN_ID/" --arg wf "$GITHUB_WORKFLOW" '
+      [.statusCheckRollup[]
+       | select((.detailsUrl // .targetUrl // "") | test($own) | not)
+       | select((.workflowName // "") == $wf | not)
+       | (.status // .state)
+       | select(IN(["IN_PROGRESS","QUEUED","PENDING","WAITING","REQUESTED","EXPECTED"][]))] | length')
 ```
 
 **Don't treat a mid-flight rollup as settled.** A `FAILURE` co-existing with checks still in flight (`$PENDING > 0`) is often a *stale cancellation-cascade* artifact, not a real failure: when several events fire near-simultaneously (e.g. Dependabot opening a PR), the `tests` concurrency group cancels all but the latest, and a cancelled contributor makes an `if: always()` merge-gate omnibus (like PRQL's `check-ok-to-merge`) resolve to conclusion `FAILURE` — *not* `cancelled`, so it slips past the post-approve cancellation awareness below and reads as red. A fresh replacement run is already in flight and will re-register the omnibus. So decide on the **settled** rollup:


### PR DESCRIPTION
## Problem

`tend-review`'s pre-APPROVE guard (`review/SKILL.md`) treats **any** terminal `FAILURE` in the check rollup as a blocker and skips the APPROVE. That misfires on a **stale cancellation-cascade `FAILURE`**: when several events fire near-simultaneously (classically Dependabot opening a PR), the `tests` concurrency group cancels all but the latest run, and a cancelled contributor makes an `if: always()` merge-gate omnibus (PRQL's `check-ok-to-merge`) resolve to conclusion `FAILURE` — *not* `cancelled`. So it slips past the post-approve cancellation awareness (`review/SKILL.md` "A check was cancelled -> do nothing") and reads as genuine red, even though a fresh replacement run is already in flight and will clear it.

Result: a clean, green-on-merits dependency bump is denied its APPROVE and the maintainer loses the bot's review signal.

## Outcome evidence

Observed this run on `PRQL/prql`, **occurrence 2** of a structural pattern the evidence gist flagged as "act on 2nd occurrence":

- **[PR #6121](https://github.com/PRQL/prql/pull/6121)** (`chore: bump docker/login-action from 4 to 4.5.2`, author `app/dependabot`), run [30650608832](https://github.com/PRQL/prql/actions/runs/30650608832). The reviewer ran a full session, correctly judged the diff "clean, correct, consistently-applied", then hit the pre-APPROVE guard: `check-ok-to-merge` showed `FAILURE` — a cancellation-cascade artifact from the concurrency-cancelled sibling run 30650608570, with a fresh `tests` batch already `QUEUED`/`IN_PROGRESS`. The bot withheld APPROVE and posted a bare `+1` reaction instead. Its near-identical sibling [PR #6120](https://github.com/PRQL/prql/pull/6120) (`chore: bump github/codeql-action`), reviewed minutes earlier once its omnibus had settled green, got a full APPROVE.
- **Occurrence 1** was [PR #6063](https://github.com/PRQL/prql/pull/6063) (`chore: bump minijinja`), run 28813989233 — same guard, same stale-cancellation `check-ok-to-merge` `FAILURE`, but the reviewer exited **fully silent** (no prior review, no `+1`).

Both cases: the reviewer's *diagnosis* was correct (clean diff, red is stale); only the guard's handling of a superseded `FAILURE` produced the missing verdict. The fallback differed (silent vs `+1`) but the root cause is identical — the guard's `select((.conclusion // .state) == "FAILURE")` has no carve-out for a cancellation-cascade omnibus.

## Fix

In the pre-APPROVE peek, compute `$PENDING` alongside `$FAILED` and decide on the **settled** rollup rather than a mid-flight snapshot:

- `$FAILED` set **and** `$PENDING > 0` → rollup not settled; foreground-poll (the Step 6 / `running-in-ci` CI-monitoring loop) until non-own checks are terminal, then re-peek. A stale cancellation-cascade `FAILURE` clears once the replacement run's omnibus goes green.
- `$FAILED` set **and** `$PENDING == 0` → genuine terminal red; hold APPROVE. If no prior substantive bot review stands, post a brief COMMENT recording the diff assessment and why approval is held, rather than exiting silent or leaving only a `+1` — a clean external-dependency bump otherwise carries zero review signal.
- `$FAILED` empty → APPROVE.

This keeps the "never rubber-stamp over genuine red" rule while no longer mistaking a superseded red for a real one, and guarantees a green-on-merits PR always leaves a visible verdict.

## Gate assessment

- **Evidence level**: High — consistent structural pattern across two independent sessions (#6063, #6121).
- **Occurrences**: 2 (meets the High band's 2–3 threshold). Structural (the written guard produces the outcome deterministically given a cancellation-cascade `FAILURE` + in-flight replacement), so recurrence is reliable; prior runs recorded it as "act on 2nd occurrence."
- **Magnitude**: Targeted fix (Normal Gate 1 bar), not a structural rewrite — refines one guard block and its fallback branch.

Full accumulated evidence: https://gist.github.com/3e3196fb3100d65d79eac98668586140
