### PR TITLE
fix(running-in-ci): leave a review that lands mid-poll to tend-mention

### DIFF
--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -320,7 +320,7 @@ The default action is a PR, not an issue. If there's a plausible fix, make it �
 
 For each finding:
 
-1. **Create a PR** — branch, fix, run full test suite, commit, push, create PR, poll CI. **Every bug fix must include a regression test that would have failed before the fix.** If a test is not feasible (e.g., pure documentation changes), note why in the PR description. When uncertain about the approach, explain the trade-offs in the description.
+1. **Create a PR** — branch, fix, run full test suite, commit, push, create PR, then poll CI per **CI Monitoring** in `/tend-ci-runner:running-in-ci`. Your job ends when those checks are terminal: a review posted on the PR while you poll belongs to `tend-mention`. **Every bug fix must include a regression test that would have failed before the fix.** If a test is not feasible (e.g., pure documentation changes), note why in the PR description. When uncertain about the approach, explain the trade-offs in the description.
 2. **Create an issue only when there's no obvious fix** — design questions, problems needing maintainer input, or findings requiring investigation beyond what the survey can provide.
 
 ## Optional steps

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -290,6 +290,12 @@ Invoke this Bash call with `timeout: 600000` (10 min). The default 2-min Bash ti
 3. Once terminal, do the follow-up: ship a green fix, comment an unresolved failure, or dismiss your approval on red.
 4. If the cap hits with checks still running, comment the still-pending checks as unverified before ending — don't exit as if done.
 
+### A review that lands while you poll is not yours to action
+
+`tend-review` fires on any PR you open, so its review often arrives while you are still polling that PR's checks. Don't act on it. `tend-mention` is dispatched on `pull_request_review` for every PR the bot authored, and that dispatch runs whether or not you also respond — so a session that starts editing is racing a run already making the same edits and running the same suite. The loser only finds out at `git push`, discards its commit, and the whole fix-and-verify cycle is paid twice for one review.
+
+Poll your checks to terminal, do the follow-up you were gated on, and exit; name the outstanding review in your summary. This covers a review that arrives *while* you work — a session dispatched to answer a specific review owns that review and actions it normally.
+
 Before dismissing local test failures as "pre-existing", check main branch CI:
 
 ```bash

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -197,11 +197,14 @@ If the PR is merged, the work is superseded. Comment if a real gap remains; do n
 A PR another tend session opened keeps that session alive polling its checks, and closing a red gate is exactly the follow-up it stays alive for — so a sibling commit can land on the branch while you edit it. Find that out at `git push` and the suite you just ran was scoped against a stale head, so the whole verify cycle is paid again after the rebase. Record the head before editing and re-check it immediately before each expensive step — full test suite, coverage or snapshot regeneration, a long build:
 
 ```bash
-BASE_OID=$(gh pr view <N> --json headRefOid --jq '.headRefOid')
+HEAD_OID=$(gh pr view <N> --json headRefOid --jq '.headRefOid')
 # ...edits...
-[ "$(gh pr view <N> --json headRefOid --jq '.headRefOid')" = "$BASE_OID" ] \
-  || echo "sibling pushed — fetch and re-scope before verifying"
+read -r NOW_OID NOW_STATE < <(gh pr view <N> --json headRefOid,state --jq '"\(.headRefOid) \(.state)"')
+[ "$NOW_OID" = "$HEAD_OID" ] && [ "$NOW_STATE" = "OPEN" ] \
+  || echo "sibling pushed or PR closed — fetch and re-scope before verifying"
 ```
+
+`state` rides along on the same call because a merged or closed PR freezes `headRefOid` at its merge-time value (see above) — the OID comparison alone passes and the expensive step runs on work that is already superseded. On a non-`OPEN` state, stop per the subsection above rather than re-scoping.
 
 If it moved, `git fetch` and read the new commits before verifying: drop whatever the sibling already landed, rebase what's left, and verify once against the new head. Expect the overlap rather than treating it as a surprise — a reviewer and a coverage gate reading the same new code ask for the same missing test. The runs API can't substitute for this check: a `schedule` or `repository_dispatch` run reports `head_branch: main`, not the branch it is editing, so a live sibling is invisible there.
 
@@ -303,12 +306,6 @@ Invoke this Bash call with `timeout: 600000` (10 min). The default 2-min Bash ti
 3. Once terminal, do the follow-up: ship a green fix, comment an unresolved failure, or dismiss your approval on red.
 4. If the cap hits with checks still running, comment the still-pending checks as unverified before ending — don't exit as if done.
 
-### A review that lands while you poll is not yours to action
-
-`tend-review` fires on any PR you open, so its review often arrives while you are still polling that PR's checks. Don't act on it. `tend-mention` is dispatched on `pull_request_review` for every PR the bot authored, and that dispatch runs whether or not you also respond — so a session that starts editing is racing a run already making the same edits and running the same suite. The loser only finds out at `git push`, discards its commit, and the whole fix-and-verify cycle is paid twice for one review.
-
-Poll your checks to terminal, do the follow-up you were gated on, and exit; name the outstanding review in your summary. This covers a review that arrives *while* you work — a session dispatched to answer a specific review owns that review and actions it normally.
-
 Before dismissing local test failures as "pre-existing", check main branch CI:
 
 ```bash
@@ -317,6 +314,12 @@ gh api "repos/{owner}/{repo}/actions/runs?branch=main&status=completed&per_page=
 ```
 
 If you cannot verify, say "I haven't confirmed whether these failures are pre-existing."
+
+### A review that lands while you poll is not yours to action
+
+`tend-review` fires on any PR you open, so its review often arrives while you are still polling that PR's checks. Don't act on it. `tend-mention` is dispatched on `pull_request_review` for every PR the bot authored, and that dispatch runs whether or not you also respond — so a session that starts editing is racing a run already making the same edits and running the same suite. The loser only finds out at `git push`, discards its commit, and the whole fix-and-verify cycle is paid twice for one review.
+
+Poll your checks to terminal, do the follow-up you were gated on, and exit; name the outstanding review in your summary. This covers a review that arrives *while* you work — a session dispatched to answer a specific review owns that review and actions it normally.
 
 ### Polling `gh run rerun --failed`
 

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -192,6 +192,19 @@ STATE=$(gh pr view <N> --json state --jq '.state')
 
 If the PR is merged, the work is superseded. Comment if a real gap remains; do not push to the now-orphan branch. After merge, `gh pr view <N> --json headRefOid` returns the SHA at merge time and never advances — polling it for a new push is a guaranteed deadlock.
 
+### Re-check the head SHA before the expensive verify, not just before the push
+
+A PR another tend session opened keeps that session alive polling its checks, and closing a red gate is exactly the follow-up it stays alive for — so a sibling commit can land on the branch while you edit it. Find that out at `git push` and the suite you just ran was scoped against a stale head, so the whole verify cycle is paid again after the rebase. Record the head before editing and re-check it immediately before each expensive step — full test suite, coverage or snapshot regeneration, a long build:
+
+```bash
+BASE_OID=$(gh pr view <N> --json headRefOid --jq '.headRefOid')
+# ...edits...
+[ "$(gh pr view <N> --json headRefOid --jq '.headRefOid')" = "$BASE_OID" ] \
+  || echo "sibling pushed — fetch and re-scope before verifying"
+```
+
+If it moved, `git fetch` and read the new commits before verifying: drop whatever the sibling already landed, rebase what's left, and verify once against the new head. Expect the overlap rather than treating it as a surprise — a reviewer and a coverage gate reading the same new code ask for the same missing test. The runs API can't substitute for this check: a `schedule` or `repository_dispatch` run reports `head_branch: main`, not the branch it is editing, so a live sibling is invisible there.
+
 ## Merging Upstream into PR Branches
 
 When asked to merge the default branch into a PR branch:


### PR DESCRIPTION
## Problem

When a session opens a PR and then stays alive polling its CI, `tend-review` fires on that PR and posts findings — and two actors race to fix them: the still-live session that opened the PR, and the `tend-mention` session dispatched by the `pull_request_review` event. Both make the same edits and run the same suite; the loser discovers the duplication at `git push`, discards its commit, and a full fix-and-verify cycle is paid twice. No wrong output reaches the repo — every existing dedup guard fires — but every guard in `running-in-ci` is anchored at the *output* boundary (`gh pr create`, `git push`, comment posting), so the collision is only ever discovered after the cost is sunk.

## Solution

Two rules, one per commit — the first removes the common case, the second bounds what the first can't reach.

### 1. A role boundary: a review that lands mid-poll isn't yours to action

Per the second of the two options in #865. The API-based sibling-run check in the first option can't see which branch a nightly run is working on — that's only visible from its checkout — so it can't close the nightly-vs-mention case it was aimed at.

The rule goes in `running-in-ci`'s **CI Monitoring** section rather than the nightly skill: the mechanism is generic to any session that opens a PR and stays alive polling it (nightly, ci-fix, triage, weekly, the hourly review skills), and CI Monitoring is where that "stay alive and poll" instruction lives. The nightly skill's step 8 gets a one-line pointer to it, since its "poll CI" step named no section to read.

The session that stands down has to be the one holding the PR: the mention dispatch fires whether or not the holder also responds, so it is the run that cannot be suppressed.

### 2. A cost bound: re-check the head SHA before the expensive verify

The role boundary cuts on *who owns the review*, and a [recurrence on `max-sixty/worktrunk`](https://github.com/max-sixty/tend/issues/865#issuecomment-5250740598) shows work colliding without the review being read at all. There, nightly never fetched the review; `codecov/patch` — a required gate on that repo — flagged the same new closure the reviewer had, so nightly added the missing test as the follow-up it was gated on ([`957358b46`](https://github.com/max-sixty/worktrunk/commit/957358b462138b52ff71ab4a9beaef8308040476), 06:56) while the mention run independently built a near-identical one. The convergence isn't luck: a reviewer and a coverage tool reading the same new code ask for the same missing test. Rule 1 permits this by construction, since closing a red required gate is the carve-out it keeps.

So the second commit puts a check on the *writing* side, where the cost is paid: record `headRefOid` before editing, re-check it immediately before each expensive step (full suite, coverage/snapshot regeneration, long build) rather than only at `git push`. On that occurrence it would have caught the sibling push at ~06:56 instead of ~07:01 — before the integration suite and the post-reset re-verify, which is where most of the wasted ~$2.14 went.

It also records why the runs-API approach doesn't work, so it isn't re-derived: both writing runs report `head_branch: main` (nightly runs on `schedule`, the mention handler on `repository_dispatch`), so a live sibling is invisible there. Only the `pull_request_target` review run carries the PR branch — confirmed against runs [31465475753](https://github.com/max-sixty/worktrunk/actions/runs/31465475753), [31466280614](https://github.com/max-sixty/worktrunk/actions/runs/31466280614), and [31466624503](https://github.com/max-sixty/worktrunk/actions/runs/31466624503).

The other shape the report floats — making a PR-holding session read-only after `gh pr create` — isn't taken here: that session is the only one gated on the PR's checks, and no dispatch fires for a red gate, so a red `codecov/patch` with no accompanying review would sit unfixed.

## What the handoff rests on — and what doesn't back it

`tend-mention`'s `verify` job short-circuits to `should_run=true` on `PR_AUTHOR == bot_name`, so every review on a bot-authored same-repo PR reaches the handle job, and the prompt for `client_payload.kind == 'pull_request_review'` instructs the session to make requested changes and push. Nightly-opened PRs are same-repo, so the fork exclusion on the relay job doesn't apply to them.

**The handoff is unbacked — the dispatch is the only thing carrying the review, and if it's lost nothing recovers it.** GitHub raises no notification for an actor's own activity, so a `tend-agent` review on a `tend-agent`-authored PR creates no notification thread at all, and the notifications poll's "stale unanswered items" path has nothing to find. And the dispatch can be lost silently: `tend-mention-handle-<PR#>` runs at `cancel-in-progress: false`, and per CLAUDE.md's "GHA queue depth = 1" note a third job arriving replaces the queued one — on a PR drawing several events, the review's handle job is exactly the one that gets replaced. Before this change the still-live session was the fallback; after it, the only residual is "name the outstanding review in your summary", which lands in the session log rather than anywhere a maintainer sees.

That is the accepted cost rather than an oversight: the duplicated fix-and-verify cycle is the common outcome and a dropped dispatch is rare, so paying the duplication on every review to insure against it is the worse deal. But the property a future reader will lean on is that the handoff has no second line of defence.

<details><summary>How the no-self-notification behaviour was checked</summary>

`gh api "notifications?all=true&per_page=100"` returns the newest 50 threads, `updated_at` desc. The newest row is `2026-08-06T04:23:44Z`.

Absent entirely — each bot-authored, each carrying bot self-reviews *newer* than that newest row, so they would sort first if a thread existed:

- this PR (#870) — opened 08:56, self-review 09:02:30
- #868 — opened 08:52, self-reviews 08:57:13 / 08:59:40 / 08:59:47

Present, but only keyed to another actor's action:

- #843 — self-reviews 07:19 and 07:23 on 08-05; thread `updated_at` `16:43:23`, ~20s after the maintainer's merge at `16:43:03`
- #840 — self-reviews 01:02–01:05; thread `updated_at` `16:44:47`, after the merge at `16:44:26`

</details>

## Testing

None — the change is skill prose, and no test covers skill markdown. Verified against the mention template's `verify` logic and prompt text (`generator/src/tend/templates/mention.yaml.j2`) that the run being handed to actually receives and actions these reviews, and against the notifications API that no self-activity thread exists to back that dispatch up. The second commit's premises were checked against the public record on `max-sixty/worktrunk`: the commit order and timing on #3799, and the `head_branch` each of the three runs reports.

---

Closes #865 — automated triage
