### PR TITLE
fix(review-runs): find the evidence log by its heading, not by recency

### DIFF
--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -83,15 +83,18 @@ Also check last month's tracking issue (if it exists) for recent carry-over.
 
 ### Recording below-threshold findings
 
-After analysis, find **the bot's existing comment** on the tracking issue and **append** new findings to it. If no bot comment exists yet, create one. This avoids notification spam from frequent runs.
+After analysis, find **this skill's own evidence comment** on the tracking issue and **append** new findings to it. If it doesn't exist yet, create one. This avoids notification spam from frequent runs.
 
 The guard must run **before any posting path** — append-existing and create-new both publish a comment that needs to embed the real run ID, and a guard placed inside one branch silently no-ops on the other. The first run after a monthly tracking issue is created always takes the create-new branch, so the guard belongs above the branch:
 
 ```bash
 REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
 BOT_LOGIN=$(gh api user --jq '.login')
+# Match the evidence log by its `## Run <id>` heading, not by "newest bot
+# comment" — other skills (nightly) post their own comments on this issue, and
+# the newest one is often not the log.
 EXISTING_COMMENT=$(gh api "repos/$REPO/issues/$TRACKING_NUMBER/comments" \
-  --jq "[.[] | select(.user.login == \"$BOT_LOGIN\")] | last | .id // empty")
+  --jq "[.[] | select(.user.login == \"$BOT_LOGIN\" and (.body | test(\"^## Run [0-9]\")))] | last | .id // empty")
 
 # Verify the run heading references this run's $GITHUB_RUN_ID literally —
 # fabricated round numbers produce dead Workflow links, see @review-gates.md.

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -116,7 +116,8 @@ if [ -n "$EXISTING_COMMENT" ]; then
     gh api "repos/$REPO/issues/$TRACKING_NUMBER/comments" -F body=@/tmp/findings.md
   fi
 else
-  # No prior bot comment on this month's tracking issue — create the first one.
+  # No prior evidence-log comment on this month's tracking issue — create the
+  # first one. Other bot comments may exist; they aren't append targets.
   gh api "repos/$REPO/issues/$TRACKING_NUMBER/comments" -F body=@/tmp/findings.md
 fi
 ```


### PR DESCRIPTION
The `review-runs` evidence log lives in one rolling comment on the monthly tracking issue, and the skill finds it with "newest comment authored by the bot". That selector is wrong whenever another skill has posted on the same issue more recently — which is now the steady state on `max-sixty/cargo-affected`, where `tend-nightly` posted its own below-threshold finding as a second comment on the `review-runs-tracking` issue.

Run the current recipe verbatim against that issue today:

```console
$ gh api "repos/max-sixty/cargo-affected/issues/73/comments" \
    --jq '[.[] | select(.user.login == "cargo-affected-bot")] | last | .id'
5188771252     # tend-nightly's comment, "## Nightly run 30984146563 — 2026-08-05"
```

The evidence log is `5150650688` ("## Run 30691987081 — 2026-08-01T08:37:18Z", 42 KB, six daily entries). A run that follows the recipe literally appends its findings under the nightly's heading and leaves the log orphaned — with no error, because both comments are valid PATCH targets. The size guard a few lines down then measures the wrong body too (2.5 KB instead of 42 KB), so it would keep appending there indefinitely.

## Why it hasn't broken yet

Both `tend-review-runs` runs since the nightly comment appeared noticed and silently deviated, hard-coding the right comment ID instead of running the selector. From each run's session JSONL:

| Run | Date | What it executed |
|---|---|---|
| [30989981741](https://github.com/max-sixty/cargo-affected/actions/runs/30989981741) | 2026-08-05 | `TARGET=5150650688` then `gh api .../issues/comments/$TARGET -X PATCH` |
| [31085867626](https://github.com/max-sixty/cargo-affected/actions/runs/31085867626) | 2026-08-06 | listed the comments, then `TARGET=5150650688` and the same PATCH |

The 2026-08-05 run also wrote down why, in its own summary: *"Nightly posted its finding as a second tracker comment, so the skill's `| last` append target now resolves to it. I appended to the review-runs comment (`5150650688`) instead to keep the log contiguous — cosmetic, no evidence lost, and the cross-skill convention would be bundled guidance rather than a repo overlay."* It classified the fix as bundled guidance and recorded it below-threshold on the tracker, which is as far as it could take it from the adopter side.

So correctness currently depends on the model spotting a broken instruction and ignoring it, two runs in a row. That's the part worth removing.

## Fix

Match the evidence log by the `## Run <id>` heading the finding format already mandates, rather than by recency. Verified against both tracking issues:

```console
$ # max-sixty/cargo-affected #73 (nightly comment present)
$ gh api ".../issues/73/comments" --jq '[.[] | select(.user.login == "cargo-affected-bot" and (.body | test("^## Run [0-9]")))] | last | .id'
5150650688     # the evidence log

$ # max-sixty/tend #801 (no interloping comment)
$ gh api ".../issues/801/comments" --jq '[.[] | select(.user.login == "tend-agent" and (.body | test("^## Run [0-9]")))] | last | .id'
5150655987     # unchanged from the old selector
```

`// empty` still falls through to the create-new branch on a fresh monthly issue, and `| last` is kept so a rollover comment (started when the previous one passes 50 KB) still wins over the one it replaced.

## Gate assessment

- **Gate 1 — confidence**: High. Structural and deterministic, not stochastic: the selector's result is fixed by what's on the issue, and the wrong answer is reproducible on demand (above). 2 occurrences of a run having to deviate (2026-08-05, 2026-08-06), both confirmed from the posting call in each session log rather than inferred from timing. High needs 2–3.
- **Gate 2 — magnitude**: Targeted fix (one jq predicate, one comment, one clause of prose), Normal bar. No new section, no restructuring.
- **Failure mode is invisible**: a literal-following run produces a successful PATCH to the wrong comment. Nothing fails, no CI turns red, and the fork would only surface when someone reads the tracker.

Not proposed here: migrating `review-runs` to the gist-backed store `review-reviewers` uses (there's a `TODO` in the file for it). That's a structural change against a very high evidence bar, and this selector is wrong regardless of where the log ends up.

Evidence log: https://gist.github.com/dca23a6e6a0d8cae2665944ba31676fb
