### PR TITLE
fix(triage): skip bot's own monthly bookkeeping tracking issues

### DIFF
--- a/.config/tend.yaml
+++ b/.config/tend.yaml
@@ -6,3 +6,21 @@ setup:
 workflows:
   ci-fix:
     watched_workflows: ["ci"]
+  triage:
+    # Skip triage on the bot's own monthly bookkeeping issues. The
+    # review-reviewers / review-runs workflows auto-open these on the 1st of
+    # each month; the `issues: opened` event otherwise fires a full tend-triage
+    # agent run that reads the issue and exits silently via the
+    # self-conversation guard — pure wasted compute, recurring every month.
+    # This mirrors the base template's `tend-outage` label skip. These two
+    # labels are tend-specific (no adopter has these workflows), so the skip
+    # lives here in tend's config rather than the generic generator default.
+    # NOTE: `if` is scalar-replaced (RFC 7396), so this restates the base
+    # condition (fork guard + tend-outage skip) and appends the two labels.
+    jobs:
+      triage:
+        if: >-
+          github.repository_owner == 'max-sixty'
+          && contains(github.event.issue.labels.*.name, 'tend-outage') == false
+          && contains(github.event.issue.labels.*.name, 'review-reviewers-tracking') == false
+          && contains(github.event.issue.labels.*.name, 'review-runs-tracking') == false

--- a/.github/workflows/tend-triage.yaml
+++ b/.github/workflows/tend-triage.yaml
@@ -17,7 +17,8 @@ concurrency:
 
 jobs:
   triage:
-    if: github.repository_owner == 'max-sixty' && contains(github.event.issue.labels.*.name, 'tend-outage') == false
+    if: github.repository_owner == 'max-sixty' && contains(github.event.issue.labels.*.name, 'tend-outage') == false && contains(github.event.issue.labels.*.name, 'review-reviewers-tracking') == false
+      && contains(github.event.issue.labels.*.name, 'review-runs-tracking') == false
     runs-on: ubuntu-24.04
     permissions:
       contents: write


### PR DESCRIPTION
## Problem

`tend-triage` fires a full agent run on the bot's **own** monthly bookkeeping issues and exits silently — pure wasted compute, recurring every month.

The `review-reviewers` and `review-runs` workflows auto-open a tracking issue on the 1st of each month (`review-reviewers-tracking: YYYY-MM`, `review-runs-tracking: YYYY-MM`). The `issues: opened` event then triggers `tend-triage`, whose `if:` only skips `tend-outage`-labeled issues. So triage checks out, sets up, spins up the Claude agent, reads the bot's own tracking issue, and exits via the self-conversation guard without posting anything.

Observed this hour: run [30674799487](https://github.com/max-sixty/tend/actions/runs/30674799487) on issue #799 (`review-reviewers-tracking: 2026-08`) — the `max-sixty/tend/claude@0.1.12` step ran to completion, no comment posted.

This is structural (the tracking issue is created deterministically with a fixed label; the trigger always fires and always no-ops) and recurring across every month:

| Month | Triage runs on tracking-issue creation |
|---|---|
| 2026-06 | 4× (`review-reviewers-tracking` dup race) + 1× (`review-runs-tracking`) |
| 2026-07 | `review-reviewers-tracking` + `review-runs-tracking` (2×) |
| 2026-08 | `review-reviewers-tracking` (1× so far) |

## Fix

Extend the triage `if:` label skip — already applied to `tend-outage` in the base template — to also skip the two tend-specific tracking labels. Since no adopter has the `review-*` workflows or their labels, the skip lives in tend's `.config/tend.yaml` rather than the generic generator default (which would leak tend-internal label names into every adopter's generated workflow).

This is the accepted loop/no-op-prevention shape per the review-reviewers skill: a label-based skip mirroring the existing `tend-outage` precedent, **not** an authorship-keyed sender filter.

The `.github/workflows/tend-triage.yaml` change is the rendered output of `uvx tend@latest init` (0.1.12, matching the pinned action ref) — regenerating touched only this one file.

## Gate assessment

- **Evidence level**: High — consistent structural pattern across ≥3 months (7 wasted triage runs total). Clears the High bar (2–3 occurrences).
- **Structural vs stochastic**: structural — no decision point; the trigger fires and no-ops every time.
- **Change type**: targeted fix (extends an existing label skip; one config stanza).
- **Passes both gates**: yes.

Evidence log: https://gist.github.com/tend-agent/e08f6e62d6478163cb425a75648eb7e4
