### PR TITLE
fix(claude-action): name the cause in the exited-non-zero outage annotation

### DIFF
--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -462,9 +462,9 @@ runs:
               # your session limit · resets 8:30am (UTC)"). Surface that last
               # assistant text so the annotation names the cause (session limit
               # vs auth failure vs server error) instead of a generic "see the
-              # artifact". report-failure.sh's enrichment then carries the
-              # annotation into the tend-outage issue for free, so a maintainer
-              # can triage without downloading logs and writing jq.
+              # artifact". The nightly enrich-tend-outage-issues.sh pass then
+              # carries the annotation into the tend-outage issue for free, so a
+              # maintainer can triage without downloading logs and writing jq.
               REASON=$(jq -r '
                 select(.type == "assistant") | .message.content[]?
                 | select(.type == "text") | .text

--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -457,7 +457,23 @@ runs:
         case "$status" in
           exited)
             if [ "$CLAUDE_EXIT" -ne 0 ]; then
-              echo "::error::claude -p exited non-zero (exit=$CLAUDE_EXIT) — see the session-logs artifact"
+              # This is the most common failure path — a session-limit exit is
+              # non-zero and emits a <synthetic> assistant message ("You've hit
+              # your session limit · resets 8:30am (UTC)"). Surface that last
+              # assistant text so the annotation names the cause (session limit
+              # vs auth failure vs server error) instead of a generic "see the
+              # artifact". report-failure.sh's enrichment then carries the
+              # annotation into the tend-outage issue for free, so a maintainer
+              # can triage without downloading logs and writing jq.
+              REASON=$(jq -r '
+                select(.type == "assistant") | .message.content[]?
+                | select(.type == "text") | .text
+              ' "$STREAM_JSON" 2>/dev/null | grep -v '^[[:space:]]*$' | tail -1)
+              if [ -n "$REASON" ]; then
+                echo "::error::claude -p exited non-zero (exit=$CLAUDE_EXIT): $REASON — see the session-logs artifact"
+              else
+                echo "::error::claude -p exited non-zero (exit=$CLAUDE_EXIT) — see the session-logs artifact"
+              fi
               tail -20 "$STDERR_LOG" 2>/dev/null || true
               exit "$CLAUDE_EXIT"
             fi


### PR DESCRIPTION
## Problem

A `tend-outage` issue records *that* a run failed but, on the most common failure path, can't say *why*. In `claude/action.yaml` the `exited` branch bailed on `CLAUDE_EXIT -ne 0` and `exit`ed **before** the `VERDICT` jq ever inspected the stream:

```bash
exited)
  if [ "$CLAUDE_EXIT" -ne 0 ]; then
    echo "::error::claude -p exited non-zero (exit=$CLAUDE_EXIT) — see the session-logs artifact"
    tail -20 "$STDERR_LOG" 2>/dev/null || true
    exit "$CLAUDE_EXIT"
  fi
  # VERDICT jq (names the cause) only ran when CLAUDE_EXIT == 0
```

A session-limit exhaustion — the single most common outage cause — exits non-zero and emits a `<synthetic>` assistant message like `You've hit your session limit · resets 8:30am (UTC)`. That text sits in the stream the action still has open, but nothing extracted it: the annotation, and the enrichment comment `enrich-tend-outage-issues.sh` derives from it, both read only the generic "see the session-logs artifact" line. A maintainer couldn't tell session-limit from auth failure from server error without downloading artifacts and writing jq.

## Solution

In the exited-non-zero branch, extract the last assistant text from the stream and fold it into the annotation, keeping the generic fallback when the stream has no assistant text:

```bash
REASON=$(jq -r '
  select(.type == "assistant") | .message.content[]?
  | select(.type == "text") | .text
' "$STREAM_JSON" 2>/dev/null | grep -v '^[[:space:]]*$' | tail -1)
```

Because the nightly `enrich-tend-outage-issues.sh` pass posts the failure *annotation* into the issue, a self-diagnosing annotation carries into the `tend-outage` issue for free — no change to the enrichment script needed.

## Testing

Inline action bash, so no pytest harness. Verified the extraction jq against a realistic stream-json sample (normal turns + tool_use + a trailing `<synthetic>` session-limit message): it returns `You've hit your session limit · resets 8:30am (UTC)`, and returns empty for an empty stream (falls back to the generic annotation). YAML re-parses cleanly.

## Scope

This is Gap 1 of #816. **Gap 2** — a recovery pass that re-runs the event-triggered workflow a dead run stranded (e.g. a `tend-review` that never retries because it fires only on `pull_request_target`) — is a larger design change with real tradeoffs (which workflows to re-run, the quota-window ordering constraint, confirming the work is still missing first). I've left that for a maintainer to weigh in on rather than ship a partial recovery mechanism here; details and the reporter's proposed shape are in the issue.

---
Closes #816 — automated triage

