### PR TITLE
fix(running-in-ci): batch pushes so the author doesn't cancel its own reviewer

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -183,12 +183,12 @@ If pushing fails (fork PR with edits disabled), fall back to posting code snippe
 
 ### Batch the push — every push restarts the reviewer
 
-`tend-review` triggers on `synchronize` under a per-PR concurrency group at `cancel-in-progress: true`, so each push to a bot-authored PR starts a fresh review run and cancels the one already running. Push twice in quick succession and the first reviewer is killed at startup having produced nothing; push after several minutes and it dies with whatever review it had assembled unsubmitted.
+`tend-review` triggers on `synchronize` under a per-PR concurrency group at `cancel-in-progress: true`, so each push to a PR starts a fresh review run and cancels the one already running. Push twice in quick succession and the first reviewer is killed at startup having produced nothing; push after several minutes and it dies with whatever review it had assembled unsubmitted.
 
 - **Commit everything before `gh pr create`.** Changelog entries, test pins, and formatting fixups belong in the initial push, not a follow-up thirty seconds later.
 - **Make the commits, then push once** — not a push after each commit. Amends and rebases count: a force-push fires `synchronize` too.
 
-A follow-up push that acts on review feedback *should* invalidate the running review — that one is correct. Land it as a single push rather than spreading the same fix over several.
+A follow-up push that acts on information the session didn't have at push time — review feedback, a red check — *should* invalidate the running review; that one is correct. What's wasteful is splitting work you already have into several pushes.
 
 ### Re-check PR state before pushing a follow-up commit
 

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -181,6 +181,15 @@ Always use `git push` without specifying a remote — `gh pr checkout` configure
 
 If pushing fails (fork PR with edits disabled), fall back to posting code snippets in a comment. Don't reference commit SHAs from temporary branches — post code inline.
 
+### Batch the push — every push restarts the reviewer
+
+`tend-review` triggers on `synchronize` under a per-PR concurrency group at `cancel-in-progress: true`, so each push to a bot-authored PR starts a fresh review run and cancels the one already running. Push twice in quick succession and the first reviewer is killed at startup having produced nothing; push after several minutes and it dies with whatever review it had assembled unsubmitted.
+
+- **Commit everything before `gh pr create`.** Changelog entries, test pins, and formatting fixups belong in the initial push, not a follow-up thirty seconds later.
+- **Make the commits, then push once** — not a push after each commit. Amends and rebases count: a force-push fires `synchronize` too.
+
+A follow-up push that acts on review feedback *should* invalidate the running review — that one is correct. Land it as a single push rather than spreading the same fix over several.
+
 ### Re-check PR state before pushing a follow-up commit
 
 Any wait that lets time pass — a CI poll, coverage fetch, sleep, background task — also gives a maintainer time to merge or close the PR. After waiting:


### PR DESCRIPTION
## Problem

`tend-review` triggers on `pull_request_target: synchronize` under a per-PR concurrency group at `cancel-in-progress: true` ([`review.yaml.j2`](https://github.com/max-sixty/tend/blob/3b46066/generator/src/tend/templates/review.yaml.j2#L9-L18)). Every push to a bot-authored PR therefore starts a replacement review run and cancels the one already going. Nothing in the skills tells the *author* side to batch its pushes, so a session that opens a PR and then pushes a follow-up commit thirty seconds later spawns a reviewer purely to kill it.

On `PRQL/prql` in the 07:44Z–08:44Z window, 5 of the 8 `tend-review` runs on bot-authored PRs were cancelled, and 4 of those posted nothing at all. Each cancellation traces to the same bot pushing again while its own reviewer was running.

| PR | head | review run | started | ended | lifetime | review posted |
|---|---|---|---|---|---|---|
| [#6149](https://github.com/PRQL/prql/pull/6149) | `43b1738a` | [31082377982](https://github.com/PRQL/prql/actions/runs/31082377982) | 07:49:05 | cancelled 07:49:45 | **40s** | no |
| [#6150](https://github.com/PRQL/prql/pull/6150) | `1979e288` | [31084139419](https://github.com/PRQL/prql/actions/runs/31084139419) | 08:15:14 | cancelled 08:15:47 | **33s** | no |
| [#6150](https://github.com/PRQL/prql/pull/6150) | `ce92ec84` | [31084169295](https://github.com/PRQL/prql/actions/runs/31084169295) | 08:15:39 | cancelled 08:15:53 | **14s** | no |
| [#6150](https://github.com/PRQL/prql/pull/6150) | `270aa2b1` | [31085384920](https://github.com/PRQL/prql/actions/runs/31085384920) | 08:33:29 | cancelled 08:35:43 | 2m14s | no |
| [#6147](https://github.com/PRQL/prql/pull/6147) | `94ceeca5` | [31081526145](https://github.com/PRQL/prql/actions/runs/31081526145) | 07:35:42 | cancelled 07:51:42 | **16m00s** | no |

The sharpest case is #6150. The session created the PR at 08:15:09, pushed `ce92ec84` (`chore: changelog entry`) ~28s later, then force-pushed it as `eaf11545` ~12s after that — `gh api repos/PRQL/prql/compare/ce92ec84...88867eeb` returns `status: diverged`, confirming the rewrite. Three review runs fired inside 42 seconds; two died before doing any work. The changelog entry had no reason not to be in the initial push.

The 16-minute loss on #6147 is the same rule from the other end: run 31081526145 had been reviewing for 16 minutes when the author session pushed `0efb4aea`, and its analysis went with it.

## Solution

A new **Batch the push** subsection under `running-in-ci`'s "Pushing to PR Branches", stating the mechanism once and two rules: commit everything before `gh pr create`, and make the commits then push once rather than pushing after each. It notes explicitly that amends and rebases fire `synchronize` too, since the #6150 case went through a force-push. A closing line keeps the legitimate case intact — a push that acts on review feedback *should* invalidate the running review; the ask is to land it as one push, not several.

`running-in-ci` is the right home because every session that pushes reads it, and the sessions producing this were `tend-mention` handle legs rather than any one workflow's skill.

## Relationship to existing work

This is the author-side counterpart to #830 / #834, not a duplicate. Those cover a *review* session cancelling itself by pushing a fix before submitting its review; the ordering rule there protects the pusher. Here the pusher is a different session entirely, and the victim is a reviewer that has no way to protect itself — so the rule has to live on the author side. The two compose: #834 makes the reviewer push last, this makes the author push once.

## Gate assessment

- **Evidence level**: High — a consistent pattern across multiple independent sessions (the #6149 handle leg, the #6150 handle leg, and the #6147 author session), not a single lapse. High requires 2–3 occurrences; this window alone has 4 cancelled-with-nothing-posted runs, and the evidence gist carries one prior recorded occurrence (`tend-nightly` pushes to its own just-opened PR, cancelling that PR's first review mid-flight — recorded at cumulative 1 with "act at 3+"). Cumulative 5.
- **Structural vs stochastic**: structural in its consequence. Given two pushes within a minute, the first review run is cancelled every time — there is no decision point in the cancellation itself, only in whether the author batches. Replaying the scenario 10 times cancels 10 times.
- **Change type**: targeted fix — a missing step added to an existing section, no new section and no workflow change. Normal bar, met.
- **Passes both gates**: yes.

## Testing

Skill prose, so no test to add. The structural claim was verified against the generator template rather than assumed: `review.yaml.j2` shows `types: [opened, synchronize, ready_for_review, reopened]` with `group: ${{ github.workflow }}-${{ github.event.pull_request.number }}` and `cancel-in-progress: true`. Every run ID, head SHA, and timestamp in the table above comes from `gh api repos/PRQL/prql/actions/runs/<id>`; the review-posted column was checked against `gh api repos/PRQL/prql/pulls/<n>/reviews`. Checked the co-loaded skills before adding guidance — `review/SKILL.md` line 370 discusses cancelled *check runs*, not the review session, and no skill carried an author-side batching rule.

Evidence log: https://gist.github.com/192514ea2c36586f9b7f842a482d62ab
