### PR TITLE
fix(check): read environment names one per line, and address them encoded

### DIFF
--- a/generator/src/tend/checks.py
+++ b/generator/src/tend/checks.py
@@ -21,6 +21,7 @@ import shutil
 import subprocess
 from dataclasses import dataclass
 from functools import cache
+from urllib.parse import quote
 
 from ruamel.yaml import YAML
 from ruamel.yaml.error import YAMLError
@@ -454,6 +455,19 @@ def _env_secret_names(repo: str) -> tuple[set[str] | None, str]:
         return None, "Could not parse environment secrets response"
 
 
+def _env_path(env_name: str) -> str:
+    """An environment name as one path segment.
+
+    GitHub admits `/` in an environment name, and `gh api` treats the path it
+    is given as already-formed — it percent-encodes a space but passes a slash
+    through as a separator, so `a/b` addresses an environment that does not
+    exist. Every such 404 reads to the callers below as a token without admin
+    access, which returns the whole credential check as skipped. `safe=""`
+    encodes the separator too; `gh` does not re-encode what it is handed.
+    """
+    return quote(env_name, safe="")
+
+
 def _branch_policies(repo: str, env_name: str) -> list[dict] | None:
     """An environment's deployment branch policies, or None if unlistable.
 
@@ -463,7 +477,7 @@ def _branch_policies(repo: str, env_name: str) -> list[dict] | None:
     listed = _gh(
         "api",
         "--paginate",
-        f"repos/{repo}/environments/{env_name}/deployment-branch-policies",
+        f"repos/{repo}/environments/{_env_path(env_name)}/deployment-branch-policies",
         "--jq",
         ".branch_policies[]",
     )
@@ -1046,7 +1060,7 @@ def check_credential_environments(
         secrets = _gh(
             "api",
             "--paginate",
-            f"repos/{repo}/environments/{env_name}/secrets",
+            f"repos/{repo}/environments/{_env_path(env_name)}/secrets",
             "--jq",
             ".secrets[].name",
         )
@@ -1061,7 +1075,7 @@ def check_credential_environments(
         holders.append(env_name)
         if env_name == TEND_ENVIRONMENT:
             continue  # Gated by its branch policy; `environment` verifies that.
-        detail = _gh("api", f"repos/{repo}/environments/{env_name}")
+        detail = _gh("api", f"repos/{repo}/environments/{_env_path(env_name)}")
         if detail is None or detail.returncode != 0:
             return CheckResult(name, None, f"Could not read environment '{env_name}'")
         try:

--- a/generator/src/tend/checks.py
+++ b/generator/src/tend/checks.py
@@ -1033,7 +1033,16 @@ def check_credential_environments(
 
     ungated: list[str] = []
     holders: list[str] = []
-    for env_name in listed.stdout.split():
+    # One name per line, not one per whitespace-separated token: GitHub admits
+    # a space in an environment name, and splitting on whitespace turns one
+    # such environment into two names that exist nowhere. Each answers 404,
+    # which is the `returncode != 0` below, so the whole check reports itself
+    # skipped for want of admin access — a credential check that stops
+    # verifying and blames the token. The real environment goes unexamined
+    # either way.
+    for env_name in listed.stdout.splitlines():
+        if not env_name:
+            continue
         secrets = _gh(
             "api",
             "--paginate",

--- a/generator/tests/test_checks.py
+++ b/generator/tests/test_checks.py
@@ -6,6 +6,7 @@ import json
 import subprocess
 from pathlib import Path
 from unittest.mock import patch
+from urllib.parse import quote
 
 import pytest
 from click.testing import CliRunner
@@ -1441,16 +1442,20 @@ def _credential_env_gh(
             if url.endswith(f"/rulesets/{ruleset_id}"):
                 return _make_completed(json.dumps(detail))
         for env_name, (secrets, detail, policies) in environments.items():
-            if url.endswith(f"/environments/{env_name}/deployment-branch-policies"):
+            # Matched percent-encoded, as GitHub answers: a name is one path
+            # segment, so a caller that interpolates it raw addresses another
+            # environment (or none) once the name holds a `/`.
+            seg = quote(env_name, safe="")
+            if url.endswith(f"/environments/{seg}/deployment-branch-policies"):
                 entries = [
                     dict(zip(("type", "name"), line.split(" ", 1)))
                     for line in policies.splitlines()
                     if line
                 ]
                 return _make_completed("\n".join(json.dumps(e) for e in entries) + "\n")
-            if url.endswith(f"/environments/{env_name}/secrets"):
+            if url.endswith(f"/environments/{seg}/secrets"):
                 return _make_completed("\n".join(secrets) + "\n")
-            if url.endswith(f"/environments/{env_name}"):
+            if url.endswith(f"/environments/{seg}"):
                 return _make_completed(json.dumps(detail))
         return _make_completed(returncode=1)
 
@@ -1615,8 +1620,7 @@ def test_credential_environments_reads_a_name_containing_a_space() -> None:
     returns one name per line. Splitting on whitespace instead made two names
     that exist nowhere; both 404, and the first 404 returned the whole check
     as skipped-for-want-of-admin — so a repo could hold an ungated credential
-    and read PASS-adjacent silence. Verified against live GitHub: `gh api`
-    encodes the space itself, so no quoting is needed here."""
+    and read PASS-adjacent silence."""
     fake = _credential_env_gh(
         {"staging deploy": (["T1"], {"protection_rules": []}, "")}
     )
@@ -1624,6 +1628,21 @@ def test_credential_environments_reads_a_name_containing_a_space() -> None:
         result = check_credential_environments("owner/repo", _config(), ["main"])
     assert result.passed is False, result.message
     assert "staging deploy" in result.message
+
+
+def test_credential_environments_reads_a_name_containing_a_slash() -> None:
+    """The other half of the same failure: GitHub admits `/` in an environment
+    name too, and a name is one path segment. Interpolating it raw addressed a
+    path that 404s, which is the same skipped-for-want-of-admin return as the
+    split above — so the name survives the read only to be lost on the way back
+    out. Verified against live GitHub: an environment named `a/b probe` lists
+    under that name, `gh api repos/<r>/environments/a/b probe/secrets` exits 1
+    with 404, and the percent-encoded path resolves."""
+    fake = _credential_env_gh({"a/b probe": (["T1"], {"protection_rules": []}, "")})
+    with patch("tend.checks._gh", side_effect=fake):
+        result = check_credential_environments("owner/repo", _config(), ["main"])
+    assert result.passed is False, result.message
+    assert "a/b probe" in result.message
 
 
 def test_credential_environments_accepts_a_human_reviewer() -> None:

--- a/generator/tests/test_checks.py
+++ b/generator/tests/test_checks.py
@@ -1610,6 +1610,22 @@ def test_credential_environments_is_keyed_on_secrets_not_on_the_name() -> None:
     assert "smoke-secrets" in result.message
 
 
+def test_credential_environments_reads_a_name_containing_a_space() -> None:
+    """GitHub admits a space in an environment name, and the list endpoint
+    returns one name per line. Splitting on whitespace instead made two names
+    that exist nowhere; both 404, and the first 404 returned the whole check
+    as skipped-for-want-of-admin — so a repo could hold an ungated credential
+    and read PASS-adjacent silence. Verified against live GitHub: `gh api`
+    encodes the space itself, so no quoting is needed here."""
+    fake = _credential_env_gh(
+        {"staging deploy": (["T1"], {"protection_rules": []}, "")}
+    )
+    with patch("tend.checks._gh", side_effect=fake):
+        result = check_credential_environments("owner/repo", _config(), ["main"])
+    assert result.passed is False, result.message
+    assert "staging deploy" in result.message
+
+
 def test_credential_environments_accepts_a_human_reviewer() -> None:
     fake = _credential_env_gh(
         {"tend-manual": (["T1"], _reviewers(("User", "maintainer")), "")}


### PR DESCRIPTION
`check_credential_environments` read the environment list with `listed.stdout.split()` and interpolated each name straight into the API path. GitHub admits both a space and a `/` in an environment name, and the list endpoint returns one name per line — so an environment called `staging deploy` became two names, `staging` and `deploy`, that exist nowhere, and one called `a/b` addressed `repos/<r>/environments/a/b/secrets`, a path that names no environment either.

Both shapes 404. The first 404 is the `secrets is None or secrets.returncode != 0` branch, which returns the **whole check** as skipped:

```
SKIP  credential-environments — Could not list secrets in 'staging' (requires admin access)
```

So the check that backs the security model's "a run the bot can cause reaches no credential" claim stops verifying, and the message blames the token rather than naming the real cause. The genuine environment is never examined either — if it holds an ungated credential, nothing reports it. One such environment costs the repo the check entirely, including for its other environments.

`splitlines()` fixes the read. `_env_path` — `quote(name, safe="")` — fixes the way back out: `gh api` percent-encodes a space itself but passes a `/` through as a path separator, and it does not re-encode the escapes it is handed, so encoding the whole name as one segment covers both shapes with one rule.

## Verification

Confirmed against live GitHub on `tend-agent/tend-integration`, with both probe environments deleted afterwards:

```console
$ gh api -X PUT "repos/$R/environments/zz%20probe" --jq '.name'
zz probe
$ gh api -X PUT "repos/$R/environments/zz%2Fprobe" --jq '.name'
zz/probe

$ gh api --paginate "repos/$R/environments" --jq '.environments[].name'
tend
zz probe
zz/probe

$ gh api "repos/$R/environments/zz/probe/secrets"          # raw slash
gh: Not Found (HTTP 404)
$ gh api "repos/$R/environments/zz%2Fprobe/secrets" --jq '.total_count'
0
$ gh api "repos/$R/environments/zz%2Fprobe" --jq '.name'
zz/probe
$ gh api "repos/$R/environments/zz%2Fprobe/deployment-branch-policies"
{"total_count":0,"branch_policies":[]}
```

The escapes survive the PUT, which is what shows `gh` passes them through rather than re-encoding the `%`. `%2F` then resolves on the detail, secrets, and deployment-branch-policies endpoints alike, where the raw `/` 404s. The last of those was read with `custom_branch_policies` enabled — that endpoint 404s on an environment with a null `deployment_branch_policy` regardless of encoding, which is the case `_policy_gate` returns on before it ever calls `_branch_policies`.

## Tests

`test_credential_environments_reads_a_name_containing_a_space` and `test_credential_environments_reads_a_name_containing_a_slash` both fail with the symptom above when the fix is reverted:

```
FAILED ...::test_credential_environments_reads_a_name_containing_a_space
AssertionError: Could not list secrets in 'staging' (requires admin access)
assert None is False
FAILED ...::test_credential_environments_reads_a_name_containing_a_slash
AssertionError: Could not list secrets in 'a/b' (requires admin access)
assert None is False
```

The shared `_credential_env_gh` fake now matches the percent-encoded segment, as GitHub answers, so a caller that interpolates a name raw stops matching and falls to the same skipped-for-want-of-admin return. Full generator suite: 353 passed.

## Scope

Deliberately narrow. The other `.split()` calls in this file are safe on their inputs — `_tags_admin_gated` splits numeric ruleset ids, and secret names are `[A-Z0-9_]` — so they are left alone rather than swept. Every other environment name reaching an API path in this file is the `TEND_ENVIRONMENT` constant.

Found by the nightly survey (bucket 8/28, `generator/src/tend/checks.py`). Independent of the other two open `checks.py` PRs (#825, #826), which both concern `_bypass_actors_above_bot`.
