### PR TITLE
docs: name Codex in the marketplace description

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "email": "m@maxroos.com"
   },
   "metadata": {
-    "description": "An autonomous junior maintainer for GitHub repos, powered by Claude — reviews PRs, triages issues, fixes CI"
+    "description": "An autonomous junior maintainer for GitHub repos, powered by Claude or OpenAI Codex — reviews PRs, triages issues, fixes CI"
   },
   "plugins": [
     {


### PR DESCRIPTION
Surfaced by tonight's rolling survey, which had `.claude-plugin/marketplace.json` in its slice.

The marketplace-level `metadata.description` is the last user-facing blurb still reading "powered by Claude". Every other one says "powered by Claude or OpenAI Codex":

| Surface | Text |
|---|---|
| `generator/pyproject.toml` | Claude or OpenAI Codex (3cbc162) |
| `generator/src/tend/cli.py` | Claude or OpenAI Codex (3cbc162) |
| `install-tend` skill frontmatter | Claude or OpenAI Codex |
| `marketplace.json` → `plugins[install-tend].description` | Claude or OpenAI Codex (c5cdb56) |
| `marketplace.json` → `metadata.description` | **Claude** ← this PR |

c5cdb56 ("docs: mention Codex in install-tend plugin descriptions") updated the plugin entry in this same file and didn't reach the marketplace blurb above it, so this looks like an oversight rather than a deliberate distinction. `claude/action.yaml`'s "powered by Claude" is correct as-is — that one *is* the Claude harness.

No test: the string isn't asserted anywhere, and it's rendered in the `/plugin marketplace` listing rather than parsed.
