### PR TITLE
skills(running-tend): give the weekly run the third-party action refs

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -145,6 +145,11 @@ the whole list.
 
 ## Weekly: bump pinned versions
 
+Title each PR `chore: bump <name> to <version>`; the uv-plus-mitmproxy PR names
+both.
+
+### Action inputs
+
 | Pin | File | Rule |
 |---|---|---|
 | `claude_version` | `claude/action.yaml` | track latest |
@@ -160,9 +165,6 @@ yq '.inputs.mitmproxy_version.default' claude/action.yaml
 curl -fsS https://pypi.org/pypi/mitmproxy/json | jq -r .info.version
 ```
 
-Title each PR `chore: bump <input> to <version>`, naming both inputs when uv
-rides along.
-
 A stale `claude` binary resolves `--model opus`/`sonnet` to a superseded alias
 target, so drift silently downgrades the model. Skim the claude-code CHANGELOG
 between the two versions for anything touching the agent paths (first-run
@@ -176,6 +178,33 @@ addon-related in its CHANGELOG against the `mitmdump` flags in
 only launches that mitmproxy and CI smokes the two together, so it needs no
 release stream of its own; move both in one PR, at whatever uv is latest then
 (`curl -fsS https://pypi.org/pypi/uv/json | jq -r .info.version`).
+
+### `uses:` refs
+
+```bash
+git grep -hoE 'uses: [^ ./][^ @]*@[^ ]+' -- ':!generator/tests' ':!*.md' \
+  | sed 's/uses: //' | grep -v '^max-sixty/tend/' | sort -u \
+  | while IFS='@' read -r action pin; do
+      latest=$(gh api "repos/$action/releases/latest" --jq .tag_name 2>/dev/null) \
+        || { printf '%-30s %-9s -> no releases; read its tags\n' "$action" "$pin"; continue; }
+      case "$pin" in "$latest" | "${latest%%.*}") continue ;; esac
+      printf '%-30s %-9s -> %s\n' "$action" "$pin" "$latest"
+    done
+```
+
+An action listed twice is pinned at two majors: refs move when someone needs a
+behavior from one of them, never in a sweep. `git grep` each drifted action for
+its call sites, then split the PRs by who runs the result.
+
+- **Ships to adopters** — `generator/src/tend/templates/` and `workflows.py`
+  render into adopters' workflow files; `claude/action.yaml` and
+  `codex/action.yaml` run in every adopter's job from the next release. One PR
+  per action, its body naming what changed across the majors it crosses.
+- **Ours alone** — the hand-maintained `.github/workflows/` files and
+  `.config/tend.yaml`. One PR for the lot.
+
+The generated `tend-*.yaml` show up in that grep too; their refs come from the
+templates and from `.config/tend.yaml`'s `setup:`, which is where they move.
 
 ## Weekly: integration test
 


### PR DESCRIPTION
The weekly bump section covered the four `*_version` action inputs. The third-party `uses:` refs had nothing watching them, and the reason is worth stating: the bundled weekly skill *reviews* dependency PRs, filtering `gh pr list` for `dependabot[bot]` and `renovate[bot]`. Neither has ever run on this repo (`gh pr list --author app/dependabot --state all` is empty, as is renovate's; there is no `.github/dependabot.yml`, vulnerability alerts return 404 "disabled", and `automated-security-fixes` is `{"enabled":false}`). So the weekly run has been a reviewer for a bot that doesn't exist here, and a ref only ever moved when someone needed a behavior from it — `actions/checkout@v7` in the generator arrived in #725 to opt into v7's fork-PR checkout, and `actions/cache@v4` has not moved since #712.

What that leaves today, from the new scan:

```
actions/cache                  v4        -> v6.1.0
actions/checkout               v6        -> v7.0.1
actions/download-artifact      v7        -> v8.0.1
actions/setup-node             v4        -> v7.0.0
actions/upload-artifact        v6        -> v7.0.1
astral-sh/setup-uv             v6        -> v9.0.0
astral-sh/setup-uv             v7        -> v9.0.0
pypa/gh-action-pypi-publish    v1.13.0   -> v1.14.2
```

An action listed twice is the signature of the failure mode: `setup-uv` sits at v6 in `.config/tend.yaml`'s `setup:` and at v7 in `ci.yaml`, because whoever needed v7 needed it in one file. `checkout` and `upload-artifact` are split the same way.

The scan skips `max-sixty/tend/*`, which the release owns and "Nightly: restamp the hand-maintained workflow refs" already covers, and the `generator/tests` fixtures, where a bump churns regtest snapshots and proves nothing. Results sort into two buckets because the PR shape differs: the generator templates and the two composite actions render into adopters' repos, so each gets its own PR naming what the majors it crosses change; the hand-maintained workflows and `.config/tend.yaml` reach only us and go in one.

## Why not dependabot

<details>
<summary>It would reach two of the three places these live, and this is the one that's ours to schedule</summary>

Dependabot's `github-actions` ecosystem scans `.github/workflows` plus a root `action.yml`, so `claude/action.yaml` and `codex/action.yaml` need an explicit `directories:` entry ([dependabot-core#6704](https://github.com/dependabot/dependabot-core/issues/6704) is open; the workarounds are in its thread). `generator/src/tend/templates/macros.yaml.j2` renders `actions/checkout@v7` into every adopter's workflows and is a Jinja template — no manager parses it, and dependabot has no regex manager. That one is the highest-stakes ref in the repo and the least reachable, so the rule has to cover it either way.

This also corrects the parenthetical in #811, which cited dependabot-core#6936 as "closed not-planned". It was closed as a duplicate of #6704, which is open. The claim that mattered there is unaffected: dependabot updates `uses:` refs, never a `default:` under `inputs:`, which is why the four `*_version` pins needed a skill rule.

</details>

The scan was run verbatim out of the skill file to produce the table above.

> _This was written by Claude Code on behalf of max-sixty_
