### PR TITLE
check: report an unreadable ruleset bypass list as unknown, not ungated

### DIFF
--- a/generator/src/tend/checks.py
+++ b/generator/src/tend/checks.py
@@ -917,14 +917,17 @@ def _policy_gate(
         if p.get("type") == "tag":
             gated = tags_ok()
             if gated is None:
-                # GitHub serves `bypass_actors` only to a repo admin, so the
-                # bot's own token reads a gating all-tags ruleset as
-                # unverifiable — the same configuration a maintainer's admin
-                # token confirms.
+                # Every unread input lands here, not just a withheld bypass
+                # list: an unlistable `/rulesets`, a ruleset that won't fetch,
+                # and a bypass actor naming a team, app, or deploy key are all
+                # None. So the message names the set rather than prescribing
+                # the admin re-run that settles only one of them.
                 unverified = _Gap(
-                    "admits tags under a ruleset this token cannot verify: only "
-                    "a repo admin reads a ruleset's bypass list, so re-run "
-                    "`tend check` as an admin to settle it",
+                    "admits tags, and whether an all-tags ruleset gates them is "
+                    "unverifiable with this token — either the rulesets aren't "
+                    "readable, a bypass list is withheld (only a repo admin "
+                    "reads one), or a bypass actor names a team, app, or deploy "
+                    "key whose membership isn't resolvable here",
                     verified=False,
                 )
             elif gated is False:
@@ -939,10 +942,14 @@ def _policy_gate(
             )
     if steerable:
         triggers = ", ".join(f"`{t}`" for t in sorted(steerable))
+        # Not "admits only verified refs": a held `unverified` means one entry
+        # didn't settle. The ref list is beside the point here anyway — the bot
+        # picks the ref — so the message states the trigger, which holds either
+        # way, and this stays a verified finding.
         return _Gap(
-            f"admits only verified refs, but a workflow reaching it runs on "
-            f"{triggers}, which the bot fires and steers against a ref the "
-            "policy already admits"
+            f"is reached by a workflow running on {triggers}, which the bot "
+            "fires and steers against a ref the policy already admits, so its "
+            "ref list does not gate it"
         )
     return unverified
 

--- a/generator/src/tend/checks.py
+++ b/generator/src/tend/checks.py
@@ -908,6 +908,11 @@ def _policy_gate(
         return _Gap(
             "has a deployment branch policy this token cannot list", verified=False
         )
+    # An unverifiable entry is held, not returned: a later entry can name a ref
+    # confirmed out of the verified set, and that finding outranks this one —
+    # the precedence `check_credential_environments` already applies when both
+    # kinds arrive from different environments.
+    unverified: _Gap | None = None
     for p in policies:
         if p.get("type") == "tag":
             gated = tags_ok()
@@ -916,13 +921,13 @@ def _policy_gate(
                 # bot's own token reads a gating all-tags ruleset as
                 # unverifiable — the same configuration a maintainer's admin
                 # token confirms.
-                return _Gap(
+                unverified = _Gap(
                     "admits tags under a ruleset this token cannot verify: only "
                     "a repo admin reads a ruleset's bypass list, so re-run "
                     "`tend check` as an admin to settle it",
                     verified=False,
                 )
-            if gated is False:
+            elif gated is False:
                 return _Gap(
                     "admits tags, and no active all-tags ruleset restricting "
                     "creation and update to admins could be verified"
@@ -939,7 +944,7 @@ def _policy_gate(
             f"{triggers}, which the bot fires and steers against a ref the "
             "policy already admits"
         )
-    return None
+    return unverified
 
 
 def check_credential_environments(

--- a/generator/src/tend/checks.py
+++ b/generator/src/tend/checks.py
@@ -242,7 +242,9 @@ def _bypass_actors_above_bot(actors: list[dict] | None, bot_name: str) -> bool |
     Returns False if one of them is the bot itself or a role at write or
     below, None when the list is withheld (only ruleset admins see
     `bypass_actors`) or names a principal this can't resolve (a team, app,
-    or deploy key). An empty list is True — nobody bypasses at all.
+    or deploy key, or any user once `bot_name` itself fails to resolve — the
+    ids have nothing to compare against). An empty list is True — nobody
+    bypasses at all.
     """
     if actors is None:
         return None
@@ -920,9 +922,10 @@ def _policy_gate(
             if gated is None:
                 # Every unread input lands here, not just a withheld bypass
                 # list: an unlistable `/rulesets`, a ruleset that won't fetch,
-                # and a bypass actor naming a team, app, or deploy key are all
-                # None. So the message names the set rather than prescribing
-                # the admin re-run that settles only one of them.
+                # a bypass actor naming a team, app, or deploy key, and a
+                # `User` actor left undecidable by an unresolvable `bot_name`
+                # are all None. So the message names the set rather than
+                # prescribing the admin re-run that settles only one of them.
                 unverified = _Gap(
                     "admits tags, and whether an all-tags ruleset gates them is "
                     "unverifiable with this token — either the rulesets aren't "

--- a/generator/src/tend/checks.py
+++ b/generator/src/tend/checks.py
@@ -208,8 +208,9 @@ def check_branch_protection(repo: str, branch: str, bot_name: str) -> CheckResul
             None,
             f"Branch '{branch}' is protected but could not verify that the bot "
             "cannot bypass its rulesets — either they aren't readable with this "
-            "token, or a bypass actor names a team, app, or deploy key whose "
-            "membership isn't resolvable here. Check the bypass list manually.",
+            "token, or a bypass actor names a principal tend cannot resolve: a "
+            "team, app, or deploy key, or any user if `bot_name` itself does not "
+            "resolve to an account. Check the bypass list manually.",
         )
 
     return CheckResult(
@@ -926,8 +927,9 @@ def _policy_gate(
                     "admits tags, and whether an all-tags ruleset gates them is "
                     "unverifiable with this token — either the rulesets aren't "
                     "readable, a bypass list is withheld (only a repo admin "
-                    "reads one), or a bypass actor names a team, app, or deploy "
-                    "key whose membership isn't resolvable here",
+                    "reads one), or a bypass actor names a principal tend "
+                    "cannot resolve: a team, app, or deploy key, or any user "
+                    "if `bot_name` itself does not resolve to an account",
                     verified=False,
                 )
             elif gated is False:

--- a/generator/src/tend/checks.py
+++ b/generator/src/tend/checks.py
@@ -856,6 +856,21 @@ def _reviewer_gate(env: dict, bot_name: str) -> str | None:
     return None
 
 
+@dataclass(frozen=True)
+class _Gap:
+    """Why a gate does not hold, and whether that verdict was verified.
+
+    `verified` is False when the token could not see enough to decide, which
+    is not the same finding as a gate confirmed absent: the module docstring's
+    invariant is that the nightly sees the answers a maintainer does, so where
+    it doesn't, the honest report is unknown. `check_branch_protection` takes
+    the same stance on an unreadable bypass list.
+    """
+
+    reason: str
+    verified: bool = True
+
+
 def _policy_gate(
     repo: str,
     env_name: str,
@@ -863,7 +878,7 @@ def _policy_gate(
     admitted: list[str],
     tags_ok,
     steerable: frozenset[str],
-) -> str | None:
+) -> _Gap | None:
     """Why this environment's deployment policy does not gate the bot, or None.
 
     A policy gates only when every entry names a ref verified out of the bot's
@@ -882,30 +897,44 @@ def _policy_gate(
     """
     policy = env.get("deployment_branch_policy")
     if not policy:
-        return "has no deployment branch policy, so every ref reaches its secrets"
+        return _Gap("has no deployment branch policy, so every ref reaches its secrets")
     if policy.get("protected_branches"):
-        return (
+        return _Gap(
             "admits all protected branches, which keys on a rule covering the "
             "branch, not on who may push it"
         )
     policies = _branch_policies(repo, env_name)
     if policies is None:
-        return "has a deployment branch policy this token cannot list"
+        return _Gap(
+            "has a deployment branch policy this token cannot list", verified=False
+        )
     for p in policies:
         if p.get("type") == "tag":
-            if tags_ok() is not True:
-                return (
+            gated = tags_ok()
+            if gated is None:
+                # GitHub serves `bypass_actors` only to a repo admin, so the
+                # bot's own token reads a gating all-tags ruleset as
+                # unverifiable — the same configuration a maintainer's admin
+                # token confirms.
+                return _Gap(
+                    "admits tags under a ruleset this token cannot verify: only "
+                    "a repo admin reads a ruleset's bypass list, so re-run "
+                    "`tend check` as an admin to settle it",
+                    verified=False,
+                )
+            if gated is False:
+                return _Gap(
                     "admits tags, and no active all-tags ruleset restricting "
                     "creation and update to admins could be verified"
                 )
         elif p["name"] not in admitted:
-            return (
+            return _Gap(
                 f"admits '{p['name']}', which tend has not verified the bot "
                 "cannot write"
             )
     if steerable:
         triggers = ", ".join(f"`{t}`" for t in sorted(steerable))
-        return (
+        return _Gap(
             f"admits only verified refs, but a workflow reaching it runs on "
             f"{triggers}, which the bot fires and steers against a ref the "
             "policy already admits"
@@ -960,6 +989,7 @@ def check_credential_environments(
     tags_ok = cache(lambda: _tags_admin_gated(repo, cfg.bot_name))
 
     ungated: list[str] = []
+    unverified: list[str] = []
     holders: list[str] = []
     for env_name in listed.stdout.split():
         secrets = _gh(
@@ -990,7 +1020,7 @@ def check_credential_environments(
         reviewer_reason = _reviewer_gate(env, cfg.bot_name)
         if reviewer_reason is None:
             continue
-        policy_reason = _policy_gate(
+        gap = _policy_gate(
             repo,
             env_name,
             env,
@@ -998,9 +1028,10 @@ def check_credential_environments(
             tags_ok,
             surface.env_steerable.get(env_name, frozenset()),
         )
-        if policy_reason is None:
+        if gap is None:
             continue
-        ungated.append(f"'{env_name}' {reviewer_reason}, and {policy_reason}")
+        found = f"'{env_name}' {reviewer_reason}, and {gap.reason}"
+        (ungated if gap.verified else unverified).append(found)
 
     if surface.ungated_oidc:
         jobs = ", ".join(f"{path}:{job}" for path, job in surface.ungated_oidc)
@@ -1020,12 +1051,12 @@ def check_credential_environments(
             "verified refs (protected branches, or tags under an admin-only "
             "all-tags ruleset); move an OIDC job into such an environment.",
         )
-    if surface.unresolved:
+    if unverified or surface.unresolved:
         return CheckResult(
             name,
             None,
             "Could not read the whole credential surface: "
-            f"{'; '.join(surface.unresolved)}",
+            f"{'; '.join([*unverified, *surface.unresolved])}",
         )
     if not holders:
         return CheckResult(name, True, "No environment holds a credential")

--- a/generator/tests/test_checks.py
+++ b/generator/tests/test_checks.py
@@ -1644,6 +1644,26 @@ def test_credential_environments_confirmed_bad_ref_outranks_a_withheld_list() ->
         assert "staging" in result.message
 
 
+def test_credential_environments_unlistable_branch_policy_is_unknown() -> None:
+    """Listing the policy entries can fail on permission alone, and an unread
+    list is not a gate confirmed absent — the same reason a withheld bypass
+    list reports unknown."""
+    inner = _credential_env_gh(
+        {"release": (["PYPI_TOKEN"], _CUSTOM_POLICY, "branch main")}
+    )
+
+    def fake(*args, **kwargs):
+        url = args[-3] if "--jq" in args else args[-1]
+        if url.endswith("/deployment-branch-policies"):
+            return _make_completed(returncode=1)
+        return inner(*args, **kwargs)
+
+    with patch("tend.checks._gh", side_effect=fake):
+        result = check_credential_environments("owner/repo", _config(), ["main"])
+    assert result.passed is None, result.message
+    assert "cannot list" in result.message
+
+
 def test_credential_environments_bot_bypassable_tag_ruleset_does_not_gate() -> None:
     """A tag ruleset whose bypass list includes a write-level role is one the
     bot walks through, so it must not credit the tag entries."""
@@ -1809,6 +1829,25 @@ def test_credential_environments_steerable_trigger_defeats_a_ref_policy() -> Non
         },
     )
     assert result.passed is False
+    assert "`release`" in result.message
+
+
+def test_credential_environments_steerable_trigger_outranks_an_unverified_tag() -> None:
+    """The trigger defeats the policy whichever way the tag entry would have
+    settled, so it is a finding the token did reach — it must not be held back
+    to unknown by the entry it could not."""
+    withheld = {k: v for k, v in _ADMIN_TAG_RULESET.items() if k != "bypass_actors"}
+    result = _credential_check(
+        {"pypi": (["PYPI_TOKEN"], _CUSTOM_POLICY, "branch main\ntag v*")},
+        tag_rulesets={"7": withheld},
+        workflows={
+            "release.yaml": (
+                "on:\n  release:\n    types: [published]\n"
+                "jobs:\n  publish:\n    environment: pypi\n"
+            )
+        },
+    )
+    assert result.passed is False, result.message
     assert "`release`" in result.message
 
 

--- a/generator/tests/test_checks.py
+++ b/generator/tests/test_checks.py
@@ -1627,6 +1627,23 @@ def test_credential_environments_withheld_bypass_list_is_unknown() -> None:
     assert "release" in result.message
 
 
+def test_credential_environments_confirmed_bad_ref_outranks_a_withheld_list() -> None:
+    """An entry naming an unverified ref is a finding the token did settle, so
+    it must not be downgraded to unknown by a tag entry it could not. The API
+    returns policy entries in creation order, so whichever comes first would
+    otherwise decide the verdict."""
+    withheld = {k: v for k, v in _ADMIN_TAG_RULESET.items() if k != "bypass_actors"}
+    for order in ("tag v*\nbranch staging", "branch staging\ntag v*"):
+        fake = _credential_env_gh(
+            {"release": (["PYPI_TOKEN"], _CUSTOM_POLICY, order)},
+            tag_rulesets={"7": withheld},
+        )
+        with patch("tend.checks._gh", side_effect=fake):
+            result = check_credential_environments("owner/repo", _config(), ["main"])
+        assert result.passed is False, f"{order}: {result.message}"
+        assert "staging" in result.message
+
+
 def test_credential_environments_bot_bypassable_tag_ruleset_does_not_gate() -> None:
     """A tag ruleset whose bypass list includes a write-level role is one the
     bot walks through, so it must not credit the tag entries."""

--- a/generator/tests/test_checks.py
+++ b/generator/tests/test_checks.py
@@ -1611,6 +1611,22 @@ def test_credential_environments_rejects_tags_without_a_ruleset() -> None:
     assert "admits tags" in result.message
 
 
+def test_credential_environments_withheld_bypass_list_is_unknown() -> None:
+    """GitHub omits `bypass_actors` below repo admin, so the bot's own token
+    reads the gating ruleset as unverifiable rather than absent. Calling that
+    a failure would fail the nightly on exactly the shape tend prescribes,
+    while a maintainer running the same check as admin sees it pass."""
+    withheld = {k: v for k, v in _ADMIN_TAG_RULESET.items() if k != "bypass_actors"}
+    fake = _credential_env_gh(
+        {"release": (["PYPI_TOKEN"], _CUSTOM_POLICY, "branch main\ntag v*")},
+        tag_rulesets={"7": withheld},
+    )
+    with patch("tend.checks._gh", side_effect=fake):
+        result = check_credential_environments("owner/repo", _config(), ["main"])
+    assert result.passed is None, result.message
+    assert "release" in result.message
+
+
 def test_credential_environments_bot_bypassable_tag_ruleset_does_not_gate() -> None:
     """A tag ruleset whose bypass list includes a write-level role is one the
     bot walks through, so it must not credit the tag entries."""


### PR DESCRIPTION
## Problem

`check_credential_environments` (added in #815, unreleased) fails on this repo, and its verdict depends on the token's permission level rather than on the repo's configuration:

```
FAIL  credential-environments — A run the bot can cause reaches a credential: 'release' has no required reviewers, and admits tags, and no active all-tags ruleset restricting creation and update to admins could be verified.
```

The `release` environment (PyPI trusted publishing, `pypi-release.yaml`) admits tags, and this repo *does* carry the all-tags ruleset the check looks for — `Tag operations`: target `tag`, active, `include: ["~ALL"]`, rules `creation` + `update`. The gate is there. What the bot cannot see is its bypass list: GitHub omits `bypass_actors` from the ruleset response below repo admin, so `_bypass_actors_above_bot(None, …)` returns None, `_tags_admin_gated` returns None, and `_policy_gate` — which credited tag entries only on `is True` — reported the environment ungated.

Verified against the API rather than inferred: reading a ruleset with no bypass actors as **admin** returns `"bypass_actors": []`; reading the same field on this repo with the bot's **write**-scoped token omits the key entirely (all three of this repo's rulesets, including the branch one).

That breaks the invariant this module's own docstring states — *"Everything read here is readable with the bot's own write-scoped token, so the nightly run sees the same answers a maintainer does"* — and it breaks it on the release-environment shape [`TODO.md`](https://github.com/max-sixty/tend/blob/4672f809cedd2f206e109761072641798aa0184e/TODO.md#L20-L38) prescribes. Once this ships, every adopter whose nightly runs `tend check` under the bot's token gets a permanent failure on a correctly-gated environment, and `--fix` cannot clear it; a maintainer running the same command as admin sees it pass.

## Solution

Split "confirmed absent" from "could not see". `_policy_gate` now returns a `_Gap(reason, verified)`, and `check_credential_environments` routes an unverified gap into the existing unknown result (`Could not read the whole credential surface: …`) instead of the failure list. A tag entry with no gating ruleset still fails, unchanged. The one other permission-shaped reason — a deployment branch policy the token cannot list — moves with it, same cause.

This is the stance `check_branch_protection` already takes on the same unreadable field: *"Ruleset check was inconclusive — don't false-positive"* → unknown, not failure.

After the change, on this repo:

```
SKIP  credential-environments — Could not read the whole credential surface: 'release' has no required reviewers, and admits tags, and whether an all-tags ruleset gates them is unverifiable with this token — either the rulesets aren't readable, a bypass list is withheld (only a repo admin reads one), or a bypass actor names a principal tend cannot resolve: a team, app, or deploy key, or any user if `bot_name` itself does not resolve to an account
```

The two genuine failures this repo has — `claude-auth` and `repo-secret-allowlist`, both #822 — still fail, so the drift report is unaffected.

## Testing

`test_credential_environments_withheld_bypass_list_is_unknown` reproduces it: the admin-shaped tag ruleset with `bypass_actors` removed, asserting unknown. It fails before the change (`assert False is None`) and passes after. Three more tests pin the rest of the split — a confirmed bad ref outranking a withheld list (both entry orders), the unlistable-policy path, and a steerable trigger outranking a held unverified tag entry — each verified to fail on the mutation that removes what it pins. Full generator suite green (331 passed), pinned `ruff` clean, and `tend check` re-run live against this repo for the output above.

---

Found while triaging #822 — it does not fix that issue, which needs a maintainer to move the token.


