### PR TITLE
fix(mention): count bot engagement outside jq so --paginate can't split it

### DIFF
--- a/generator/src/tend/templates/mention.yaml.j2
+++ b/generator/src/tend/templates/mention.yaml.j2
@@ -275,8 +275,16 @@ jobs:
               if printf '%s\n' "$ISSUE_BODY" | grep -qF '@<<cfg.bot_name>>'; then
                 echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
               fi
+              # Count outside jq: `gh api --paginate` applies `--jq` once per
+              # page, so a reduction inside it (`| length`) emits one count per
+              # page rather than one overall. Past 100 comments the variable
+              # holds e.g. `100\n7`, the `-gt` below errors with `integer
+              # expression expected`, and the failed test falls through to
+              # should_run=false — the bot goes quiet on its most-engaged
+              # threads. A per-element stream paginates fine; `wc -l` does the
+              # reduction over the merged output.
               BOT_COMMENTS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments" \
-                --jq '[.[] | select(.user.login == "<<cfg.bot_name>>")] | length')
+                --jq '.[] | select(.user.login == "<<cfg.bot_name>>") | .id' | wc -l)
               if [ "$BOT_COMMENTS" -gt "0" ]; then
                 echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
               fi
@@ -294,15 +302,16 @@ jobs:
             echo "reason=participation" >> "$GITHUB_OUTPUT"; exit 0
           fi
 
+          # Counted outside jq — see the note on the issue-comment count above.
           BOT_REVIEWS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
-            --jq '[.[] | select(.user.login == "<<cfg.bot_name>>")] | length')
+            --jq '.[] | select(.user.login == "<<cfg.bot_name>>") | .id' | wc -l)
           if [ "$BOT_REVIEWS" -gt "0" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "reason=participation" >> "$GITHUB_OUTPUT"; exit 0
           fi
 
           BOT_COMMENTS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
-            --jq '[.[] | select(.user.login == "<<cfg.bot_name>>")] | length')
+            --jq '.[] | select(.user.login == "<<cfg.bot_name>>") | .id' | wc -l)
           if [ "$BOT_COMMENTS" -gt "0" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "reason=participation" >> "$GITHUB_OUTPUT"; exit 0

--- a/generator/src/tend/templates/mention.yaml.j2
+++ b/generator/src/tend/templates/mention.yaml.j2
@@ -275,15 +275,14 @@ jobs:
               if printf '%s\n' "$ISSUE_BODY" | grep -qF '@<<cfg.bot_name>>'; then
                 echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
               fi
-              # Count outside jq: `gh api --paginate` applies `--jq` once per
-              # page, so a reduction inside it (`| length`) emits one count per
-              # page rather than one overall. Past 100 comments the variable
-              # holds e.g. `100\n7`, the `-gt` below errors with `integer
-              # expression expected`, and the failed test falls through to
-              # should_run=false — the bot goes quiet on its most-engaged
-              # threads. Capture the stream and test it for emptiness — the
-              # bare substitution keeps a failing `gh api` fatal under GHA's
-              # default `bash -e`.
+              # Don't reduce inside jq: `gh api --paginate` applies `--jq` once
+              # per page, so `| length` emits one count per page rather than one
+              # overall. Past 100 comments the variable holds e.g. `100\n7`, a
+              # numeric test on it errors with `integer expression expected`,
+              # and the failed test falls through to should_run=false — the bot
+              # goes quiet on its most-engaged threads. Capture the per-element
+              # stream and test it for emptiness — the bare substitution also
+              # keeps a failing `gh api` fatal under GHA's default `bash -e`.
               BOT_COMMENTS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments" \
                 --jq '.[] | select(.user.login == "<<cfg.bot_name>>") | .id')
               if [ -n "$BOT_COMMENTS" ]; then

--- a/generator/src/tend/templates/mention.yaml.j2
+++ b/generator/src/tend/templates/mention.yaml.j2
@@ -281,11 +281,12 @@ jobs:
               # holds e.g. `100\n7`, the `-gt` below errors with `integer
               # expression expected`, and the failed test falls through to
               # should_run=false — the bot goes quiet on its most-engaged
-              # threads. A per-element stream paginates fine; `wc -l` does the
-              # reduction over the merged output.
+              # threads. Capture the stream and test it for emptiness — the
+              # bare substitution keeps a failing `gh api` fatal under GHA's
+              # default `bash -e`.
               BOT_COMMENTS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments" \
-                --jq '.[] | select(.user.login == "<<cfg.bot_name>>") | .id' | wc -l)
-              if [ "$BOT_COMMENTS" -gt "0" ]; then
+                --jq '.[] | select(.user.login == "<<cfg.bot_name>>") | .id')
+              if [ -n "$BOT_COMMENTS" ]; then
                 echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
               fi
               echo "should_run=false" >> "$GITHUB_OUTPUT"; exit 0
@@ -302,17 +303,17 @@ jobs:
             echo "reason=participation" >> "$GITHUB_OUTPUT"; exit 0
           fi
 
-          # Counted outside jq — see the note on the issue-comment count above.
+          # Captured, not counted — see the note on the issue-comment lookup above.
           BOT_REVIEWS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
-            --jq '.[] | select(.user.login == "<<cfg.bot_name>>") | .id' | wc -l)
-          if [ "$BOT_REVIEWS" -gt "0" ]; then
+            --jq '.[] | select(.user.login == "<<cfg.bot_name>>") | .id')
+          if [ -n "$BOT_REVIEWS" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "reason=participation" >> "$GITHUB_OUTPUT"; exit 0
           fi
 
           BOT_COMMENTS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
-            --jq '.[] | select(.user.login == "<<cfg.bot_name>>") | .id' | wc -l)
-          if [ "$BOT_COMMENTS" -gt "0" ]; then
+            --jq '.[] | select(.user.login == "<<cfg.bot_name>>") | .id')
+          if [ -n "$BOT_COMMENTS" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "reason=participation" >> "$GITHUB_OUTPUT"; exit 0
           fi

--- a/generator/tests/_regtest_outputs/test_generate.test_sandbox_levers_regtest.out
+++ b/generator/tests/_regtest_outputs/test_generate.test_sandbox_levers_regtest.out
@@ -261,8 +261,16 @@ jobs:
               if printf '%s\n' "$ISSUE_BODY" | grep -qF '@test-bot'; then
                 echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
               fi
+              # Count outside jq: `gh api --paginate` applies `--jq` once per
+              # page, so a reduction inside it (`| length`) emits one count per
+              # page rather than one overall. Past 100 comments the variable
+              # holds e.g. `100\n7`, the `-gt` below errors with `integer
+              # expression expected`, and the failed test falls through to
+              # should_run=false ? the bot goes quiet on its most-engaged
+              # threads. A per-element stream paginates fine; `wc -l` does the
+              # reduction over the merged output.
               BOT_COMMENTS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments" \
-                --jq '[.[] | select(.user.login == "test-bot")] | length')
+                --jq '.[] | select(.user.login == "test-bot") | .id' | wc -l)
               if [ "$BOT_COMMENTS" -gt "0" ]; then
                 echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
               fi
@@ -280,15 +288,16 @@ jobs:
             echo "reason=participation" >> "$GITHUB_OUTPUT"; exit 0
           fi
 
+          # Counted outside jq ? see the note on the issue-comment count above.
           BOT_REVIEWS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
-            --jq '[.[] | select(.user.login == "test-bot")] | length')
+            --jq '.[] | select(.user.login == "test-bot") | .id' | wc -l)
           if [ "$BOT_REVIEWS" -gt "0" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "reason=participation" >> "$GITHUB_OUTPUT"; exit 0
           fi
 
           BOT_COMMENTS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
-            --jq '[.[] | select(.user.login == "test-bot")] | length')
+            --jq '.[] | select(.user.login == "test-bot") | .id' | wc -l)
           if [ "$BOT_COMMENTS" -gt "0" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "reason=participation" >> "$GITHUB_OUTPUT"; exit 0

--- a/generator/tests/_regtest_outputs/test_generate.test_sandbox_levers_regtest.out
+++ b/generator/tests/_regtest_outputs/test_generate.test_sandbox_levers_regtest.out
@@ -261,15 +261,14 @@ jobs:
               if printf '%s\n' "$ISSUE_BODY" | grep -qF '@test-bot'; then
                 echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
               fi
-              # Count outside jq: `gh api --paginate` applies `--jq` once per
-              # page, so a reduction inside it (`| length`) emits one count per
-              # page rather than one overall. Past 100 comments the variable
-              # holds e.g. `100\n7`, the `-gt` below errors with `integer
-              # expression expected`, and the failed test falls through to
-              # should_run=false ? the bot goes quiet on its most-engaged
-              # threads. Capture the stream and test it for emptiness ? the
-              # bare substitution keeps a failing `gh api` fatal under GHA's
-              # default `bash -e`.
+              # Don't reduce inside jq: `gh api --paginate` applies `--jq` once
+              # per page, so `| length` emits one count per page rather than one
+              # overall. Past 100 comments the variable holds e.g. `100\n7`, a
+              # numeric test on it errors with `integer expression expected`,
+              # and the failed test falls through to should_run=false ? the bot
+              # goes quiet on its most-engaged threads. Capture the per-element
+              # stream and test it for emptiness ? the bare substitution also
+              # keeps a failing `gh api` fatal under GHA's default `bash -e`.
               BOT_COMMENTS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments" \
                 --jq '.[] | select(.user.login == "test-bot") | .id')
               if [ -n "$BOT_COMMENTS" ]; then

--- a/generator/tests/_regtest_outputs/test_generate.test_sandbox_levers_regtest.out
+++ b/generator/tests/_regtest_outputs/test_generate.test_sandbox_levers_regtest.out
@@ -267,11 +267,12 @@ jobs:
               # holds e.g. `100\n7`, the `-gt` below errors with `integer
               # expression expected`, and the failed test falls through to
               # should_run=false ? the bot goes quiet on its most-engaged
-              # threads. A per-element stream paginates fine; `wc -l` does the
-              # reduction over the merged output.
+              # threads. Capture the stream and test it for emptiness ? the
+              # bare substitution keeps a failing `gh api` fatal under GHA's
+              # default `bash -e`.
               BOT_COMMENTS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments" \
-                --jq '.[] | select(.user.login == "test-bot") | .id' | wc -l)
-              if [ "$BOT_COMMENTS" -gt "0" ]; then
+                --jq '.[] | select(.user.login == "test-bot") | .id')
+              if [ -n "$BOT_COMMENTS" ]; then
                 echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
               fi
               echo "should_run=false" >> "$GITHUB_OUTPUT"; exit 0
@@ -288,17 +289,17 @@ jobs:
             echo "reason=participation" >> "$GITHUB_OUTPUT"; exit 0
           fi
 
-          # Counted outside jq ? see the note on the issue-comment count above.
+          # Captured, not counted ? see the note on the issue-comment lookup above.
           BOT_REVIEWS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
-            --jq '.[] | select(.user.login == "test-bot") | .id' | wc -l)
-          if [ "$BOT_REVIEWS" -gt "0" ]; then
+            --jq '.[] | select(.user.login == "test-bot") | .id')
+          if [ -n "$BOT_REVIEWS" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "reason=participation" >> "$GITHUB_OUTPUT"; exit 0
           fi
 
           BOT_COMMENTS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
-            --jq '.[] | select(.user.login == "test-bot") | .id' | wc -l)
-          if [ "$BOT_COMMENTS" -gt "0" ]; then
+            --jq '.[] | select(.user.login == "test-bot") | .id')
+          if [ -n "$BOT_COMMENTS" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "reason=participation" >> "$GITHUB_OUTPUT"; exit 0
           fi

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
@@ -261,8 +261,16 @@ jobs:
               if printf '%s\n' "$ISSUE_BODY" | grep -qF '@test-bot'; then
                 echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
               fi
+              # Count outside jq: `gh api --paginate` applies `--jq` once per
+              # page, so a reduction inside it (`| length`) emits one count per
+              # page rather than one overall. Past 100 comments the variable
+              # holds e.g. `100\n7`, the `-gt` below errors with `integer
+              # expression expected`, and the failed test falls through to
+              # should_run=false ? the bot goes quiet on its most-engaged
+              # threads. A per-element stream paginates fine; `wc -l` does the
+              # reduction over the merged output.
               BOT_COMMENTS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments" \
-                --jq '[.[] | select(.user.login == "test-bot")] | length')
+                --jq '.[] | select(.user.login == "test-bot") | .id' | wc -l)
               if [ "$BOT_COMMENTS" -gt "0" ]; then
                 echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
               fi
@@ -280,15 +288,16 @@ jobs:
             echo "reason=participation" >> "$GITHUB_OUTPUT"; exit 0
           fi
 
+          # Counted outside jq ? see the note on the issue-comment count above.
           BOT_REVIEWS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
-            --jq '[.[] | select(.user.login == "test-bot")] | length')
+            --jq '.[] | select(.user.login == "test-bot") | .id' | wc -l)
           if [ "$BOT_REVIEWS" -gt "0" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "reason=participation" >> "$GITHUB_OUTPUT"; exit 0
           fi
 
           BOT_COMMENTS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
-            --jq '[.[] | select(.user.login == "test-bot")] | length')
+            --jq '.[] | select(.user.login == "test-bot") | .id' | wc -l)
           if [ "$BOT_COMMENTS" -gt "0" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "reason=participation" >> "$GITHUB_OUTPUT"; exit 0

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
@@ -261,15 +261,14 @@ jobs:
               if printf '%s\n' "$ISSUE_BODY" | grep -qF '@test-bot'; then
                 echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
               fi
-              # Count outside jq: `gh api --paginate` applies `--jq` once per
-              # page, so a reduction inside it (`| length`) emits one count per
-              # page rather than one overall. Past 100 comments the variable
-              # holds e.g. `100\n7`, the `-gt` below errors with `integer
-              # expression expected`, and the failed test falls through to
-              # should_run=false ? the bot goes quiet on its most-engaged
-              # threads. Capture the stream and test it for emptiness ? the
-              # bare substitution keeps a failing `gh api` fatal under GHA's
-              # default `bash -e`.
+              # Don't reduce inside jq: `gh api --paginate` applies `--jq` once
+              # per page, so `| length` emits one count per page rather than one
+              # overall. Past 100 comments the variable holds e.g. `100\n7`, a
+              # numeric test on it errors with `integer expression expected`,
+              # and the failed test falls through to should_run=false ? the bot
+              # goes quiet on its most-engaged threads. Capture the per-element
+              # stream and test it for emptiness ? the bare substitution also
+              # keeps a failing `gh api` fatal under GHA's default `bash -e`.
               BOT_COMMENTS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments" \
                 --jq '.[] | select(.user.login == "test-bot") | .id')
               if [ -n "$BOT_COMMENTS" ]; then

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
@@ -267,11 +267,12 @@ jobs:
               # holds e.g. `100\n7`, the `-gt` below errors with `integer
               # expression expected`, and the failed test falls through to
               # should_run=false ? the bot goes quiet on its most-engaged
-              # threads. A per-element stream paginates fine; `wc -l` does the
-              # reduction over the merged output.
+              # threads. Capture the stream and test it for emptiness ? the
+              # bare substitution keeps a failing `gh api` fatal under GHA's
+              # default `bash -e`.
               BOT_COMMENTS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments" \
-                --jq '.[] | select(.user.login == "test-bot") | .id' | wc -l)
-              if [ "$BOT_COMMENTS" -gt "0" ]; then
+                --jq '.[] | select(.user.login == "test-bot") | .id')
+              if [ -n "$BOT_COMMENTS" ]; then
                 echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
               fi
               echo "should_run=false" >> "$GITHUB_OUTPUT"; exit 0
@@ -288,17 +289,17 @@ jobs:
             echo "reason=participation" >> "$GITHUB_OUTPUT"; exit 0
           fi
 
-          # Counted outside jq ? see the note on the issue-comment count above.
+          # Captured, not counted ? see the note on the issue-comment lookup above.
           BOT_REVIEWS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
-            --jq '.[] | select(.user.login == "test-bot") | .id' | wc -l)
-          if [ "$BOT_REVIEWS" -gt "0" ]; then
+            --jq '.[] | select(.user.login == "test-bot") | .id')
+          if [ -n "$BOT_REVIEWS" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "reason=participation" >> "$GITHUB_OUTPUT"; exit 0
           fi
 
           BOT_COMMENTS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
-            --jq '.[] | select(.user.login == "test-bot") | .id' | wc -l)
-          if [ "$BOT_COMMENTS" -gt "0" ]; then
+            --jq '.[] | select(.user.login == "test-bot") | .id')
+          if [ -n "$BOT_COMMENTS" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "reason=participation" >> "$GITHUB_OUTPUT"; exit 0
           fi

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
@@ -261,8 +261,16 @@ jobs:
               if printf '%s\n' "$ISSUE_BODY" | grep -qF '@test-bot'; then
                 echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
               fi
+              # Count outside jq: `gh api --paginate` applies `--jq` once per
+              # page, so a reduction inside it (`| length`) emits one count per
+              # page rather than one overall. Past 100 comments the variable
+              # holds e.g. `100\n7`, the `-gt` below errors with `integer
+              # expression expected`, and the failed test falls through to
+              # should_run=false ? the bot goes quiet on its most-engaged
+              # threads. A per-element stream paginates fine; `wc -l` does the
+              # reduction over the merged output.
               BOT_COMMENTS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments" \
-                --jq '[.[] | select(.user.login == "test-bot")] | length')
+                --jq '.[] | select(.user.login == "test-bot") | .id' | wc -l)
               if [ "$BOT_COMMENTS" -gt "0" ]; then
                 echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
               fi
@@ -280,15 +288,16 @@ jobs:
             echo "reason=participation" >> "$GITHUB_OUTPUT"; exit 0
           fi
 
+          # Counted outside jq ? see the note on the issue-comment count above.
           BOT_REVIEWS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
-            --jq '[.[] | select(.user.login == "test-bot")] | length')
+            --jq '.[] | select(.user.login == "test-bot") | .id' | wc -l)
           if [ "$BOT_REVIEWS" -gt "0" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "reason=participation" >> "$GITHUB_OUTPUT"; exit 0
           fi
 
           BOT_COMMENTS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
-            --jq '[.[] | select(.user.login == "test-bot")] | length')
+            --jq '.[] | select(.user.login == "test-bot") | .id' | wc -l)
           if [ "$BOT_COMMENTS" -gt "0" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "reason=participation" >> "$GITHUB_OUTPUT"; exit 0

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
@@ -261,15 +261,14 @@ jobs:
               if printf '%s\n' "$ISSUE_BODY" | grep -qF '@test-bot'; then
                 echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
               fi
-              # Count outside jq: `gh api --paginate` applies `--jq` once per
-              # page, so a reduction inside it (`| length`) emits one count per
-              # page rather than one overall. Past 100 comments the variable
-              # holds e.g. `100\n7`, the `-gt` below errors with `integer
-              # expression expected`, and the failed test falls through to
-              # should_run=false ? the bot goes quiet on its most-engaged
-              # threads. Capture the stream and test it for emptiness ? the
-              # bare substitution keeps a failing `gh api` fatal under GHA's
-              # default `bash -e`.
+              # Don't reduce inside jq: `gh api --paginate` applies `--jq` once
+              # per page, so `| length` emits one count per page rather than one
+              # overall. Past 100 comments the variable holds e.g. `100\n7`, a
+              # numeric test on it errors with `integer expression expected`,
+              # and the failed test falls through to should_run=false ? the bot
+              # goes quiet on its most-engaged threads. Capture the per-element
+              # stream and test it for emptiness ? the bare substitution also
+              # keeps a failing `gh api` fatal under GHA's default `bash -e`.
               BOT_COMMENTS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments" \
                 --jq '.[] | select(.user.login == "test-bot") | .id')
               if [ -n "$BOT_COMMENTS" ]; then

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
@@ -267,11 +267,12 @@ jobs:
               # holds e.g. `100\n7`, the `-gt` below errors with `integer
               # expression expected`, and the failed test falls through to
               # should_run=false ? the bot goes quiet on its most-engaged
-              # threads. A per-element stream paginates fine; `wc -l` does the
-              # reduction over the merged output.
+              # threads. Capture the stream and test it for emptiness ? the
+              # bare substitution keeps a failing `gh api` fatal under GHA's
+              # default `bash -e`.
               BOT_COMMENTS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments" \
-                --jq '.[] | select(.user.login == "test-bot") | .id' | wc -l)
-              if [ "$BOT_COMMENTS" -gt "0" ]; then
+                --jq '.[] | select(.user.login == "test-bot") | .id')
+              if [ -n "$BOT_COMMENTS" ]; then
                 echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
               fi
               echo "should_run=false" >> "$GITHUB_OUTPUT"; exit 0
@@ -288,17 +289,17 @@ jobs:
             echo "reason=participation" >> "$GITHUB_OUTPUT"; exit 0
           fi
 
-          # Counted outside jq ? see the note on the issue-comment count above.
+          # Captured, not counted ? see the note on the issue-comment lookup above.
           BOT_REVIEWS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
-            --jq '.[] | select(.user.login == "test-bot") | .id' | wc -l)
-          if [ "$BOT_REVIEWS" -gt "0" ]; then
+            --jq '.[] | select(.user.login == "test-bot") | .id')
+          if [ -n "$BOT_REVIEWS" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "reason=participation" >> "$GITHUB_OUTPUT"; exit 0
           fi
 
           BOT_COMMENTS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
-            --jq '.[] | select(.user.login == "test-bot") | .id' | wc -l)
-          if [ "$BOT_COMMENTS" -gt "0" ]; then
+            --jq '.[] | select(.user.login == "test-bot") | .id')
+          if [ -n "$BOT_COMMENTS" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "reason=participation" >> "$GITHUB_OUTPUT"; exit 0
           fi

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
@@ -261,8 +261,16 @@ jobs:
               if printf '%s\n' "$ISSUE_BODY" | grep -qF '@test-bot'; then
                 echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
               fi
+              # Count outside jq: `gh api --paginate` applies `--jq` once per
+              # page, so a reduction inside it (`| length`) emits one count per
+              # page rather than one overall. Past 100 comments the variable
+              # holds e.g. `100\n7`, the `-gt` below errors with `integer
+              # expression expected`, and the failed test falls through to
+              # should_run=false ? the bot goes quiet on its most-engaged
+              # threads. A per-element stream paginates fine; `wc -l` does the
+              # reduction over the merged output.
               BOT_COMMENTS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments" \
-                --jq '[.[] | select(.user.login == "test-bot")] | length')
+                --jq '.[] | select(.user.login == "test-bot") | .id' | wc -l)
               if [ "$BOT_COMMENTS" -gt "0" ]; then
                 echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
               fi
@@ -280,15 +288,16 @@ jobs:
             echo "reason=participation" >> "$GITHUB_OUTPUT"; exit 0
           fi
 
+          # Counted outside jq ? see the note on the issue-comment count above.
           BOT_REVIEWS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
-            --jq '[.[] | select(.user.login == "test-bot")] | length')
+            --jq '.[] | select(.user.login == "test-bot") | .id' | wc -l)
           if [ "$BOT_REVIEWS" -gt "0" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "reason=participation" >> "$GITHUB_OUTPUT"; exit 0
           fi
 
           BOT_COMMENTS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
-            --jq '[.[] | select(.user.login == "test-bot")] | length')
+            --jq '.[] | select(.user.login == "test-bot") | .id' | wc -l)
           if [ "$BOT_COMMENTS" -gt "0" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "reason=participation" >> "$GITHUB_OUTPUT"; exit 0

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
@@ -261,15 +261,14 @@ jobs:
               if printf '%s\n' "$ISSUE_BODY" | grep -qF '@test-bot'; then
                 echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
               fi
-              # Count outside jq: `gh api --paginate` applies `--jq` once per
-              # page, so a reduction inside it (`| length`) emits one count per
-              # page rather than one overall. Past 100 comments the variable
-              # holds e.g. `100\n7`, the `-gt` below errors with `integer
-              # expression expected`, and the failed test falls through to
-              # should_run=false ? the bot goes quiet on its most-engaged
-              # threads. Capture the stream and test it for emptiness ? the
-              # bare substitution keeps a failing `gh api` fatal under GHA's
-              # default `bash -e`.
+              # Don't reduce inside jq: `gh api --paginate` applies `--jq` once
+              # per page, so `| length` emits one count per page rather than one
+              # overall. Past 100 comments the variable holds e.g. `100\n7`, a
+              # numeric test on it errors with `integer expression expected`,
+              # and the failed test falls through to should_run=false ? the bot
+              # goes quiet on its most-engaged threads. Capture the per-element
+              # stream and test it for emptiness ? the bare substitution also
+              # keeps a failing `gh api` fatal under GHA's default `bash -e`.
               BOT_COMMENTS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments" \
                 --jq '.[] | select(.user.login == "test-bot") | .id')
               if [ -n "$BOT_COMMENTS" ]; then

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
@@ -267,11 +267,12 @@ jobs:
               # holds e.g. `100\n7`, the `-gt` below errors with `integer
               # expression expected`, and the failed test falls through to
               # should_run=false ? the bot goes quiet on its most-engaged
-              # threads. A per-element stream paginates fine; `wc -l` does the
-              # reduction over the merged output.
+              # threads. Capture the stream and test it for emptiness ? the
+              # bare substitution keeps a failing `gh api` fatal under GHA's
+              # default `bash -e`.
               BOT_COMMENTS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments" \
-                --jq '.[] | select(.user.login == "test-bot") | .id' | wc -l)
-              if [ "$BOT_COMMENTS" -gt "0" ]; then
+                --jq '.[] | select(.user.login == "test-bot") | .id')
+              if [ -n "$BOT_COMMENTS" ]; then
                 echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
               fi
               echo "should_run=false" >> "$GITHUB_OUTPUT"; exit 0
@@ -288,17 +289,17 @@ jobs:
             echo "reason=participation" >> "$GITHUB_OUTPUT"; exit 0
           fi
 
-          # Counted outside jq ? see the note on the issue-comment count above.
+          # Captured, not counted ? see the note on the issue-comment lookup above.
           BOT_REVIEWS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
-            --jq '.[] | select(.user.login == "test-bot") | .id' | wc -l)
-          if [ "$BOT_REVIEWS" -gt "0" ]; then
+            --jq '.[] | select(.user.login == "test-bot") | .id')
+          if [ -n "$BOT_REVIEWS" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "reason=participation" >> "$GITHUB_OUTPUT"; exit 0
           fi
 
           BOT_COMMENTS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
-            --jq '.[] | select(.user.login == "test-bot") | .id' | wc -l)
-          if [ "$BOT_COMMENTS" -gt "0" ]; then
+            --jq '.[] | select(.user.login == "test-bot") | .id')
+          if [ -n "$BOT_COMMENTS" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "reason=participation" >> "$GITHUB_OUTPUT"; exit 0
           fi

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -704,6 +704,40 @@ def test_mention_verify_skips_bot_comments_without_mention(tmp_path: Path) -> No
     )
 
 
+def test_mention_verify_engagement_counts_reduce_outside_jq(tmp_path: Path) -> None:
+    """Engagement counts must not reduce inside a `--paginate`d `--jq`.
+
+    `gh api --paginate` applies `--jq` once per page, so `--jq '[...] | length'`
+    emits one count per page instead of one overall. Past 100 records the
+    variable holds `100\\n7`, the `[ "$X" -gt "0" ]` guard below it errors with
+    `integer expression expected` and returns 2, and the failed test falls
+    through to should_run=false — the bot stops answering participants on
+    exactly the threads where it has engaged the most, with nothing going red.
+    Keep the filter a per-element stream and reduce over the merged output."""
+    cfg = Config.load(_minimal_config(tmp_path))
+    workflows = {wf.filename: wf for wf in generate_all(cfg)}
+    data = yaml.safe_load(workflows["tend-mention.yaml"].content)
+    check_step = next(
+        s for s in data["jobs"]["verify"]["steps"] if s.get("id") == "check"
+    )
+    run = check_step["run"]
+
+    # Every `--jq` under `--paginate` must stay a streaming filter. `--slurp` is
+    # not an escape hatch: `gh api` rejects it alongside `--jq`. Join
+    # backslash-continued lines first — the `--jq` sits on its own line.
+    for line in run.replace("\\\n", " ").splitlines():
+        if "--paginate" not in line or "--jq" not in line:
+            continue
+        assert "| length" not in line, (
+            f"reduction inside a --paginate'd --jq runs per page: {line.strip()}"
+        )
+
+    assert run.count("| wc -l)") == 3, (
+        "the three engagement counts (issue comments, PR reviews, PR comments) "
+        "must reduce outside jq so pagination can't split the count"
+    )
+
+
 def test_mention_verify_skips_self_authored_comments(tmp_path: Path) -> None:
     """The bot's own comments must not spin up a handle session.
 

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -704,8 +704,10 @@ def test_mention_verify_skips_bot_comments_without_mention(tmp_path: Path) -> No
     )
 
 
-def test_mention_verify_engagement_counts_reduce_outside_jq(tmp_path: Path) -> None:
-    """Engagement counts must not reduce inside a `--paginate`d `--jq`.
+def test_mention_verify_engagement_lookups_survive_pagination(
+    tmp_path: Path,
+) -> None:
+    """Engagement lookups must not reduce inside a `--paginate`d `--jq`.
 
     `gh api --paginate` applies `--jq` once per page, so `--jq '[...] | length'`
     emits one count per page instead of one overall. Past 100 records the
@@ -713,7 +715,12 @@ def test_mention_verify_engagement_counts_reduce_outside_jq(tmp_path: Path) -> N
     `integer expression expected` and returns 2, and the failed test falls
     through to should_run=false — the bot stops answering participants on
     exactly the threads where it has engaged the most, with nothing going red.
-    Keep the filter a per-element stream and reduce over the merged output."""
+
+    Keep the filter a per-element stream, capture it bare, and test it for
+    emptiness. Reducing the stream through a pipe (`| wc -l`) would fix the
+    count but move the substitution's exit status off `gh`, so under the step's
+    default `bash -e` a failed API call would read as "no engagement" on a green
+    job — the same silent-quiet failure, relocated."""
     cfg = Config.load(_minimal_config(tmp_path))
     workflows = {wf.filename: wf for wf in generate_all(cfg)}
     data = yaml.safe_load(workflows["tend-mention.yaml"].content)
@@ -732,9 +739,13 @@ def test_mention_verify_engagement_counts_reduce_outside_jq(tmp_path: Path) -> N
             f"reduction inside a --paginate'd --jq runs per page: {line.strip()}"
         )
 
-    assert run.count("| wc -l)") == 3, (
-        "the three engagement counts (issue comments, PR reviews, PR comments) "
-        "must reduce outside jq so pagination can't split the count"
+    assert run.count("| .id')") == 3, (
+        "the three engagement lookups (issue comments, PR reviews, PR comments) "
+        "must capture the raw stream, so a failing `gh api` still trips errexit"
+    )
+    assert '-gt "0" ]' not in run, (
+        "guard on an empty stream (`[ -n ... ]`) — a numeric comparison is what "
+        "a split count breaks"
     )
 
 


### PR DESCRIPTION
## Problem

`tend-mention`'s verify step derives three engagement counts by reducing inside a `--paginate`d `--jq`:

```bash
BOT_REVIEWS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
  --jq '[.[] | select(.user.login == "<<cfg.bot_name>>")] | length')
```

`gh` applies `--jq` once per page, so the reduction emits one count *per page* rather than one overall. `--paginate` requests `per_page=100`, so it takes more than 100 reviews or more than 100 issue comments on a single thread to cross — past that the variable holds e.g. `100\n7`, and the guard immediately below it errors:

```
$ BOT_REVIEWS=$(printf '100\n7\n'); if [ "$BOT_REVIEWS" -gt "0" ]; then echo run; else echo "rc=$?"; fi
bash: [: 100
7: integer expression expected
rc=2
```

`test` returning 2 makes the `if` false, so the step falls through to `should_run=false`. The bot stops answering participants on exactly the threads where it has engaged the most — silently, with nothing going red. All three sites are on the engagement path that decides whether a non-mention comment gets a session at all: the issue-comment count, the PR-review count, and the PR-comment count.

These render into every adopter's `tend-mention.yaml`, not just ours.

## Solution

Keep the filter a per-element stream — which paginates fine — capture it bare, and test it for emptiness. The values are only ever compared against zero, so no count is needed:

```bash
BOT_REVIEWS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
  --jq '.[] | select(.user.login == "<<cfg.bot_name>>") | .id')
if [ -n "$BOT_REVIEWS" ]; then
```

Reducing through a pipe (`| wc -l`) would fix the count but move the substitution's exit status off `gh` and onto `wc`. The step declares no `shell:`, so it runs under GHA's default `bash -e {0}` — errexit on, pipefail off — and a failing `gh api` would then read as "no engagement" on a green job rather than aborting the step:

```
$ bash -e -c 'X=$(false | wc -l); echo "survived, X=[$X]"'
survived, X=[0]
$ bash -e -c 'X=$(false); echo survived'; echo "rc=$?"
rc=1
```

`set -o pipefail` is not a safe alternative in this step: `grep -qF` on the review-comment scan exits on first match, `gh` takes SIGPIPE, and the pipeline resolves 141 — under pipefail that `if` goes false and a first-contact mention inside an inline comment is missed. `--slurp` is not available either: `gh api` rejects it with `the --slurp option is not supported with --jq or --template`.

The fourth `--paginate` in that step — the review-comment body scan piped to `grep -qF` — is already a per-element stream and is unchanged.

## Testing

New `test_mention_verify_engagement_lookups_survive_pagination` asserts no `--paginate`d `--jq` in the verify step carries a `| length` reduction, that the three lookups capture the raw stream, and that no `-gt "0" ]` numeric comparison remains. It fails against the old template. Regtest snapshots for the mention workflow are updated; `uv run pytest` is green (328 passed).

Mechanism verified live, forcing multiple pages with `per_page=1` against this repo's PR #835 (4 bot review records):

```
$ gh api --paginate "repos/max-sixty/tend/pulls/835/reviews?per_page=1" \
    --jq '[.[] | select(.user.login == "tend-agent")] | length'
1
1
1
1
1

$ gh api --paginate "repos/max-sixty/tend/pulls/835/reviews?per_page=1" \
    --jq '.[] | select(.user.login == "tend-agent") | .id' | wc -l
5
```

The empty case is unchanged: no matching records means an empty stream, so `[ -n ... ]` is correctly false.

Only the template is touched — `.github/workflows/tend-mention.yaml` picks this up from `uvx tend@latest init` after the next release, per the generated-workflow rule in `CLAUDE.md`.

Found while reviewing #835, which fixed the same per-page-`--jq` shape in the `review` skill's `ORPHAN_ID` guard. Separate file and separate concern, so it lands separately.
