### PR TITLE
fix(review): re-review after a force-push instead of trusting the re-anchored review SHA

### DIFF
--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -68,7 +68,7 @@ if [ -n "$LAST_REVIEW_AT" ]; then
 fi
 ```
 
-If `FORCE_PUSHED` is non-zero, the commit the bot reviewed was rewritten away: ignore `LAST_REVIEW_SHA` entirely and review `HEAD_SHA` in full. The incremental below can't run either — `LAST_REVIEW_SHA` now names the current head rather than anything the bot read, so `LAST_REVIEW_SHA..HEAD_SHA` is empty and every trivial-skip heuristic keyed on it under-reports.
+If `FORCE_PUSHED` is non-zero, the commit the bot reviewed was rewritten away: ignore `LAST_REVIEW_SHA` entirely and review `HEAD_SHA` in full. The incremental below can't run either — `LAST_REVIEW_SHA` now names the current head rather than anything the bot read, so `LAST_REVIEW_SHA..HEAD_SHA` is empty and every trivial-skip heuristic keyed on it under-reports. If that prior review was an `APPROVED` and the re-review lands on findings rather than an approval, dismiss it too — it is re-anchored onto the rewritten head, so posting a COMMENT alone leaves the PR reading as bot-approved. `jq -r '.state, .id' <<<"$LAST_REVIEW"` gives the state and the `$REVIEW_ID` for step 6's `reviews/$REVIEW_ID/dismissals` call.
 
 Otherwise, if `LAST_REVIEW_SHA == HEAD_SHA`, this commit has already been reviewed — exit silently. Two exceptions: an unanswered conversation question directed at the bot (check below), or `EVENT_ACTION == "ready_for_review"` (the PR just transitioned out of draft, so any prior review was a draft-mode review and the author is now asking for a full one — proceed).
 

--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -46,14 +46,30 @@ SUBSTANTIVE=$(gh api --paginate "repos/$REPO/pulls/<number>/comments" \
 # IMPORTANT: REST reviews carry `.commit_id`, NOT the `.commit.oid` that
 # `gh pr view --json reviews` returns — don't confuse the two. `gh api --jq`
 # accepts no `--arg`/`--argjson`, so pipe to `jq` rather than using `--jq`.
-LAST_REVIEW_SHA=$(gh api --paginate "repos/$REPO/pulls/<number>/reviews" \
-  | jq -rs --argjson sub "$SUBSTANTIVE" --arg bot "$BOT_LOGIN" \
+LAST_REVIEW=$(gh api --paginate "repos/$REPO/pulls/<number>/reviews" \
+  | jq -s --argjson sub "$SUBSTANTIVE" --arg bot "$BOT_LOGIN" \
     'add | [.[] | select(.user.login == $bot)
                 | select((.body | length) > 0 or (.id | IN($sub[])) or .state == "APPROVED")]
-         | last | .commit_id // empty')
+         | last // {}')
+LAST_REVIEW_SHA=$(jq -r '.commit_id // empty' <<<"$LAST_REVIEW")
+
+# A force-push does not just move HEAD — GitHub re-points the prior review's
+# `.commit_id` at the NEW head, so `LAST_REVIEW_SHA == HEAD_SHA` reads true for
+# code nothing ever reviewed and the run exits silently, leaving a stale APPROVE
+# standing as the active verdict. (An ordinary push leaves the old anchor
+# intact; only a rewrite re-points it, so `.commit_id` alone can't tell the two
+# apart.) Probe the timeline for a rewrite newer than that review.
+LAST_REVIEW_AT=$(jq -r '.submitted_at // empty' <<<"$LAST_REVIEW")
+FORCE_PUSHED=0
+[ -n "$LAST_REVIEW_AT" ] && FORCE_PUSHED=$(
+  gh api --paginate "repos/$REPO/issues/<number>/timeline" \
+    | jq -s --arg at "$LAST_REVIEW_AT" \
+      'add | [.[] | select(.event == "head_ref_force_pushed" and .created_at > $at)] | length')
 ```
 
-If `LAST_REVIEW_SHA == HEAD_SHA`, this commit has already been reviewed — exit silently. Two exceptions: an unanswered conversation question directed at the bot (check below), or `EVENT_ACTION == "ready_for_review"` (the PR just transitioned out of draft, so any prior review was a draft-mode review and the author is now asking for a full one — proceed).
+If `FORCE_PUSHED` is non-zero, the commit the bot reviewed was rewritten away: ignore `LAST_REVIEW_SHA` entirely and review `HEAD_SHA` in full. The incremental below can't run either — `LAST_REVIEW_SHA` now names the current head rather than anything the bot read, so `LAST_REVIEW_SHA..HEAD_SHA` is empty and every trivial-skip heuristic keyed on it under-reports.
+
+Otherwise, if `LAST_REVIEW_SHA == HEAD_SHA`, this commit has already been reviewed — exit silently. Two exceptions: an unanswered conversation question directed at the bot (check below), or `EVENT_ACTION == "ready_for_review"` (the PR just transitioned out of draft, so any prior review was a draft-mode review and the author is now asking for a full one — proceed).
 
 If the bot reviewed a previous commit (`LAST_REVIEW_SHA` exists but differs from `HEAD_SHA`), judge what was pushed since. Read two signals, both leak-free against base-merges:
 

--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -359,9 +359,19 @@ GitHub returns `422 Unprocessable Entity` with "Line could not be resolved" when
 # `gh api --paginate` applies `--jq` to each page separately, so a `| last`
 # inside `--jq` returns one id *per page* — pipe to `jq -rs 'add | …'` to reduce
 # over the merged array instead.
+#
+# The force-push filter from the pre-post guard is required here too, and the
+# consequence of omitting it is worse than a skipped run: a body-bearing review
+# from before a rewrite reports `.commit_id == $HEAD_SHA`, passes the body-length
+# test, and the PUT below overwrites that older review's text with this run's
+# findings — destroying a published review and leaving the new body over the old
+# review's inline comments on code that no longer exists.
+LAST_FORCE_PUSH_AT=$(gh api --paginate "repos/$REPO/issues/<number>/timeline" \
+  | jq -rs 'add | [.[] | select(.event == "head_ref_force_pushed") | .created_at] | max // ""')
 ORPHAN_ID=$(gh api --paginate "repos/$REPO/pulls/<number>/reviews" \
-  | jq -rs --arg bot "$BOT_LOGIN" --arg head "$HEAD_SHA" \
-    'add | [.[] | select(.user.login == $bot and .commit_id == $head and (.body | length) > 0)]
+  | jq -rs --arg bot "$BOT_LOGIN" --arg head "$HEAD_SHA" --arg fp "$LAST_FORCE_PUSH_AT" \
+    'add | [.[] | select(.user.login == $bot and .commit_id == $head and (.body | length) > 0)
+                | select($fp == "" or .submitted_at > $fp)]
          | last | .id // empty')
 ```
 

--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -61,10 +61,11 @@ LAST_REVIEW_SHA=$(jq -r '.commit_id // empty' <<<"$LAST_REVIEW")
 # apart.) Probe the timeline for a rewrite newer than that review.
 LAST_REVIEW_AT=$(jq -r '.submitted_at // empty' <<<"$LAST_REVIEW")
 FORCE_PUSHED=0
-[ -n "$LAST_REVIEW_AT" ] && FORCE_PUSHED=$(
-  gh api --paginate "repos/$REPO/issues/<number>/timeline" \
+if [ -n "$LAST_REVIEW_AT" ]; then
+  FORCE_PUSHED=$(gh api --paginate "repos/$REPO/issues/<number>/timeline" \
     | jq -s --arg at "$LAST_REVIEW_AT" \
       'add | [.[] | select(.event == "head_ref_force_pushed" and .created_at > $at)] | length')
+fi
 ```
 
 If `FORCE_PUSHED` is non-zero, the commit the bot reviewed was rewritten away: ignore `LAST_REVIEW_SHA` entirely and review `HEAD_SHA` in full. The incremental below can't run either — `LAST_REVIEW_SHA` now names the current head rather than anything the bot read, so `LAST_REVIEW_SHA..HEAD_SHA` is empty and every trivial-skip heuristic keyed on it under-reports.
@@ -249,12 +250,22 @@ read -r CURRENT_HEAD PR_STATE < <(gh pr view <number> --json commits,state \
 # left on the current HEAD would read as "already reviewed" and discard this run's
 # review at the last step, after all the work. Shell state doesn't carry between
 # tool calls, so re-derive $SUBSTANTIVE here.
+#
+# The force-push re-anchoring from step 1 lands on this guard too, and harder: a
+# review submitted against the rewritten-away commit now reports
+# `.commit_id == $HEAD_SHA`, so it reads as "already reviewed" and discards the
+# very re-review step 1's `FORCE_PUSHED` probe just unblocked. Drop reviews older
+# than the newest rewrite; anything submitted after it really did anchor here.
 # NOTE: REST API uses .commit_id (not .commit.oid from gh pr view --json)
 SUBSTANTIVE=$(gh api --paginate "repos/$REPO/pulls/<number>/comments" \
   --jq '.[] | select(.in_reply_to_id == null) | .pull_request_review_id' | jq -s 'unique')
+LAST_FORCE_PUSH_AT=$(gh api --paginate "repos/$REPO/issues/<number>/timeline" \
+  | jq -rs 'add | [.[] | select(.event == "head_ref_force_pushed") | .created_at] | max // ""')
 ALREADY_POSTED=$(gh api --paginate "repos/$REPO/pulls/<number>/reviews" \
   | jq -rs --argjson sub "$SUBSTANTIVE" --arg bot "$BOT_LOGIN" --arg head "$HEAD_SHA" \
+    --arg fp "$LAST_FORCE_PUSH_AT" \
     'add | [.[] | select(.user.login == $bot and .commit_id == $head)
+                | select($fp == "" or .submitted_at > $fp)
                 | select((.body | length) > 0 or (.id | IN($sub[])) or .state == "APPROVED")]
          | last | .submitted_at // empty')
 [ -n "$ALREADY_POSTED" ] && echo "Already reviewed — skipping" && exit 0


### PR DESCRIPTION
A force-push doesn't just move a PR's head — GitHub also re-points the prior review's `.commit_id` at the **new** head. `tend-review`'s pre-flight guard compares that field against `HEAD_SHA` to decide whether the current commit has already been reviewed, so after a rewrite it reads `LAST_REVIEW_SHA == HEAD_SHA`, exits silently, and leaves a stale APPROVE standing as the active verdict on code the bot never read.

## Observed

[`PRQL/prql#6158`](https://github.com/PRQL/prql/pull/6158) (dependabot, `js-yaml` bump). `prql-bot` submitted an empty-body APPROVE at 06:09:36Z; the head at that moment was `abb3853a` — confirmed by the `tend-mention` run the review itself triggered six seconds later, which carries `headSha=abb3853a`. Dependabot then rebased at 07:40:18Z (`head_ref_force_pushed` → `cc020720`), which re-triggered [`tend-review` 31158576591](https://github.com/PRQL/prql/actions/runs/31158576591). The agent ran the full 1 m 47 s and posted nothing.

The reviews endpoint now reports that 06:09:36Z review against a commit created at 07:40:16Z:

```
{"id":4880377370,"state":"APPROVED","submitted_at":"2026-08-07T06:09:36Z",
 "commit_id":"cc0207205f99c5481b8404c805a16a43c91fb3af","body":""}
```

The session log shows the guard firing on exactly that, and the reasoning is correct given what it was told to read:

> The current HEAD has already been reviewed and approved. There are no conversation comments, no unanswered questions directed at the bot, and no unresolved bot review threads to resolve. The triggering event was `synchronize`, not `ready_for_review`, so no exception applies. Exiting silently without posting — the existing approval stands as the active verdict.

## Control

An ordinary push leaves the old anchor intact, so `.commit_id` alone cannot distinguish the two cases. On [`PRQL/prql#6159`](https://github.com/PRQL/prql/pull/6159), a review submitted at 06:58:45Z still reports `commit_id=779b096d` after `177c1997` landed on top — the guard works there, which is why this has stayed invisible.

## Fix

Probe the timeline for a `head_ref_force_pushed` newer than the last substantive bot review. Non-zero ⇒ the reviewed commit was rewritten away, so ignore `LAST_REVIEW_SHA` and review the head in full. The incremental path has to be skipped too: after a rewrite `LAST_REVIEW_SHA` names the current head, so `LAST_REVIEW_SHA..HEAD_SHA` is empty and every trivial-skip heuristic keyed on it under-reports the change.

The existing `LAST_REVIEW_SHA` extraction is refactored to keep the whole review record rather than just `.commit_id`, so `submitted_at` comes from the same substantive-filtered pick — no second query, no risk of the two fields resolving to different reviews.

Verified live against three shapes: `#6158` (force-pushed after approval) → 1; `#6159` (ordinary push) → 0; `#6161` (no prior bot review) → empty anchor, 0.

## Gates

- **Evidence level**: High, **structural** — no decision point. Every force-push after a bot review re-points the anchor and defeats the comparison identically.
- **Occurrences**: 2 for the failure class. This one, plus [#828](https://github.com/max-sixty/tend/issues/828) — the same `LAST_REVIEW_SHA == HEAD_SHA` guard skipping a real commit because the anchor had moved to something the bot never reviewed (fixed for the reply-container mechanism in [#835](https://github.com/max-sixty/tend/pull/835); the force-push mechanism is untouched by that fix).
- **Magnitude**: targeted fix — one probe plus one condition, no new section. Normal bar.
- Wrong-outcome shape, beyond the skipped work: the review record reads "approved `cc020720`" for a commit the bot never fetched, and the sequence generalizes to approve-then-rewrite.

Evidence log: https://gist.github.com/192514ea2c36586f9b7f842a482d62ab
