### PR TITLE
fix(review-reviewers): stop a skipped init-tracking from cancelling the whole matrix

### DIFF
--- a/.github/workflows/review-reviewers.yaml
+++ b/.github/workflows/review-reviewers.yaml
@@ -17,6 +17,10 @@ jobs:
   # legs find an existing issue instead of racing to create one. Without this,
   # the first cron tick of each new month produced N-1 duplicate tracking
   # issues (one per matrix leg that lost the find-or-create race).
+  #
+  # This is an optimisation, not a precondition: the skill still carries its own
+  # find-or-create fallback, so the matrix runs even when this job doesn't
+  # complete (see `if:` on the matrix job below).
   init-tracking:
     runs-on: ubuntu-24.04
     environment:
@@ -47,6 +51,11 @@ jobs:
 
   review-reviewers:
     needs: init-tracking
+    # Run even when init-tracking failed or never got a runner — losing the
+    # race guard costs at most a duplicate tracking issue on the first tick of
+    # a month, while gating on it costs the whole analysis window for every
+    # target repo. Not `always()`: a user cancelling the run should stop here.
+    if: ${{ !cancelled() }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/review-reviewers.yaml
+++ b/.github/workflows/review-reviewers.yaml
@@ -52,7 +52,7 @@ jobs:
   review-reviewers:
     needs: init-tracking
     # Run even when init-tracking failed or never got a runner — losing the
-    # race guard costs at most a duplicate tracking issue on the first tick of
+    # race guard costs up to N-1 duplicate tracking issues on the first tick of
     # a month, while gating on it costs the whole analysis window for every
     # target repo. Not `always()`: a user cancelling the run should stop here.
     if: ${{ !cancelled() }}

--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -82,7 +82,7 @@ GIST_DESC="review-reviewers evidence: $TARGET $MONTH"
 
 The tracking issue lives on tend (the current repo). It indexes gists via one comment per new gist — no per-run comments, no body edits.
 
-The workflow's `init-tracking` job runs before the matrix and creates the monthly tracking issue if absent, so matrix legs always find an existing one. The find-or-create logic below remains the fallback for ad-hoc invocations and as a safety net; sort lowest-numbered first in case a race ever does produce duplicates. `gh issue create` prints the new issue's URL; parse the number from its basename.
+The workflow's `init-tracking` job runs before the matrix and creates the monthly tracking issue if absent, so on a normal tick matrix legs find an existing one. It is not a precondition — the matrix runs even when that job fails or never gets a runner, so the find-or-create logic below is a live code path on the first tick of a month, not only a fallback for ad-hoc invocations. Sort lowest-numbered first so a lost race degrades to a duplicate rather than a crash. `gh issue create` prints the new issue's URL; parse the number from its basename.
 
 ```bash
 TRACKING_NUMBER=$(gh issue list --state open --label "$TRACKING_LABEL" \


### PR DESCRIPTION
`review-reviewers` lost **8 h 15 m** of coverage today across all five target repos, and the cause was a two-line gate in its own workflow rather than anything in a skill.

## What happened

A critical GitHub Actions incident ([status page](https://stspg.io/rcz3fcm83sff), created 2026-08-06T15:22:49Z, still `investigating`) made runner acquisition unreliable. Four consecutive `review-reviewers` ticks then failed identically — `init-tracking` sat unscheduled for ~15 minutes, GitHub marked it `cancelled`, and because the matrix job has a hard `needs: init-tracking`, all five legs were `skipped` without ever trying for a runner:

| Run | Created | `init-tracking` | matrix |
|---|---|---|---|
| [31122877870](https://github.com/max-sixty/tend/actions/runs/31122877870) | 17:21:15Z | `cancelled` | `skipped` ×5 |
| [31125649607](https://github.com/max-sixty/tend/actions/runs/31125649607) | 18:17:43Z | `cancelled` | `skipped` ×5 |
| [31126978811](https://github.com/max-sixty/tend/actions/runs/31126978811) | 19:34:17Z | `cancelled` | `skipped` ×5 |
| [31128259981](https://github.com/max-sixty/tend/actions/runs/31128259981) | 21:22:19Z | `cancelled` | `skipped` ×5 |

That's 20 leg-analyses discarded. The legs were not themselves unschedulable: in [31119653960](https://github.com/max-sixty/tend/actions/runs/31119653960) (16:23Z) `init-tracking` did succeed, and matrix legs went on to acquire runners and run — `numbagg/numbagg` completed successfully at 16:34Z during the same incident.

## Why the gate isn't worth its cost

`init-tracking` exists to win a find-or-create race that can only bite on the **first cron tick of a month** — before that tick, no tracking issue exists for the new month and N legs would each try to create one. The `review-reviewers` skill still carries its own find-or-create fallback, sorting lowest-numbered-first precisely so a lost race degrades to a duplicate rather than a crash. This change makes that path load-bearing on a first-tick failure rather than a pure safety net, so the skill's wording is updated in the same commit to say so.

So the gate trades *up to N-1 duplicate tracking issues (four, at today's five legs), once a month* against *the entire analysis window for every target repo, every time the job can't get a runner*. This change keeps `needs:` — so `init-tracking` still runs first and still wins the race on every normal tick — and only relaxes the failure propagation.

`!cancelled()` rather than `always()` is deliberate: a user cancelling the run should still stop the matrix.

## Gate assessment

- **Evidence level: High** — 4 occurrences in a single window, all with byte-identical job shape.
- **Structural, not stochastic.** A hard `needs:` gate always propagates; there is no decision point for the agent to get right. Confirmed against the last 14 `review-reviewers` failures: the `init=cancelled → matrix=skipped` shape appears **only** on today's four, while every 2026-08-05 failure ran `init=success` with the matrix reaching the agent. The gate is the amplifier; the incident is only the trigger.
- **Change type: removal of a gate** — 2 functional lines. Under the magnitude gate a removal clears at 1 occurrence; this has 4.
- **Not an incident workaround.** The skill's own rule is to record transient upstream incidents rather than commit code around them, and this run recorded the rest of the incident's damage without acting on it. This one is different in kind: it removes a permanent single point of failure that will amplify the *next* infrastructure hiccup the same way, and it stays correct after the incident resolves.
- **Dedup**: no open or closed tend issue or PR mentions `init-tracking`. #845 (cadence) and #858 (per-leg branch names) touch this workflow but not this gate.

Evidence log: https://gist.github.com/192514ea2c36586f9b7f842a482d62ab

Found while analysing `PRQL/prql` in run [31132205674](https://github.com/max-sixty/tend/actions/runs/31132205674) — the run that had to absorb all four lost windows.

