### PR TITLE
config: drop the secret-name overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,8 @@ why the Codex subscription `auth.json` path isn't supported;
 [docs/security-model.md](docs/security-model.md) has the full leak
 breakdown.
 
-All other options — secret name overrides, setup steps, protected branches,
-workflow overrides, schedules — are documented in
+All other options — setup steps, protected branches, workflow overrides,
+schedules — are documented in
 [`docs/tend.example.yaml`](docs/tend.example.yaml).
 
 ## Project context

--- a/docs/tend.example.yaml
+++ b/docs/tend.example.yaml
@@ -46,9 +46,9 @@ bot_name: my-project-bot
 
 # ## Secrets
 #
-# Required secrets, by harness — stored in the repo's `tend` GitHub
-# Environment (install-tend creates it; a workflow the bot pushes to a
-# branch cannot read them there):
+# Required secrets, by harness, under these exact names — stored in the
+# repo's `tend` GitHub Environment (install-tend creates it; a workflow the
+# bot pushes to a branch cannot read them there):
 #
 # | Harness    | Required                                                                  |
 # |------------|---------------------------------------------------------------------------|
@@ -78,14 +78,6 @@ bot_name: my-project-bot
 # `notifications:write`, `gists:write`, plus the account-level `Profile:
 # read and write` permission (for the bio). `notifications:write` is
 # required so the action can mark threads read after handling an event.
-#
-# Override names if the repo uses different secret names:
-#
-# secrets:
-#   bot_token: MY_BOT_PAT
-#   claude_token: MY_CLAUDE_TOKEN        # claude (OAuth)
-#   anthropic_api_key: MY_ANTHROPIC_KEY  # claude (API key)
-#   openai_key: MY_OPENAI_KEY            # codex
 #
 # `tend check` flags repo-level secrets not in an explicit allowlist — each
 # entry is a deliberate acceptance that any workflow the repo runs can read

--- a/generator/src/tend/checks.py
+++ b/generator/src/tend/checks.py
@@ -25,7 +25,13 @@ from functools import cache
 from ruamel.yaml import YAML
 from ruamel.yaml.error import YAMLError
 
-from tend.config import Config
+from tend.config import (
+    ANTHROPIC_API_KEY_SECRET,
+    BOT_TOKEN_SECRET,
+    CLAUDE_TOKEN_SECRET,
+    OPENAI_KEY_SECRET,
+    Config,
+)
 from tend.workflows import TEND_ENVIRONMENT
 
 
@@ -1415,7 +1421,7 @@ def run_all_checks(cfg: Config, repo: str | None = None) -> list[CheckResult]:
 
     # The engine-specific auth secret is verified by check_claude_auth /
     # check_codex_auth below, which name the relevant one in their message.
-    required_secrets = [cfg.bot_token_secret]
+    required_secrets = [BOT_TOKEN_SECRET]
 
     # The operational secrets are deliberately absent from `allowed`: they
     # belong to the environment, and a copy left at repo level is readable by
@@ -1434,14 +1440,14 @@ def run_all_checks(cfg: Config, repo: str | None = None) -> list[CheckResult]:
     results.append(check_credential_environments(repo, cfg, admitted))
     results.append(check_secrets(repo, required_secrets))
     if cfg.harness == "claude":
-        results.append(check_claude_auth(repo, cfg))
+        results.append(check_claude_auth(repo))
     else:
-        results.append(check_codex_auth(repo, cfg))
+        results.append(check_codex_auth(repo))
     results.append(check_repo_secret_allowlist(repo, allowed))
     return results
 
 
-def check_claude_auth(repo: str, cfg: Config) -> CheckResult:
+def check_claude_auth(repo: str) -> CheckResult:
     """Claude needs either CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY —
     both being absent is the failure mode. Both being set is fine; the
     action prefers the OAuth token.
@@ -1449,41 +1455,35 @@ def check_claude_auth(repo: str, cfg: Config) -> CheckResult:
     names, err = _env_secret_names(repo)
     if names is None:
         return CheckResult("claude-auth", None, err)
-    has_oauth = cfg.claude_token_secret in names
-    has_key = cfg.anthropic_api_key_secret in names
-    if has_oauth or has_key:
-        which = []
-        if has_oauth:
-            which.append(cfg.claude_token_secret)
-        if has_key:
-            which.append(cfg.anthropic_api_key_secret)
+    which = [s for s in (CLAUDE_TOKEN_SECRET, ANTHROPIC_API_KEY_SECRET) if s in names]
+    if which:
         return CheckResult(
             "claude-auth", True, f"Claude auth secret present: {', '.join(which)}"
         )
     return CheckResult(
         "claude-auth",
         False,
-        f"Claude harness selected but neither {cfg.claude_token_secret} nor "
-        f"{cfg.anthropic_api_key_secret} is set in the '{TEND_ENVIRONMENT}' environment.",
+        f"Claude harness selected but neither {CLAUDE_TOKEN_SECRET} nor "
+        f"{ANTHROPIC_API_KEY_SECRET} is set in the '{TEND_ENVIRONMENT}' environment.",
     )
 
 
-def check_codex_auth(repo: str, cfg: Config) -> CheckResult:
+def check_codex_auth(repo: str) -> CheckResult:
     """Codex needs OPENAI_API_KEY — absence is the failure mode. The
     subscription auth.json path is not supported.
     """
     names, err = _env_secret_names(repo)
     if names is None:
         return CheckResult("codex-auth", None, err)
-    if cfg.openai_key_secret in names:
+    if OPENAI_KEY_SECRET in names:
         return CheckResult(
             "codex-auth",
             True,
-            f"Codex auth secret present: {cfg.openai_key_secret}",
+            f"Codex auth secret present: {OPENAI_KEY_SECRET}",
         )
     return CheckResult(
         "codex-auth",
         False,
-        f"Codex harness selected but {cfg.openai_key_secret} "
+        f"Codex harness selected but {OPENAI_KEY_SECRET} "
         f"is not set in the '{TEND_ENVIRONMENT}' environment.",
     )

--- a/generator/src/tend/config.py
+++ b/generator/src/tend/config.py
@@ -40,14 +40,32 @@ KNOWN_TOP_LEVEL = {
     "workflows",
 }
 KNOWN_HARNESSES = {"claude", "codex"}
-# Claude harness reads claude_token (OAuth) and anthropic_api_key (console.
-# anthropic.com) — adopters set one. Codex harness reads openai_key.
-KNOWN_SECRETS_KEYS = {
-    "bot_token",
-    "claude_token",
-    "anthropic_api_key",
-    "openai_key",
-    "allowed",
+KNOWN_SECRETS_KEYS = {"allowed"}
+
+# The operational secrets, by fixed name. Claude reads the OAuth token
+# (subscription) or the API key (console.anthropic.com) — adopters set one;
+# Codex reads the OpenAI key. Not configurable: `install-tend` creates the
+# `tend` environment and fills it from scratch, so there is no pre-existing
+# secret whose name an adopter would want to keep.
+BOT_TOKEN_SECRET = "TEND_BOT_TOKEN"
+CLAUDE_TOKEN_SECRET = "CLAUDE_CODE_OAUTH_TOKEN"
+ANTHROPIC_API_KEY_SECRET = "ANTHROPIC_API_KEY"
+OPENAI_KEY_SECRET = "OPENAI_API_KEY"
+OPERATIONAL_SECRETS = {
+    BOT_TOKEN_SECRET,
+    CLAUDE_TOKEN_SECRET,
+    ANTHROPIC_API_KEY_SECRET,
+    OPENAI_KEY_SECRET,
+}
+# Keys that once renamed those secrets. A leftover one is refused rather
+# than warned past: ignoring it would generate workflows reading the fixed
+# name while the adopter's secret still answers to the old one, and every
+# job would fail on an empty token.
+REMOVED_SECRETS_KEYS = {
+    "bot_token": BOT_TOKEN_SECRET,
+    "claude_token": CLAUDE_TOKEN_SECRET,
+    "anthropic_api_key": ANTHROPIC_API_KEY_SECRET,
+    "openai_key": OPENAI_KEY_SECRET,
 }
 _GITHUB_USERNAME = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$")
 # POSIX-ish env var name: letters, digits, underscore; not starting with a digit.
@@ -160,10 +178,6 @@ class Config:
     bot_name: str
     default_branch: str
     protected_branches: list[str]
-    bot_token_secret: str
-    claude_token_secret: str
-    anthropic_api_key_secret: str
-    openai_key_secret: str
     harness: str
     model: str
     effort: str
@@ -272,7 +286,17 @@ class Config:
             )
 
         secrets = raw.get("secrets", {}) or {}
-        unknown_secrets = set(secrets.keys()) - KNOWN_SECRETS_KEYS
+        removed = sorted(set(secrets) & set(REMOVED_SECRETS_KEYS))
+        if removed:
+            renames = ", ".join(
+                f"secrets.{key} → {REMOVED_SECRETS_KEYS[key]}" for key in removed
+            )
+            raise click.ClickException(
+                f"Removed secret name override(s): {renames}. The operational "
+                "secret names are fixed — rename each secret to the name shown "
+                "and drop the key."
+            )
+        unknown_secrets = set(secrets) - KNOWN_SECRETS_KEYS
         for key in sorted(unknown_secrets):
             click.echo(f"Warning: unknown secrets key '{key}'", err=True)
 
@@ -509,21 +533,12 @@ class Config:
                 'e.g. allowed: ["CODECOV_TOKEN"]'
             )
 
-        bot_token_secret = secrets.get("bot_token", "TEND_BOT_TOKEN")
-        claude_token_secret = secrets.get("claude_token", "CLAUDE_CODE_OAUTH_TOKEN")
-        anthropic_api_key_secret = secrets.get("anthropic_api_key", "ANTHROPIC_API_KEY")
-        openai_key_secret = secrets.get("openai_key", "OPENAI_API_KEY")
         # The allowlist is the one deliberate exception to "no repo-level
         # secrets", for tokens whose exposure the maintainer accepts. The
         # operational secrets are never that: allowlisting one would let a
         # repo-level copy pass `tend check`, handing any workflow the bot
         # pushes exactly what the environment gate denies.
-        blessed = {
-            bot_token_secret,
-            claude_token_secret,
-            anthropic_api_key_secret,
-            openai_key_secret,
-        } & set(allowed)
+        blessed = OPERATIONAL_SECRETS & set(allowed)
         if blessed:
             raise click.ClickException(
                 f"secrets.allowed must not include {', '.join(sorted(blessed))}: "
@@ -536,10 +551,6 @@ class Config:
             bot_name=bot_name,
             default_branch="main",
             protected_branches=protected_branches,
-            bot_token_secret=bot_token_secret,
-            claude_token_secret=claude_token_secret,
-            anthropic_api_key_secret=anthropic_api_key_secret,
-            openai_key_secret=openai_key_secret,
             harness=harness,
             model=model,
             effort=effort,

--- a/generator/src/tend/templates/macros.yaml.j2
+++ b/generator/src/tend/templates/macros.yaml.j2
@@ -24,12 +24,12 @@
         if: <<if_condition>>
 {% endif %}
         with:
-          github_token: ${{ secrets.<<cfg.bot_token_secret>> }}
+          github_token: ${{ secrets.<<bot_token_secret>> }}
 {% if cfg.harness == 'claude' %}
-          claude_code_oauth_token: ${{ secrets.<<cfg.claude_token_secret>> }}
-          anthropic_api_key: ${{ secrets.<<cfg.anthropic_api_key_secret>> }}
+          claude_code_oauth_token: ${{ secrets.<<claude_token_secret>> }}
+          anthropic_api_key: ${{ secrets.<<anthropic_api_key_secret>> }}
 {% else %}
-          openai_api_key: ${{ secrets.<<cfg.openai_key_secret>> }}
+          openai_api_key: ${{ secrets.<<openai_key_secret>> }}
 {% if cfg.effort %}
           effort: <<cfg.effort>>
 {% endif %}
@@ -147,7 +147,7 @@
 {% endif %}
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.<<cfg.bot_token_secret>> }}
+          token: ${{ secrets.<<bot_token_secret>> }}
 {%- endmacro %}
 
 {# YAML block scalar prompt at column 10, with the supplied text indented at

--- a/generator/src/tend/templates/mention.yaml.j2
+++ b/generator/src/tend/templates/mention.yaml.j2
@@ -319,7 +319,7 @@ jobs:
 
           echo "should_run=false" >> "$GITHUB_OUTPUT"
         env:
-          GITHUB_TOKEN: ${{ secrets.<<cfg.bot_token_secret>> }}
+          GITHUB_TOKEN: ${{ secrets.<<bot_token_secret>> }}
           EVENT_NAME: ${{ github.event_name }}
           COMMENT_BODY: ${{ github.event.comment.body }}
           COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
@@ -348,7 +348,7 @@ jobs:
         env:
           REPO: ${{ github.repository }}
           COMMENT_ID: ${{ github.event.comment.id || github.event.client_payload.id }}
-          GITHUB_TOKEN: ${{ secrets.<<cfg.bot_token_secret>> }}
+          GITHUB_TOKEN: ${{ secrets.<<bot_token_secret>> }}
 
   handle:
     needs: verify
@@ -375,7 +375,7 @@ jobs:
             echo "::warning::PR is $PR_STATE — staying on default branch"
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.<<cfg.bot_token_secret>> }}
+          GITHUB_TOKEN: ${{ secrets.<<bot_token_secret>> }}
           PR_NUMBER: ${{ github.event_name == 'issue_comment' && github.event.issue.number || github.event.client_payload.pr }}
 
       - name: Compute queue delay
@@ -412,4 +412,4 @@ jobs:
           REPO: ${{ github.repository }}
           COMMENT_ID: ${{ github.event.comment.id || github.event.client_payload.id }}
           BOT_NAME: <<cfg.bot_name>>
-          GITHUB_TOKEN: ${{ secrets.<<cfg.bot_token_secret>> }}
+          GITHUB_TOKEN: ${{ secrets.<<bot_token_secret>> }}

--- a/generator/src/tend/templates/notifications.yaml.j2
+++ b/generator/src/tend/templates/notifications.yaml.j2
@@ -113,7 +113,7 @@ jobs:
             echo "$COUNT processable notification(s) — proceeding"
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.<<cfg.bot_token_secret>> }}
+          GITHUB_TOKEN: ${{ secrets.<<bot_token_secret>> }}
 
 <<checkout(cfg, ref=cfg.default_branch, if_condition=skip_condition)>>
 <<setup>><<agent_step(cfg, block_prompt(prompt), if_condition=skip_condition)>>

--- a/generator/src/tend/templates/review.yaml.j2
+++ b/generator/src/tend/templates/review.yaml.j2
@@ -36,7 +36,7 @@ jobs:
       - name: Resolve PR checkout ref
         id: pr_ref
         env:
-          GITHUB_TOKEN: ${{ secrets.<<cfg.bot_token_secret>> }}
+          GITHUB_TOKEN: ${{ secrets.<<bot_token_secret>> }}
           PR: ${{ github.event.pull_request.number }}
         run: |
           if gh api "repos/${{ github.repository }}/git/ref/pull/$PR/merge" --silent 2>/dev/null; then

--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -15,7 +15,14 @@ from jinja2 import Environment, PackageLoader, StrictUndefined
 from jinja2.runtime import Macro
 from ruamel.yaml import YAML
 
-from tend.config import Config, WorkflowConfig
+from tend.config import (
+    ANTHROPIC_API_KEY_SECRET,
+    BOT_TOKEN_SECRET,
+    CLAUDE_TOKEN_SECRET,
+    OPENAI_KEY_SECRET,
+    Config,
+    WorkflowConfig,
+)
 
 # Variable delimiters are swapped from `{{`/`}}` to `<<`/`>>` so GitHub
 # Actions expressions (`${{ github.foo }}`, ubiquitous in generated YAML)
@@ -83,6 +90,12 @@ TEND_ENVIRONMENT = "tend"
 _JINJA.globals["header"] = HEADER
 _JINJA.globals["tend_version"] = _TEND_VERSION
 _JINJA.globals["tend_environment"] = TEND_ENVIRONMENT
+# Secret names reach the templates as globals rather than literals so the
+# names `tend check` looks for and the names the workflows read cannot drift.
+_JINJA.globals["bot_token_secret"] = BOT_TOKEN_SECRET
+_JINJA.globals["claude_token_secret"] = CLAUDE_TOKEN_SECRET
+_JINJA.globals["anthropic_api_key_secret"] = ANTHROPIC_API_KEY_SECRET
+_JINJA.globals["openai_key_secret"] = OPENAI_KEY_SECRET
 
 
 # Register every macro defined in `macros.yaml.j2` as a Jinja global so

--- a/generator/tests/test_checks.py
+++ b/generator/tests/test_checks.py
@@ -31,7 +31,13 @@ from tend.checks import (
     run_all_checks,
 )
 from tend.cli import main
-from tend.config import Config
+from tend.config import (
+    ANTHROPIC_API_KEY_SECRET,
+    BOT_TOKEN_SECRET,
+    CLAUDE_TOKEN_SECRET,
+    OPENAI_KEY_SECRET,
+    Config,
+)
 from tend.workflows import TEND_ENVIRONMENT
 
 
@@ -40,8 +46,6 @@ def _config(
     bot_name: str = "bot",
     default_branch: str = "main",
     protected_branches: list[str] | None = None,
-    bot_token_secret: str = "T1",
-    claude_token_secret: str = "T2",
     harness: str = "claude",
     model: str = "opus",
 ) -> Config:
@@ -50,10 +54,6 @@ def _config(
         bot_name=bot_name,
         default_branch=default_branch,
         protected_branches=protected_branches or [],
-        bot_token_secret=bot_token_secret,
-        claude_token_secret=claude_token_secret,
-        anthropic_api_key_secret="ANTHROPIC_API_KEY",
-        openai_key_secret="OPENAI_API_KEY",
         harness=harness,
         model=model,
         effort="",
@@ -68,6 +68,13 @@ def _make_completed(
     return subprocess.CompletedProcess(
         args=[], returncode=returncode, stdout=stdout, stderr=stderr
     )
+
+
+def _secret_names(args: tuple, *names: str) -> str:
+    """A secrets listing in whichever shape the caller asked for: objects for
+    `gh secret list --json name`, bare names for the `--jq` reads."""
+    listed = [{"name": n} for n in names] if "--json" in args else list(names)
+    return json.dumps(listed) + "\n"
 
 
 def _write_config(tmp_path: Path, content: str = "bot_name: test-bot") -> Path:
@@ -886,7 +893,11 @@ def _gh_all_pass(*admitted: str):
             # Two callers read this path with different `--jq` shapes: the
             # membership check wants a JSON array, the environment sweep one
             # name per line. The fake answers whichever was asked for.
-            names = ["T1", "T2"] if url.endswith(f"{TEND_ENVIRONMENT}/secrets") else []
+            names = (
+                [BOT_TOKEN_SECRET, CLAUDE_TOKEN_SECRET]
+                if url.endswith(f"{TEND_ENVIRONMENT}/secrets")
+                else []
+            )
             if any(a.startswith("[.secrets") for a in args):
                 return _make_completed(json.dumps(names))
             return _make_completed("\n".join(names) + "\n")
@@ -953,7 +964,7 @@ def test_run_all_checks_flags_operational_secrets_left_at_repo_level() -> None:
     def gh_with_repo_level_copy(*args, **kwargs) -> subprocess.CompletedProcess[str]:
         url = args[1]
         if "environments/tend/secrets" not in url and url.endswith("actions/secrets"):
-            return _make_completed('["T1"]\n')
+            return _make_completed(json.dumps([BOT_TOKEN_SECRET]) + "\n")
         return _gh_all_pass()(*args, **kwargs)
 
     with (
@@ -967,7 +978,7 @@ def test_run_all_checks_flags_operational_secrets_left_at_repo_level() -> None:
         "a repo-level copy of the bot token must be flagged — it is readable "
         "from any branch the bot can push"
     )
-    assert "T1" in allowlist[0].message
+    assert BOT_TOKEN_SECRET in allowlist[0].message
 
 
 def test_run_all_checks_allowlist_catches_unexpected() -> None:
@@ -1039,9 +1050,9 @@ def test_codex_engine_passes_with_openai_key() -> None:
         if "collaborators" in url:
             return _make_completed("write\n")
         if "secrets" in url:
-            if "--json" in args:
-                return _make_completed('[{"name":"T1"},{"name":"OPENAI_API_KEY"}]\n')
-            return _make_completed('["T1","OPENAI_API_KEY"]\n')
+            return _make_completed(
+                _secret_names(args, BOT_TOKEN_SECRET, OPENAI_KEY_SECRET)
+            )
         return _make_completed(returncode=1)
 
     with (
@@ -1052,7 +1063,7 @@ def test_codex_engine_passes_with_openai_key() -> None:
     codex_check = [r for r in results if r.name == "codex-auth"]
     assert len(codex_check) == 1
     assert codex_check[0].passed is True
-    assert "OPENAI_API_KEY" in codex_check[0].message
+    assert OPENAI_KEY_SECRET in codex_check[0].message
 
 
 def test_codex_engine_fails_when_no_auth() -> None:
@@ -1069,9 +1080,7 @@ def test_codex_engine_fails_when_no_auth() -> None:
         if "collaborators" in url:
             return _make_completed("write\n")
         if "secrets" in url:
-            if "--json" in args:
-                return _make_completed('[{"name":"T1"}]\n')
-            return _make_completed('["T1"]\n')
+            return _make_completed(_secret_names(args, BOT_TOKEN_SECRET))
         return _make_completed(returncode=1)
 
     with (
@@ -1081,7 +1090,7 @@ def test_codex_engine_fails_when_no_auth() -> None:
         results = run_all_checks(_config(harness="codex"), repo="owner/repo")
     codex_check = [r for r in results if r.name == "codex-auth"]
     assert codex_check[0].passed is False
-    assert "OPENAI_API_KEY" in codex_check[0].message
+    assert OPENAI_KEY_SECRET in codex_check[0].message
 
 
 def test_claude_engine_omits_codex_auth_check() -> None:
@@ -1096,7 +1105,6 @@ def test_claude_engine_omits_codex_auth_check() -> None:
 
 def test_claude_engine_passes_with_oauth_token() -> None:
     """Engine=claude with the OAuth token secret set passes claude-auth."""
-    # _gh_all_pass returns ["T1","T2"] — T2 is claude_token_secret.
     with (
         patch("shutil.which", return_value="/usr/bin/gh"),
         patch("tend.checks._gh", side_effect=_gh_all_pass()),
@@ -1105,7 +1113,7 @@ def test_claude_engine_passes_with_oauth_token() -> None:
     claude_check = [r for r in results if r.name == "claude-auth"]
     assert len(claude_check) == 1
     assert claude_check[0].passed is True
-    assert "T2" in claude_check[0].message
+    assert CLAUDE_TOKEN_SECRET in claude_check[0].message
 
 
 def test_claude_engine_passes_with_api_key() -> None:
@@ -1122,9 +1130,9 @@ def test_claude_engine_passes_with_api_key() -> None:
         if "collaborators" in url:
             return _make_completed("write\n")
         if "secrets" in url:
-            if "--json" in args:
-                return _make_completed('[{"name":"T1"},{"name":"ANTHROPIC_API_KEY"}]\n')
-            return _make_completed('["T1","ANTHROPIC_API_KEY"]\n')
+            return _make_completed(
+                _secret_names(args, BOT_TOKEN_SECRET, ANTHROPIC_API_KEY_SECRET)
+            )
         return _make_completed(returncode=1)
 
     with (
@@ -1134,7 +1142,7 @@ def test_claude_engine_passes_with_api_key() -> None:
         results = run_all_checks(_config(), repo="owner/repo")
     claude_check = [r for r in results if r.name == "claude-auth"]
     assert claude_check[0].passed is True
-    assert "ANTHROPIC_API_KEY" in claude_check[0].message
+    assert ANTHROPIC_API_KEY_SECRET in claude_check[0].message
 
 
 def test_claude_engine_fails_when_no_auth() -> None:
@@ -1151,9 +1159,7 @@ def test_claude_engine_fails_when_no_auth() -> None:
         if "collaborators" in url:
             return _make_completed("write\n")
         if "secrets" in url:
-            if "--json" in args:
-                return _make_completed('[{"name":"T1"}]\n')
-            return _make_completed('["T1"]\n')
+            return _make_completed(_secret_names(args, BOT_TOKEN_SECRET))
         return _make_completed(returncode=1)
 
     with (
@@ -1163,8 +1169,8 @@ def test_claude_engine_fails_when_no_auth() -> None:
         results = run_all_checks(_config(), repo="owner/repo")
     claude_check = [r for r in results if r.name == "claude-auth"]
     assert claude_check[0].passed is False
-    assert "T2" in claude_check[0].message
-    assert "ANTHROPIC_API_KEY" in claude_check[0].message
+    assert CLAUDE_TOKEN_SECRET in claude_check[0].message
+    assert ANTHROPIC_API_KEY_SECRET in claude_check[0].message
 
 
 def test_run_all_checks_deduplicates_default_branch() -> None:

--- a/generator/tests/test_config_edge_cases.py
+++ b/generator/tests/test_config_edge_cases.py
@@ -9,7 +9,7 @@ import pytest
 from tests import _yaml as yaml
 from click import ClickException
 
-from tend.config import Config
+from tend.config import BOT_TOKEN_SECRET, Config
 from tend.workflows import generate_all
 
 
@@ -44,8 +44,6 @@ def test_bot_name_only(tmp_path: Path) -> None:
     assert cfg.bot_name == "my-bot"
     assert cfg.model == "opus"
     assert cfg.protected_branches == []
-    assert cfg.bot_token_secret == "TEND_BOT_TOKEN"
-    assert cfg.claude_token_secret == "CLAUDE_CODE_OAUTH_TOKEN"
     assert cfg.setup == []
     assert cfg.workflows == {}
     assert cfg.allowed_repo_secrets == []
@@ -706,18 +704,34 @@ def test_allowed_secrets_string_rejected(tmp_path: Path) -> None:
 def test_allowed_secrets_refuses_operational_names(tmp_path: Path) -> None:
     """Allowlisting an operational secret would let a repo-level copy pass
     `tend check` — one config line quietly re-opening what the environment
-    gate closes — so the config is refused at the edge. The check applies to
-    the resolved names, so a renamed bot token is caught under its rename."""
+    gate closes — so the config is refused at the edge."""
+    path = _write_config(
+        tmp_path,
+        dedent("""\
+        bot_name: my-bot
+        secrets:
+          allowed: ["CODECOV_TOKEN", "TEND_BOT_TOKEN"]
+    """),
+    )
+    with pytest.raises(ClickException, match=BOT_TOKEN_SECRET):
+        Config.load(path)
+
+
+def test_secret_name_override_refused(tmp_path: Path) -> None:
+    """The per-adopter name overrides are gone. Ignoring a leftover one would
+    generate workflows reading the fixed name while the adopter's secret still
+    answers to the old one, so it fails with the rename to make."""
     path = _write_config(
         tmp_path,
         dedent("""\
         bot_name: my-bot
         secrets:
           bot_token: MY_BOT_PAT
-          allowed: ["CODECOV_TOKEN", "MY_BOT_PAT"]
     """),
     )
-    with pytest.raises(ClickException, match="MY_BOT_PAT"):
+    with pytest.raises(
+        ClickException, match=rf"secrets\.bot_token → {BOT_TOKEN_SECRET}"
+    ):
         Config.load(path)
 
 

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -13,7 +13,13 @@ import click
 from click.testing import CliRunner
 
 from tend.cli import main
-from tend.config import BOT_TOKEN_SECRET, OPERATIONAL_SECRETS, Config
+from tend.config import (
+    ANTHROPIC_API_KEY_SECRET,
+    BOT_TOKEN_SECRET,
+    CLAUDE_TOKEN_SECRET,
+    OPENAI_KEY_SECRET,
+    Config,
+)
 from tend.workflows import (
     _deep_merge,
     GENERATORS,
@@ -279,15 +285,23 @@ def test_workflows_read_only_the_operational_secrets(
 
     The names are fixed constants shared by the templates and the checks, so
     the failure this guards is a template naming a secret that nothing
-    provisions — which surfaces only as an empty token at run time.
-    `secrets.GITHUB_TOKEN` is workflow-scoped rather than stored, so it is
-    outside the set."""
+    provisions — which surfaces only as an empty token at run time. The set
+    is per harness because the checks are: `check_claude_auth` verifies the
+    Claude pair and `check_codex_auth` the OpenAI key, so a claude workflow
+    reading `secrets.OPENAI_API_KEY` is unprovisioned as surely as one
+    reading a name nothing defines. `secrets.GITHUB_TOKEN` is
+    workflow-scoped rather than stored, so it is outside the set."""
+    verified = {BOT_TOKEN_SECRET} | (
+        {CLAUDE_TOKEN_SECRET, ANTHROPIC_API_KEY_SECRET}
+        if harness == "claude"
+        else {OPENAI_KEY_SECRET}
+    )
     cfg = Config.load(_minimal_config(tmp_path, f"harness: {harness}\n"))
     for wf in generate_all(cfg):
         read = set(re.findall(r"secrets\.([A-Za-z0-9_]+)", wf.content))
-        assert read - {"GITHUB_TOKEN"} <= OPERATIONAL_SECRETS, (
-            f"{wf.filename} reads a secret outside the operational set: "
-            f"{sorted(read - {'GITHUB_TOKEN'} - OPERATIONAL_SECRETS)}"
+        assert read - {"GITHUB_TOKEN"} <= verified, (
+            f"{wf.filename} reads a secret the {harness} harness does not "
+            f"provision: {sorted(read - {'GITHUB_TOKEN'} - verified)}"
         )
         assert BOT_TOKEN_SECRET in read, f"{wf.filename} missing the bot token"
 

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -13,7 +13,7 @@ import click
 from click.testing import CliRunner
 
 from tend.cli import main
-from tend.config import Config
+from tend.config import BOT_TOKEN_SECRET, OPERATIONAL_SECRETS, Config
 from tend.workflows import (
     _deep_merge,
     GENERATORS,
@@ -271,20 +271,25 @@ def test_empty_setup_no_blank_lines(tmp_path: Path) -> None:
         assert "\n\n\n" not in wf.content, f"{wf.filename} has triple blank lines"
 
 
-def test_custom_secrets(tmp_path: Path) -> None:
-    extra = dedent("""\
-        secrets:
-          bot_token: MY_BOT_PAT
-          claude_token: MY_CLAUDE
-          anthropic_api_key: MY_API_KEY
-    """)
-    cfg = Config.load(_minimal_config(tmp_path, extra))
+@pytest.mark.parametrize("harness", ["claude", "codex"])
+def test_workflows_read_only_the_operational_secrets(
+    tmp_path: Path, harness: str
+) -> None:
+    """Every stored secret a workflow reads is one `tend check` verifies.
+
+    The names are fixed constants shared by the templates and the checks, so
+    the failure this guards is a template naming a secret that nothing
+    provisions — which surfaces only as an empty token at run time.
+    `secrets.GITHUB_TOKEN` is workflow-scoped rather than stored, so it is
+    outside the set."""
+    cfg = Config.load(_minimal_config(tmp_path, f"harness: {harness}\n"))
     for wf in generate_all(cfg):
-        assert "MY_BOT_PAT" in wf.content, f"{wf.filename} missing custom bot token"
-        assert "MY_CLAUDE" in wf.content, f"{wf.filename} missing custom claude token"
-        assert "MY_API_KEY" in wf.content, (
-            f"{wf.filename} missing custom anthropic_api_key secret"
+        read = set(re.findall(r"secrets\.([A-Za-z0-9_]+)", wf.content))
+        assert read - {"GITHUB_TOKEN"} <= OPERATIONAL_SECRETS, (
+            f"{wf.filename} reads a secret outside the operational set: "
+            f"{sorted(read - {'GITHUB_TOKEN'} - OPERATIONAL_SECRETS)}"
         )
+        assert BOT_TOKEN_SECRET in read, f"{wf.filename} missing the bot token"
 
 
 def test_claude_workflows_emit_both_auth_inputs(tmp_path: Path) -> None:

--- a/generator/tests/test_migrate.py
+++ b/generator/tests/test_migrate.py
@@ -46,7 +46,6 @@ def test_migrate_full_config_round_trips_through_config_load(tmp_path: Path) -> 
         model = "sonnet"
 
         [secrets]
-        bot_token = "MY_BOT_PAT"
         allowed = ["CODECOV_TOKEN"]
 
         [[setup]]
@@ -71,7 +70,6 @@ def test_migrate_full_config_round_trips_through_config_load(tmp_path: Path) -> 
     assert cfg.bot_name == "test-bot"
     assert cfg.protected_branches == ["v1", "v2"]
     assert cfg.model == "sonnet"
-    assert cfg.bot_token_secret == "MY_BOT_PAT"
     assert cfg.allowed_repo_secrets == ["CODECOV_TOKEN"]
     assert len(cfg.setup) == 2
     assert cfg.setup[0].fields == {"uses": "astral-sh/setup-uv@v6"}

--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -82,18 +82,10 @@ bot_name: <bot-name>
 # effort: medium   # optional: low | medium | high | xhigh
 ```
 
-Check whether the repo already has a bot token secret under a non-default name:
+List the secrets the repo already holds:
 
 ```bash
 gh secret list --repo "$REPO" --json name --jq '.[].name'
-```
-
-If a bot-token-like secret exists (e.g., `GH_BOT_TOKEN`, `ROBOT_PAT`),
-suggest overriding the default name rather than creating a duplicate:
-
-```yaml
-secrets:
-  bot_token: GH_BOT_TOKEN
 ```
 
 Any repo-level secret not in `secrets.allowed` triggers a `tend check`
@@ -732,10 +724,8 @@ rm -rf "$HOME/.config/gh-bots/<bot-name>"
 
 ### 8c. Push token to secret
 
-Copy the bot's token to the environment secret (`<secret-name>` is the
-`secrets.bot_token` value from §1, default `TEND_BOT_TOKEN`; trust
-this over any name an audit issue quotes) and verify the `Updated`
-timestamp is fresh:
+Copy the bot's token to the `TEND_BOT_TOKEN` environment secret and verify
+the `Updated` timestamp is fresh:
 
 ```bash
 BOT_GH_TOKEN=$(env -u GH_TOKEN -u GITHUB_TOKEN \
@@ -743,7 +733,7 @@ BOT_GH_TOKEN=$(env -u GH_TOKEN -u GITHUB_TOKEN \
 if [ -z "$BOT_GH_TOKEN" ]; then
   echo "bot token empty — fix step 8 first" >&2
 else
-  gh secret set <secret-name> --repo "$REPO" --env tend --body "$BOT_GH_TOKEN"
+  gh secret set TEND_BOT_TOKEN --repo "$REPO" --env tend --body "$BOT_GH_TOKEN"
   gh secret list --repo "$REPO" --env tend
 fi
 ```
@@ -839,7 +829,7 @@ line picks the row that matches the chosen harness):
 - [ ] Bot account: `<bot-name>` exists on GitHub
 - [ ] Harness auth (claude): `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` secret set
 - [ ] Harness auth (codex): `OPENAI_API_KEY` secret set
-- [ ] Bot token: the `secrets.bot_token` secret (default `TEND_BOT_TOKEN`) set with `repo`+`workflow`+`notifications`+`write:discussion`+`gist`+`user` scopes
+- [ ] Bot token: `TEND_BOT_TOKEN` set with `repo`+`workflow`+`notifications`+`write:discussion`+`gist`+`user` scopes
 - [ ] Bot access: repo collaborator with write access, invitation accepted
 - [ ] Bot bio: profile bio reflects the authorization stance
 - [ ] Committed (push requires explicit permission)

--- a/plugins/install-tend/skills/install-tend/references/tend.example.yaml
+++ b/plugins/install-tend/skills/install-tend/references/tend.example.yaml
@@ -46,9 +46,9 @@ bot_name: my-project-bot
 
 # ## Secrets
 #
-# Required secrets, by harness — stored in the repo's `tend` GitHub
-# Environment (install-tend creates it; a workflow the bot pushes to a
-# branch cannot read them there):
+# Required secrets, by harness, under these exact names — stored in the
+# repo's `tend` GitHub Environment (install-tend creates it; a workflow the
+# bot pushes to a branch cannot read them there):
 #
 # | Harness    | Required                                                                  |
 # |------------|---------------------------------------------------------------------------|
@@ -78,14 +78,6 @@ bot_name: my-project-bot
 # `notifications:write`, `gists:write`, plus the account-level `Profile:
 # read and write` permission (for the bio). `notifications:write` is
 # required so the action can mark threads read after handling an event.
-#
-# Override names if the repo uses different secret names:
-#
-# secrets:
-#   bot_token: MY_BOT_PAT
-#   claude_token: MY_CLAUDE_TOKEN        # claude (OAuth)
-#   anthropic_api_key: MY_ANTHROPIC_KEY  # claude (API key)
-#   openai_key: MY_OPENAI_KEY            # codex
 #
 # `tend check` flags repo-level secrets not in an explicit allowlist — each
 # entry is a deliberate acceptance that any workflow the repo runs can read

--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -27,7 +27,7 @@ The script prints `key=value` lines. Act on `STATUS`:
 
 - `STATUS=ok`: all scopes present. Search open issues for a PAT scope audit tracking issue (`gh issue list --state open --search "PAT in:title"`); if found, close it with a comment noting the scopes are now granted.
 - `STATUS=fine-grained`: no `X-OAuth-Scopes` header. Fine-grained PATs have no documented self-introspection endpoint — skip.
-- `STATUS=missing`: open or update a tracking issue. Use a title containing "PAT" (e.g. `Bot PAT: missing scopes`) so future runs can dedup by title search. Before creating, run `gh issue list --state open --search "PAT in:title"` and update the existing issue with `gh issue edit` if one is already open. The body lists the values from `MISSING=`, names the secret to update by its real name (the `secrets.bot_token` value from `.config/tend.yaml`, default `TEND_BOT_TOKEN` — never a placeholder), and links step 8 of the `install-tend` skill for remediation: https://github.com/max-sixty/tend/blob/main/plugins/install-tend/skills/install-tend/SKILL.md#8-bot-token-and-secret
+- `STATUS=missing`: open or update a tracking issue. Use a title containing "PAT" (e.g. `Bot PAT: missing scopes`) so future runs can dedup by title search. Before creating, run `gh issue list --state open --search "PAT in:title"` and update the existing issue with `gh issue edit` if one is already open. The body lists the values from `MISSING=`, names the secret to update (`TEND_BOT_TOKEN`), and links step 8 of the `install-tend` skill for remediation: https://github.com/max-sixty/tend/blob/main/plugins/install-tend/skills/install-tend/SKILL.md#8-bot-token-and-secret
 
 ## Step 2: Check tend configuration drift
 


### PR DESCRIPTION
`secrets.bot_token`, `.claude_token`, `.anthropic_api_key` and `.openai_key` renamed the four operational secrets per adopter. No config anywhere set one — every adopter and tend itself run the defaults, and the only thing exercising the path was a test fixture.

The case they existed for is closed. The overrides let an adopter whose repo already held a differently-named PAT point tend at it rather than minting a duplicate; since the operational secrets moved into the `tend` environment, `install-tend` creates that environment and fills it from scratch, so there is no pre-existing secret whose name is worth keeping. An org-level copy is an explicit `check_secrets` failure rather than a stand-in, so that route is closed too. `install-tend`'s §1 was still telling adopters to reach for the override in exactly the case that no longer works.

The names become module constants in `config.py`. The templates read them as Jinja globals, following `tend_environment`, so the names `tend check` looks for and the names the workflows read cannot drift; `check_claude_auth` and `check_codex_auth` no longer need a `Config` at all. The `secrets.allowed` refusal now intersects against `OPERATIONAL_SECRETS` and behaves as before. A leftover override key fails with the rename to make, rather than being warned past into workflows that read a secret the adopter doesn't have.

`test_custom_secrets` had nothing left to assert; in its place `test_workflows_read_only_the_operational_secrets` checks, per harness, that every stored secret a workflow reads is one `tend check` verifies — the bot token plus that harness's own auth secret, so a claude workflow reading `secrets.OPENAI_API_KEY` fails as surely as one reading a name nothing defines.

Rendered YAML is byte-identical — every regtest output is unchanged, so adopters see no diff on their next regen. 338 tests pass and `pre-commit run --all-files` is clean. `uvx`-equivalent `tend init --dry-run` against this repo's config emits `TEND_BOT_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY` and `GITHUB_TOKEN` and nothing else; `tend check` reports the same two pre-existing failures on `CLAUDE_CODE_OAUTH_TOKEN` still sitting at repo level, which are the outstanding half of the credential migration `TODO.md` tracks and untouched here.

> _This was written by Claude Code on behalf of max-sixty_
