### PR TITLE
fix(report-failure): name the trigger a stranded outage row points at

### DIFF
--- a/shared/steps/report-failure.sh
+++ b/shared/steps/report-failure.sh
@@ -16,16 +16,32 @@ LABEL="tend-outage"
 TITLE="Bot temporarily unavailable"
 RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
-# Build a one-line reference to the triggering context
+# Build a one-line reference to the triggering context. This is the only
+# pointer back to the work the failure stranded, so every trigger that
+# carries one names it; `// empty` keeps a missing field out of the cell as
+# blank rather than the literal `null` jq would otherwise print.
 REF=""
 if [ "$GITHUB_EVENT_NAME" = "pull_request_target" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ]; then
-  PR_NUM=$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")
-  REF="#${PR_NUM}"
+  PR_NUM=$(jq -r '.pull_request.number // empty' "$GITHUB_EVENT_PATH")
+  REF="${PR_NUM:+#${PR_NUM}}"
 elif [ "$GITHUB_EVENT_NAME" = "issues" ] || [ "$GITHUB_EVENT_NAME" = "issue_comment" ]; then
-  ISSUE_NUM=$(jq -r '.issue.number' "$GITHUB_EVENT_PATH")
-  REF="#${ISSUE_NUM}"
+  ISSUE_NUM=$(jq -r '.issue.number // empty' "$GITHUB_EVENT_PATH")
+  REF="${ISSUE_NUM:+#${ISSUE_NUM}}"
+elif [ "$GITHUB_EVENT_NAME" = "repository_dispatch" ]; then
+  # tend-mention relays review events through a secretless job that re-posts
+  # them as a repository_dispatch, so the PR number arrives in the payload
+  # rather than in a `pull_request` object.
+  PR_NUM=$(jq -r '.client_payload.pr // empty' "$GITHUB_EVENT_PATH")
+  REF="${PR_NUM:+#${PR_NUM}}"
 elif [ "$GITHUB_EVENT_NAME" = "workflow_run" ]; then
-  REF="CI fix for workflow run"
+  # Link the run being fixed — without its id there is no way back to the
+  # failure the ci-fix job was dispatched to handle.
+  UPSTREAM_ID=$(jq -r '.workflow_run.id // empty' "$GITHUB_EVENT_PATH")
+  if [ -n "$UPSTREAM_ID" ]; then
+    REF="CI fix for [run ${UPSTREAM_ID}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${UPSTREAM_ID})"
+  else
+    REF="CI fix for workflow run"
+  fi
 fi
 
 TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)


### PR DESCRIPTION
## Problem

The `Trigger` column of a `tend-outage` row is the only pointer back to the work a failed run stranded. It goes blank for the one trigger where that pointer matters most, and prints `#null` when a field is missing.

**`repository_dispatch` is unhandled.** `tend-mention` relays review events through a secretless job that re-posts them as a `repository_dispatch`, so the handle job runs on that event and the PR number arrives as `client_payload.pr` rather than in a `pull_request` object. The `if`/`elif` chain has no branch for it, so every failure on the relay path records `Trigger: N/A` — and a relayed review is exactly the case a maintainer can't recover from the run alone, since `tend-review` fires only on `pull_request_target` and never retries. This path is in constant use: `gh api "repos/max-sixty/tend/actions/runs?event=repository_dispatch"` returns a steady stream of `tend-mention` runs.

**`workflow_run` names no run.** The ci-fix path hardcodes `REF="CI fix for workflow run"`, discarding `workflow_run.id` — the id of the CI failure the job was dispatched to fix.

**Missing fields render as `null`.** `jq -r '.issue.number'` prints the literal string `null` when the field is absent, so the cell reads `#null` rather than falling back to `N/A`.

## Solution

Add a `repository_dispatch` branch reading `client_payload.pr`, link the upstream run id in the `workflow_run` branch, and give every extraction `// empty` plus a `${VAR:+…}` guard so an absent field leaves the cell blank (rendered as `N/A` by the existing `${REF:-N/A}`) instead of `#null`.

## Testing

`shared/steps/` has no shell test harness — shellcheck via pre-commit is the only automated gate, and it passes on the changed file. So the block was exercised directly: the REF logic was sliced out of the script (between the `# Build a one-line reference` comment and `TIMESTAMP=`) and sourced under crafted `GITHUB_EVENT_PATH` payloads, before and after.

Before, on `origin/main`:

```
repository_dispatch  -> N/A
workflow_run         -> CI fix for workflow run
issues (no number)   -> #null
```

After:

```
relayed review               -> #815
relay w/o pr                 -> N/A
ci-fix                       -> CI fix for [run 30795510450](https://github.com/max-sixty/tend/actions/runs/30795510450)
ci-fix w/o id                -> CI fix for workflow run
PR event                     -> #821
PR event w/o number          -> N/A
issue comment                -> #808
issue w/o number             -> N/A
schedule                     -> N/A
```

Adding a real harness for `shared/steps/` is worth considering separately — three of the recent outage-path fixes have all landed in scripts nothing can test — but that is a bigger change than this fix warrants, so it is not bundled here.

## Scope

Separate from the other two open changes on this path, and textually disjoint from both. #818 names the *cause* of a failure (in `claude/action.yaml`); #809 dedups *rows* across matrix legs (in the `EXISTING` branch of this same script, lines 49+). This one fixes what the row *points at*, in the REF block at lines 19–29.
