### PR TITLE
review-reviewers: restore the headless claude harness on a current pin

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -29,7 +29,13 @@ Tend has Claude-powered workflows beyond the generated `tend-*` set:
 
 These use the tend composite action and produce `claude-session-logs*` artifacts,
 but their names don't match the `tend-*` prefix that scripts filter on by
-default.
+default. `uvx tend@latest init` doesn't rewrite them either, so their
+`max-sixty/tend/<harness>@X.Y.Z` pins move only when someone edits the file.
+When a regen bumps the generated workflows, restamp these to match:
+
+```bash
+rg 'max-sixty/tend/' .github/workflows/   # every ref: same harness, same tag
+```
 
 ### Usage analysis
 

--- a/.github/workflows/review-reviewers.yaml
+++ b/.github/workflows/review-reviewers.yaml
@@ -68,7 +68,7 @@ jobs:
           fetch-tags: true
           token: ${{ secrets.TEND_BOT_TOKEN }}
 
-      - uses: max-sixty/tend/claude-interactive@0.1.9
+      - uses: max-sixty/tend/claude@0.1.12
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,9 +42,10 @@ Four pieces:
      step bodies as scripts under `shared/steps/`; they differ only in how
      completion is supervised — headless `-p` exit code vs the PTY Stop-hook
      sentinel. `claude` is the default and recommended path (simpler, no
-     PTY); `claude-interactive` is a footnoted variant. Both bill against
-     the Claude subscription — the 2026-06-15 per-token metering that once
-     distinguished them is paused.
+     PTY). `claude-interactive` is kept in case the paused 2026-06-15
+     metering resumes, since it covered `claude -p` but not interactive
+     sessions. While it stays paused the two bill identically and nothing
+     else distinguishes them.
    - `max-sixty/tend/codex@X.Y.Z` (Codex) — installs `@openai/codex` and
      shells out to `codex exec`. Skills are staged on disk and an
      `AGENTS.md` in `$CODEX_HOME` teaches Codex to resolve

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,10 @@ Four pieces:
      PTY). `claude-interactive` is kept in case the paused 2026-06-15
      metering resumes, since it covered `claude -p` but not interactive
      sessions. While it stays paused the two bill identically and nothing
-     else distinguishes them.
+     else distinguishes them, so it is supported but undocumented: the
+     generator accepts `harness: claude-interactive`, and the adopter-facing
+     docs (README, `tend.example.yaml`, install-tend, security model) leave
+     it out.
    - `max-sixty/tend/codex@X.Y.Z` (Codex) — installs `@openai/codex` and
      shells out to `codex exec`. Skills are staged on disk and an
      `AGENTS.md` in `$CODEX_HOME` teaches Codex to resolve

--- a/README.md
+++ b/README.md
@@ -249,5 +249,10 @@ MIT
 
 [^interactive]: A third harness, `claude-interactive`, runs the same
     `claude` binary under a PTY supervisor (`script(1)` with a `Stop`-hook
-    sentinel) instead of headless `-p`. Same proxy isolation and auth as the
-    default Claude harness. Opt in with `harness: claude-interactive`.
+    sentinel) rather than headless `-p`. Same proxy isolation, auth, and
+    billing as the default Claude harness. It's kept in case Anthropic's
+    [paused subscription
+    change](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan)
+    resumes; it would meter `claude -p` but not interactive sessions.
+    While it stays paused, `claude` does the same job with less machinery.
+    Opt in with `harness: claude-interactive`.

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Full threat model: [docs/security-model.md](docs/security-model.md).
 
 `.config/tend.yaml` — only `bot_name` is required. The default harness runs
 Claude; `harness: codex` selects OpenAI Codex (see
-[Harnesses](#harnesses) below).[^interactive]
+[Harnesses](#harnesses) below).
 
 ```yaml
 bot_name: my-project-bot
@@ -194,9 +194,9 @@ workflow names `tend-ci-fix` watches, PR title conventions, label policies.
 
 ## Harnesses
 
-Tend supports two harnesses. Pick whichever fits the credentials and
+Tend supports Claude and Codex. Pick whichever fits the credentials and
 billing path that already work for you; both run the same workflows and
-skills.[^interactive]
+skills.
 
 ### Claude (default)
 
@@ -246,13 +246,3 @@ The install-tend skill offers to add this automatically during setup.
 ## License
 
 MIT
-
-[^interactive]: A third harness, `claude-interactive`, runs the same
-    `claude` binary under a PTY supervisor (`script(1)` with a `Stop`-hook
-    sentinel) rather than headless `-p`. Same proxy isolation, auth, and
-    billing as the default Claude harness. It's kept in case Anthropic's
-    [paused subscription
-    change](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan)
-    resumes; it would meter `claude -p` but not interactive sessions.
-    While it stays paused, `claude` does the same job with less machinery.
-    Opt in with `harness: claude-interactive`.

--- a/claude-interactive/action.yaml
+++ b/claude-interactive/action.yaml
@@ -1,15 +1,14 @@
 name: Tend (Claude interactive)
 description: >-
-  Tend's interactive-Claude harness: runs the official `claude` binary
-  inside a PTY (via `script(1)`) instead of going through
-  `claude-code-action` / `@anthropic-ai/claude-agent-sdk`. A Stop hook
-  writes a sentinel file the supervisor watches for; on fire, the session
-  is terminated cleanly. Inputs
-  overlap with `action.yaml`'s for the common ones (auth, prompt, model,
-  bot_name, allowed_tools, system_prompt_append, show_full_output); inputs
-  that only existed for the Agent-SDK harness (`use_sticky_comment`,
-  `additional_permissions`, `allowed_bots`, `allowed_non_write_users`)
-  are not accepted here.
+  Tend's PTY-supervised Claude harness: runs the official `claude` binary
+  inside a PTY (via `script(1)`) rather than headless `claude -p`. A Stop
+  hook writes a sentinel file the supervisor watches for; on fire, the
+  session is terminated cleanly. Everything else matches
+  `claude/action.yaml`: same inputs and defaults (a pre-commit hook fails
+  the commit if the two surfaces drift), same sandbox user, same credential
+  proxy, same billing. It exists in case Anthropic's paused subscription
+  change resumes; that change would meter `claude -p` but not interactive
+  sessions. `claude` is the default and recommended harness.
 
 inputs:
   github_token:

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -78,9 +78,8 @@ nightly regen, as a reviewable workflow-file diff in their own repo. Adopters ex
 same way they trust any third-party action's publisher; pinning to `X.Y.Z`
 (or a commit SHA) bounds that trust to a reviewed, immutable point.
 
-**Config pinning.** Both Claude harnesses (`claude/action.yaml` and
-`claude-interactive/action.yaml`) restore RCE-relevant config from the PR base branch
-before the agent starts: `.claude/`, `.mcp.json`, `.claude.json`,
+**Config pinning.** The Claude harness actions restore RCE-relevant config from
+the PR base branch before the agent starts: `.claude/`, `.mcp.json`, `.claude.json`,
 `.gitmodules`, `.ripgreprc`, `.husky`, plus `CLAUDE.md`/`CLAUDE.local.md` as a
 prompt-injection defense. A malicious PR's `SessionStart` hook, MCP server, or
 injected `CLAUDE.md` is reverted before Claude reads it. The restoration runs
@@ -90,10 +89,9 @@ in shell; the path list and ordering mirror claude-code-action's
 overwritten, so review skills can optionally inspect what the PR changed without
 those files ever being executed.
 
-**Credential isolation (Claude harnesses).** Both `claude/action.yaml` (headless
-`claude -p`) and `claude-interactive/action.yaml` (PTY) run the agent as a separate
-non-sudo `tend-sandbox` user, sharing the proxy machinery under the top-level
-`proxy/`. Both the bot PAT and the Anthropic credential (OAuth token
+**Credential isolation (Claude harnesses).** The Claude harness actions run the
+agent as a separate non-sudo `tend-sandbox` user, sharing the proxy machinery
+under the top-level `proxy/`. Both the bot PAT and the Anthropic credential (OAuth token
 or API key) live only in a local mitmproxy that the agent reaches over
 `HTTPS_PROXY`; the proxy injects each into requests to its own hosts (the PAT for
 GitHub hosts, the Anthropic secret for `api.anthropic.com`) and tunnels

--- a/docs/tend.example.yaml
+++ b/docs/tend.example.yaml
@@ -15,8 +15,7 @@ bot_name: my-project-bot
 #
 # Which agent runtime to use. Defaults to "claude" (the official `claude`
 # binary run headless behind a credential-injecting proxy). "codex" runs
-# OpenAI Codex via `codex exec`. (A third harness, "claude-interactive",
-# runs the same binary under a PTY; see README "Harnesses".)
+# OpenAI Codex via `codex exec`.
 #
 # harness: codex
 
@@ -164,9 +163,9 @@ bot_name: my-project-bot
 # ## Sandbox setup (Claude-family harnesses)
 #
 # `setup:` above runs as the RUNNER user, around the composite action — it
-# does not reach the agent's environment. The `claude` and `claude-interactive`
-# harnesses run the agent as a separate, non-sudo sandbox user with a fixed
-# env allowlist, so runner-side PATH/env changes don't carry in. These three
+# does not reach the agent's environment. Claude-family harnesses run the
+# agent as a separate, non-sudo sandbox user with a fixed env allowlist, so
+# runner-side PATH/env changes don't carry in. These three
 # keys reach INSIDE that sandbox, before the agent launches:
 #
 # - `sandbox_path`: directories prepended to the sandbox PATH. A leading `~`

--- a/plugins/install-tend/skills/install-tend/references/security-model.md
+++ b/plugins/install-tend/skills/install-tend/references/security-model.md
@@ -108,7 +108,7 @@ harness-auth credential whose form depends on `harness` in
 |-------|---------|
 | Bot token (PAT or App) | GitHub API and git operations. Consistent bot identity. |
 | Harness auth (one of, per harness) | Authenticates the agent runtime. |
-| ↳ Claude OAuth token | `harness: claude` or `harness: claude-interactive`: authenticates Claude Code to the Anthropic API. |
+| ↳ Claude OAuth token | `harness: claude`: authenticates Claude Code to the Anthropic API. |
 | ↳ `OPENAI_API_KEY` | `harness: codex`: standard OpenAI API key, per-token billing. The subscription `auth.json` path is not supported (see above). |
 
 A single bot token is safe across workflows because the merge restriction

--- a/plugins/install-tend/skills/install-tend/references/tend.example.yaml
+++ b/plugins/install-tend/skills/install-tend/references/tend.example.yaml
@@ -15,8 +15,7 @@ bot_name: my-project-bot
 #
 # Which agent runtime to use. Defaults to "claude" (the official `claude`
 # binary run headless behind a credential-injecting proxy). "codex" runs
-# OpenAI Codex via `codex exec`. (A third harness, "claude-interactive",
-# runs the same binary under a PTY; see README "Harnesses".)
+# OpenAI Codex via `codex exec`.
 #
 # harness: codex
 
@@ -164,9 +163,9 @@ bot_name: my-project-bot
 # ## Sandbox setup (Claude-family harnesses)
 #
 # `setup:` above runs as the RUNNER user, around the composite action — it
-# does not reach the agent's environment. The `claude` and `claude-interactive`
-# harnesses run the agent as a separate, non-sudo sandbox user with a fixed
-# env allowlist, so runner-side PATH/env changes don't carry in. These three
+# does not reach the agent's environment. Claude-family harnesses run the
+# agent as a separate, non-sudo sandbox user with a fixed env allowlist, so
+# runner-side PATH/env changes don't carry in. These three
 # keys reach INSIDE that sandbox, before the agent launches:
 #
 # - `sandbox_path`: directories prepended to the sandbox PATH. A leading `~`

--- a/plugins/tend-ci-runner/scripts/token-report.sh
+++ b/plugins/tend-ci-runner/scripts/token-report.sh
@@ -83,10 +83,10 @@ for row in "${ROWS[@]}"; do
   RUNDIR="$WORKDIR/$RUN_ID"
   mkdir -p "$RUNDIR"
 
-  # Two artifact prefixes since the interactive harness lands: the
-  # SDK action uploads `claude-session-logs-X`, the interactive action
-  # uploads `claude-interactive-session-logs-X`. A consumer repo may
-  # have both in flight during a harness migration, so we accept either.
+  # Two artifact prefixes: the default `claude` action uploads
+  # `claude-session-logs-X`, the `claude-interactive` action uploads
+  # `claude-interactive-session-logs-X`. A consumer repo may have both in
+  # flight during a harness migration, so we accept either.
   if ! gh run download "$RUN_ID" "${repo_args[@]}" \
       --pattern 'claude-session-logs*' \
       --pattern 'claude-interactive-session-logs*' \


### PR DESCRIPTION
`review-reviewers.yaml` was the last thing anywhere still running `claude-interactive`, pinned at `0.1.9` while every generated `tend-*` workflow sits on `claude@0.1.12`. This restores it to the default harness and takes `claude-interactive` out of the adopter-facing docs.

## Why it diverged

It never chose the interactive harness on its own merits. When tend dogfooded `claude-interactive` across all eight generated workflows, this file was bumped to match — pure parity, no review-reviewers-specific reason. The metering pause then rolled the generated workflows back to `claude` by regenerating them, and `review-reviewers.yaml` is hand-maintained, so the rollback didn't reach it. Two later bumps kept it current on the wrong harness.

Nothing in the job depends on interactive behaviour: it passes five inputs, all accepted by `claude@0.1.12` with identical semantics, and its `permissions:` block already matches the generated workflows exactly. The harness timeout default rises 3h → 5h50m, matching every other tend workflow and leaving the intended 10-minute buffer under the 6h job cap. Session-log artifacts change prefix from `claude-interactive-session-logs*` to `claude-session-logs*`, which `token-report.sh` already accepts and which the `review-reviewers` skill's own download pattern only matched in the `claude-` form.

The root cause was a missing feedback path rather than a bad pin, so tend's `running-tend` overlay now records that `init` doesn't rewrite the non-generated workflows and that their refs need restamping when a regen moves the generated ones.

## `claude-interactive` stays supported, stops being advertised

The docs recorded the metering pause correctly. Anthropic's help centre still carries it, verified against the article: "Claude Agent SDK, `claude -p`, and third-party app usage still draw from your subscription's usage limits." What they didn't do was close the loop — the README footnote described *what* the harness is without ever saying when to pick it, which for a config key an adopter chooses from is a trap.

The resolution is to keep shipping it and stop presenting it. `harness: claude-interactive` still validates, still generates, still runs; it's gone from the README (footnote and both markers), `tend.example.yaml`, the install-tend secrets table, and the security model, none of which now name it. CLAUDE.md records that this is deliberate so it doesn't get re-added.

`claude-interactive/action.yaml`'s own description was separately stale: it still sold itself as the alternative to `claude-code-action` / `@anthropic-ai/claude-agent-sdk` and listed Agent-SDK-only inputs it "does not accept". The default harness stopped using the SDK when it moved to headless `claude -p`, and a pre-commit hook now fails the commit if the two input surfaces diverge at all. It now says what the harness actually is and the one scenario it's kept for.

`debug-tend-run` keeps its `claude-interactive-session-logs*` routing row. That's a lookup for an artifact someone already has in hand rather than a menu entry, and dropping it would break debugging for a configuration that still works.

> _This was written by Claude Code on behalf of max-sixty_
