### PR TITLE
fix(review-runs): look for in-thread maintainer corrections, not just dispositions

### DIFF
--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -193,12 +193,19 @@ Dispositions — merged, closed, relabeled, reverted — are only half the signa
 ```bash
 # Human replies in the window, on any issue or PR thread. Both endpoints are
 # repo-wide and take `since`, so this is two calls regardless of thread count.
+# `--paginate` is required, not cosmetic: the response is ascending by
+# `created_at`, so a single 100-item page drops the *newest* comments — the
+# ones a fresh correction sits in. The bot's own comments consume that budget
+# before the filter runs, so a busy day truncates with nothing in the output
+# to say so.
 for endpoint in issues pulls; do
-  gh api "repos/$REPO/$endpoint/comments?since=$SINCE&per_page=100" \
+  gh api --paginate "repos/$REPO/$endpoint/comments?since=$SINCE&per_page=100" \
     --jq '.[] | select(.user.login != "'"$BOT_LOGIN"'")
-          | {at: .created_at, url: .html_url, body: .body[0:300]}'
+          | {created: .created_at, updated: .updated_at, url: .html_url, body: .body[0:300]}'
 done
 ```
+
+`since` filters on `updated_at`, not `created_at`, so results include older comments edited inside the window — a comment created days before `$SINCE` is a real hit, not a broken filter. That is worth having (an edited claim is still a correction); the projection reports both timestamps so the reason a row qualified is visible.
 
 Write "no maintainer corrections" into the tracking issue only after that query ran — future runs read the phrase as ground truth when counting occurrences under Gate 1, so an unchecked all-clear suppresses the evidence it exists to accumulate.
 

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -183,10 +183,24 @@ For each analyzed run, compare what the bot did against what happened next. The 
 mention, notifications, weekly, and review-reviewers runs get the same treatment: find the bot's output and check whether it was accepted.
 
 ```bash
-# Example: check if a bot PR was merged or closed
+# Bot PR dispositions — merged or closed in the window
 gh pr list --author "$BOT_LOGIN" --state all --json number,title,state,closedAt \
   --jq '.[] | select(.closedAt > "'$SINCE'")'
 ```
+
+Dispositions — merged, closed, relabeled, reverted — are only half the signal. A maintainer replying in-thread that a bot claim was wrong, leaving labels and state untouched, is equally a correction, and on an issue-heavy repo it is the most common one. No disposition query can see it. Read the threads where the bot commented in the window and count a contradiction as a finding:
+
+```bash
+# Human replies in the window, on any issue or PR thread. Both endpoints are
+# repo-wide and take `since`, so this is two calls regardless of thread count.
+for endpoint in issues pulls; do
+  gh api "repos/$REPO/$endpoint/comments?since=$SINCE&per_page=100" \
+    --jq '.[] | select(.user.login != "'"$BOT_LOGIN"'")
+          | {at: .created_at, url: .html_url, body: .body[0:300]}'
+done
+```
+
+Write "no maintainer corrections" into the tracking issue only after that query ran — future runs read the phrase as ground truth when counting occurrences under Gate 1, so an unchecked all-clear suppresses the evidence it exists to accumulate.
 
 ## Step 5: Deduplicate
 


### PR DESCRIPTION
## Problem

`review-runs` **Step 4: Cross-check outcomes** is the only place a run discovers that a maintainer disagreed with tend's output, and `running-in-ci` → **Learning from Feedback** depends on that discovery. But Step 4's single recipe was `gh pr list --author "$BOT_LOGIN"` — a PR-disposition query — and its prose asked only about merges, closures, and relabels. Every question it posed was answerable from state changes.

That misses the most common correction shape on an issue-heavy repo: a maintainer replying in-thread that a bot claim was wrong, leaving the issue's labels and state untouched. Nothing in the section asks for it, so a run following Step 4 as written reports "0 maintainer corrective comments" while one sits in its window.

The miss compounds: the all-clear gets written into the monthly tracking issue, and future runs read it as ground truth when counting occurrences under Gate 1 — so a recurring correction never accumulates the occurrences its own gate requires. Structural, not stochastic; there is no decision point.

## Solution

Adds the mirror-image query next to the existing disposition one — same repo-wide `since` endpoints, inverted login filter — plus a sentence naming in-thread contradiction as a correction class, and a note that "no maintainer corrections" should only be written after the query ran.

`issues/comments` covers issue and PR conversation comments; `pulls/comments` covers inline review replies, where corrections to `tend-review` output land. Both are repo-wide, so it's two calls regardless of how many threads the bot touched.

The query is `--paginate`d. That is load-bearing rather than cosmetic: the response is ascending by `created_at`, so a single 100-item page drops the *newest* comments — precisely where a fresh correction sits — and the bot's own comments consume that budget before the login filter runs. A silently truncated result would reintroduce the miss this PR exists to close.

The projection reports `updated_at` alongside `created_at`, because `since` filters on `updated_at`: a comment created before the window appears on the strength of an in-window edit. That is worth keeping — an edited claim is still a correction — but without both timestamps it reads as a broken filter.

## Testing

Ran the recipe verbatim against this repo. It surfaces exactly the class of comment the disposition query cannot see — e.g. [#800](https://github.com/max-sixty/tend/pull/800#issuecomment-5152652855) ("Not worth the complication.") and [#817](https://github.com/max-sixty/tend/issues/817#issuecomment-5172269199), neither reachable from a closed/merged/relabeled signal. Both endpoints accept `since`; the `for endpoint in issues pulls` form and the nested-quoting in the `jq` filter were executed as written, not just composed.

Measured the truncation the `--paginate` guards against, over a 7-day window on this repo: the unpaginated call returns 100 rows, `--paginate` returns 142, and the 42 dropped are the newest — the boundary landed at `2026-08-04T16:28:43Z`. In this particular window all 42 were the bot's own comments, so no human comment was actually lost; the mechanism is what's demonstrated, not an observed loss.

Confirmed the ordering claim directly: `created_at` is monotonic across the response and `updated_at` is not. Confirmed the `since` semantics the same way — a comment created `2026-08-01T08:39:05Z` appears in a 24h window because it was updated `2026-08-04T08:50:03Z`.

Also verified the reported miss reproduces from the skill text alone: Step 4 before this change contained no query filtering for non-bot comments.

---
Closes #827 — automated triage
