### PR TITLE
check: settle a withheld ruleset bypass list with current_user_can_bypass

### DIFF
--- a/generator/src/tend/checks.py
+++ b/generator/src/tend/checks.py
@@ -303,7 +303,12 @@ def _ruleset_excludes_bot(data: dict, bot_name: str) -> bool | None:
     if verdict is not None:
         return verdict
     can_bypass = data.get("current_user_can_bypass")
-    if can_bypass is None or _authenticated_login() != bot_name:
+    login = _authenticated_login()
+    # Casefolded: `bot_name` is hand-written in `.config/tend.yaml` while the
+    # API returns the canonical casing, and every other comparison of the two
+    # (`_reviewer_gate`, and the URL paths GitHub resolves case-insensitively)
+    # already tolerates the difference.
+    if can_bypass is None or login is None or login.casefold() != bot_name.casefold():
         return None
     return can_bypass == CANNOT_BYPASS
 

--- a/generator/src/tend/checks.py
+++ b/generator/src/tend/checks.py
@@ -52,6 +52,14 @@ BYPASS_ROLE_IDS = frozenset({ROLE_ID_MAINTAIN, ROLE_ID_ADMIN})
 # the ruleset, so the bot can't be ruled out.
 BYPASS_ACTOR_TYPES_ABOVE_BOT = frozenset({"OrganizationAdmin", "EnterpriseOwner"})
 
+# The one `current_user_can_bypass` value that grants the requester no bypass.
+# Every other value names a mode in which it bypasses — the docs list `always`
+# and `pull_requests_only`, live responses also return `exempt` — so reading
+# only `never` as blocked fails closed on a value added later. This is the
+# reading `shared/steps/security-preflight.sh` already applies to the same
+# field with the same token.
+CANNOT_BYPASS = "never"
+
 # Triggers a write-scoped actor can both fire *and* steer — it decides not only
 # that the run happens but what the run publishes. A deployment branch policy
 # does not gate these, because the actor fires them at a ref the policy already
@@ -268,6 +276,38 @@ def _bypass_actors_above_bot(actors: list[dict] | None, bot_name: str) -> bool |
     return None if unresolved else True
 
 
+def _authenticated_login() -> str | None:
+    """The login `gh` is authenticated as, or None when it can't be read."""
+    result = _gh("api", "user", "--jq", ".login")
+    if result is None or result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def _ruleset_excludes_bot(data: dict, bot_name: str) -> bool | None:
+    """Whether a ruleset payload keeps a write-access bot out.
+
+    `bypass_actors` is the first signal, but GitHub serves it only to a ruleset
+    admin — and `tend check` runs under the bot's own write-scoped token, so on
+    a correctly locked-down repo the key is absent from every ruleset it reads,
+    whatever the list holds. Absent is therefore not empty: tend's own `--fix`
+    writes an admin bypass, and that ruleset reads back with no `bypass_actors`
+    key at all.
+
+    `current_user_can_bypass` closes that gap from the other side. It answers
+    for the requesting user only, which is exactly the actor in question
+    whenever the requester *is* the bot — and it accounts for team and app
+    membership the actor list leaves unresolvable.
+    """
+    verdict = _bypass_actors_above_bot(data.get("bypass_actors"), bot_name)
+    if verdict is not None:
+        return verdict
+    can_bypass = data.get("current_user_can_bypass")
+    if can_bypass is None or _authenticated_login() != bot_name:
+        return None
+    return can_bypass == CANNOT_BYPASS
+
+
 def _ruleset_blocks_bot(repo: str, ruleset_id: int, bot_name: str) -> bool | None:
     """Whether a ruleset's bypass list keeps a write-access bot out.
 
@@ -284,7 +324,7 @@ def _ruleset_blocks_bot(repo: str, ruleset_id: int, bot_name: str) -> bool | Non
         return None
     if not isinstance(data, dict):
         return None
-    return _bypass_actors_above_bot(data.get("bypass_actors"), bot_name)
+    return _ruleset_excludes_bot(data, bot_name)
 
 
 def _tags_admin_gated(repo: str, bot_name: str) -> bool | None:
@@ -292,8 +332,9 @@ def _tags_admin_gated(repo: str, bot_name: str) -> bool | None:
 
     True when a tag-target ruleset covers `~ALL` tags with nothing excluded,
     restricts `creation` and `update` (force-pushing an existing tag fires
-    `update`), and every bypass actor outranks write — the shape install-tend's
-    ref-protection step creates. Narrower patterns are not credited: deciding
+    `update`), and the bot is out of its bypass list (`_ruleset_excludes_bot`) —
+    the shape install-tend's ref-protection step creates, and also the stricter
+    no-bypass-at-all shape. Narrower patterns are not credited: deciding
     whether a pattern set covers an environment policy's tag entries would
     re-implement GitHub's matcher, and the recipe's rule is all-tags on
     purpose.
@@ -324,7 +365,7 @@ def _tags_admin_gated(repo: str, bot_name: str) -> bool | None:
             continue
         if not {"creation", "update"} <= {r.get("type") for r in data.get("rules", [])}:
             continue
-        verdict = _bypass_actors_above_bot(data.get("bypass_actors"), bot_name)
+        verdict = _ruleset_excludes_bot(data, bot_name)
         if verdict is True:
             return True
         unresolved = unresolved or verdict is None

--- a/generator/tests/test_checks.py
+++ b/generator/tests/test_checks.py
@@ -380,6 +380,20 @@ def test_ruleset_bypass_list_withheld_but_token_is_the_bot() -> None:
         assert _has_restrict_updates_ruleset("owner/repo", "main", "my-bot") is True
 
 
+def test_ruleset_bypass_list_withheld_login_case_differs() -> None:
+    """`bot_name` is hand-written in the config and GitHub returns the canonical
+    casing, so a case-only difference must still identify the same account —
+    otherwise the check silently reverts to the false FAIL."""
+    fake = _gh_ruleset(
+        _make_branch_rules("update"),
+        None,
+        ruleset_json=json.dumps({"current_user_can_bypass": "never"}),
+        login="My-Bot",
+    )
+    with patch("tend.checks._gh", side_effect=fake):
+        assert _has_restrict_updates_ruleset("owner/repo", "main", "my-bot") is True
+
+
 def test_ruleset_bypass_list_withheld_and_the_bot_can_bypass() -> None:
     """The same field also turns an unverifiable into a definite finding: a bot
     GitHub says is exempt walks through the rule, whoever else is on the list."""

--- a/generator/tests/test_checks.py
+++ b/generator/tests/test_checks.py
@@ -120,15 +120,21 @@ def _gh_ruleset(
     bypass_actors: list[dict[str, object]] | None,
     user_id: int | None = None,
     ruleset_json: str | None = None,
+    login: str | None = None,
 ) -> object:
     """Build a `_gh` fake serving the calls `_has_restrict_updates_ruleset` makes:
     `/rules/branches/<branch>` returns `rules`; `/rulesets/<id>` returns a ruleset
     with `bypass_actors` (or `ruleset_json` verbatim if given, or returncode=1 if
-    both are None); `users/<login>` returns `user_id` (or returncode=1 if None)."""
+    both are None); `users/<login>` returns `user_id` (or returncode=1 if None);
+    `user` returns `login` (or returncode=1 if None)."""
 
     def fake(*args: str, **kwargs: object) -> subprocess.CompletedProcess[str] | None:
         if "/rules/branches/" in args[1]:
             return _make_completed(rules)
+        if args[1] == "user":
+            if login is None:
+                return _make_completed(returncode=1)
+            return _make_completed(f"{login}\n")
         if args[1].startswith("users/"):
             if user_id is None:
                 return _make_completed(returncode=1)
@@ -342,15 +348,63 @@ def test_ruleset_bypass_list_not_visible() -> None:
     """GitHub omits `bypass_actors` below ruleset-admin → unverifiable, not empty.
 
     Reading the missing key as an empty list would report "nobody bypasses" —
-    a false pass for exactly the caller who can't see the danger.
+    a false pass for exactly the caller who can't see the danger. The
+    `current_user_can_bypass` answer here describes someone other than the bot,
+    so it settles nothing.
     """
     fake = _gh_ruleset(
         _make_branch_rules("update"),
         None,
         ruleset_json=json.dumps({"current_user_can_bypass": "never"}),
+        login="a-maintainer",
     )
     with patch("tend.checks._gh", side_effect=fake):
         assert _has_restrict_updates_ruleset("owner/repo", "main", "my-bot") is None
+
+
+def test_ruleset_bypass_list_withheld_but_token_is_the_bot() -> None:
+    """`current_user_can_bypass` answers for the requester, so when the requester
+    is the bot it settles the question the withheld list can't.
+
+    This is the common case, not a corner: `tend check` runs under the bot's own
+    write-scoped token, which is below ruleset-admin on every correctly
+    locked-down repo, so `bypass_actors` is absent from every ruleset it reads.
+    """
+    fake = _gh_ruleset(
+        _make_branch_rules("update"),
+        None,
+        ruleset_json=json.dumps({"current_user_can_bypass": "never"}),
+        login="my-bot",
+    )
+    with patch("tend.checks._gh", side_effect=fake):
+        assert _has_restrict_updates_ruleset("owner/repo", "main", "my-bot") is True
+
+
+def test_ruleset_bypass_list_withheld_and_the_bot_can_bypass() -> None:
+    """The same field also turns an unverifiable into a definite finding: a bot
+    GitHub says is exempt walks through the rule, whoever else is on the list."""
+    fake = _gh_ruleset(
+        _make_branch_rules("update"),
+        None,
+        ruleset_json=json.dumps({"current_user_can_bypass": "exempt"}),
+        login="my-bot",
+    )
+    with patch("tend.checks._gh", side_effect=fake):
+        assert _has_restrict_updates_ruleset("owner/repo", "main", "my-bot") is False
+
+
+def test_ruleset_bypass_unknown_current_user_value_is_a_bypass() -> None:
+    """`never` is the only value that denies the bypass, so a mode added later
+    reads as one — the same fail-closed reading the action's preflight applies
+    to this field."""
+    fake = _gh_ruleset(
+        _make_branch_rules("update"),
+        None,
+        ruleset_json=json.dumps({"current_user_can_bypass": "some_new_mode"}),
+        login="my-bot",
+    )
+    with patch("tend.checks._gh", side_effect=fake):
+        assert _has_restrict_updates_ruleset("owner/repo", "main", "my-bot") is False
 
 
 def test_only_non_update_rules() -> None:
@@ -1412,12 +1466,14 @@ def _credential_env_gh(
     tag_rulesets: dict[str, dict] | None = None,
     workflows: dict[str, str | None] | None = None,
     unreadable_workflows: bool = False,
+    login: str | None = None,
 ):
     """A `_gh` fake serving the calls `check_credential_environments` makes: the
     environment list; per environment its secret names, detail, and
     deployment-branch-policy lines (`"<type> <name>"` per line); the tag
-    rulesets (id → detail) the tag gate reads when a policy admits tags; and
-    the workflow tree the OIDC and trigger reads parse."""
+    rulesets (id → detail) the tag gate reads when a policy admits tags; the
+    authenticated login (`login`, unreadable when None); and the workflow tree
+    the OIDC and trigger reads parse."""
     tag_rulesets = tag_rulesets or {}
 
     def fake(*args, **kwargs) -> subprocess.CompletedProcess[str]:
@@ -1426,6 +1482,10 @@ def _credential_env_gh(
                 return _make_completed(returncode=1)
             return _make_completed(_workflow_tree(workflows or {}))
         url = args[-3] if "--jq" in args else args[-1]
+        if url == "user":
+            if login is None:
+                return _make_completed(returncode=1)
+            return _make_completed(f"{login}\n")
         if url.endswith("/environments"):
             return _make_completed("\n".join(environments) + "\n")
         if url.endswith("/rulesets"):
@@ -1593,6 +1653,25 @@ def test_credential_environments_accepts_tags_under_an_admin_ruleset() -> None:
     fake = _credential_env_gh(
         {"release": (["PYPI_TOKEN"], _CUSTOM_POLICY, "branch main\ntag v*")},
         tag_rulesets={"7": _ADMIN_TAG_RULESET},
+    )
+    with patch("tend.checks._gh", side_effect=fake):
+        result = check_credential_environments("owner/repo", _config(), ["main"])
+    assert result.passed is True, result.message
+
+
+def test_credential_environments_accepts_tags_under_a_no_bypass_ruleset() -> None:
+    """The shape a locked-down consumer actually has: an all-tags ruleset with no
+    bypass at all, read by the bot's own token, which GitHub serves without a
+    `bypass_actors` key. Reported as a permanent false FAIL on a repo whose tags
+    the bot demonstrably cannot touch.
+    """
+    no_bypass = {
+        k: v for k, v in _ADMIN_TAG_RULESET.items() if k != "bypass_actors"
+    } | {"current_user_can_bypass": "never"}
+    fake = _credential_env_gh(
+        {"release": (["PYPI_TOKEN"], _CUSTOM_POLICY, "branch main\ntag v*")},
+        tag_rulesets={"7": no_bypass},
+        login="bot",
     )
     with patch("tend.checks._gh", side_effect=fake):
         result = check_credential_environments("owner/repo", _config(), ["main"])


### PR DESCRIPTION
## Problem

`tend check` reports a FAIL on repos whose tags are locked down exactly as tend's own recipe prescribes:

> **`secret-environments`** — the `release` and `signing` environments each hold secrets, have no required reviewers, and admit tags, and no active all-tags ruleset restricting tag creation/update to admins could be verified.

Reported in #824 against max-sixty/worktrunk. It reproduces on this repo: on `main` at 4672f809cedd2f206e109761072641798aa0184e, `tend check` run as `tend-agent` fails `credential-environments` for the `release` environment, and passes `branch-protection:main` only through the weak `.protected` fallback rather than by confirming the ruleset.

## Root cause

GitHub serves a ruleset's `bypass_actors` **only to a ruleset admin**. `tend check` runs under the bot's own write-scoped token, so on a correctly locked-down repo the key is absent from every ruleset it reads — and `_bypass_actors_above_bot` maps absent to `None` (unverifiable). Every ruleset verdict is therefore unverifiable in the nightly, which `_tags_admin_gated` turns into "no all-tags ruleset could be verified" and `_policy_gate` turns into a FAIL.

Absent is *not* empty, so #824's suggested "treat a missing `bypass_actors` as no bypass actors" would be a false pass: this repo's `Merge access` ruleset was created by tend's own `--fix` with an admin bypass actor, and it reads back to the bot with no `bypass_actors` key at all. Verified against live GitHub on a repo where the bot *is* admin — as a ruleset admin, an empty bypass list is served as `"bypass_actors": []`, never omitted.

## Solution

Use `current_user_can_bypass`, which GitHub returns to any reader and which answers the question for the requesting user only — exactly the actor in question when the requester is the bot. `bypass_actors` stays the first signal; the new fallback fires only when that list is unusable **and** `gh api user` says the token is the configured `bot_name`. `never` means blocked; every other value names a bypass mode, so an unrecognized one fails closed.

This is the reading [`shared/steps/security-preflight.sh`](https://github.com/max-sixty/tend/blob/4672f809cedd2f206e109761072641798aa0184e/shared/steps/security-preflight.sh#L26-L35) already applies to the same field with the same token for the merge restriction, and which `docs/security-model.md` describes as "GitHub's own evaluation of the bot's standing — teams, custom roles, and org-level rulesets included". The check was simply not using it.

Side effect: it also settles cases the actor list can never decide. A `Team` or `Integration` bypass actor whose membership isn't visible used to be permanently unverifiable; GitHub has already resolved it into `current_user_can_bypass`.

## Relationship to #825

Same root cause, different remedy — a maintainer should pick one. #825 keeps the verdict unverifiable and stops reporting it as a failure (FAIL → "could not read the whole credential surface"). This PR removes the unverifiability in the case the nightly actually runs in, so the check reports a real PASS and a genuinely ungated environment can't hide in the unknown bucket. They are compatible if both land: #825's unknown branch would then cover only the residual cases (a non-bot token that isn't a ruleset admin), and its test still passes under this change.

## Testing

Four unit tests, three of which fail on `main`; plus a live before/after on this repo.

<details><summary>Live A/B on max-sixty/tend, run as <code>tend-agent</code></summary>

Before (in-tree `main`):

```
PASS  branch-protection:main — Branch 'main' is protected
FAIL  credential-environments — A run the bot can cause reaches a credential: 'release' has no required reviewers, and admits tags, and no active all-tags ruleset restricting creation and update to admins could be verified.
```

After:

```
PASS  branch-protection:main — Branch 'main' is protected (restrict-updates ruleset)
PASS  credential-environments — Credential-holding environments are gated: cloudflare-deploy, codex-auth-refresh, github-pages, release, tend
```

The branch-protection line changes too: it was passing on the "can't read details — assume OK" fallback, and now passes on a positively verified ruleset.

</details>

<details><summary>API evidence that absent ≠ empty</summary>

Read as the write-access bot, `repos/max-sixty/tend/rulesets/14219339` (`Merge access`, created by `tend check --fix` with `bypass_actors: [{actor_id: 5, actor_type: RepositoryRole}]`):

```json
{"name": "Merge access", "current_user_can_bypass": "never", "bypass_actors": <key absent>}
```

Two probe rulesets created on `tend-agent/tend-integration`, where the bot is admin, then deleted:

| ruleset | `bypass_actors` (as admin) | `current_user_can_bypass` |
|---|---|---|
| bypass = admin role | `[{"actor_id": 5, "actor_type": "RepositoryRole", ...}]` | `exempt` |
| bypass = none | `[]` | `never` |

So a ruleset admin always sees the list, empty included; a non-admin never does. And `exempt` is a live value the documented enum (`always`, `pull_requests_only`, `never`) doesn't list — hence treating anything but `never` as a bypass.

</details>

Closes #824
