### PR TITLE
fix(running-in-ci): state the rule, not the incident, in overlay proposals

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -703,7 +703,7 @@ When the correction identifies a gap or bug in a **bundled** skill — the same 
      --jq '.[] | select([.files[].path] | index(".claude/skills/running-tend/SKILL.md"))'
    ```
    If one is open, add to it instead of opening a second.
-3. **Draft a minimal edit.** One short rule, in the maintainer's words where practical. Place it under an appropriate heading. New SKILL.md files start with YAML frontmatter:
+3. **Draft a minimal edit.** State the rule, not the incident that produced it — no verbatim quotes of the maintainer's comment, no reconstruction of the exchange. A few lines of instruction is the target; step 4's PR body is where the case history goes. Place it under an appropriate heading. New SKILL.md files start with YAML frontmatter:
    ```markdown
    ---
    name: running-tend


### PR DESCRIPTION
## Problem

`running-in-ci` → **Learning from Feedback** → *How to propose* told the bot to draft the overlay rule "in the maintainer's words where practical". Read as an instruction to quote, it produces overlay sections built around the incident rather than the rule — verbatim maintainer quotes plus a reconstruction of the exchange, with the actual instruction a sentence or two of the total. That is the opposite of the "minimal edit" the same step asks for, and it pins a maintainer's wording into a document they didn't author, which future runs then cite back at them.

The bundled skills carried no counter-guidance: nothing under `plugins/tend-ci-runner/skills/` told a run authoring an overlay to leave the case history out. Tend's own `CLAUDE.md` has it ("No specific past-case references", "Be brief"), but that governs authoring in this repo and never ships to consumers, so the consumer-facing path had only the quote instruction.

## Solution

Step 3 now states the rule instead: no verbatim quotes, no reconstruction of the exchange, a few lines of instruction. Step 4 already requires the PR body to quote the triggering feedback and link the thread, so the case history keeps a home — it just isn't the skill file. One line changed; no other step is affected.

## Testing

Prose-only change to a bundled skill; there is no test surface over skill text, and `plugins/` is outside the generator's regtest snapshots. Verified by reading the section that the replacement leaves step 4's "body quotes the triggering feedback and links the thread" requirement intact, so nothing that was captured before is dropped now.

---

Closes #841 — automated triage
