### PR TITLE
skills(review-reviewers): confirm run→output attribution from the posting run's log

### DIFF
--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -309,14 +309,25 @@ Review the subagent's summary. If all outputs are accepted and no sanity-check f
 
 For runs with negative outcome signals (or suspicious lack of output), spawn another cheap subagent to download and inspect the specific session logs.
 
-**Also escalate whenever a finding will name *which run* produced an output.** A timestamp falling inside a run's start/end span does not attribute the output to it: several runs are live at once — a long scheduled run that opened the PR, the event-triggered handle answering a review on it, a racing sibling — and any of them can post. Attributing by wall-clock inclusion credits the wrong run, and the run ID then ships in a public comment. Confirm from the posting run's own log before a run ID enters a finding:
+**Also escalate whenever a finding will name *which run* produced an output.** A timestamp falling inside a run's start/end span does not attribute the output to it: several runs are live at once — a long scheduled run that opened the PR, the event-triggered handle answering a review on it, a racing sibling — and any of them can post. Attributing by wall-clock inclusion credits the wrong run, and the run ID then ships in a public comment. Confirm from the posting run's own log before a run ID enters a finding.
+
+Grep for the write *shape*, not the endpoint — `/comments` and `/reviews` are the GET paths too, and reading the thread is the first thing nearly every run does. Don't truncate the tool input: a `git push` or `gh issue comment` often sits hundreds of characters into a longer command. Scan every `*.jsonl` under the run directory, since a subagent posts from its own `subagents/agent-*.jsonl`.
 
 ```bash
-jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "tool_use") | "\(.name): \(.input | tostring | .[0:200])"' FILE \
-  | grep -E 'comments/[0-9]+/replies|/(reviews|comments)\b|issue comment|pr comment|git push'
+WRITES='gh (pr|issue) (comment|review|create)|--method POST|-X POST|comments/[0-9]+/replies|git push'
+
+# Claude logs
+for f in $(find /tmp/session-logs/<run-id> -name '*.jsonl'); do
+  jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "tool_use") | "\(.name): \(.input | tostring)"' "$f"
+done | grep -E "$WRITES"
+
+# Codex logs — same idea against the rollout schema (/install-tend:debug-tend-run)
+for f in $(find /tmp/session-logs/<run-id> -name '*.jsonl'); do
+  jq -r 'select(.payload.type == "function_call") | "\(.payload.name): \(.payload.arguments)"' "$f"
+done | grep -E "$WRITES"
 ```
 
-The run whose log contains the posting call is the author; a run whose log ends in a read-only sweep posted nothing, however well its span brackets the timestamp.
+The run whose log contains the posting call is the author. Presence is the strong signal; before concluding a run posted *nothing*, confirm you ran the variant matching the artifact you downloaded — the wrong one returns empty regardless of what the run did.
 
 Use a cheap subagent (e.g. Haiku / gpt-mini) and a prompt like:
 

--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -337,7 +337,7 @@ Use a cheap subagent (e.g. Haiku / gpt-mini) and a prompt like:
 >
 > The concerning outcome was: <signal from Step 2>.
 >
-> If your answer will name **which run produced an output**, say which output and confirm it from the log before answering — run the `WRITES` recipe above over every `*.jsonl` under the download directory, and quote the matching tool call verbatim rather than summarising it. Don't use the truncated query below for this: the write often sits hundreds of characters into a longer command.
+> If your answer will name **which run produced an output**, say which output and confirm it from the log before answering — run <paste the `WRITES` recipe above> over every `*.jsonl` under the download directory, and quote the matching tool call verbatim rather than summarising it. Don't use the truncated query below for this: the write often sits hundreds of characters into a longer command.
 >
 > **JSONL parsing** — each line has a `type` field (`user`, `assistant`, `system`). Key queries:
 > ```

--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -309,6 +309,15 @@ Review the subagent's summary. If all outputs are accepted and no sanity-check f
 
 For runs with negative outcome signals (or suspicious lack of output), spawn another cheap subagent to download and inspect the specific session logs.
 
+**Also escalate whenever a finding will name *which run* produced an output.** A timestamp falling inside a run's start/end span does not attribute the output to it: several runs are live at once — a long scheduled run that opened the PR, the event-triggered handle answering a review on it, a racing sibling — and any of them can post. Attributing by wall-clock inclusion credits the wrong run, and the run ID then ships in a public comment. Confirm from the posting run's own log before a run ID enters a finding:
+
+```bash
+jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "tool_use") | "\(.name): \(.input | tostring | .[0:200])"' FILE \
+  | grep -E 'comments/[0-9]+/replies|/(reviews|comments)\b|issue comment|pr comment|git push'
+```
+
+The run whose log contains the posting call is the author; a run whose log ends in a read-only sweep posted nothing, however well its span brackets the timestamp.
+
 Use a cheap subagent (e.g. Haiku / gpt-mini) and a prompt like:
 
 > Investigate session logs for run <run-id> on `$ARGUMENTS`.

--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -314,7 +314,7 @@ For runs with negative outcome signals (or suspicious lack of output), spawn ano
 Grep for the write *shape*, not the endpoint — `/comments` and `/reviews` are the GET paths too, and reading the thread is the first thing nearly every run does. Don't truncate the tool input: a `git push` or `gh issue comment` often sits hundreds of characters into a longer command. Scan every `*.jsonl` under the run directory, since a subagent posts from its own `subagents/agent-*.jsonl`.
 
 ```bash
-WRITES='gh (pr|issue) (comment|review|create)|--method POST|-X POST|comments/[0-9]+/replies|git push'
+WRITES='gh (pr|issue) (comment|review|create|edit)|--method (POST|PATCH|PUT)|-X (POST|PATCH|PUT)|comments/[0-9]+/replies|git push|resolveReviewThread'
 
 # Claude logs
 for f in $(find /tmp/session-logs/<run-id> -name '*.jsonl'); do
@@ -327,7 +327,7 @@ for f in $(find /tmp/session-logs/<run-id> -name '*.jsonl'); do
 done | grep -E "$WRITES"
 ```
 
-The run whose log contains the posting call is the author. Presence is the strong signal; before concluding a run posted *nothing*, confirm you ran the variant matching the artifact you downloaded — the wrong one returns empty regardless of what the run did.
+The run whose log contains the posting call is the author. Presence is the strong signal; before concluding a run posted *nothing*, confirm you ran the variant matching the artifact you downloaded — the wrong one returns empty regardless of what the run did — and that the write you're chasing has a shape `WRITES` covers.
 
 Use a cheap subagent (e.g. Haiku / gpt-mini) and a prompt like:
 
@@ -336,6 +336,8 @@ Use a cheap subagent (e.g. Haiku / gpt-mini) and a prompt like:
 > Download: `gh run download <run-id> -R $ARGUMENTS --pattern 'claude-session-logs*' --pattern 'codex-session-logs*' --dir /tmp/session-logs/<run-id>/` (both patterns are passed because the artifact prefix depends on the target repo's harness — Claude uploads `claude-session-logs*`, Codex uploads `codex-session-logs*`)
 >
 > The concerning outcome was: <signal from Step 2>.
+>
+> If your answer will name **which run produced an output**, say which output and confirm it from the log before answering — run the `WRITES` recipe above over every `*.jsonl` under the download directory, and quote the matching tool call verbatim rather than summarising it. Don't use the truncated query below for this: the write often sits hundreds of characters into a longer command.
 >
 > **JSONL parsing** — each line has a `type` field (`user`, `assistant`, `system`). Key queries:
 > ```


### PR DESCRIPTION
A `review-reviewers` leg named the wrong run as the author of a public comment, and that run ID then shipped in a public comment on an open PR ([#849](https://github.com/max-sixty/tend/pull/849#issuecomment-5201962818)). The mis-attribution came from mapping outputs to runs by wall-clock inclusion — the comment's timestamp fell inside that run's span, so it was credited to it. Several runs are live at once on a busy PR, so the span proves nothing.

## What actually happened

On `max-sixty/cargo-affected` PR #77, four bot sessions overlapped between 07:21Z and 07:41Z. Attribution read from each session's own log (the tool call that posted):

| Output | Credited in #849 to | Actually posted by (session log) |
| --- | --- | --- |
| commit `56406d76` + inline reply `3726782508` | mention handle `31081009768` | `tend-nightly` `31080083613` — the run that opened the PR, still running |
| inline reply `3726818957` | mention handle `31081269852` | mention handle `31081009768` |

`31081269852` and `31081591885` — the two hops triggered by the synthetic reply containers that #849 exists to suppress — each ran a read-only sweep and posted nothing. Their logs contain no posting call and both end with an explicit silent-exit decision.

This matters for #849: its comment escalates the case to "an unguarded container caused the bot to post additional public output." That did not happen in this window. Both public replies came from a hop that #849's own predicate keeps firing (the genuine self-review) and from a racing sibling session outside the chain entirely. The guard's real value — suppressing two no-op agent runs and their queue slots — is unchanged. Correction posted on the PR.

## Root cause

Step 2's run→output mapping is branch- and time-based, which is the right cheap first pass. Nothing then tells the analyst that the mapping is provisional. Step 3 escalates to session logs only on "negative outcome signals (or suspicious lack of output)", so a finding whose *claim* is an attribution — this run did that — never triggers the one check that could confirm it. The leg that produced the error recorded "session-log inspection: not needed — the mention chain's decisions are fully determined by the review records", which is true of the decisions and false of the authorship.

## Change

One paragraph in Step 3 adding a third escalation trigger: when a finding will name which run produced an output, confirm it from that run's log, with the `jq | grep` for the posting call. Ten lines, at the point where the escalation decision is made.

## Gate assessment

- **Evidence level**: High. Direct occurrence this window, confirmed against four session logs. The class — attribution errors reaching a finding — stands at 5 across recorded legs: three cheap-subagent mis-attributions, the human-vs-bot actor case now addressed by [#864](https://github.com/max-sixty/tend/pull/864), and this run-vs-run case. The evidence log's standing carry pre-registered exactly this ("verify any subagent claim before it enters a finding, especially actor attribution **and run→output mapping**"); it has now fired for the second half.
- **Occurrences**: 1 direct + 4 historical in class, against a High threshold of 2–3.
- **Structural**: yes. Overlapping runs make wall-clock attribution ambiguous every time; the skill offers no other attribution method, so the same reasoning reproduces the same error.
- **Change type**: targeted fix (one paragraph + a recipe at an existing decision point), Normal bar.
- **Relation to #864**: complementary and non-overlapping. #864 fixes *actor* attribution (which login) in Step 2; this fixes *run* attribution (which session) in Step 3. Textually adjacent, so whichever lands second wants a trivial rebase.

Evidence log: https://gist.github.com/dca23a6e6a0d8cae2665944ba31676fb
