### PR TITLE
fix(mark-notification-read): treat a null run_started_at as absent

### DIFF
--- a/generator/tests/test_shared_steps.py
+++ b/generator/tests/test_shared_steps.py
@@ -124,6 +124,30 @@ def test_mark_notification_read_tolerates_run_metadata_failure(
     )
 
 
+def test_mark_notification_read_treats_a_null_timestamp_as_absent(
+    tmp_path: Path, gh_env: dict[str, str]
+) -> None:
+    """A 200 whose body lacks `run_started_at` must be handled like a failure.
+
+    `gh --jq` prints the literal `null` for a missing field, which is non-empty
+    and so survives the `-z` guard. It then reaches the jq comparison as a
+    string, and every ISO-8601 timestamp sorts before `null` by codepoint — so
+    the `updated_at <= $started` filter matches every thread and the run marks
+    read the mid-run activity the guard exists to preserve. The notification
+    here is dated two months *after* the run, so a PATCH can only come from
+    that inversion.
+    """
+    gh_env["NOTIFICATIONS_JSON"] = _notifications(tmp_path, "2026-03-01T00:00:00Z")
+    gh_env["FAKE_RUN_STARTED_AT"] = "null"
+
+    result = _run(gh_env)
+
+    assert result.returncode == 0, result.stderr
+    assert not any("-X PATCH" in c for c in _calls(gh_env)), (
+        "marked a thread read against a `null` run_started_at"
+    )
+
+
 def test_mark_notification_read_marks_thread_predating_the_run(
     tmp_path: Path, gh_env: dict[str, str]
 ) -> None:

--- a/shared/steps/mark-notification-read.sh
+++ b/shared/steps/mark-notification-read.sh
@@ -39,8 +39,14 @@ esac
 # timestamp the `updated_at <= started` guard can't be evaluated, and marking
 # unconditionally would swallow activity that arrived mid-run — so skip this
 # cycle and leave the thread unread for the scheduled poll to pick up.
+#
+# `null` counts as absent: a 200 whose body lacks the field leaves `gh --jq`
+# printing the literal string, which is non-empty and so passes `-z`. It then
+# reaches the jq guard below as a *string*, and every ISO-8601 timestamp sorts
+# before `null` by codepoint — so `updated_at <= $started` holds for everything
+# and the run marks read exactly the mid-run activity it means to preserve.
 if ! RUN_STARTED_AT=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
-  --jq '.run_started_at') || [ -z "$RUN_STARTED_AT" ]; then
+  --jq '.run_started_at') || [ -z "$RUN_STARTED_AT" ] || [ "$RUN_STARTED_AT" = "null" ]; then
   echo "::warning::Could not read run_started_at; leaving notification unread (non-fatal)"
   exit 0
 fi


### PR DESCRIPTION
## Problem

#843 added a guard so a transient failure fetching `run_started_at` leaves the notification unread rather than failing the step. It tests `[ -z "$RUN_STARTED_AT" ]`, which covers a `gh api` that exits non-zero — but not a 200 whose body lacks the field. `gh --jq` prints the literal string `null` there, which is non-empty and passes `-z`.

`null` then reaches the filter as a *string*:

```bash
jq -r --arg started "$RUN_STARTED_AT" '.[] | select(.subject.url == $url and .updated_at <= $started) | .id'
```

Every ISO-8601 timestamp sorts before `null` by codepoint (`2` is `0x32`, `n` is `0x6e`), so `updated_at <= "null"` is true for every thread. The step marks read exactly the mid-run activity the guard exists to preserve — silently, since it's the success path.

Reproduced against the real script with the existing `test_shared_steps.py` fake `gh`, using a notification dated two months *after* the run started:

```console
$ FAKE_RUN_STARTED_AT=null bash shared/steps/mark-notification-read.sh
$ cat gh-calls.log
api repos/owner/repo/actions/runs/12345 --jq .run_started_at
api notifications
api notifications/threads/999 -X PATCH     # ← marked read anyway
```

## Fix

Extend the guard to treat `null` as absent, so the missing-field case takes the same skip-this-cycle path as a failed fetch:

```bash
|| [ -z "$RUN_STARTED_AT" ] || [ "$RUN_STARTED_AT" = "null" ]; then
```

Plus a regression test that asserts nothing is marked read against a `null` timestamp. It fails on `main` with `marked a thread read against a null run_started_at` and passes with the fix.

## On reachability

I want to be straight about this: I could not construct a live case where `/actions/runs/{id}` returns 200 without `run_started_at` — the field has been on that endpoint for years, and an HTTP error exits `gh` non-zero and is already handled. So this is hardening against a shape the API doesn't currently produce, not a bug anyone is hitting.

What makes it worth the two lines is the failure mode rather than its likelihood: the wrong branch is the *success* path, it swallows unread notifications instead of erroring, and #843 already decided this is a place where being wrong should cost a skipped cycle and not silent data loss. Happy for it to be closed if that's the wrong trade.
