### PR TITLE
fix(actions): report an outage when the run fails ahead of the agent

### DIFF
--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -616,13 +616,17 @@ runs:
     # out as a red run and nothing else; a rate-limit preflight abort held
     # every workflow on this repo for a full UTC day without filing a thing.
     #
-    # The security preflight is the one exclusion: its failure is a config
-    # refusal, not an outage. It stays failing until a human fixes the repo's
-    # branch protection, so it would file "Bot temporarily unavailable" and
-    # append a row on every subsequent trigger, forever, without ever naming
-    # the cause. It is also the one case where reporting would have the bot
-    # write to the repo with its PAT right after the security gate refused to
-    # let it operate there.
+    # The security preflight is the one exclusion, and what carves it out is
+    # that reporting would have the bot write to the repo (`gh issue create`,
+    # and `gh issue close` on the reconcile path) with its PAT immediately
+    # after the security gate refused to let it operate there. Its failure is
+    # also persistent — red until a human fixes branch protection, so an issue
+    # titled "Bot temporarily unavailable" would collect a row per trigger —
+    # but that argument doesn't single it out: `Validate auth configured` and
+    # the adopter's `sandbox_setup:` fail the same way and stay in. Bounding
+    # that repeated append belongs in `report-failure.sh`, where it covers
+    # every such step at once (#859); enumerating more step ids here would go
+    # stale as steps move.
     - name: Report failure
       if: failure() && steps.security.outcome != 'failure'
       shell: bash

--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -607,8 +607,15 @@ runs:
           "*Cost at API list prices — a large multiple of the effective rate on Claude Code subscriptions.*"
         ' <<< "$USAGE" >> "$GITHUB_STEP_SUMMARY"
 
+    # Gate on the job being red, not on the agent step specifically. A dozen
+    # steps run before `claude` — the two preflights, auth validation, the
+    # proxy and sandbox build, the adopter's `sandbox_setup:` — and any of
+    # them failing strands the same work, so each needs to reach the outage
+    # tracker. Keying on `steps.claude.outcome` meant a pre-agent failure went
+    # out as a red run and nothing else; a rate-limit preflight abort held
+    # every workflow on this repo for a full UTC day without filing a thing.
     - name: Report failure
-      if: failure() && steps.claude.outcome == 'failure'
+      if: failure()
       shell: bash
       run: bash "${{ github.action_path }}/../shared/steps/report-failure.sh"
       env:

--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -115,6 +115,7 @@ runs:
     # and runs the script (reached via ../shared/steps, since this action is
     # one level deep).
     - name: Security preflight
+      id: security
       shell: bash
       run: bash "${{ github.action_path }}/../shared/steps/security-preflight.sh"
       env:
@@ -608,14 +609,22 @@ runs:
         ' <<< "$USAGE" >> "$GITHUB_STEP_SUMMARY"
 
     # Gate on the job being red, not on the agent step specifically. A dozen
-    # steps run before `claude` — the two preflights, auth validation, the
-    # proxy and sandbox build, the adopter's `sandbox_setup:` — and any of
+    # steps run before `claude` — the rate-limit preflight, auth validation,
+    # the proxy and sandbox build, the adopter's `sandbox_setup:` — and any of
     # them failing strands the same work, so each needs to reach the outage
     # tracker. Keying on `steps.claude.outcome` meant a pre-agent failure went
     # out as a red run and nothing else; a rate-limit preflight abort held
     # every workflow on this repo for a full UTC day without filing a thing.
+    #
+    # The security preflight is the one exclusion: its failure is a config
+    # refusal, not an outage. It stays failing until a human fixes the repo's
+    # branch protection, so it would file "Bot temporarily unavailable" and
+    # append a row on every subsequent trigger, forever, without ever naming
+    # the cause. It is also the one case where reporting would have the bot
+    # write to the repo with its PAT right after the security gate refused to
+    # let it operate there.
     - name: Report failure
-      if: failure()
+      if: failure() && steps.security.outcome != 'failure'
       shell: bash
       run: bash "${{ github.action_path }}/../shared/steps/report-failure.sh"
       env:

--- a/codex/action.yaml
+++ b/codex/action.yaml
@@ -332,10 +332,11 @@ runs:
 
     # Gate on the job being red, not on the agent step specifically — see the
     # matching note in claude/action.yaml, including why the security preflight
-    # is excluded. Every step ahead of `codex` (the rate-limit preflight, the
-    # CLI and plugin installs, the AGENTS.md staging, the fork-PR pinning)
-    # strands the same work when it fails, and keying on `steps.codex.outcome`
-    # kept all of them out of the outage tracker.
+    # is excluded. Every step ahead of `codex` (the rate-limit preflight, bot-ID
+    # resolution, auth validation, the CLI and plugin installs, the AGENTS.md
+    # staging, the fork-PR pinning) strands the same work when it fails, and
+    # keying on `steps.codex.outcome` kept all of them out of the outage
+    # tracker.
     - name: Report failure
       if: failure() && steps.security.outcome != 'failure'
       shell: bash

--- a/codex/action.yaml
+++ b/codex/action.yaml
@@ -83,6 +83,7 @@ runs:
     # Preflight/teardown step bodies are shared with the Claude actions via
     # ../shared/steps; codex's auth, prompt staging, and run path are its own.
     - name: Security preflight
+      id: security
       shell: bash
       run: bash "${{ github.action_path }}/../shared/steps/security-preflight.sh"
       env:
@@ -330,12 +331,13 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github_token }}
 
     # Gate on the job being red, not on the agent step specifically — see the
-    # matching note in claude/action.yaml. Every step ahead of `codex` (the
-    # preflights, the plugin staging, the adopter's setup) strands the same
-    # work when it fails, and keying on `steps.codex.outcome` kept all of them
-    # out of the outage tracker.
+    # matching note in claude/action.yaml, including why the security preflight
+    # is excluded. Every step ahead of `codex` (the rate-limit preflight, the
+    # CLI and plugin installs, the AGENTS.md staging, the fork-PR pinning)
+    # strands the same work when it fails, and keying on `steps.codex.outcome`
+    # kept all of them out of the outage tracker.
     - name: Report failure
-      if: failure()
+      if: failure() && steps.security.outcome != 'failure'
       shell: bash
       run: bash "${{ github.action_path }}/../shared/steps/report-failure.sh"
       env:

--- a/codex/action.yaml
+++ b/codex/action.yaml
@@ -329,8 +329,13 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
 
+    # Gate on the job being red, not on the agent step specifically — see the
+    # matching note in claude/action.yaml. Every step ahead of `codex` (the
+    # preflights, the plugin staging, the adopter's setup) strands the same
+    # work when it fails, and keying on `steps.codex.outcome` kept all of them
+    # out of the outage tracker.
     - name: Report failure
-      if: failure() && steps.codex.outcome == 'failure'
+      if: failure()
       shell: bash
       run: bash "${{ github.action_path }}/../shared/steps/report-failure.sh"
       env:

--- a/shared/steps/report-failure.sh
+++ b/shared/steps/report-failure.sh
@@ -2,8 +2,11 @@
 # File or append to a `tend-outage` issue when a run fails, so outages are
 # tracked until resolved. Shared verbatim by both harness actions; the caller
 # gates it on the job being red, so a failure anywhere in the action — the
-# preflights and sandbox build ahead of the agent as much as the agent
-# itself — lands in the tracker.
+# rate-limit preflight and sandbox build ahead of the agent as much as the
+# agent itself — lands in the tracker. The one exclusion is the security
+# preflight: that failure is a persistent config refusal rather than an
+# outage, and the issue this files ("temporarily unavailable", closed once
+# resolved) would never resolve.
 #
 # Just records the run link. Error annotations and logs are not reliably
 # available while the job is in_progress, so the nightly skill enriches these

--- a/shared/steps/report-failure.sh
+++ b/shared/steps/report-failure.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # File or append to a `tend-outage` issue when a run fails, so outages are
-# tracked until resolved. Shared verbatim by both harness actions; the
-# caller gates it on the agent step having failed.
+# tracked until resolved. Shared verbatim by both harness actions; the caller
+# gates it on the job being red, so a failure anywhere in the action — the
+# preflights and sandbox build ahead of the agent as much as the agent
+# itself — lands in the tracker.
 #
 # Just records the run link. Error annotations and logs are not reliably
 # available while the job is in_progress, so the nightly skill enriches these


### PR DESCRIPTION
## Problem

A run that fails **before** the agent step never reaches the outage tracker. `Report failure` is gated on the agent step specifically:

```yaml
- name: Report failure
  if: failure() && steps.claude.outcome == 'failure'
```

Twelve steps run ahead of `claude` — the security preflight, the rate-limit preflight, bot-ID resolution, auth validation, proxy/uv install, sensitive-config restore, prompt composition, the mitmproxy cache, the sandbox build, the binary and plugin installs, and the adopter's `sandbox_setup:`. When any of them fails, `steps.claude.outcome` is `skipped`, the conjunct is false, and the run goes out red with no `tend-outage` issue and no comment on an existing one. The work it stranded leaves no trace anywhere a maintainer looks. `codex/action.yaml` carries the identical gate on `steps.codex.outcome`.

## What it cost

On `max-sixty/tend` between 2026-08-05T11:37Z and 2026-08-06T00:07Z, the rate-limit preflight aborted **every** agent run on the repo — 36 failed runs across four workflows:

| Workflow | Failed / total |
|---|---|
| `tend-notifications` | 19 / 20 |
| `review-reviewers` | 12 / 13 |
| `tend-review` | 4 / 4 |
| `tend-mention` | 1 / 1 |

Every one aborted on the same line, with the burst counters at zero — the bot's daily item count had crossed the spike threshold and, since the guard runs before anything that could change that count, it stayed crossed until the UTC date rolled:

```
Rate limit: burst=0 PRs, 0 issues (20min); today=16 (limit: 15)
##[error]Rate limit: bot created 16 items today, above spike limit of 15 (baseline: 17 over past 6 days)
```

And in all 36, the outage step never ran — from the raw logs of both a [`review-reviewers` leg](https://github.com/max-sixty/tend/actions/runs/31055440109) and a [`tend-review` run](https://github.com/max-sixty/tend/actions/runs/31047860817):

```
##[start-action display=Report failure;id=__max-sixty_tend.__run_13]
##[end-action id=__max-sixty_tend.__run_13;outcome=skipped;conclusion=skipped;duration_ms=0]
```

Zero `tend-outage` issues were filed or commented on across the whole 12.5-hour window; the label's most recent issues are still #831 and #832 from 2026-08-04, both closed. Those two got filed precisely because that outage failed *inside* the agent step. So the tracker works — it just can't see the half of the action that runs first, which is where a whole-repo, day-long stop lives.

The blackout self-cleared at 00:00Z when the daily counter reset, so nothing here needs a revert; the reason a maintainer never saw it is what this PR fixes.

## Fix

Gate on the job being red rather than on which step reddened it, in both harness actions, and correct the `report-failure.sh` header comment that documented the old contract. A pre-agent failure strands exactly the same work as an agent failure, so it belongs in the same tracker.

The widened gate also admits post-agent failures (`Mark event notification read`, `Token usage`). Those are rarer and the agent's work has already shipped by then, but the run is still red and still worth a row — an outage issue that occasionally over-reports is the right side to err on relative to one that misses a 12-hour stop.

**One exclusion: the security preflight.** `security-preflight.sh` failing means the repo isn't safely gated for the bot — an unprotected default branch, or an update ruleset the bot can bypass. That's a config refusal, not an outage, and it's persistent: it stays failing until a human fixes the repo, so under a bare `failure()` gate it would file an issue titled "Bot temporarily unavailable" and append a row on every subsequent trigger, indefinitely, while the reporter records only a run link and so never names the cause. It's also the one path where reporting has the action write to the repo (`gh issue create`, plus `gh issue close` on the reconcile path) with the bot's PAT right after the security gate refused to let it operate there. The step now carries `id: security` and the gate is `if: failure() && steps.security.outcome != 'failure'`; it's the first step in both actions, so every other failure leaves that outcome `success` and the widening is otherwise unaffected. Note that the PAT-write argument is what carves it out, not persistence: `Validate auth configured` and the adopter's `sandbox_setup:` also fail deterministically until a human edits config, and they stay in. Bounding that repeated append belongs in `report-failure.sh`, where one change covers every such step without an enumerated exclusion list — tracked in #859.

**The rate-limit abort's remediation is itself a counted item.** Worth stating because the direction is counterintuitive when this is read back later: the tiers `rate-limit-preflight.sh` enforces count bot-authored issues — `RECENT_ISSUES` via `repos/$REPO/issues?creator=$BOT`, `TODAY_POSTS` via `search/issues?q=author:...` — so the first abort under the new gate creates a `tend-outage` issue and thereby nudges the very counter it tripped on. It's self-limiting rather than a loop: every later failure appends a *comment* to the now-open issue, and comments appear in neither query, so the exposure is +1 item per open-issue cycle.

This is diagnosability only — it doesn't touch the rate-limit thresholds. #856, from a sibling leg of this same run, retunes the guard that caused this particular blackout by demoting its spike tier to a creation pause. The two are complementary rather than overlapping: #856 stops the spike tier from failing the run at all, and this PR makes the tiers that still abort — the two burst checks and the hard limit it keeps — plus every other pre-agent step land in the tracker when they do.

## Gate assessment

- **Evidence level**: Critical — 36 failed runs, four workflows, a 12.5-hour total stop of the bot on its own repo, invisible end to end. Acts on one occurrence.
- **Structural, not stochastic**: no decision point. `steps.claude.outcome` is `skipped` for every pre-agent failure, so the condition is false 100% of the time, for every consumer of both actions.
- **Change type**: targeted fix — one `if:` expression per action plus a comment correction.
- **Passes both gates.**

Evidence log: https://gist.github.com/dca23a6e6a0d8cae2665944ba31676fb

Related but distinct — both assume the agent step failed and so never fire on this path: #818 (naming the cause in the exited-non-zero annotation) and #809 (deduping outage comments across matrix legs).


