### PR TITLE
fix(triage): substitute the issue number into the PR-body templates

### DIFF
--- a/plugins/tend-ci-runner/skills/triage/SKILL.md
+++ b/plugins/tend-ci-runner/skills/triage/SKILL.md
@@ -124,7 +124,7 @@ Step 3's duplicate check catches identical fixes. It misses the *same root cause
    [How the fix was verified — mention the reproduction test]
 
    ---
-   Closes #<issue-number> — automated triage"
+   Closes #$ARGUMENTS — automated triage"
    ```
 4. Wait for CI per **CI Monitoring** in `/tend-ci-runner:running-in-ci`.
 
@@ -141,7 +141,7 @@ gh pr create --title "test: reproduction for #$ARGUMENTS" --body "## Context
 Adds a failing test that reproduces #$ARGUMENTS. The fix is not yet included — this PR captures the reproduction so a maintainer can investigate.
 
 ---
-Automated triage for #<issue-number>"
+Automated triage for #$ARGUMENTS"
 ```
 
 Note the PR number for the comment.


### PR DESCRIPTION
## Problem

Two `gh pr create` recipes in the triage skill mix substitution styles inside a single command. The commit message and PR title on the surrounding lines use `$ARGUMENTS`; the body ends with a hand-typed `#<issue-number>`:

```bash
git commit -m "fix: <description>

Closes #$ARGUMENTS"
git push -u origin fix/issue-$ARGUMENTS
gh pr create --title "fix: <description>" --body "## Problem
...
Closes #<issue-number> — automated triage"
```

`/tend-ci-runner:running-in-ci` names this exact shape as the one to avoid — "Never ship literal placeholders in user-visible content… a deferred substitution that never ran". These are command blocks meant to run verbatim, so a run that follows the recipe literally ships `Closes #<issue-number> — automated triage` into a public PR body, and the issue never gets linked.

## Solution

Use `$ARGUMENTS` in both bodies, matching the commit message and title in the same block. Two one-line changes.

Scoped deliberately to the two executable blocks. The `#PR_NUMBER` / `#EXISTING_ISSUE` tokens further down are inside the "Reply examples" section, which states up front that the examples "illustrate the tone… they aren't text to paste" — those are placeholders in prose the agent rewrites, not in a command it runs, so they're left alone.

## Testing

No test — the change is skill prose, and the repo has no harness that executes skill code blocks. Verified by inspection that `$ARGUMENTS` is already the substitution the surrounding lines of both blocks use.
