### PR TITLE
check: refuse a job that names the environment and files a deployment

### DIFF
--- a/generator/src/tend/checks.py
+++ b/generator/src/tend/checks.py
@@ -563,6 +563,60 @@ def check_environment(repo: str, admitted: list[str]) -> CheckResult:
     )
 
 
+def check_environment_deployments(repo: str) -> CheckResult:
+    """No job files a GitHub deployment for the operational-secret environment.
+
+    The environment is a secret scope rather than a deploy target, but GitHub
+    files a deployment for every job that names one, against whatever the run
+    belongs to — under `pull_request_target` that is the pull request itself,
+    so a single omission puts a "<bot> deployed to <env>" line on every push
+    to every PR. `deployment: false` is the only lever: the environment object
+    takes `wait_timer`, `prevent_self_review`, `reviewers` and
+    `deployment_branch_policy`, and nothing there suppresses the record.
+
+    Generated workflows take the block from one macro that a generator test
+    pins, so this is the same invariant for the workflows tend did not write —
+    a repo's own hand-maintained jobs, where the omission is invisible to
+    whoever makes it. The gate still holds and the secrets still arrive; the
+    only symptom is noise in someone else's timeline, which is why nothing
+    else catches it.
+    """
+    name = "environment-deployments"
+
+    files = _fetch_workflow_files(repo)
+    if files is None:
+        return CheckResult(
+            name, None, ".github/workflows could not be read from the default branch"
+        )
+    offenders = [
+        f"{path} job '{job_id}'"
+        for path, text in sorted(files.items())
+        if text is not None
+        for job_id in sorted(_parse_workflow(path, text).filed_deployments)
+    ]
+    if offenders:
+        return CheckResult(
+            name,
+            False,
+            f"Jobs name the '{TEND_ENVIRONMENT}' environment without "
+            f"`deployment: false`, so GitHub files a deployment record for "
+            f"every run and posts it on the pull request: {', '.join(offenders)}. "
+            "Add `deployment: false` beside the environment's `name:` — a "
+            "generated `tend-*.yaml` takes it from `uvx tend@latest init` "
+            "instead of a hand edit.",
+        )
+    unread = sorted(path for path, text in files.items() if text is None)
+    if unread:
+        return CheckResult(
+            name, None, f"Workflows could not be read: {', '.join(unread)}"
+        )
+    return CheckResult(
+        name,
+        True,
+        f"No job files a deployment for the '{TEND_ENVIRONMENT}' environment",
+    )
+
+
 _WORKFLOWS_QUERY = """
 query($owner: String!, $name: String!) {
   repository(owner: $owner, name: $name) {
@@ -631,6 +685,7 @@ class _WorkflowFacts:
     environments: frozenset[str]  # environments its jobs deploy to
     oidc_environments: frozenset[str]  # …of those, ones a job mints OIDC in
     oidc_without_environment: frozenset[str]  # job ids minting OIDC ungated
+    filed_deployments: frozenset[str]  # job ids naming tend that file a record
     unresolved: tuple[str, ...]
 
 
@@ -656,11 +711,11 @@ def _parse_workflow(path: str, text: str) -> _WorkflowFacts:
         data = YAML(typ="safe").load(io.StringIO(text))
     except (YAMLError, ValueError):
         return _WorkflowFacts(
-            path, empty, False, empty, empty, empty, empty, unparsable
+            path, empty, False, empty, empty, empty, empty, empty, unparsable
         )
     if not isinstance(data, dict):
         return _WorkflowFacts(
-            path, empty, False, empty, empty, empty, empty, unparsable
+            path, empty, False, empty, empty, empty, empty, empty, unparsable
         )
 
     # YAML 1.1 documents (`%YAML 1.1`) turn the `on:` key into the boolean
@@ -686,6 +741,7 @@ def _parse_workflow(path: str, text: str) -> _WorkflowFacts:
     environments: set[str] = set()
     oidc_environments: set[str] = set()
     oidc_without_environment: set[str] = set()
+    filed_deployments: set[str] = set()
     unresolved: list[str] = []
 
     for job_id, job in jobs.items():
@@ -702,9 +758,12 @@ def _parse_workflow(path: str, text: str) -> _WorkflowFacts:
         permissions = job.get("permissions", workflow_permissions)
         oidc = _permissions_grant_oidc(permissions)
 
-        environment = job.get("environment")
-        if isinstance(environment, dict):
-            environment = environment.get("name")
+        declared = job.get("environment")
+        environment = declared
+        deployment = None
+        if isinstance(declared, dict):
+            environment = declared.get("name")
+            deployment = declared.get("deployment")
         if environment is None:
             if oidc:
                 oidc_without_environment.add(str(job_id))
@@ -715,6 +774,12 @@ def _parse_workflow(path: str, text: str) -> _WorkflowFacts:
             )
             continue
         environments.add(environment)
+        # The operational-secret environment is a secret scope, so a job naming
+        # it deploys nothing and the record GitHub would file for it is pure
+        # noise on whatever the run belongs to. Only the shorthand and an
+        # explicit `deployment: true` file one; both are the same mistake.
+        if environment == TEND_ENVIRONMENT and deployment is not False:
+            filed_deployments.add(str(job_id))
         if oidc:
             oidc_environments.add(environment)
 
@@ -726,6 +791,7 @@ def _parse_workflow(path: str, text: str) -> _WorkflowFacts:
         environments=frozenset(environments),
         oidc_environments=frozenset(oidc_environments),
         oidc_without_environment=frozenset(oidc_without_environment),
+        filed_deployments=frozenset(filed_deployments),
         unresolved=tuple(unresolved),
     )
 
@@ -1364,6 +1430,7 @@ def run_all_checks(cfg: Config, repo: str | None = None) -> list[CheckResult]:
     results.append(check_bot_permission(repo, cfg.bot_name))
     admitted = admitted_refs(results)
     results.append(check_environment(repo, admitted))
+    results.append(check_environment_deployments(repo))
     results.append(check_credential_environments(repo, cfg, admitted))
     results.append(check_secrets(repo, required_secrets))
     if cfg.harness == "claude":

--- a/generator/tests/test_checks.py
+++ b/generator/tests/test_checks.py
@@ -14,6 +14,7 @@ from tend.checks import (
     admitted_refs,
     check_credential_environments,
     check_environment,
+    check_environment_deployments,
     fix_environment,
     ROLE_ID_ADMIN,
     ROLE_ID_MAINTAIN,
@@ -1011,9 +1012,9 @@ def test_run_all_checks_with_protected_branches() -> None:
             _config(protected_branches=["v1", "v2"]),
             repo="owner/repo",
         )
-    # default + v1 + v2 + bot-permission + environment + credential-environments
-    # + secrets + claude-auth + allowlist = 9
-    assert len(results) == 9
+    # default + v1 + v2 + bot-permission + environment + environment-deployments
+    # + credential-environments + secrets + claude-auth + allowlist = 10
+    assert len(results) == 10
     bp_results = [r for r in results if r.name.startswith("branch-protection:")]
     assert len(bp_results) == 3
     assert {r.name for r in bp_results} == {
@@ -1176,9 +1177,9 @@ def test_run_all_checks_deduplicates_default_branch() -> None:
             _config(protected_branches=["main", "v1"]),
             repo="owner/repo",
         )
-    # main (deduped) + v1 + bot-permission + environment + credential-environments
-    # + secrets + claude-auth + allowlist = 8
-    assert len(results) == 8
+    # main (deduped) + v1 + bot-permission + environment + environment-deployments
+    # + credential-environments + secrets + claude-auth + allowlist = 9
+    assert len(results) == 9
     bp_results = [r for r in results if r.name.startswith("branch-protection:")]
     assert len(bp_results) == 2
     assert {r.name for r in bp_results} == {
@@ -1478,6 +1479,80 @@ _CUSTOM_POLICY = {
         "custom_branch_policies": True,
     }
 }
+
+
+_GENERATED_JOB = """\
+name: tend-review
+on: pull_request_target
+jobs:
+  review:
+    runs-on: ubuntu-24.04
+    environment:
+      name: tend
+      deployment: false
+    steps:
+      - run: echo hello
+"""
+
+
+def test_environment_deployments_passes_on_the_generated_shape() -> None:
+    """The block the `environment()` macro emits files no deployment."""
+    with patch(
+        "tend.checks._fetch_workflow_files",
+        return_value={"tend-review.yaml": _GENERATED_JOB},
+    ):
+        result = check_environment_deployments("owner/repo")
+    assert result.passed is True
+
+
+def test_environment_deployments_flags_the_shorthand() -> None:
+    """`environment: tend` gates the job exactly as well, so nothing else in
+    the repo fails — the only symptom is a deployment record posted on every
+    push to every PR, which is why this check exists at all."""
+    text = _GENERATED_JOB.replace(
+        "    environment:\n      name: tend\n      deployment: false\n",
+        "    environment: tend\n",
+    )
+    with patch(
+        "tend.checks._fetch_workflow_files", return_value={"tend-review.yaml": text}
+    ):
+        result = check_environment_deployments("owner/repo")
+    assert result.passed is False
+    assert "tend-review.yaml job 'review'" in result.message
+
+
+def test_environment_deployments_flags_deployment_true() -> None:
+    """Spelling the default out loud files the same record."""
+    text = _GENERATED_JOB.replace("deployment: false", "deployment: true")
+    with patch(
+        "tend.checks._fetch_workflow_files", return_value={"tend-review.yaml": text}
+    ):
+        result = check_environment_deployments("owner/repo")
+    assert result.passed is False
+
+
+def test_environment_deployments_leaves_real_deploy_targets_alone() -> None:
+    """A release environment deploys something, so its record is the point.
+    The check is the operational-secret environment's, not every job's."""
+    text = _GENERATED_JOB.replace(
+        "      name: tend\n      deployment: false\n", "      name: release\n"
+    )
+    # Without this the substitution could silently miss and leave a compliant
+    # `tend` job behind, which passes for the wrong reason.
+    assert "      name: release\n" in text and "      name: tend\n" not in text
+    with patch(
+        "tend.checks._fetch_workflow_files", return_value={"release.yaml": text}
+    ):
+        result = check_environment_deployments("owner/repo")
+    assert result.passed is True
+
+
+def test_environment_deployments_unreadable_does_not_pass() -> None:
+    """A workflow tend could not read holds jobs it cannot vouch for, so the
+    claim is withheld rather than granted."""
+    with patch("tend.checks._fetch_workflow_files", return_value={"opaque.yaml": None}):
+        result = check_environment_deployments("owner/repo")
+    assert result.passed is None
 
 
 def test_credential_environments_none_holding_secrets_passes() -> None:

--- a/generator/tests/test_integration.py
+++ b/generator/tests/test_integration.py
@@ -404,9 +404,9 @@ def test_check_full_pipeline_with_mocked_gh(
 
     assert result.exit_code == 0, result.output
     assert "FAIL" not in result.output
-    # branch-protection + bot-permission + environment + credential-environments
-    # + secrets + claude-auth + allowlist = 7
-    assert result.output.count("PASS") == 7
+    # branch-protection + bot-permission + environment + environment-deployments
+    # + credential-environments + secrets + claude-auth + allowlist = 8
+    assert result.output.count("PASS") == 8
 
 
 def test_check_full_pipeline_branch_not_protected(


### PR DESCRIPTION
Follow-up to #852, which added `deployment: false` to the generated workflows. That left it a per-call-site opt-in, and the omission is invisible to whoever makes it: the gate still holds, the secrets still arrive, and the only symptom is a `<bot> deployed to tend` line on someone else's pull request. Generated workflows take the block from one macro that a generator test pins; nothing covered the workflows tend did not write, which is where a repo's own hand-maintained jobs live.

There is no environment-level lever to reach for instead. The environment object accepts `wait_timer`, `prevent_self_review`, `reviewers` and `deployment_branch_policy`, and none of them suppress the record or hide the environment from the UI — `deployment: false` is workflow-side only. So the invariant has to be enforced where workflows are written.

`tend check` already parses every workflow on the default branch for the credential sweep, so this rides the same fetch: a job naming the operational-secret environment must set `deployment: false`, and the bare `environment: tend` and an explicit `deployment: true` are the same mistake. It is that environment's check rather than every job's — a `release` environment deploys something, so its record is the point.

<details>
<summary>Against live repos</summary>

On both `max-sixty/tend` and `max-sixty/worktrunk` it names the nine generated jobs still carrying the string form:

```
FAIL  environment-deployments — Jobs name the 'tend' environment without `deployment: false`,
so GitHub files a deployment record for every run and posts it on the pull request:
tend-ci-fix.yaml job 'fix-ci', tend-mention.yaml job 'handle', tend-mention.yaml job 'verify',
tend-nightly.yaml job 'nightly', tend-notifications.yaml job 'notifications',
tend-review-runs.yaml job 'review-runs', tend-review.yaml job 'review',
tend-triage.yaml job 'triage', tend-weekly.yaml job 'weekly'.
```

Those nine clear on the regeneration that follows the next release. The two hand-maintained workflows converted in #852 (`review-reviewers.yaml`, `integration-secrets.yaml`) pass, which is also what confirms the parser reads the mapping form.

</details>

The failure message routes each case to its own fix, since a generated `tend-*.yaml` must not be hand-edited — it points those at `uvx tend@latest init`.

> _This was written by Claude Code on behalf of max-sixty_
