### PR TITLE
skills(review-gates): don't re-propose maintainer-rejected remediations

### DIFF
--- a/plugins/tend-ci-runner/shared/review-gates.md
+++ b/plugins/tend-ci-runner/shared/review-gates.md
@@ -49,6 +49,15 @@ For each finding, state:
 
 Only proceed to act on findings that pass both gates.
 
+### Suppression: maintainer-rejected remediations
+
+A finding can clear both gates and still be off-limits. If a maintainer has already **rejected** its remediation, do not re-propose — recurrence does not reopen a settled call. A structural pattern that recurs every month is still settled if the maintainer weighed the fix and declined it. Rejection signals in the current repo's history:
+
+- A prior PR proposing this fix was closed by a maintainer — read the closing comment for the rationale.
+- The pattern is documented as an accepted non-issue in a skill's intentional-patterns list.
+
+When either holds, record the recurrence as a carry observation with a pointer to the rejection and move on — no PR, no issue. Re-propose only if new evidence changes the tradeoff the maintainer weighed (e.g. the cost grew by an order of magnitude), and name that change explicitly.
+
 ## Finding format
 
 Each run appends findings to the skill's evidence store under a `## Run <run-id>` heading. **Always derive the run ID, timestamp, and repo from the CI environment — never hand-type them.** Past sessions have filled the `<run-id>` placeholder with fabricated round numbers (e.g. `24294000000`) when the skill didn't explicitly point at `$GITHUB_RUN_ID`, producing dead link-anchors in the evidence log.


### PR DESCRIPTION
Adds a suppression rule to the shared review gates: a finding whose remediation a maintainer has already **rejected** must not be re-proposed, even when the underlying pattern keeps recurring. Applies to both `review-runs` and `review-reviewers` (the file is symlinked into both skills).

## Why

The recurring "`tend-triage` fires a full agent run on the bot's own monthly tracking-issue creation and exits via the self-conversation guard" finding has been surfaced by `review-runs` across multiple months. This window it recurred again (run [30692158824](https://github.com/max-sixty/tend/actions/runs/30692158824), `tend-triage` on `review-runs-tracking: 2026-08` creation, ~$0.50 / 2 min).

The maintainer has now settled it:

- PR #800 (structural `if:` skip) was **closed** — _"Not worth the complication ... the skip permanently puts tend-internal label names in `.config/tend.yaml` plus a regenerated workflow to keep in sync. The guard already covers this case."_
- PR #802 **merged**, documenting the no-op as an accepted non-issue in the `review-reviewers` intentional-patterns list.

That disposition lived only in the `review-reviewers` skill. `review-runs` — which independently re-derives the same finding every month, classifies it High/structural, and would clear both gates — has no rule telling it the fix was already declined. Without codification the next monthly `review-runs` run re-proposes a fix the maintainer explicitly closed. This is an invisible failure mode (the wasted re-proposal isn't a CI failure), so it qualifies for codification on a single post-rejection occurrence.

The gate lives in the shared file so it covers any future maintainer-rejected finding, not just this one — recurrence alone never reopens a settled call.

## Change

One subsection under "Applying the gates": how to detect a rejected remediation (closed fix PR; documented non-issue), and that the correct disposition is a carry observation pointing at the rejection, with re-proposal allowed only when new evidence changes the tradeoff the maintainer weighed.
