### PR TITLE
fix(mention): skip the synthetic reply container the bot's own inline reply creates

### DIFF
--- a/generator/src/tend/templates/mention.yaml.j2
+++ b/generator/src/tend/templates/mention.yaml.j2
@@ -256,6 +256,11 @@ jobs:
           # so a first-contact @-mention inside an inline comment is detected
           # on PRs where the bot has no prior engagement. One object per line,
           # so `--paginate` concatenates pages instead of reducing within one.
+          # Keep the `{body, in_reply_to_id}` construction: `in_reply_to_id` is
+          # an *optional* property, absent rather than null on a fresh comment,
+          # and building the object normalizes absent to null so the `== null`
+          # select below counts both shapes. A bare `.in_reply_to_id` stream
+          # would emit nothing for a fresh comment and skip every container.
           if [ "$KIND" = "pull_request_review" ]; then
             INLINE=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PAYLOAD_PR/reviews/$PAYLOAD_ID/comments" \
               --jq '.[] | {body, in_reply_to_id}')

--- a/generator/src/tend/templates/mention.yaml.j2
+++ b/generator/src/tend/templates/mention.yaml.j2
@@ -207,8 +207,8 @@ jobs:
           # comments on purpose: the pull_request_review *submission* kind is
           # deliberately left out, since a review the bot leaves on its own PR
           # is its reviewer role (the prompt is told to action it), not a
-          # self-loop. The only self-review skip is the terminal empty-body
-          # APPROVED gate below.
+          # self-loop. The only self-review skips are the terminal empty-body
+          # APPROVED gate and the synthetic reply container, both below.
           if { [ "$KIND" = "issue_comment" ] || [ "$KIND" = "pull_request_review_comment" ]; } \
              && [ "$COMMENT_AUTHOR" = "<<cfg.bot_name>>" ]; then
             echo "should_run=false" >> "$GITHUB_OUTPUT"
@@ -254,12 +254,34 @@ jobs:
           # A review's record includes review.body (checked above) but NOT the
           # bodies of the inline comments attached to the review. Fetch them
           # so a first-contact @-mention inside an inline comment is detected
-          # on PRs where the bot has no prior engagement.
+          # on PRs where the bot has no prior engagement. One object per line,
+          # so `--paginate` concatenates pages instead of reducing within one.
           if [ "$KIND" = "pull_request_review" ]; then
-            if gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PAYLOAD_PR/reviews/$PAYLOAD_ID/comments" \
-                 --jq '.[].body' | grep -qF '@<<cfg.bot_name>>'; then
+            INLINE=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PAYLOAD_PR/reviews/$PAYLOAD_ID/comments" \
+              --jq '.[] | {body, in_reply_to_id}')
+
+            if printf '%s\n' "$INLINE" | jq -r '.body' | grep -qF '@<<cfg.bot_name>>'; then
               echo "should_run=true" >> "$GITHUB_OUTPUT"
               echo "reason=mention" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            # Replying to a review thread wraps the reply in a synthetic
+            # zero-body COMMENTED review, so the bot's own inline reply arrives
+            # here as a `pull_request_review` submission as well as the
+            # `pull_request_review_comment` the skip above already drops. Same
+            # artifact, second event path: without this the engagement heuristic
+            # below sees a bot-authored PR (or BOT_REVIEWS > 0) and spins up a
+            # full handle job that the prompt's self-loop guard then exits.
+            # Narrower than the comment skip on purpose — a real review the bot
+            # submits with inline comments and no body carries actionable signal,
+            # so require that *every* inline comment be a reply
+            # (`in_reply_to_id` set). A container with any fresh inline comment
+            # still fires.
+            if [ "$REVIEW_AUTHOR" = "<<cfg.bot_name>>" ] \
+               && [ -z "$COMMENT_BODY" ] \
+               && [ "$(printf '%s\n' "$INLINE" | jq -s '[.[] | select(.in_reply_to_id == null)] | length')" = "0" ]; then
+              echo "should_run=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
           fi

--- a/generator/tests/_regtest_outputs/test_generate.test_sandbox_levers_regtest.out
+++ b/generator/tests/_regtest_outputs/test_generate.test_sandbox_levers_regtest.out
@@ -193,8 +193,8 @@ jobs:
           # comments on purpose: the pull_request_review *submission* kind is
           # deliberately left out, since a review the bot leaves on its own PR
           # is its reviewer role (the prompt is told to action it), not a
-          # self-loop. The only self-review skip is the terminal empty-body
-          # APPROVED gate below.
+          # self-loop. The only self-review skips are the terminal empty-body
+          # APPROVED gate and the synthetic reply container, both below.
           if { [ "$KIND" = "issue_comment" ] || [ "$KIND" = "pull_request_review_comment" ]; } \
              && [ "$COMMENT_AUTHOR" = "test-bot" ]; then
             echo "should_run=false" >> "$GITHUB_OUTPUT"
@@ -240,12 +240,34 @@ jobs:
           # A review's record includes review.body (checked above) but NOT the
           # bodies of the inline comments attached to the review. Fetch them
           # so a first-contact @-mention inside an inline comment is detected
-          # on PRs where the bot has no prior engagement.
+          # on PRs where the bot has no prior engagement. One object per line,
+          # so `--paginate` concatenates pages instead of reducing within one.
           if [ "$KIND" = "pull_request_review" ]; then
-            if gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PAYLOAD_PR/reviews/$PAYLOAD_ID/comments" \
-                 --jq '.[].body' | grep -qF '@test-bot'; then
+            INLINE=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PAYLOAD_PR/reviews/$PAYLOAD_ID/comments" \
+              --jq '.[] | {body, in_reply_to_id}')
+
+            if printf '%s\n' "$INLINE" | jq -r '.body' | grep -qF '@test-bot'; then
               echo "should_run=true" >> "$GITHUB_OUTPUT"
               echo "reason=mention" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            # Replying to a review thread wraps the reply in a synthetic
+            # zero-body COMMENTED review, so the bot's own inline reply arrives
+            # here as a `pull_request_review` submission as well as the
+            # `pull_request_review_comment` the skip above already drops. Same
+            # artifact, second event path: without this the engagement heuristic
+            # below sees a bot-authored PR (or BOT_REVIEWS > 0) and spins up a
+            # full handle job that the prompt's self-loop guard then exits.
+            # Narrower than the comment skip on purpose ? a real review the bot
+            # submits with inline comments and no body carries actionable signal,
+            # so require that *every* inline comment be a reply
+            # (`in_reply_to_id` set). A container with any fresh inline comment
+            # still fires.
+            if [ "$REVIEW_AUTHOR" = "test-bot" ] \
+               && [ -z "$COMMENT_BODY" ] \
+               && [ "$(printf '%s\n' "$INLINE" | jq -s '[.[] | select(.in_reply_to_id == null)] | length')" = "0" ]; then
+              echo "should_run=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
           fi

--- a/generator/tests/_regtest_outputs/test_generate.test_sandbox_levers_regtest.out
+++ b/generator/tests/_regtest_outputs/test_generate.test_sandbox_levers_regtest.out
@@ -242,6 +242,11 @@ jobs:
           # so a first-contact @-mention inside an inline comment is detected
           # on PRs where the bot has no prior engagement. One object per line,
           # so `--paginate` concatenates pages instead of reducing within one.
+          # Keep the `{body, in_reply_to_id}` construction: `in_reply_to_id` is
+          # an *optional* property, absent rather than null on a fresh comment,
+          # and building the object normalizes absent to null so the `== null`
+          # select below counts both shapes. A bare `.in_reply_to_id` stream
+          # would emit nothing for a fresh comment and skip every container.
           if [ "$KIND" = "pull_request_review" ]; then
             INLINE=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PAYLOAD_PR/reviews/$PAYLOAD_ID/comments" \
               --jq '.[] | {body, in_reply_to_id}')

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
@@ -193,8 +193,8 @@ jobs:
           # comments on purpose: the pull_request_review *submission* kind is
           # deliberately left out, since a review the bot leaves on its own PR
           # is its reviewer role (the prompt is told to action it), not a
-          # self-loop. The only self-review skip is the terminal empty-body
-          # APPROVED gate below.
+          # self-loop. The only self-review skips are the terminal empty-body
+          # APPROVED gate and the synthetic reply container, both below.
           if { [ "$KIND" = "issue_comment" ] || [ "$KIND" = "pull_request_review_comment" ]; } \
              && [ "$COMMENT_AUTHOR" = "test-bot" ]; then
             echo "should_run=false" >> "$GITHUB_OUTPUT"
@@ -240,12 +240,34 @@ jobs:
           # A review's record includes review.body (checked above) but NOT the
           # bodies of the inline comments attached to the review. Fetch them
           # so a first-contact @-mention inside an inline comment is detected
-          # on PRs where the bot has no prior engagement.
+          # on PRs where the bot has no prior engagement. One object per line,
+          # so `--paginate` concatenates pages instead of reducing within one.
           if [ "$KIND" = "pull_request_review" ]; then
-            if gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PAYLOAD_PR/reviews/$PAYLOAD_ID/comments" \
-                 --jq '.[].body' | grep -qF '@test-bot'; then
+            INLINE=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PAYLOAD_PR/reviews/$PAYLOAD_ID/comments" \
+              --jq '.[] | {body, in_reply_to_id}')
+
+            if printf '%s\n' "$INLINE" | jq -r '.body' | grep -qF '@test-bot'; then
               echo "should_run=true" >> "$GITHUB_OUTPUT"
               echo "reason=mention" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            # Replying to a review thread wraps the reply in a synthetic
+            # zero-body COMMENTED review, so the bot's own inline reply arrives
+            # here as a `pull_request_review` submission as well as the
+            # `pull_request_review_comment` the skip above already drops. Same
+            # artifact, second event path: without this the engagement heuristic
+            # below sees a bot-authored PR (or BOT_REVIEWS > 0) and spins up a
+            # full handle job that the prompt's self-loop guard then exits.
+            # Narrower than the comment skip on purpose ? a real review the bot
+            # submits with inline comments and no body carries actionable signal,
+            # so require that *every* inline comment be a reply
+            # (`in_reply_to_id` set). A container with any fresh inline comment
+            # still fires.
+            if [ "$REVIEW_AUTHOR" = "test-bot" ] \
+               && [ -z "$COMMENT_BODY" ] \
+               && [ "$(printf '%s\n' "$INLINE" | jq -s '[.[] | select(.in_reply_to_id == null)] | length')" = "0" ]; then
+              echo "should_run=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
           fi

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
@@ -242,6 +242,11 @@ jobs:
           # so a first-contact @-mention inside an inline comment is detected
           # on PRs where the bot has no prior engagement. One object per line,
           # so `--paginate` concatenates pages instead of reducing within one.
+          # Keep the `{body, in_reply_to_id}` construction: `in_reply_to_id` is
+          # an *optional* property, absent rather than null on a fresh comment,
+          # and building the object normalizes absent to null so the `== null`
+          # select below counts both shapes. A bare `.in_reply_to_id` stream
+          # would emit nothing for a fresh comment and skip every container.
           if [ "$KIND" = "pull_request_review" ]; then
             INLINE=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PAYLOAD_PR/reviews/$PAYLOAD_ID/comments" \
               --jq '.[] | {body, in_reply_to_id}')

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
@@ -193,8 +193,8 @@ jobs:
           # comments on purpose: the pull_request_review *submission* kind is
           # deliberately left out, since a review the bot leaves on its own PR
           # is its reviewer role (the prompt is told to action it), not a
-          # self-loop. The only self-review skip is the terminal empty-body
-          # APPROVED gate below.
+          # self-loop. The only self-review skips are the terminal empty-body
+          # APPROVED gate and the synthetic reply container, both below.
           if { [ "$KIND" = "issue_comment" ] || [ "$KIND" = "pull_request_review_comment" ]; } \
              && [ "$COMMENT_AUTHOR" = "test-bot" ]; then
             echo "should_run=false" >> "$GITHUB_OUTPUT"
@@ -240,12 +240,34 @@ jobs:
           # A review's record includes review.body (checked above) but NOT the
           # bodies of the inline comments attached to the review. Fetch them
           # so a first-contact @-mention inside an inline comment is detected
-          # on PRs where the bot has no prior engagement.
+          # on PRs where the bot has no prior engagement. One object per line,
+          # so `--paginate` concatenates pages instead of reducing within one.
           if [ "$KIND" = "pull_request_review" ]; then
-            if gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PAYLOAD_PR/reviews/$PAYLOAD_ID/comments" \
-                 --jq '.[].body' | grep -qF '@test-bot'; then
+            INLINE=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PAYLOAD_PR/reviews/$PAYLOAD_ID/comments" \
+              --jq '.[] | {body, in_reply_to_id}')
+
+            if printf '%s\n' "$INLINE" | jq -r '.body' | grep -qF '@test-bot'; then
               echo "should_run=true" >> "$GITHUB_OUTPUT"
               echo "reason=mention" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            # Replying to a review thread wraps the reply in a synthetic
+            # zero-body COMMENTED review, so the bot's own inline reply arrives
+            # here as a `pull_request_review` submission as well as the
+            # `pull_request_review_comment` the skip above already drops. Same
+            # artifact, second event path: without this the engagement heuristic
+            # below sees a bot-authored PR (or BOT_REVIEWS > 0) and spins up a
+            # full handle job that the prompt's self-loop guard then exits.
+            # Narrower than the comment skip on purpose ? a real review the bot
+            # submits with inline comments and no body carries actionable signal,
+            # so require that *every* inline comment be a reply
+            # (`in_reply_to_id` set). A container with any fresh inline comment
+            # still fires.
+            if [ "$REVIEW_AUTHOR" = "test-bot" ] \
+               && [ -z "$COMMENT_BODY" ] \
+               && [ "$(printf '%s\n' "$INLINE" | jq -s '[.[] | select(.in_reply_to_id == null)] | length')" = "0" ]; then
+              echo "should_run=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
           fi

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
@@ -242,6 +242,11 @@ jobs:
           # so a first-contact @-mention inside an inline comment is detected
           # on PRs where the bot has no prior engagement. One object per line,
           # so `--paginate` concatenates pages instead of reducing within one.
+          # Keep the `{body, in_reply_to_id}` construction: `in_reply_to_id` is
+          # an *optional* property, absent rather than null on a fresh comment,
+          # and building the object normalizes absent to null so the `== null`
+          # select below counts both shapes. A bare `.in_reply_to_id` stream
+          # would emit nothing for a fresh comment and skip every container.
           if [ "$KIND" = "pull_request_review" ]; then
             INLINE=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PAYLOAD_PR/reviews/$PAYLOAD_ID/comments" \
               --jq '.[] | {body, in_reply_to_id}')

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
@@ -193,8 +193,8 @@ jobs:
           # comments on purpose: the pull_request_review *submission* kind is
           # deliberately left out, since a review the bot leaves on its own PR
           # is its reviewer role (the prompt is told to action it), not a
-          # self-loop. The only self-review skip is the terminal empty-body
-          # APPROVED gate below.
+          # self-loop. The only self-review skips are the terminal empty-body
+          # APPROVED gate and the synthetic reply container, both below.
           if { [ "$KIND" = "issue_comment" ] || [ "$KIND" = "pull_request_review_comment" ]; } \
              && [ "$COMMENT_AUTHOR" = "test-bot" ]; then
             echo "should_run=false" >> "$GITHUB_OUTPUT"
@@ -240,12 +240,34 @@ jobs:
           # A review's record includes review.body (checked above) but NOT the
           # bodies of the inline comments attached to the review. Fetch them
           # so a first-contact @-mention inside an inline comment is detected
-          # on PRs where the bot has no prior engagement.
+          # on PRs where the bot has no prior engagement. One object per line,
+          # so `--paginate` concatenates pages instead of reducing within one.
           if [ "$KIND" = "pull_request_review" ]; then
-            if gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PAYLOAD_PR/reviews/$PAYLOAD_ID/comments" \
-                 --jq '.[].body' | grep -qF '@test-bot'; then
+            INLINE=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PAYLOAD_PR/reviews/$PAYLOAD_ID/comments" \
+              --jq '.[] | {body, in_reply_to_id}')
+
+            if printf '%s\n' "$INLINE" | jq -r '.body' | grep -qF '@test-bot'; then
               echo "should_run=true" >> "$GITHUB_OUTPUT"
               echo "reason=mention" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            # Replying to a review thread wraps the reply in a synthetic
+            # zero-body COMMENTED review, so the bot's own inline reply arrives
+            # here as a `pull_request_review` submission as well as the
+            # `pull_request_review_comment` the skip above already drops. Same
+            # artifact, second event path: without this the engagement heuristic
+            # below sees a bot-authored PR (or BOT_REVIEWS > 0) and spins up a
+            # full handle job that the prompt's self-loop guard then exits.
+            # Narrower than the comment skip on purpose ? a real review the bot
+            # submits with inline comments and no body carries actionable signal,
+            # so require that *every* inline comment be a reply
+            # (`in_reply_to_id` set). A container with any fresh inline comment
+            # still fires.
+            if [ "$REVIEW_AUTHOR" = "test-bot" ] \
+               && [ -z "$COMMENT_BODY" ] \
+               && [ "$(printf '%s\n' "$INLINE" | jq -s '[.[] | select(.in_reply_to_id == null)] | length')" = "0" ]; then
+              echo "should_run=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
           fi

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
@@ -242,6 +242,11 @@ jobs:
           # so a first-contact @-mention inside an inline comment is detected
           # on PRs where the bot has no prior engagement. One object per line,
           # so `--paginate` concatenates pages instead of reducing within one.
+          # Keep the `{body, in_reply_to_id}` construction: `in_reply_to_id` is
+          # an *optional* property, absent rather than null on a fresh comment,
+          # and building the object normalizes absent to null so the `== null`
+          # select below counts both shapes. A bare `.in_reply_to_id` stream
+          # would emit nothing for a fresh comment and skip every container.
           if [ "$KIND" = "pull_request_review" ]; then
             INLINE=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PAYLOAD_PR/reviews/$PAYLOAD_ID/comments" \
               --jq '.[] | {body, in_reply_to_id}')

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -902,9 +902,10 @@ def test_mention_self_comment_skip_spares_review_submissions(
     role speaking, not a self-loop — the prompt is told to action it. That
     signal arrives as a `pull_request_review` submission event, distinct from
     the `pull_request_review_comment` inline-comment event the skip covers, so
-    it must still reach the actionable path. The only self-review that is
-    skipped is the terminal empty-body APPROVED case (see
-    test_mention_skips_bot_approved_review).
+    it must still reach the actionable path. The only self-reviews that are
+    skipped are the terminal empty-body APPROVED case (see
+    test_mention_skips_bot_approved_review) and the synthetic reply container
+    (see test_mention_skips_bot_reply_container).
 
     This pins the boundary against a later "skip self-authored reviews too, for
     consistency" edit that would silently break the review -> fix loop: the
@@ -937,16 +938,80 @@ def test_mention_self_comment_skip_spares_review_submissions(
         "submission kind — a bot self-review is actionable reviewer signal"
     )
 
-    # The sole author-keyed skip for a review submission is the terminal
-    # empty-body APPROVED gate; a COMMENTED / non-empty-body bot self-review
-    # falls through to the actionable PR_AUTHOR == bot short-circuit.
-    review_skip = run[run.index('[ "$KIND" = "pull_request_review" ]') :]
-    assert '[ "$REVIEW_STATE" = "approved" ]' in review_skip
-    assert '[ -z "$COMMENT_BODY" ]' in review_skip
+    # Two author-keyed skips exist for a review submission — the terminal
+    # empty-body APPROVED gate here, and the reply-container gate pinned by
+    # test_mention_skips_bot_reply_container. Slice to the APPROVED one alone
+    # (it ends at the INLINE fetch the container gate reuses), so this assertion
+    # keeps discriminating rather than passing on either. A COMMENTED /
+    # non-empty-body bot self-review that is not one of those two falls through
+    # to the actionable PR_AUTHOR == bot short-circuit.
+    approved_skip = run[
+        run.index('[ "$KIND" = "pull_request_review" ]') : run.index("INLINE=$(")
+    ]
+    assert '[ "$REVIEW_STATE" = "approved" ]' in approved_skip
+    assert '[ -z "$COMMENT_BODY" ]' in approved_skip
     assert '[ "$PR_AUTHOR" = "test-bot" ]' in run, (
         "a bot self-review that isn't the terminal empty approval must reach "
         "the actionable PR_AUTHOR == bot short-circuit"
     )
+
+
+def test_mention_skips_bot_reply_container(tmp_path: Path) -> None:
+    """Replying to a review thread wraps the reply in a synthetic zero-body
+    COMMENTED review, so the bot's own inline reply reaches verify a second
+    time as a `pull_request_review` submission — the kind the self-authored
+    comment skip deliberately spares. That container is the same comment on a
+    second event path, not a review, so the gate must drop it before the
+    engagement heuristic counts it (BOT_REVIEWS > 0) or short-circuits on the
+    bot-authored PR and spins up a handle job the prompt's self-loop guard
+    then exits with nothing posted.
+
+    The gate is narrower than the comment skip on purpose, and the narrowing is
+    load-bearing in both directions:
+
+    - `REVIEW_AUTHOR` — `pull_request_review_comment` subscribes to `edited`
+      only, so the container is the *sole* path by which a human's freshly
+      created inline reply reaches the bot. Widening this gate to be
+      authorship-agnostic silences the bot on every human reply to its own
+      review threads, with no test failing and no red run to notice.
+    - every inline comment being a reply — an empty-body bot review that owns a
+      *fresh* inline comment still carries actionable signal, so it must fire.
+    """
+    cfg = Config.load(_minimal_config(tmp_path))
+    wf = generate_mention(cfg)
+    data = yaml.safe_load(wf.content)
+    check_step = next(
+        s for s in data["jobs"]["verify"]["steps"] if s.get("id") == "check"
+    )
+    run = check_step["run"]
+
+    # `in_reply_to_id` is an *optional* property on the review-comments
+    # endpoint: it is absent, not null, on a fresh comment. Constructing
+    # `{body, in_reply_to_id}` is what normalizes absent to null so the
+    # `== null` select catches both shapes — a bare `.in_reply_to_id` stream
+    # would drop fresh comments from the count entirely and skip every
+    # container. It also keeps one object per line, so `--paginate`, which
+    # applies `--jq` once per page, concatenates rather than reducing within a
+    # page (#839).
+    assert "--jq '.[] | {body, in_reply_to_id}'" in run
+
+    count = "jq -s '[.[] | select(.in_reply_to_id == null)] | length'"
+    assert count in run, "the skip must key on there being no *fresh* comment"
+
+    # Author and an empty review body are both required, so a human's reply
+    # container and a bot container carrying a body each still fire.
+    reply_gate = run[run.index("INLINE=$(") :]
+    assert '[ "$REVIEW_AUTHOR" = "test-bot" ]' in reply_gate
+    assert '[ -z "$COMMENT_BODY" ]' in reply_gate
+
+    # The @-mention scan over the inline bodies runs first, so a mention the
+    # bot quotes inside a reply still summons it.
+    inline_scan = "printf '%s\\n' \"$INLINE\" | jq -r '.body' | grep -qF '@test-bot'"
+    assert run.index(inline_scan) < run.index(count)
+
+    # And the skip precedes the engagement heuristic that would otherwise count
+    # this very container as prior participation.
+    assert run.index(count) < run.index("BOT_REVIEWS=$(")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`tend-mention`'s verify gate skips the bot's own comments — `issue_comment` and `pull_request_review_comment` where the comment author is the bot — because the bot never needs to respond to itself. The `pull_request_review` submission kind is deliberately left out of that skip, since a review the bot leaves on its own PR is its reviewer role.

But replying to a review thread (`POST /pulls/{n}/comments/{id}/replies`) wraps the reply in a **synthetic zero-body `COMMENTED` review** — the same artifact #828 documents. So the bot's own inline reply arrives twice: once as the `pull_request_review_comment` the skip already drops, and once as a `pull_request_review` submission it doesn't. The container isn't a review; it's the same comment on a second event path.

Nothing downstream catches it. The empty-body gate one block up requires `REVIEW_STATE = approved`, and a reply container is `commented`. The inline `@`-mention scan finds nothing (the bot doesn't summon itself). The engagement heuristic then sees a bot-authored PR — or `BOT_REVIEWS > 0` from the container itself — and returns `should_run=true, reason=participation`, spinning up a full `handle` job that the prompt's self-loop guard exits with nothing posted.

## Evidence

Three occurrences on `PRQL/prql`, recorded across two windows in the [evidence gist](https://gist.github.com/192514ea2c36586f9b7f842a482d62ab), all on bot-authored PRs where the bot answered its own review threads inline:

| Dispatched handle | PR | Cost |
| --- | --- | --- |
| [30894437460](https://github.com/PRQL/prql/actions/runs/30894437460) | #6141 | agent ran 9 m 16 s, posted nothing |
| [30894732823](https://github.com/PRQL/prql/actions/runs/30894732823) | #6141 | agent ran 7 m 35 s, posted nothing |
| [30991732962](https://github.com/PRQL/prql/actions/runs/30991732962) | [#6144](https://github.com/PRQL/prql/pull/6144) | queued 20 m, then cancelled |

The third is this run's window. Its container ([review 4862824760](https://github.com/PRQL/prql/pull/6144#pullrequestreview-4862824760)) has `body: ""`, `state: COMMENTED`, and exactly one inline comment — a reply:

```
$ gh api repos/PRQL/prql/pulls/6144/reviews/4862824760/comments \
    --jq '.[] | {id, in_reply_to_id, user: .user.login}'
{"id":3719317911,"in_reply_to_id":3719296566,"user":"prql-bot"}
```

Its `handle` job sat pending behind a live sibling for 20 minutes and was then evicted by GHA's queue-depth-1 replacement when a real dispatch arrived. That is the harm beyond wasted agent minutes: a container carrying no work occupies the one queue slot `cancel-in-progress: false` leaves, and the next event has to displace it.

## Fix

Reuse the inline-comment fetch the gate already makes, and skip when the review is bot-authored, has an empty body, and **every** inline comment is a reply:

```
if [ "$REVIEW_AUTHOR" = "<<cfg.bot_name>>" ] \
   && [ -z "$COMMENT_BODY" ] \
   && [ "$(printf '%s\n' "$INLINE" | jq -s '[.[] | select(.in_reply_to_id == null)] | length')" = "0" ]; then
  echo "should_run=false" >> "$GITHUB_OUTPUT"
  exit 0
fi
```

Deliberately narrower than the own-comment skip. The reason the `pull_request_review` path was left unguarded still holds — a real review the bot submits with inline comments and no body carries actionable signal — so the guard requires that no inline comment be a *fresh* one. Any container with a single non-reply comment still fires, and the `@`-mention scan runs first, so a mention inside a reply still wins.

The fetch changes from a piped `--jq '.[].body'` to a variable holding `{body, in_reply_to_id}` objects, one per line, so `--paginate` concatenates pages rather than reducing within each — the hazard #839 describes. The object form is load-bearing for a second reason: `in_reply_to_id` is an *optional* property, absent rather than null on a fresh comment, and constructing the object normalizes absent to null so `select(.in_reply_to_id == null)` counts fresh comments at all. A bare `.in_reply_to_id` stream emits nothing for them, and the gate would skip every container — including the real bot reviews it is written to spare.

A structural test (`test_mention_skips_bot_reply_container`) pins the four shapes above plus the three properties the regtest snapshots don't hold: the skip landing before the engagement heuristic, the inline `@`-mention scan running first, and the `REVIEW_AUTHOR` conjunction. That last is the load-bearing half — `pull_request_review_comment` subscribes to `edited` only, so this container is the sole path by which a human's freshly created inline reply reaches the bot, and an authorship-agnostic gate would silence the bot on every human reply to its own review threads with no test failing.

Verified the discriminator against the shapes it has to separate:

| Inline comments | non-reply count | Result |
| --- | --- | --- |
| one reply | 0 | skip |
| one fresh comment | 1 | fires |
| one reply + one fresh | 1 | fires |
| none | 0 | skip |

## Gate assessment

- **Evidence level**: High — 3 occurrences across two PRs and two windows, deterministic in each.
- **Structural**: yes. The event shape always passes the existing gate; there is no decision point where the bot could have behaved differently.
- **Change type**: targeted fix — one condition added beside the adjacent empty-body-APPROVED guard, no new mechanism.
- **Both gates pass** (High needs 2–3; a targeted fix carries the normal bar).

Distinct from #835, which fixes the same underlying artifact in the `review` skill's three review-record guards. That PR does not touch `mention.yaml.j2`; this is the second surface the container reaches.

`generator/` tests pass (327), with the four `mention` regtest snapshots regenerated. `bash -n` clean on every rendered `run:` step.

