### PR TITLE
fix(review): ignore synthetic reply containers in all three review-record guards

### DIFF
--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -36,9 +36,10 @@ EVENT_ACTION=$(jq -r '.action // ""' < "${GITHUB_EVENT_PATH:-/dev/null}" 2>/dev/
 # (`POST /pulls/{n}/comments/{id}/replies`) makes GitHub wrap the reply in a
 # synthetic zero-body COMMENTED review anchored at the then-current HEAD, so the
 # newest review record routinely points at a commit nothing reviewed. Count a
-# record only when it has a body or owns a top-level (non-reply) inline comment
-# — reply containers have neither, while an empty-body review carrying real
-# inline findings still anchors.
+# record only when it has a body, owns a top-level (non-reply) inline comment, or
+# is an APPROVED review — reply containers are always zero-body COMMENTED, while
+# an empty-body approval and an empty-body review carrying real inline findings
+# both still anchor.
 SUBSTANTIVE=$(gh api --paginate "repos/$REPO/pulls/<number>/comments" \
   --jq '.[] | select(.in_reply_to_id == null) | .pull_request_review_id' | jq -s 'unique')
 
@@ -48,7 +49,7 @@ SUBSTANTIVE=$(gh api --paginate "repos/$REPO/pulls/<number>/comments" \
 LAST_REVIEW_SHA=$(gh api --paginate "repos/$REPO/pulls/<number>/reviews" \
   | jq -rs --argjson sub "$SUBSTANTIVE" --arg bot "$BOT_LOGIN" \
     'add | [.[] | select(.user.login == $bot)
-                | select((.body | length) > 0 or (.id | IN($sub[])))]
+                | select((.body | length) > 0 or (.id | IN($sub[])) or .state == "APPROVED")]
          | last | .commit_id // empty')
 ```
 

--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -32,12 +32,24 @@ PR_AUTHOR=$(gh pr view <number> --json author --jq '.author.login')
 IS_DRAFT=$(gh pr view <number> --json isDraft --jq '.isDraft')
 EVENT_ACTION=$(jq -r '.action // ""' < "${GITHUB_EVENT_PATH:-/dev/null}" 2>/dev/null)
 
-# Find the bot's most recent review (any state counts — COMMENTED reviews carry
-# inline comments even when the body is empty).
-# IMPORTANT: `gh pr view --json reviews` returns `.commit.oid` (NOT `.commit_id`).
-# The REST API (`gh api .../reviews`) uses `.commit_id` — don't confuse the two.
-LAST_REVIEW_SHA=$(gh pr view <number> --json reviews \
-  --jq "[.reviews[] | select(.author.login == \"$BOT_LOGIN\")] | last | .commit.oid // empty")
+# Find the bot's most recent *real* review. Replying to a review thread
+# (`POST /pulls/{n}/comments/{id}/replies`) makes GitHub wrap the reply in a
+# synthetic zero-body COMMENTED review anchored at the then-current HEAD, so the
+# newest review record routinely points at a commit nothing reviewed. Count a
+# record only when it has a body or owns a top-level (non-reply) inline comment
+# — reply containers have neither, while an empty-body review carrying real
+# inline findings still anchors.
+SUBSTANTIVE=$(gh api --paginate "repos/$REPO/pulls/<number>/comments" \
+  --jq '.[] | select(.in_reply_to_id == null) | .pull_request_review_id' | jq -s 'unique')
+
+# IMPORTANT: REST reviews carry `.commit_id`, NOT the `.commit.oid` that
+# `gh pr view --json reviews` returns — don't confuse the two. `gh api --jq`
+# accepts no `--arg`/`--argjson`, so pipe to `jq` rather than using `--jq`.
+LAST_REVIEW_SHA=$(gh api --paginate "repos/$REPO/pulls/<number>/reviews" \
+  | jq -rs --argjson sub "$SUBSTANTIVE" --arg bot "$BOT_LOGIN" \
+    'add | [.[] | select(.user.login == $bot)
+                | select((.body | length) > 0 or (.id | IN($sub[])))]
+         | last | .commit_id // empty')
 ```
 
 If `LAST_REVIEW_SHA == HEAD_SHA`, this commit has already been reviewed — exit silently. Two exceptions: an unanswered conversation question directed at the bot (check below), or `EVENT_ACTION == "ready_for_review"` (the PR just transitioned out of draft, so any prior review was a draft-mode review and the author is now asking for a full one — proceed).

--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -329,8 +329,13 @@ GitHub returns `422 Unprocessable Entity` with "Line could not be resolved" when
 # The body-length test is what distinguishes an orphan from a synthetic reply
 # container sitting on the same HEAD: case (a) persists the body, a container
 # never has one. Without it, the PUT below would overwrite an unrelated reply.
+# `gh api --paginate` applies `--jq` to each page separately, so a `| last`
+# inside `--jq` returns one id *per page* — pipe to `jq -rs 'add | …'` to reduce
+# over the merged array instead.
 ORPHAN_ID=$(gh api --paginate "repos/$REPO/pulls/<number>/reviews" \
-  --jq "[.[] | select(.user.login == \"$BOT_LOGIN\" and .commit_id == \"$HEAD_SHA\" and (.body | length) > 0)] | last | .id // empty")
+  | jq -rs --arg bot "$BOT_LOGIN" --arg head "$HEAD_SHA" \
+    'add | [.[] | select(.user.login == $bot and .commit_id == $head and (.body | length) > 0)]
+         | last | .id // empty')
 ```
 
 Then, in either case, **move the failed inline comments into the review body** as fenced code blocks with file paths, and:

--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -228,9 +228,19 @@ read -r CURRENT_HEAD PR_STATE < <(gh pr view <number> --json commits,state \
 [ "$CURRENT_HEAD" != "$HEAD_SHA" ] && echo "HEAD moved — skipping" && exit 0
 [ "$PR_STATE" != "OPEN" ] && echo "PR is $PR_STATE — skipping" && exit 0
 
+# Same substantive-review filter as step 1, and for the same reason: a synthetic
+# reply container is anchored at whatever HEAD was when the reply posted, so one
+# left on the current HEAD would read as "already reviewed" and discard this run's
+# review at the last step, after all the work. Shell state doesn't carry between
+# tool calls, so re-derive $SUBSTANTIVE here.
 # NOTE: REST API uses .commit_id (not .commit.oid from gh pr view --json)
-ALREADY_POSTED=$(gh api "repos/$REPO/pulls/<number>/reviews" \
-  --jq "[.[] | select(.user.login == \"$BOT_LOGIN\" and .commit_id == \"$HEAD_SHA\")] | last | .submitted_at // empty")
+SUBSTANTIVE=$(gh api --paginate "repos/$REPO/pulls/<number>/comments" \
+  --jq '.[] | select(.in_reply_to_id == null) | .pull_request_review_id' | jq -s 'unique')
+ALREADY_POSTED=$(gh api --paginate "repos/$REPO/pulls/<number>/reviews" \
+  | jq -rs --argjson sub "$SUBSTANTIVE" --arg bot "$BOT_LOGIN" --arg head "$HEAD_SHA" \
+    'add | [.[] | select(.user.login == $bot and .commit_id == $head)
+                | select((.body | length) > 0 or (.id | IN($sub[])) or .state == "APPROVED")]
+         | last | .submitted_at // empty')
 [ -n "$ALREADY_POSTED" ] && echo "Already reviewed — skipping" && exit 0
 ```
 
@@ -316,8 +326,11 @@ GitHub returns `422 Unprocessable Entity` with "Line could not be resolved" when
 **Check which case you are in before deciding how to recover** — query for an orphan review on the current HEAD first, then branch on the result.
 
 ```bash
-ORPHAN_ID=$(gh api "repos/$REPO/pulls/<number>/reviews" \
-  --jq "[.[] | select(.user.login == \"$BOT_LOGIN\" and .commit_id == \"$HEAD_SHA\")] | last | .id // empty")
+# The body-length test is what distinguishes an orphan from a synthetic reply
+# container sitting on the same HEAD: case (a) persists the body, a container
+# never has one. Without it, the PUT below would overwrite an unrelated reply.
+ORPHAN_ID=$(gh api --paginate "repos/$REPO/pulls/<number>/reviews" \
+  --jq "[.[] | select(.user.login == \"$BOT_LOGIN\" and .commit_id == \"$HEAD_SHA\" and (.body | length) > 0)] | last | .id // empty")
 ```
 
 Then, in either case, **move the failed inline comments into the review body** as fenced code blocks with file paths, and:


### PR DESCRIPTION
## Problem

`review` derives three separate signals from the bot's own review records, and all three counted any record the bot owns. GitHub creates the *same* record shape for something that is not a review: replying to a review thread via `POST /pulls/{n}/comments/{id}/replies` wraps the reply in a synthetic zero-body `COMMENTED` review anchored at whatever HEAD was when the reply posted. So after any `tend-mention` run answers review threads inline — its normal response path — containers sit on the current HEAD, and every guard that asks "did the bot review this commit?" answers yes:

- **`LAST_REVIEW_SHA`** (step 1) advances to a commit nothing reviewed, so the next `tend-review` run computes its incremental against code it never read and skips everything before it under the trivial-change heuristic. This is #828.
- **`ALREADY_POSTED`** (step 5, *Posting mechanics*) becomes a false positive and the run exits at `Already reviewed — skipping`. Same lost-review-signal symptom, relocated to the close-out — and it costs more, because the run has already read the diff and formed the verdict before throwing it away. Fixing the derivation doesn't cover it: that routes the run *into* a full review, and this guard then discards the result.
- **`ORPHAN_ID`** (*Recovering from inline comment 422 errors*) resolves to the container, so the case-(a) recovery would `PUT` the review body over an unrelated inline reply.

Nothing goes red in any of the three; the run reports a well-reasoned decision to stay silent. On a repo where the bot both authors and reviews its own PRs, that removes the PR's only review signal. It is deterministic — no decision point — so it recurs on every reply-then-push flow.

## Solution

Count a review record only when it carries a body, owns at least one *top-level* (non-reply) inline comment, or is `APPROVED`. Reply containers have none of the three; an empty-body review carrying real inline findings still anchors, and so does an empty-body approval. `LAST_REVIEW_SHA` and `ALREADY_POSTED` use the full predicate (the latter re-derives `SUBSTANTIVE`, since shell state doesn't carry between tool calls); `ORPHAN_ID` needs only the body test, because a case-(a) orphan always persisted a body and a container never has one. The review and comment calls are `--paginate`d — container churn is exactly what pushes a PR past one page of reviews — and each reduction runs over the merged array via `jq -rs 'add | …'`, not inside `--jq`: `gh` applies `--jq` per page, so a `| last` there yields one record *per page* rather than one overall.

Where the two shapes are genuinely indistinguishable (a UI review whose only content is thread replies), the filter skips it — that moves `LAST_REVIEW_SHA` *earlier*, widening the incremental. The failure direction is more review, not less.

## Testing

No test file covers skill prompt text, so the reproduction is a live API comparison rather than a committed test.

**Step 1, against `max-sixty/cargo-affected` PR #54** — the case in #828:

| review | `commit_id` | body | comments |
|---|---|---|---|
| 4851810736 | `1ffcde2` | 2441 chars | 2 top-level |
| 4851851883 | `551e059` | 0 | 1 reply (`in_reply_to_id` 3710403279) |
| 4851852052 | `551e059` | 0 | 1 reply (`in_reply_to_id` 3710403291) |

The old recipe returns `551e059` — a commit with no review, and the one whose refactor got skipped. The new recipe returns `1ffcde2`, the real review.

**Steps 5 and the 422 recovery, against this PR's own records.** `tend-mention` answered both threads from the first review after the `8699228` push, so the containers landed on the then-current HEAD:

| record | `commit_id` | body | inline comments |
|---|---|---|---|
| 4860021420 | `b75b165` | 2286 | 2 top-level |
| 4860032792 | `8699228` | 0 | 1 reply (`in_reply_to_id` 3717103568) |
| 4860032847 | `8699228` | 0 | 1 reply (`in_reply_to_id` 3717103574) |
| 4860059883 | `8699228` | 2812 | 0 |

Evaluated against `8699228` as the reviewing run saw it — that is, before its own record 4860059883 existed — the old `ALREADY_POSTED` returns `2026-08-05T00:32:19Z` and the old `ORPHAN_ID` returns `4860032847`. Neither is a review; following the skill literally, that review would not have been posted at all. The new guards discard both containers: at `8699228` they return `2026-08-05T00:39:33Z` and `4860059883`, the one real review at that SHA, and at `7a11332` and `cdbf065` both return empty, where no review exists yet. The zero-body `APPROVED` records on #812 (`02f8dce`) and #820 (`3a5621c`, alongside two containers) both still anchor, which is what the `APPROVED` clause is for.

Other consumers of the same records were checked and left alone: `weekly` filters on `state == "APPROVED"` (reply containers are always `COMMENTED`), and `notifications` counts recent bot reviews for dedup, where a reply container legitimately means the bot responded.

---

Closes #828 — automated triage
