### PR TITLE
fix(skills): key the --body exemption on shell hazards, and fix the recipes that trip it

### DIFF
--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -132,8 +132,11 @@ if [ -z "$GIST_ID" ]; then
   fi
   GIST_ID=$(basename "$GIST_URL")
   # First time this month for this target — announce the gist on the tracking issue
-  gh issue comment "$TRACKING_NUMBER" \
-    --body "Evidence gist for \`$TARGET\`: $GIST_URL"
+  # printf, not an inline --body: the backticks are literal inside single
+  # quotes, so nothing needs escaping and bash can't run the span.
+  printf 'Evidence gist for `%s`: %s\n' "$TARGET" "$GIST_URL" \
+    > /tmp/gist-announce.md
+  gh issue comment "$TRACKING_NUMBER" --body-file /tmp/gist-announce.md
 else
   GIST_URL="https://gist.github.com/$GIST_ID"
 fi

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -425,7 +425,7 @@ If `EXISTING` is greater than 0, **do not post** — another run already handled
 
 ## Comment Formatting
 
-**Compose bodies with the Write tool, then post with `--body-file`.** The composed file is reviewable before it ships, quoting and escaping are non-issues, and line wrapping is just file content. The bot writes to `/tmp/` constantly — one more file is cheap. `--body "…"` is fine only for a one-line body containing no backtick, `$`, `\`, or `!`. Inside double quotes bash runs a backticked span as a command and substitutes its output, so a markdown inline-code span is silently deleted from the posted comment: `` --body "`some-check` now passes" `` ships as ` now passes`. Inline code appears in nearly every body the bot writes, and single-quoting instead breaks on any apostrophe, so reach for `--body-file` whenever the text is anything but plain prose.
+**Compose bodies with the Write tool, then post with `--body-file`.** The composed file is reviewable before it ships, quoting and escaping are non-issues, and line wrapping is just file content. The bot writes to `/tmp/` constantly — one more file is cheap. `--body "…"` is fine only for a one-line body containing no backtick, `$`, or `\`. Inside double quotes bash runs a backticked span as a command and substitutes its output, so a markdown inline-code span is silently deleted from the posted comment: `` --body "`some-check` now passes" `` ships as ` now passes`. Inline code appears in nearly every body the bot writes, and single-quoting instead breaks on any apostrophe, so reach for `--body-file` whenever the text is anything but plain prose.
 
 ```bash
 # After writing /tmp/comment-body.md with the Write tool:

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -425,7 +425,7 @@ If `EXISTING` is greater than 0, **do not post** — another run already handled
 
 ## Comment Formatting
 
-**Compose bodies with the Write tool, then post with `--body-file`.** The composed file is reviewable before it ships, quoting and escaping are non-issues, and line wrapping is just file content. The bot writes to `/tmp/` constantly — one more file is cheap. For one-line bodies, `--body "…"` is fine.
+**Compose bodies with the Write tool, then post with `--body-file`.** The composed file is reviewable before it ships, quoting and escaping are non-issues, and line wrapping is just file content. The bot writes to `/tmp/` constantly — one more file is cheap. `--body "…"` is fine only for a one-line body containing no backtick, `$`, `\`, or `!`. Inside double quotes bash runs a backticked span as a command and substitutes its output, so a markdown inline-code span is silently deleted from the posted comment: `` --body "`some-check` now passes" `` ships as ` now passes`. Inline code appears in nearly every body the bot writes, and single-quoting instead breaks on any apostrophe, so reach for `--body-file` whenever the text is anything but plain prose.
 
 ```bash
 # After writing /tmp/comment-body.md with the Write tool:

--- a/plugins/tend-ci-runner/skills/triage/SKILL.md
+++ b/plugins/tend-ci-runner/skills/triage/SKILL.md
@@ -128,7 +128,7 @@ Step 3's duplicate check catches identical fixes. It misses the *same root cause
    [How the fix was verified — mention the reproduction test]
 
    ---
-   Closes #<issue number> — automated triage
+   Closes #$ARGUMENTS — automated triage
    ```
 
    ```bash
@@ -151,10 +151,10 @@ Compose the body with the Write tool at `/tmp/pr-body.md`:
 
 ```markdown
 ## Context
-Adds a failing test that reproduces #<issue number>. The fix is not yet included — this PR captures the reproduction so a maintainer can investigate.
+Adds a failing test that reproduces #$ARGUMENTS. The fix is not yet included — this PR captures the reproduction so a maintainer can investigate.
 
 ---
-Automated triage for #<issue number>
+Automated triage for #$ARGUMENTS
 ```
 
 ```bash

--- a/plugins/tend-ci-runner/skills/triage/SKILL.md
+++ b/plugins/tend-ci-runner/skills/triage/SKILL.md
@@ -114,7 +114,11 @@ Step 3's duplicate check catches identical fixes. It misses the *same root cause
 
    Closes #$ARGUMENTS"
    git push -u origin fix/issue-$ARGUMENTS
-   gh pr create --title "fix: <description>" --body "## Problem
+   ```
+   Compose the body with the Write tool at `/tmp/pr-body.md` — the fill-ins below are freeform prose that routinely carries markdown inline code, which bash executes inside a double-quoted `--body`:
+
+   ```markdown
+   ## Problem
    [What the issue reported and the root cause]
 
    ## Solution
@@ -124,7 +128,11 @@ Step 3's duplicate check catches identical fixes. It misses the *same root cause
    [How the fix was verified — mention the reproduction test]
 
    ---
-   Closes #$ARGUMENTS — automated triage"
+   Closes #<issue number> — automated triage
+   ```
+
+   ```bash
+   gh pr create --title "fix: <description>" --body-file /tmp/pr-body.md
    ```
 4. Wait for CI per **CI Monitoring** in `/tend-ci-runner:running-in-ci`.
 
@@ -137,11 +145,20 @@ git checkout -b repro/issue-$ARGUMENTS
 git add -A
 git commit -m "test: add reproduction for #$ARGUMENTS"
 git push -u origin repro/issue-$ARGUMENTS
-gh pr create --title "test: reproduction for #$ARGUMENTS" --body "## Context
-Adds a failing test that reproduces #$ARGUMENTS. The fix is not yet included — this PR captures the reproduction so a maintainer can investigate.
+```
+
+Compose the body with the Write tool at `/tmp/pr-body.md`:
+
+```markdown
+## Context
+Adds a failing test that reproduces #<issue number>. The fix is not yet included — this PR captures the reproduction so a maintainer can investigate.
 
 ---
-Automated triage for #$ARGUMENTS"
+Automated triage for #<issue number>
+```
+
+```bash
+gh pr create --title "test: reproduction for #$ARGUMENTS" --body-file /tmp/pr-body.md
 ```
 
 Note the PR number for the comment.

--- a/plugins/tend-ci-runner/skills/weekly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/weekly/SKILL.md
@@ -34,9 +34,12 @@ If no dependency PRs are open, note "0 dependency PRs to process" and continue t
    if [ "$LAST_APPROVAL_SHA" = "$HEAD_SHA" ]; then
      echo "Already approved on this commit; skipping."
    else
-     # Compose a one-line review body naming the package, bump type, and what you
-     # checked — e.g. "ruff 0.13 → 0.14 (patch), CI green, no API changes".
-     gh pr review <number> --approve --body "$REVIEW_BODY"
+     # Use the Write tool to compose /tmp/review-body.md — one line naming the
+     # package, bump type, and what you checked, e.g. "ruff 0.13 → 0.14 (patch),
+     # CI green, no API changes". Write it to a file rather than an inline
+     # --body: a package name written as inline code puts a backtick in a
+     # double-quoted argument, and bash runs the span as a command.
+     gh pr review <number> --approve --body-file /tmp/review-body.md
    fi
    ```
 4. If CI is failing, comment with the failure summary and skip


### PR DESCRIPTION
A `tend-nightly` run on `numbagg/numbagg` posted a public issue comment whose leading words were deleted by bash command substitution. The comment body was one line, so the bot took the `Comment Formatting` exemption — "For one-line bodies, `--body "…"` is fine" — and passed the text as a double-quoted shell argument. The text contained markdown inline code, and bash ran it.

## Evidence

Run [31158810529](https://github.com/numbagg/numbagg/actions/runs/31158810529) (`tend-nightly`, 2026-08-07T07:43:51Z). From the session log, the command as issued:

```
gh issue edit 716 --body-file /tmp/drift-body.md && gh issue comment 716 --body "`environment-deployments` now passes — the regenerated workflows from #723 emit \`deployment: false\` on the ...
```

Its result, same log:

```
https://github.com/numbagg/numbagg/issues/716
/usr/bin/bash: line 1: environment-deployments: command not found
https://github.com/numbagg/numbagg/issues/716#issuecomment-5214064857
```

The comment posted as ` now passes — the regenerated workflows from #723 emit ...` — the opening `` `environment-deployments` `` was executed as a command and replaced with its empty output. The bot noticed the stderr, re-read the body, and repaired it via `PATCH` about 15 seconds later, so the comment reads correctly now; `created_at` 07:46:22Z against `updated_at` 07:46:37Z is the remaining trace. The corrupted text still went out in the creation-time notification emails, and the repair edit fired a second `tend-mention` run.

Note the same command escaped the *later* spans (`` \`deployment: false\` ``) but not the leading one — escaping applied unevenly is the characteristic shape here, not a one-off typo.

## Root cause

The exemption is keyed on the wrong property. Line count has nothing to do with whether a string is safe in double quotes; backtick, `$`, and `\` do. A one-line body is in fact the *most* likely to be a single sentence of dense inline code, which is exactly the unsafe case. Given a one-line body containing a backtick, bash eats it every time — the bot followed the guidance as written and still shipped corrupted output.

## Change

Two commits.

**The rule.** Narrows the exemption to bodies with no shell-active characters, names the mechanism, and shows the failure inline. One sentence replaced; no new section. `!` is *not* on the hazard list: history expansion only fires in an interactive shell, and the harness runs commands with `histexpand` off (`set -o | grep histexpand` → `off`; `echo "wow! great"` prints intact). Listing it would err safe, but in a sentence whose whole point is keying on the actual hazard, a phantom entry costs the list its authority.

**The recipes the rule governs.** A run copies these verbatim, so they outrank the prose — and the ones below were already out of compliance with the sentence being replaced, since they're multi-line:

- `skills/triage/SKILL.md` — both `gh pr create … --body "## Problem` / `--body "## Context` templates move to `--body-file`. Their fill-ins (`[What the issue reported and the root cause]`, `[What was fixed and why]`) are freeform prose that routinely carries inline code: the incident's exact path.
- `skills/weekly/SKILL.md` — the dependency-approval step moves to `--body-file`. The expansion at the call site was safe on its own (parameter expansion doesn't re-scan for command substitution), but the recipe left the assignment to the agent, and a package name written as inline code puts the backtick there.
- `skills/review-reviewers/SKILL.md` — the gist announcement was correctly escaped, but it read as non-compliant against the new sentence. Writing it with `printf` keeps both expansions, needs no escaping at all, and leaves the rule with no in-tree exception:

  ```bash
  printf 'Evidence gist for `%s`: %s\n' "$TARGET" "$GIST_URL" > /tmp/gist-announce.md
  gh issue comment "$TRACKING_NUMBER" --body-file /tmp/gist-announce.md
  ```
## Gate assessment

- **Evidence level**: Critical (clearly wrong outcome — corrupted public content, confirmed from two independent sources: the session log's `command not found` and the posted body via the API). **1 occurrence**, which Critical acts on.
- **Structural, not stochastic**: no decision point. Replaying this scenario ten times corrupts ten times — the model was *complying* with the rule, and the rule licenses the hazard. The self-repair is the stochastic part, and it can't be relied on.
- **Change type**: targeted fix / narrowing of one existing sentence — near the removal end of Gate 2, whose bar is low.
- **Historical**: no prior occurrence of this shape recorded in the `numbagg/numbagg` evidence gists for 2026-07 or 2026-08; no open tend issue or PR covers it (checked `--body`/`body-file`/backtick/command-substitution across open and closed issues and PRs).

Evidence: https://gist.github.com/19b5ab297bb7ac7e1e9a44d595ccde0f

