### PR TITLE
workflows: name the environment with `deployment: false`

### DIFF
--- a/.github/workflows/integration-secrets.yaml
+++ b/.github/workflows/integration-secrets.yaml
@@ -27,7 +27,9 @@ jobs:
     runs-on: ubuntu-24.04
     # The source secrets live in this repo's `tend` environment; a manual
     # dispatch runs on the default branch, which its policy admits.
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     steps:
       - name: Reseed tend-agent/tend-integration secrets
         # The bot PAT plays both roles: it authenticates the `gh secret
@@ -79,11 +81,14 @@ jobs:
           # they name the environment only a release after the generator
           # does. Delete the copies once they do; until then the fixture
           # would be left with secrets none of its jobs could read.
+          # The environment block the generator emits is three lines, of which
+          # `name:` at six columns appears nowhere else in the file: job keys
+          # sit at four, and a step's is `- name:`.
           if gh api repos/tend-agent/tend-integration/contents/.github/workflows/tend-review.yaml \
-               -H "Accept: application/vnd.github.raw" | grep -q 'environment: tend'; then
+               -H "Accept: application/vnd.github.raw" | grep -qx '      name: tend'; then
             for s in TEND_BOT_TOKEN CLAUDE_CODE_OAUTH_TOKEN; do
               gh secret delete "$s" --repo tend-agent/tend-integration 2>/dev/null || true
             done
           else
-            echo "Fixture workflows predate the environment gate; keeping repo-level copies until the next regeneration."
+            echo "Fixture workflows predate the current environment block; keeping repo-level copies until the next regeneration."
           fi

--- a/.github/workflows/review-reviewers.yaml
+++ b/.github/workflows/review-reviewers.yaml
@@ -19,7 +19,9 @@ jobs:
   # issues (one per matrix leg that lost the find-or-create race).
   init-tracking:
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       issues: write
     steps:
@@ -56,7 +58,9 @@ jobs:
           - max-sixty/worktrunk
           - numbagg/numbagg
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       contents: write
       pull-requests: write

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     hooks:
       - id: typos
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.10
+    rev: v1.7.12
     hooks:
       - id: actionlint
   # The composite actions' shared step bodies live in standalone scripts

--- a/TODO.md
+++ b/TODO.md
@@ -23,7 +23,8 @@ generated workflow names it. What remains:
    differ.
 
    Jobs running at `refs/heads/main` are admitted by the policy as it stands,
-   so `environment: tend` is the whole change: worktrunk's benchmark gist
+   so adding `environment: {name: tend, deployment: false}` is the whole
+   change: worktrunk's benchmark gist
    append and its two create-issue-on-failure jobs, prql's
    `update-rust-toolchain` (all four `schedule`-only, and already `if`-gated
    to it) and prql's backport. A `pull_request_target` run reports

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -115,8 +115,12 @@ secret value back through the API, and expiring with the job.
 *Operational secrets* — the bot PAT and the harness auth — live in the
 `tend` environment, whose policy names the default branch and any
 `protected_branches`. Every generated job that reads a secret carries
-`environment: tend`; jobs that hold none (mention's relay, below) must not,
-since naming it would cost them the refs the policy excludes. This closes
+`environment: {name: tend, deployment: false}`; jobs that hold none
+(mention's relay, below) must not, since naming it would cost them the refs
+the policy excludes. `deployment: false` keeps GitHub from filing a
+deployment record for a job that deploys nothing — under
+`pull_request_target` those land on the pull request itself, one line per
+push — and leaves the policy check untouched. This closes
 the classic no-merge exfiltration: a write-scoped actor (a leaked PAT, or a
 hijacked session that can push a branch) commits a workflow that prints the
 secrets and reads them from its own run. Branch protection never touched

--- a/generator/src/tend/templates/ci-fix.yaml.j2
+++ b/generator/src/tend/templates/ci-fix.yaml.j2
@@ -15,7 +15,7 @@ jobs:
   fix-ci:
     if: <<fork_guard_prefix(cfg)>>github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-24.04
-    environment: <<tend_environment>>
+<<environment()>>
     permissions:
 <<permissions(issues=False)>>
     steps:

--- a/generator/src/tend/templates/macros.yaml.j2
+++ b/generator/src/tend/templates/macros.yaml.j2
@@ -59,6 +59,26 @@
           <<prompt_body>>
 {%- endmacro %}
 
+{# Environment block at column 4. The environment is a secret scope, not a
+   deploy target: its branch policy is what stops a workflow pushed to a
+   feature branch reading the operational secrets (see TEND_ENVIRONMENT in
+   workflows.py). GitHub does not separate the two, so a job naming one also
+   gets a deployment record, filed against whatever the run belongs to — under
+   `pull_request_target` that is the PR's own head, so every push to every PR
+   grew a "<bot> deployed to tend" line in its timeline.
+
+   `deployment: false` drops the record and keeps the gate. Checked against
+   live GitHub rather than assumed, because dropping the record could as
+   easily have dropped the check that files it: with the property set, a job
+   on an admitted ref still receives the environment's secrets, and one on an
+   excluded ref is still refused before its first step with `Branch "x" is not
+   allowed to deploy to <env> due to environment protection rules`. #}
+{% macro environment() %}
+    environment:
+      name: <<tend_environment>>
+      deployment: false
+{%- endmacro %}
+
 {# Permissions block at column 6. `issues` defaults to True because every
    workflow except ci-fix needs it. The trailing inline conditional avoids
    the trim_blocks-eats-the-separator issue between `actions: read` and

--- a/generator/src/tend/templates/mention.yaml.j2
+++ b/generator/src/tend/templates/mention.yaml.j2
@@ -119,7 +119,7 @@ jobs:
       (github.event_name == 'issue_comment' &&
         !contains(github.event.issue.labels.*.name, 'tend-outage'))
     runs-on: ubuntu-24.04
-    environment: <<tend_environment>>
+<<environment()>>
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
       reason: ${{ steps.check.outputs.reason }}
@@ -348,7 +348,7 @@ jobs:
       group: ${{ github.workflow }}-handle-${{ github.event.issue.number || github.event.client_payload.pr }}
       cancel-in-progress: false
     runs-on: ubuntu-24.04
-    environment: <<tend_environment>>
+<<environment()>>
     permissions:
 <<permissions()>>
     steps:

--- a/generator/src/tend/templates/notifications.yaml.j2
+++ b/generator/src/tend/templates/notifications.yaml.j2
@@ -8,7 +8,7 @@ on:
 jobs:
   notifications:
 <<fork_guard_if(cfg)>>    runs-on: ubuntu-24.04
-    environment: <<tend_environment>>
+<<environment()>>
     permissions:
 <<permissions()>>
     steps:

--- a/generator/src/tend/templates/review.yaml.j2
+++ b/generator/src/tend/templates/review.yaml.j2
@@ -17,7 +17,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     runs-on: ubuntu-24.04
-    environment: <<tend_environment>>
+<<environment()>>
     permissions:
 <<permissions()>>
     steps:

--- a/generator/src/tend/templates/scheduled.yaml.j2
+++ b/generator/src/tend/templates/scheduled.yaml.j2
@@ -8,7 +8,7 @@ on:
 jobs:
   <<name>>:
 <<fork_guard_if(cfg)>>    runs-on: ubuntu-24.04
-    environment: <<tend_environment>>
+<<environment()>>
     permissions:
 <<permissions()>>
     steps:

--- a/generator/src/tend/templates/triage.yaml.j2
+++ b/generator/src/tend/templates/triage.yaml.j2
@@ -12,7 +12,7 @@ jobs:
   triage:
     if: <<fork_guard_prefix(cfg)>>contains(github.event.issue.labels.*.name, 'tend-outage') == false
     runs-on: ubuntu-24.04
-    environment: <<tend_environment>>
+<<environment()>>
     permissions:
 <<permissions()>>
     steps:

--- a/generator/tests/_regtest_outputs/test_generate.test_extras_apply_path_regtest.out
+++ b/generator/tests/_regtest_outputs/test_generate.test_extras_apply_path_regtest.out
@@ -17,7 +17,9 @@ jobs:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-ci-fix.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-ci-fix.yaml].out
@@ -17,7 +17,9 @@ jobs:
   fix-ci:
     if: github.repository_owner == 'test-owner' && github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-nightly.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-nightly.yaml].out
@@ -16,7 +16,9 @@ jobs:
   nightly:
     if: github.repository_owner == 'test-owner'
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
@@ -16,7 +16,9 @@ jobs:
   notifications:
     if: github.repository_owner == 'test-owner'
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-review-runs.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-review-runs.yaml].out
@@ -16,7 +16,9 @@ jobs:
   review-runs:
     if: github.repository_owner == 'test-owner'
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-triage.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-triage.yaml].out
@@ -19,7 +19,9 @@ jobs:
   triage:
     if: github.repository_owner == 'test-owner' && contains(github.event.issue.labels.*.name, 'tend-outage') == false
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-weekly.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-weekly.yaml].out
@@ -16,7 +16,9 @@ jobs:
   weekly:
     if: github.repository_owner == 'test-owner'
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_sandbox_levers_regtest.out
+++ b/generator/tests/_regtest_outputs/test_generate.test_sandbox_levers_regtest.out
@@ -105,7 +105,9 @@ jobs:
       (github.event_name == 'issue_comment' &&
         !contains(github.event.issue.labels.*.name, 'tend-outage'))
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
       reason: ${{ steps.check.outputs.reason }}
@@ -334,7 +336,9 @@ jobs:
       group: ${{ github.workflow }}-handle-${{ github.event.issue.number || github.event.client_payload.pr }}
       cancel-in-progress: false
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[ci-fix].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[ci-fix].out
@@ -17,7 +17,9 @@ jobs:
   fix-ci:
     if: github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
@@ -105,7 +105,9 @@ jobs:
       (github.event_name == 'issue_comment' &&
         !contains(github.event.issue.labels.*.name, 'tend-outage'))
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
       reason: ${{ steps.check.outputs.reason }}
@@ -334,7 +336,9 @@ jobs:
       group: ${{ github.workflow }}-handle-${{ github.event.issue.number || github.event.client_payload.pr }}
       cancel-in-progress: false
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[nightly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[nightly].out
@@ -15,7 +15,9 @@ on:
 jobs:
   nightly:
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[notifications].out
@@ -15,7 +15,9 @@ on:
 jobs:
   notifications:
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[review-runs].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[review-runs].out
@@ -15,7 +15,9 @@ on:
 jobs:
   review-runs:
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[review].out
@@ -17,7 +17,9 @@ jobs:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[triage].out
@@ -19,7 +19,9 @@ jobs:
   triage:
     if: contains(github.event.issue.labels.*.name, 'tend-outage') == false
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[weekly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[weekly].out
@@ -15,7 +15,9 @@ on:
 jobs:
   weekly:
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[ci-fix].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[ci-fix].out
@@ -17,7 +17,9 @@ jobs:
   fix-ci:
     if: github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
@@ -105,7 +105,9 @@ jobs:
       (github.event_name == 'issue_comment' &&
         !contains(github.event.issue.labels.*.name, 'tend-outage'))
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
       reason: ${{ steps.check.outputs.reason }}
@@ -334,7 +336,9 @@ jobs:
       group: ${{ github.workflow }}-handle-${{ github.event.issue.number || github.event.client_payload.pr }}
       cancel-in-progress: false
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[nightly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[nightly].out
@@ -15,7 +15,9 @@ on:
 jobs:
   nightly:
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
@@ -15,7 +15,9 @@ on:
 jobs:
   notifications:
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review-runs].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review-runs].out
@@ -15,7 +15,9 @@ on:
 jobs:
   review-runs:
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review].out
@@ -17,7 +17,9 @@ jobs:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[triage].out
@@ -19,7 +19,9 @@ jobs:
   triage:
     if: contains(github.event.issue.labels.*.name, 'tend-outage') == false
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[weekly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[weekly].out
@@ -15,7 +15,9 @@ on:
 jobs:
   weekly:
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[ci-fix].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[ci-fix].out
@@ -17,7 +17,9 @@ jobs:
   fix-ci:
     if: github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
@@ -105,7 +105,9 @@ jobs:
       (github.event_name == 'issue_comment' &&
         !contains(github.event.issue.labels.*.name, 'tend-outage'))
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
       reason: ${{ steps.check.outputs.reason }}
@@ -334,7 +336,9 @@ jobs:
       group: ${{ github.workflow }}-handle-${{ github.event.issue.number || github.event.client_payload.pr }}
       cancel-in-progress: false
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[nightly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[nightly].out
@@ -15,7 +15,9 @@ on:
 jobs:
   nightly:
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
@@ -15,7 +15,9 @@ on:
 jobs:
   notifications:
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review-runs].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review-runs].out
@@ -15,7 +15,9 @@ on:
 jobs:
   review-runs:
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review].out
@@ -17,7 +17,9 @@ jobs:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[triage].out
@@ -19,7 +19,9 @@ jobs:
   triage:
     if: contains(github.event.issue.labels.*.name, 'tend-outage') == false
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[weekly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[weekly].out
@@ -15,7 +15,9 @@ on:
 jobs:
   weekly:
     runs-on: ubuntu-24.04
-    environment: tend
+    environment:
+      name: tend
+      deployment: false
     permissions:
       contents: write
       pull-requests: write

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -347,13 +347,20 @@ def test_operational_secrets_imply_environment(tmp_path: Path) -> None:
                 for s in _strings(job)
                 for ref in re.findall(r"secrets\.[A-Za-z0-9_]+", s)
             )
-            assert (job.get("environment") == "tend") == reads_secret, (
-                f"{wf.filename}:{job_name} "
-                + (
-                    "reads an operational secret without naming the environment"
-                    if reads_secret
-                    else "names the environment but holds no secret"
-                )
+            # `deployment: false` is part of the asserted shape, not just the
+            # name: dropping it leaves the gate working and costs only a
+            # deployment record per run, which GitHub posts as a "<bot>
+            # deployed to tend" line on every PR the run belongs to. Nothing
+            # else would fail, so this is where it gets caught.
+            names_environment = job.get("environment") == {
+                "name": "tend",
+                "deployment": False,
+            }
+            assert names_environment == reads_secret, f"{wf.filename}:{job_name} " + (
+                "reads an operational secret without naming the environment "
+                "as `{name: tend, deployment: false}`"
+                if reads_secret
+                else "names the environment but holds no secret"
             )
 
 


### PR DESCRIPTION
GitHub files a deployment record for every job that names an environment, and files it against whatever the run belongs to. Under `pull_request_target` that is the PR's own head, so since 0.1.13 put `environment: tend` on the generated workflows, every push to every PR in an adopter repo grows a "<bot> deployed to tend" line in its timeline. worktrunk collected 74 records on the first day, four of them on a single PR.

The environment is a secret scope, not a deploy target. `deployment: false` says so: GitHub files no record, and the branch policy still gates the job.

That last clause is the one worth doubting, since dropping the record could as easily have dropped the check that files it, so it was probed against live GitHub rather than read off the docs.

<details>
<summary>Probe: same environment, same main-only policy, with and without the property</summary>

A `gated` environment holding `PROBE_SECRET`, branch policy admitting only `main`, and two jobs differing solely in the property.

| | secret on an admitted ref | excluded ref | deployment record |
|---|---|---|---|
| `environment: gated` | yes | refused | filed |
| `environment: {name: gated, deployment: false}` | yes | refused | none |

On `main` the `deployment: false` job reported `GITHUB_REF=refs/heads/main` and `HAS_SECRET=yes len=24`. On a feature branch it failed with zero steps executed:

```
Branch "nodeploy-branch" is not allowed to deploy to gated due to environment protection rules.
```

The control job without the property failed identically and filed a record; the `deployment: false` job filed none, on either ref.

</details>

The block moves into an `environment()` macro so the seven call sites cannot drift apart, and `test_operational_secrets_imply_environment` asserts the whole block rather than just the name — dropping `deployment: false` leaves the gate working and costs only PR noise, so nothing else would catch it.

actionlint learned the key in v1.7.12, so the pre-commit pin moves up from v1.7.10. An adopter pinning an older actionlint will flag their regenerated workflows until they bump; worktrunk runs no actionlint and prql is already on v1.7.12.

This repo's own generated `tend-*.yaml` still carry the string form. They regenerate from the published tend after the next release, as usual — which is also when the fix reaches adopters.

> _This was written by Claude Code on behalf of max-sixty_
