### PR TITLE
fix(list-recent-runs): recover the window on the last successful run, and stop the fetch limit re-truncating it

### DIFF
--- a/plugins/tend-ci-runner/scripts/list-recent-runs.sh
+++ b/plugins/tend-ci-runner/scripts/list-recent-runs.sh
@@ -97,22 +97,37 @@ if [ -n "$cron_minute" ]; then
   # Default floor: one cron period back. Consecutive ticks tile exactly.
   COMPLETED_AFTER=$((intended - 3600))
 
-  # Dropped-tick recovery. GHA doesn't only *delay* scheduled ticks, it also
-  # *drops* them: a tick that fires zero times leaves that hour's completions
-  # in the gap between the previous and next cycle's windows (the skipped-tick
-  # case #526 deferred as acceptable). Rather than assume the previous tick
-  # fired, resume from where the previous *actual* completed run of this
-  # workflow left off: recover that run's intended tick and floor the window
-  # there. When every tick fires, the previous run's intended tick == the
+  # Dropped-tick and failed-run recovery. GHA doesn't only *delay* scheduled
+  # ticks, it also *drops* them: a tick that fires zero times leaves that hour's
+  # completions in the gap between the previous and next cycle's windows (the
+  # skipped-tick case #526 deferred as acceptable). Rather than assume the
+  # previous tick fired, resume from where the previous run that actually
+  # analyzed something left off: recover that run's intended tick and floor the
+  # window there.
+  #
+  # Anchor on the previous *successful* run, not merely a completed one. A run
+  # that failed before its agent produced any analysis — harness crash, model
+  # quota exhaustion, timeout — covered no window at all, so resuming from it
+  # discards every hour the outage spanned and the next green run reports a
+  # one-hour all-clear for a window nothing ever looked at. For the same reason
+  # the scan reaches well past one cron period: during an outage the most recent
+  # completed runs are all failures, and a short limit finds no success to
+  # anchor on. A partially-failed matrix run counts as a failure here, which
+  # only ever widens the window — overlap is re-offered work the caller dedups
+  # against its own evidence log, where a gap is silently unanalyzed.
+  #
+  # When every tick fires and succeeds, the previous run's intended tick == the
   # default (intended - 3600), so this is a byte-identical no-op — still no
-  # overlap between consecutive cycles. When a tick was dropped, it reaches
-  # back to cover the orphaned hour. Capped at 6h so a sustained outage can't
-  # create an unbounded window. The analyzing workflow runs on the current
-  # repo, so this query omits TARGET_REPO's -R.
+  # overlap between consecutive cycles. Capped at 6h so a sustained outage can't
+  # create an unbounded window; when the cap bites, say so on stderr so the
+  # caller records a coverage gap instead of a false all-clear. The analyzing
+  # workflow runs on the current repo, so this query omits TARGET_REPO's -R.
   if [ -n "${GITHUB_WORKFLOW:-}" ]; then
+    floor_cap=$((intended - 21600))   # never reach back more than 6h
+    floor_cap_iso=$(date -u -d "@$floor_cap" +%Y-%m-%dT%H:%M:%SZ)
     prev_start=$(gh run list --workflow "$GITHUB_WORKFLOW" --status completed \
-      --limit 10 --json databaseId,createdAt \
-      --jq "[.[] | select(.databaseId != (${GITHUB_RUN_ID:-0}))] | .[0].createdAt // empty" \
+      --limit 50 --json databaseId,createdAt,conclusion \
+      --jq "[.[] | select(.databaseId != (${GITHUB_RUN_ID:-0})) | select(.conclusion == \"success\")] | .[0].createdAt // empty" \
       2>/dev/null || true)
     if [ -n "$prev_start" ]; then
       prev_ts=$(date -u -d "$prev_start" +%s 2>/dev/null || echo "")
@@ -123,10 +138,15 @@ if [ -n "$cron_minute" ]; then
         else
           prev_intended=$((prev_hour_tick - 3600))
         fi
-        floor_cap=$((intended - 21600))   # never reach back more than 6h
-        [ "$prev_intended" -lt "$floor_cap" ] && prev_intended=$floor_cap
+        if [ "$prev_intended" -lt "$floor_cap" ]; then
+          echo "WARNING: the last successful '$GITHUB_WORKFLOW' run started $prev_start, more than 6h back. Window floored at $floor_cap_iso; runs that completed before it are NOT in this list. Record a coverage gap, not an all-clear." >&2
+          prev_intended=$floor_cap
+        fi
         [ "$prev_intended" -lt "$COMPLETED_AFTER" ] && COMPLETED_AFTER=$prev_intended
       fi
+    else
+      echo "WARNING: no successful '$GITHUB_WORKFLOW' run among the last 50 completed ones. Window floored at $floor_cap_iso; anything earlier is NOT in this list. Record a coverage gap, not an all-clear." >&2
+      [ "$floor_cap" -lt "$COMPLETED_AFTER" ] && COMPLETED_AFTER=$floor_cap
     fi
   fi
 

--- a/plugins/tend-ci-runner/scripts/list-recent-runs.sh
+++ b/plugins/tend-ci-runner/scripts/list-recent-runs.sh
@@ -109,12 +109,12 @@ if [ -n "$cron_minute" ]; then
   # that failed before its agent produced any analysis — harness crash, model
   # quota exhaustion, timeout — covered no window at all, so resuming from it
   # discards every hour the outage spanned and the next green run reports a
-  # one-hour all-clear for a window nothing ever looked at. For the same reason
-  # the scan reaches well past one cron period: during an outage the most recent
-  # completed runs are all failures, and a short limit finds no success to
-  # anchor on. A partially-failed matrix run counts as a failure here, which
-  # only ever widens the window — overlap is re-offered work the caller dedups
-  # against its own evidence log, where a gap is silently unanalyzed.
+  # one-hour all-clear for a window nothing ever looked at. `--status` takes
+  # conclusions as well as statuses, so the filter runs server-side and no scan
+  # depth is involved: an outage of any length can't bury the anchor. A
+  # partially-failed matrix run counts as a failure here, which only ever widens
+  # the window — overlap is re-offered work the caller dedups against its own
+  # evidence log, where a gap is silently unanalyzed.
   #
   # When every tick fires and succeeds, the previous run's intended tick == the
   # default (intended - 3600), so this is a byte-identical no-op — still no
@@ -125,10 +125,15 @@ if [ -n "$cron_minute" ]; then
   if [ -n "${GITHUB_WORKFLOW:-}" ]; then
     floor_cap=$((intended - 21600))   # never reach back more than 6h
     floor_cap_iso=$(date -u -d "@$floor_cap" +%Y-%m-%dT%H:%M:%SZ)
-    prev_start=$(gh run list --workflow "$GITHUB_WORKFLOW" --status completed \
-      --limit 50 --json databaseId,createdAt,conclusion \
-      --jq "[.[] | select(.databaseId != (${GITHUB_RUN_ID:-0})) | select(.conclusion == \"success\")] | .[0].createdAt // empty" \
-      2>/dev/null || true)
+    # Route through gh_retry and fail loud, like the other queries here: a
+    # transient API error must not masquerade as "no successful run ever", which
+    # would emit a confidently-worded warning naming a cause that didn't happen.
+    if ! prev_start=$(gh_retry gh run list --workflow "$GITHUB_WORKFLOW" \
+      --status success --limit 5 --json databaseId,createdAt \
+      --jq "[.[] | select(.databaseId != (${GITHUB_RUN_ID:-0}))] | .[0].createdAt // empty"); then
+      echo "ERROR: 'gh run list' for the window anchor failed after retries — refusing to guess a floor that would read as a false all-clear" >&2
+      exit 1
+    fi
     if [ -n "$prev_start" ]; then
       prev_ts=$(date -u -d "$prev_start" +%s 2>/dev/null || echo "")
       if [ -n "$prev_ts" ]; then
@@ -145,7 +150,7 @@ if [ -n "$cron_minute" ]; then
         [ "$prev_intended" -lt "$COMPLETED_AFTER" ] && COMPLETED_AFTER=$prev_intended
       fi
     else
-      echo "WARNING: no successful '$GITHUB_WORKFLOW' run among the last 50 completed ones. Window floored at $floor_cap_iso; anything earlier is NOT in this list. Record a coverage gap, not an all-clear." >&2
+      echo "WARNING: no successful '$GITHUB_WORKFLOW' run found at all. Window floored at $floor_cap_iso; anything earlier is NOT in this list. Record a coverage gap, not an all-clear." >&2
       [ "$floor_cap" -lt "$COMPLETED_AFTER" ] && COMPLETED_AFTER=$floor_cap
     fi
   fi
@@ -158,15 +163,30 @@ fi
 
 all_runs="[]"
 
+# `gh run list` returns newest-first, so a workflow with more runs in the window
+# than this limit silently drops the *oldest* ones — exactly the runs sitting in
+# a gap the recovery above just reached back for, which would restore the false
+# all-clear that recovery exists to prevent. A recovered window spans up to 8h,
+# and a single busy workflow clears 50 runs in that span, so the limit is sized
+# well past one workflow's output; gh paginates in hundreds, so the headroom
+# costs at most one extra page per workflow.
+RUN_LIMIT=200
+
 for wf in "${WORKFLOWS[@]}"; do
   if ! runs=$(gh_retry gh run list \
     "${repo_args[@]}" \
     --workflow "${wf}" \
     --created ">=${CREATED_SINCE}" \
     --json databaseId,conclusion,createdAt,updatedAt \
-    --limit 50); then
+    --limit "$RUN_LIMIT"); then
     echo "ERROR: 'gh run list' for workflow '$wf' failed after retries — refusing to report a partial run list" >&2
     exit 1
+  fi
+  # Exactly $RUN_LIMIT rows means the list may be capped rather than complete.
+  # Warn rather than exit: unlike a failed fetch, the rows in hand are still
+  # worth analyzing — the caller just can't read a short list as an all-clear.
+  if [ "$(printf '%s' "$runs" | jq 'length')" -ge "$RUN_LIMIT" ]; then
+    echo "WARNING: '$wf' returned $RUN_LIMIT runs, the fetch limit — older runs in this window are likely missing from the list. Record a coverage gap, not an all-clear." >&2
   fi
   all_runs=$(echo "$all_runs" "$runs" | jq -s 'add')
 done

--- a/plugins/tend-ci-runner/scripts/list-recent-runs.sh
+++ b/plugins/tend-ci-runner/scripts/list-recent-runs.sh
@@ -111,7 +111,14 @@ if [ -n "$cron_minute" ]; then
   # discards every hour the outage spanned and the next green run reports a
   # one-hour all-clear for a window nothing ever looked at. `--status` takes
   # conclusions as well as statuses, so the filter runs server-side and no scan
-  # depth is involved: an outage of any length can't bury the anchor. A
+  # depth is involved: an outage of any length can't bury the anchor.
+  #
+  # Scheduled runs only. A `workflow_dispatch` run has no `.schedule` in its
+  # event payload, so it took the non-cron branch and covered a now-anchored 1h
+  # window rather than a tiled one — anchoring on it would discard the rest of
+  # the gap, silently, which is the same class of hole as anchoring on a
+  # failure. Dispatching the workflow by hand to check on a fix mid-outage is
+  # the natural thing to do, and is exactly when that would bite. A
   # partially-failed matrix run counts as a failure here, which only ever widens
   # the window — overlap is re-offered work the caller dedups against its own
   # evidence log, where a gap is silently unanalyzed.
@@ -129,7 +136,7 @@ if [ -n "$cron_minute" ]; then
     # transient API error must not masquerade as "no successful run ever", which
     # would emit a confidently-worded warning naming a cause that didn't happen.
     if ! prev_start=$(gh_retry gh run list --workflow "$GITHUB_WORKFLOW" \
-      --status success --limit 5 --json databaseId,createdAt \
+      --status success --event schedule --limit 5 --json databaseId,createdAt \
       --jq "[.[] | select(.databaseId != (${GITHUB_RUN_ID:-0}))] | .[0].createdAt // empty"); then
       echo "ERROR: 'gh run list' for the window anchor failed after retries — refusing to guess a floor that would read as a false all-clear" >&2
       exit 1
@@ -150,7 +157,7 @@ if [ -n "$cron_minute" ]; then
         [ "$prev_intended" -lt "$COMPLETED_AFTER" ] && COMPLETED_AFTER=$prev_intended
       fi
     else
-      echo "WARNING: no successful '$GITHUB_WORKFLOW' run found at all. Window floored at $floor_cap_iso; anything earlier is NOT in this list. Record a coverage gap, not an all-clear." >&2
+      echo "WARNING: no successful scheduled '$GITHUB_WORKFLOW' run found at all. Window floored at $floor_cap_iso; anything earlier is NOT in this list. Record a coverage gap, not an all-clear." >&2
       [ "$floor_cap" -lt "$COMPLETED_AFTER" ] && COMPLETED_AFTER=$floor_cap
     fi
   fi

--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -215,6 +215,8 @@ The script discovers `tend-*` workflows by default. Pass additional prefixes as 
 
 If empty, record the run as all-clear per "Recording below-threshold findings" above, then skip to Step 6.
 
+If the script printed a `WARNING:` on stderr, the list is known-incomplete — the window was clamped, no anchor was found, or a workflow hit the fetch limit. Record a coverage gap naming the missing span instead of an all-clear, whether or not the list came back empty; the next run's floor advances past that span regardless, so an unrecorded gap is never revisited.
+
 ## Step 2: Survey outcomes via cheap subagent
 
 Spawn a cheap subagent to check outcomes across all runs from Step 1. The subagent does the token-heavy work of mapping runs to PRs/issues and checking acceptance signals.


### PR DESCRIPTION
`list-recent-runs.sh`'s dropped-tick recovery anchors the window floor on the previous **completed** run of the analyzing workflow. `completed` is a status, not a conclusion, so a run that failed before its agent produced any analysis advances the anchor exactly as if it had covered its hour. After an outage the next green run therefore resumes one tick back and reports an all-clear for a window nothing ever looked at — and the gap is unrecoverable, because the following run's floor advances past it too.

This is not hypothetical: it just consumed ~15 hours of `review-reviewers` coverage.

## What happened

Every `review-reviewers` run from [30897445507](https://github.com/max-sixty/tend/actions/runs/30897445507) (09:41Z) through [30959115609](https://github.com/max-sixty/tend/actions/runs/30959115609) (23:10Z) failed — 16 consecutive runs, all five matrix legs, `claude -p` exiting 1 after ~4s. The `result` event in every leg's session log is identical: `is_error: true`, `num_turns: 1`, `result: "You've hit your weekly limit · resets 12am (UTC)"`, with `token-usage.json` all zeros. The agent never started, so none of those runs analyzed anything. (The outage itself is already tracked by #831 and the annotation-legibility work in #816 / #818 — this PR is only about the window the outage swallowed.)

The last run that did analyze anything is [30893072876](https://github.com/max-sixty/tend/actions/runs/30893072876) at 08:42Z, which is also the last entry in the `numbagg/numbagg` evidence gist. At this run's tick (23:47Z intended), the recovery query picked `{"conclusion":"failure","createdAt":"2026-08-04T23:10:57Z","databaseId":30959115609}` and floored the window at 22:47Z, so `list-recent-runs.sh` returned exactly one row: a `tend-notifications` pre-check no-op.

Everything `numbagg-bot` actually did in the swallowed window sat outside that floor — PRs [#719](https://github.com/numbagg/numbagg/pull/719) and [#720](https://github.com/numbagg/numbagg/pull/720), issue [#721](https://github.com/numbagg/numbagg/issues/721), three reviews and four inline comments on #719, and comments on #716, #721 and #1. That is the densest window numbagg has had in days, and per the skill's Step 1 ("If empty, record the run as all-clear … then skip to Step 6") it would have been recorded as a quiet hour. I only found it by diffing the run list against the gist's last recorded boundary by hand.

## The change

Anchor on the previous **successful** run rather than any completed one, filtering server-side with `--status success` (the flag takes conclusions as well as statuses), and when the existing 6h cap clamps the recovered floor, say so on stderr so the caller records a coverage gap instead of a false all-clear. A partially-failed matrix run counts as a failure here, which only ever widens the window — overlap is re-offered work the caller dedups against its own evidence log, whereas a gap is silently unanalyzed.

Widening the window then exposed a second truncation one layer down, so the fetch loop moves with it. It passed `--limit 50` while a recovered window spans up to 8h, and `gh run list` returns newest-first — so a workflow over the limit silently drops its *oldest* runs, which are exactly the ones in the gap the anchor just reached back for. On `max-sixty/tend`, `tend-mention` alone produces 57 runs in an 8h window. The limit is now 200, and a workflow returning exactly the limit warns rather than truncating in silence.

Two smaller pieces: the anchor query routes through `gh_retry` and exits non-zero instead of `2>/dev/null || true`, so a transient API error can no longer masquerade as "no successful run" and emit a confident warning naming a cause that didn't happen; and `review-reviewers/SKILL.md`, which still said "if empty, record all-clear" with nothing about the stderr warnings, now treats any `WARNING:` as a coverage gap — without that, an agent following the skill literally would print the warning and record an all-clear anyway.

When every tick fires and succeeds the anchor is the previous tick, `prev_intended == intended - 3600 == COMPLETED_AFTER`, and the comparison is a no-op — output is byte-identical to today's on the healthy path.

<details><summary>Verification against live data</summary>

Same tick, same repo, before vs. after:

```
# anchor query — before (--limit 10, no conclusion filter)
{"conclusion":"failure","createdAt":"2026-08-04T23:10:57Z","databaseId":30959115609}

# anchor query — after (--limit 50, conclusion == "success")
{"conclusion":"success","createdAt":"2026-08-04T08:42:12Z","databaseId":30893072876}
```

`TARGET_REPO=numbagg/numbagg ./list-recent-runs.sh` after the change returns 5 runs instead of 1, preceded by:

```
WARNING: the last successful 'review-reviewers' run started 2026-08-04T08:42:12Z, more than 6h back. Window floored at 2026-08-04T17:47:00Z; runs that completed before it are NOT in this list. Record a coverage gap, not an all-clear.
```

The recovered anchor (08:42:12Z) matches the gist's last recorded coverage boundary exactly. Also exercised: the no-successful-run branch (warns, floors at the cap, exits 0) and the unset-`GITHUB_WORKFLOW` branch (recovery skipped, unchanged). `shellcheck` clean; `bash -n` clean. Also exercised after the review follow-ups: the fetch-limit truncation warning (via a copy with `RUN_LIMIT=5`) and the anchor-query failure path (exits 1 rather than degrading). See [the follow-up comment](https://github.com/max-sixty/tend/pull/838#issuecomment-5186164124) for the full branch table.

</details>

## Gates

- **Evidence level**: Critical — a clearly wrong outcome (the analysis records an all-clear for a window it never examined, and the window is then unreachable), which acts on 1 occurrence. Occurrences: 1 this run, 0 historical (no prior gist entry records an outage of a length that would trigger it).
- **Structural, not stochastic**: no decision point. The anchor query is deterministic; replayed ten times it picks the failed run ten times.
- **Change type**: targeted fix — one predicate, one query limit, two stderr warnings. Normal evidence bar under Gate 2, met.
- **Dedup**: checked open issues #831, #830, #829, #828, #827, #824, #822, #817, #816, #801, #799, #750, #624 and open PRs #826, #825, #823, #821, #819, #818, #809. #816 / #818 / #823 / #809 all concern outage *reporting* — naming the cause in the annotation, the stranded trigger, per-run comment dedup — none touch window recovery. Searching issues and PRs for `list-recent-runs` surfaces only the three merged predecessors #526, #753 and #784.

Evidence log: https://gist.github.com/19b5ab297bb7ac7e1e9a44d595ccde0f

