### PR TITLE
fix(mark-notification-read): tolerate a transient run-metadata fetch failure

### DIFF
--- a/generator/tests/test_shared_steps.py
+++ b/generator/tests/test_shared_steps.py
@@ -25,7 +25,7 @@ printf '%s\\n' "$*" >> "$GH_CALLS"
 case "$2" in
   repos/*/actions/runs/*)
     [ -n "${FAIL_RUN_META:-}" ] && exit 1
-    echo "$RUN_STARTED_AT"
+    echo "$FAKE_RUN_STARTED_AT"
     ;;
   notifications)
     cat "$NOTIFICATIONS_JSON"
@@ -58,7 +58,10 @@ def gh_env(tmp_path: Path) -> dict[str, str]:
         "GITHUB_EVENT_PATH": str(event),
         "GITHUB_REPOSITORY": "owner/repo",
         "GITHUB_RUN_ID": "12345",
-        "RUN_STARTED_AT": "2026-01-02T00:00:00Z",
+        # Deliberately not `RUN_STARTED_AT`: the script assigns that name, and
+        # an inherited value would let the happy-path tests pass even if the
+        # fetched timestamp were never used.
+        "FAKE_RUN_STARTED_AT": "2026-01-02T00:00:00Z",
     }
 
 

--- a/generator/tests/test_shared_steps.py
+++ b/generator/tests/test_shared_steps.py
@@ -1,0 +1,145 @@
+"""Tests for the composite actions' shared step bodies (shared/steps/*.sh).
+
+These scripts run as `bash <script>` inside both harness actions, so a
+non-zero exit fails the step and turns an otherwise-successful agent run red.
+They aren't part of the generator package; the tests live here because this is
+the repo's only Python suite, and shellcheck (pre-commit) can't catch runtime
+behaviour.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MARK_NOTIFICATION_READ = REPO_ROOT / "shared" / "steps" / "mark-notification-read.sh"
+
+# `gh api` stand-in. Records every invocation so a test can assert which calls
+# the script made, and fails the run-metadata fetch when FAIL_RUN_META is set.
+FAKE_GH = """#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$GH_CALLS"
+case "$2" in
+  repos/*/actions/runs/*)
+    [ -n "${FAIL_RUN_META:-}" ] && exit 1
+    echo "$RUN_STARTED_AT"
+    ;;
+  notifications)
+    cat "$NOTIFICATIONS_JSON"
+    ;;
+  notifications/threads/*)
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+"""
+
+
+@pytest.fixture
+def gh_env(tmp_path: Path) -> dict[str, str]:
+    """A fake `gh` on PATH plus the Actions env the script reads."""
+    bindir = tmp_path / "fakebin"
+    bindir.mkdir()
+    gh = bindir / "gh"
+    gh.write_text(FAKE_GH)
+    gh.chmod(0o755)
+
+    event = tmp_path / "event.json"
+    event.write_text(json.dumps({"issue": {"number": 7}}))
+
+    return {
+        "PATH": f"{bindir}:/usr/bin:/bin",
+        "GH_CALLS": str(tmp_path / "gh-calls.log"),
+        "GITHUB_EVENT_NAME": "issues",
+        "GITHUB_EVENT_PATH": str(event),
+        "GITHUB_REPOSITORY": "owner/repo",
+        "GITHUB_RUN_ID": "12345",
+        "RUN_STARTED_AT": "2026-01-02T00:00:00Z",
+    }
+
+
+def _run(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(MARK_NOTIFICATION_READ)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _calls(env: dict[str, str]) -> list[str]:
+    return Path(env["GH_CALLS"]).read_text().splitlines()
+
+
+def _notifications(tmp_path: Path, updated_at: str) -> str:
+    """One unread notification for issue 7 of owner/repo."""
+    path = tmp_path / "notifications.json"
+    path.write_text(
+        json.dumps(
+            [
+                {
+                    "id": "999",
+                    "updated_at": updated_at,
+                    "subject": {
+                        "url": "https://api.github.com/repos/owner/repo/issues/7"
+                    },
+                }
+            ]
+        )
+    )
+    return str(path)
+
+
+def test_mark_notification_read_tolerates_run_metadata_failure(
+    tmp_path: Path, gh_env: dict[str, str]
+) -> None:
+    """A transient failure fetching `run_started_at` must not fail the step.
+
+    The script runs under `set -e`, so an unguarded `gh api` there aborts it
+    non-zero. The step is gated on `if: success()` in both harness actions, so
+    that exit turns a fully-successful agent run into a red job. The correct
+    disposition is to skip this cycle and leave the thread unread — the
+    scheduled tend-notifications poll picks it up.
+    """
+    gh_env["NOTIFICATIONS_JSON"] = _notifications(tmp_path, "2026-01-01T00:00:00Z")
+    gh_env["FAIL_RUN_META"] = "1"
+
+    result = _run(gh_env)
+
+    assert result.returncode == 0, (
+        f"script aborted on a transient run-metadata error (exit "
+        f"{result.returncode}); stderr:\n{result.stderr}"
+    )
+    # Without the timestamp the `updated_at <= started` guard can't be
+    # evaluated, so nothing may be marked read.
+    assert not any("-X PATCH" in c for c in _calls(gh_env)), (
+        "marked a thread read without knowing when the run started"
+    )
+
+
+def test_mark_notification_read_marks_thread_predating_the_run(
+    tmp_path: Path, gh_env: dict[str, str]
+) -> None:
+    """The happy path still marks a thread whose activity predates the run."""
+    gh_env["NOTIFICATIONS_JSON"] = _notifications(tmp_path, "2026-01-01T00:00:00Z")
+
+    result = _run(gh_env)
+
+    assert result.returncode == 0, result.stderr
+    assert "api notifications/threads/999 -X PATCH" in _calls(gh_env)
+
+
+def test_mark_notification_read_leaves_activity_newer_than_the_run(
+    tmp_path: Path, gh_env: dict[str, str]
+) -> None:
+    """Activity that arrived after the run started stays unread."""
+    gh_env["NOTIFICATIONS_JSON"] = _notifications(tmp_path, "2026-03-01T00:00:00Z")
+
+    result = _run(gh_env)
+
+    assert result.returncode == 0, result.stderr
+    assert not any("-X PATCH" in c for c in _calls(gh_env))

--- a/shared/steps/mark-notification-read.sh
+++ b/shared/steps/mark-notification-read.sh
@@ -34,8 +34,16 @@ case "$GITHUB_EVENT_NAME" in
     ;;
 esac
 
-RUN_STARTED_AT=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
-  --jq '.run_started_at')
+# Same tolerance as the fetch below: the agent run already succeeded, so a
+# transient API error here must not fail the composite action. Without the
+# timestamp the `updated_at <= started` guard can't be evaluated, and marking
+# unconditionally would swallow activity that arrived mid-run — so skip this
+# cycle and leave the thread unread for the scheduled poll to pick up.
+if ! RUN_STARTED_AT=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+  --jq '.run_started_at') || [ -z "$RUN_STARTED_AT" ]; then
+  echo "::warning::Could not read run_started_at; leaving notification unread (non-fatal)"
+  exit 0
+fi
 
 # Wrap in a subshell — a transient API error (non-JSON response)
 # must not fail the composite action.


### PR DESCRIPTION
## Problem

`shared/steps/mark-notification-read.sh` runs under `set -eo pipefail`, and its `run_started_at` fetch is unguarded:

```bash
RUN_STARTED_AT=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
  --jq '.run_started_at')
```

A transient `gh api` error there aborts the script non-zero. Both harness actions gate the step on `if: success()` (`claude/action.yaml:514`, `codex/action.yaml:325`), so it only ever runs after the agent already finished its work — and its failure turns a fully-successful run into a red job.

The very next call in the same file is already wrapped for exactly this reason ("a transient API error (non-JSON response) must not fail the composite action"), so this is the one call in the script that doesn't hold the line the file sets for itself.

Reproduced with a `gh` stub that fails only on the run-metadata call: the script exits 1.

## Solution

Guard the fetch and skip the cycle when the timestamp can't be read. Skipping is the right disposition rather than marking unconditionally: without `run_started_at` the `updated_at <= started` comparison can't be evaluated, and marking anyway would swallow activity that arrived mid-run. The scheduled `tend-notifications` poll picks up anything left unread.

## Testing

New `generator/tests/test_shared_steps.py` drives the script with a fake `gh` on `PATH` — the same technique `test_notifications_precheck_tolerates_transient_non_json` already uses for the notifications pre-check. Three cases:

- run-metadata fetch fails → exit 0, and no thread is marked read
- activity predating the run → thread marked read (unchanged behaviour)
- activity newer than the run → left unread (unchanged behaviour)

The first fails on `main` (`exit 1`) and passes with the fix. Full suite: 330 passed. `shellcheck -S warning` and `ruff check`/`format` clean.

This is the first test in the repo covering `shared/steps/`; until now those scripts had only shellcheck, which can't see runtime behaviour. The module docstring notes why they live under `generator/tests/` despite not being part of the generator package.
