### PR TITLE
fix(token-report): raise the per-workflow run limit, and say when it's hit

### DIFF
--- a/plugins/tend-ci-runner/scripts/token-report.sh
+++ b/plugins/tend-ci-runner/scripts/token-report.sh
@@ -65,17 +65,17 @@ fi
 # totals below under-report with nothing marking the shortfall. The limit is
 # per workflow, not per report, so it only has to clear the busiest one; a
 # repo's chattiest workflow can run several times an hour, and at this script's
-# own documented 168 h default that already reaches the high hundreds. Sized
-# well past that: the limit only bounds the listing call, which pages
-# internally, so headroom here is free — the per-run `gh run download` loop
-# below costs what the window actually holds, whatever this number is.
+# own documented 168 h default that already reaches the high hundreds. Capped
+# at 1000 because that is the ceiling: the Actions runs endpoint stops
+# paginating there whatever `total_count` says, so a larger constant is
+# unreachable and would only make the guard below unable to fire.
 #
 # Warn rather than trust, in both directions. A count landing on the limit is
 # the only symptom of truncation visible without re-querying `.total_count`,
 # and a failed fetch is the same silent under-report at full strength: it drops
 # every run of that workflow, and a length of 0 is not an exact-limit hit, so
 # the truncation guard alone would pass straight over it.
-RUN_LIMIT=2000
+RUN_LIMIT=1000
 ALL_RUNS="[]"
 for wf in "${WORKFLOWS[@]}"; do
   if ! runs=$(gh run list "${repo_args[@]}" --workflow "$wf" --created ">=$SINCE" --status completed \

--- a/plugins/tend-ci-runner/scripts/token-report.sh
+++ b/plugins/tend-ci-runner/scripts/token-report.sh
@@ -58,11 +58,23 @@ if [ ${#WORKFLOWS[@]} -eq 0 ]; then
   exit 0
 fi
 
-# Collect all completed runs across workflows
+# Collect all completed runs across workflows.
+#
+# `gh run list` returns newest-first and silently stops at --limit, so a
+# workflow busier than the limit drops the *oldest* runs in the window and the
+# totals below under-report with nothing marking the shortfall. The limit is
+# per workflow, not per report, so it only has to clear the busiest one; a
+# repo's chattiest workflow can run several times an hour. Warn on an exact-hit
+# rather than silently trusting it — a count landing precisely on the limit is
+# the one symptom of truncation visible without re-querying.
+RUN_LIMIT=500
 ALL_RUNS="[]"
 for wf in "${WORKFLOWS[@]}"; do
   runs=$(gh run list "${repo_args[@]}" --workflow "$wf" --created ">=$SINCE" --status completed \
-    --json databaseId,conclusion,createdAt,name --limit 100 2>/dev/null || echo "[]")
+    --json databaseId,conclusion,createdAt,name --limit "$RUN_LIMIT" 2>/dev/null || echo "[]")
+  if [ "$(echo "$runs" | jq 'length')" -eq "$RUN_LIMIT" ]; then
+    echo >&2 "WARNING: '$wf' returned exactly $RUN_LIMIT runs — the window is likely truncated and the totals below under-report it."
+  fi
   ALL_RUNS=$(echo "$ALL_RUNS" "$runs" | jq -s 'add | unique_by(.databaseId)')
 done
 

--- a/plugins/tend-ci-runner/scripts/token-report.sh
+++ b/plugins/tend-ci-runner/scripts/token-report.sh
@@ -64,16 +64,26 @@ fi
 # workflow busier than the limit drops the *oldest* runs in the window and the
 # totals below under-report with nothing marking the shortfall. The limit is
 # per workflow, not per report, so it only has to clear the busiest one; a
-# repo's chattiest workflow can run several times an hour. Warn on an exact-hit
-# rather than silently trusting it — a count landing precisely on the limit is
-# the one symptom of truncation visible without re-querying.
-RUN_LIMIT=500
+# repo's chattiest workflow can run several times an hour, and at this script's
+# own documented 168 h default that already reaches the high hundreds. Sized
+# well past that: the limit only bounds the listing call, which pages
+# internally, so headroom here is free — the per-run `gh run download` loop
+# below costs what the window actually holds, whatever this number is.
+#
+# Warn rather than trust, in both directions. A count landing on the limit is
+# the only symptom of truncation visible without re-querying `.total_count`,
+# and a failed fetch is the same silent under-report at full strength: it drops
+# every run of that workflow, and a length of 0 is not an exact-limit hit, so
+# the truncation guard alone would pass straight over it.
+RUN_LIMIT=2000
 ALL_RUNS="[]"
 for wf in "${WORKFLOWS[@]}"; do
-  runs=$(gh run list "${repo_args[@]}" --workflow "$wf" --created ">=$SINCE" --status completed \
-    --json databaseId,conclusion,createdAt,name --limit "$RUN_LIMIT" 2>/dev/null || echo "[]")
-  if [ "$(echo "$runs" | jq 'length')" -eq "$RUN_LIMIT" ]; then
-    echo >&2 "WARNING: '$wf' returned exactly $RUN_LIMIT runs — the window is likely truncated and the totals below under-report it."
+  if ! runs=$(gh run list "${repo_args[@]}" --workflow "$wf" --created ">=$SINCE" --status completed \
+    --json databaseId,conclusion,createdAt,name --limit "$RUN_LIMIT" 2>/dev/null); then
+    echo >&2 "WARNING: 'gh run list' for '$wf' failed — its runs are absent from the totals below."
+    runs="[]"
+  elif [ "$(echo "$runs" | jq 'length')" -ge "$RUN_LIMIT" ]; then
+    echo >&2 "WARNING: '$wf' returned $RUN_LIMIT runs, the fetch limit — older runs in the window are missing and the totals below under-report it."
   fi
   ALL_RUNS=$(echo "$ALL_RUNS" "$runs" | jq -s 'add | unique_by(.databaseId)')
 done

--- a/plugins/tend-ci-runner/scripts/token-report.sh
+++ b/plugins/tend-ci-runner/scripts/token-report.sh
@@ -83,7 +83,7 @@ for wf in "${WORKFLOWS[@]}"; do
     echo >&2 "WARNING: 'gh run list' for '$wf' failed — its runs are absent from the totals below."
     runs="[]"
   elif [ "$(echo "$runs" | jq 'length')" -ge "$RUN_LIMIT" ]; then
-    echo >&2 "WARNING: '$wf' returned $RUN_LIMIT runs, the fetch limit — older runs in the window are missing and the totals below under-report it."
+    echo >&2 "WARNING: '$wf' returned $RUN_LIMIT runs, the Actions API's pagination ceiling — older runs in the window are unreachable and the totals below under-report it. Narrow HOURS to bring the window under the ceiling; raising RUN_LIMIT cannot help."
   fi
   ALL_RUNS=$(echo "$ALL_RUNS" "$runs" | jq -s 'add | unique_by(.databaseId)')
 done


### PR DESCRIPTION
`token-report.sh` fetches each workflow's runs with `--limit 100`. `gh run list` returns newest-first and stops there silently, so on a workflow busier than 100 runs in the window the report drops the oldest ones and totals them at zero — with nothing in the output saying so.

## Measured on this repo

Current 24 h window:

```
$ gh run list --workflow tend-mention --created ">=$SINCE" --status completed --json databaseId --limit 100 | jq length
100
$ gh run list --workflow tend-mention --created ">=$SINCE" --status completed --json databaseId --limit 400 | jq length
116
```

16 of 116 `tend-mention` runs (14%) are outside today's report, and their tokens are simply absent from the totals. `tend-review` returns 44 at both limits, so it isn't affected today — the shortfall is per workflow and moves with whichever one is chattiest.

This matters because the report's output is the fleet cost figure `review-runs` records in its evidence log every day, and #801's entries have been reading it as a complete accounting. Under-reporting is also the direction that hides a problem: a workflow that suddenly runs hot is exactly the one that crosses 100 and starts having its excess dropped.

## Change

Three things, all small:

- **`--limit 1000`.** The limit is per workflow, not per report, so it only has to clear the busiest one. 500 was the first draft and it was already underfoot: at this script's own documented 168 h default, `tend-mention` returns **497** today, so a default-argument call would have started tripping the new warning within a day. Narrowing the documented default instead would have moved that cost out of sight rather than removed it. 1000 is the ceiling rather than a comfort margin — the Actions runs endpoint stops paginating there whatever `total_count` says, so anything larger is unreachable *and* puts the truncation guard beyond what the fetch can ever return, i.e. buys no runs and costs the warning. It is also the value that makes `-ge` trip exactly at the ceiling.
- **Warn on an exact hit.** A count landing on the limit is the only symptom of truncation visible without re-querying `.total_count`, so the loop says so on stderr rather than trusting it.
- **Warn on a failed fetch.** The original line swallowed any `gh run list` error into `[]` via `|| echo`, which the truncation guard reads as "0 runs, not truncated" — so an API blip removed an entire workflow from the totals with no marker at all. That is the same silent under-report at full strength, and strictly worse than the tail-drop this PR started out fixing. Branching on the exit status covers it. Warning rather than exiting, unlike the sibling in `list-recent-runs.sh`, because this script has no `gh_retry` behind it and a bare `exit 1` would make one blip fatal to a report that is otherwise still useful.

Raising a limit alone would only move the cliff. The two warnings are what make the next crossing — from either direction — visible instead of silent. The residual this doesn't fix: at exactly 1000 the report is still truncated, just no longer silently. Getting the full set past the ceiling needs `.total_count` off the API or a narrower window per fetch, both more than this PR is for — and a loud partial beats a silent one.

Verified all three branches against the API: `tend-review` → 52 runs, silent; a nonexistent workflow → the fetch warning; `tend-mention` at `--limit 100` → exactly 100, the truncation warning. The ceiling and the guard's reachability at the new constant, measured on this repo:

```
$ gh api ".../actions/workflows/250047576/runs?status=completed&per_page=100&page=10" --jq '.workflow_runs | length'
100
$ gh api ".../actions/workflows/250047576/runs?status=completed&per_page=100&page=11" --jq '.workflow_runs | length'
0
$ gh run list --workflow tend-mention --created ">=2000-01-01T00:00:00Z" --status completed --json databaseId --limit 2000 | jq length
1000
$ gh run list --workflow tend-mention --created ">=2000-01-01T00:00:00Z" --status completed --json databaseId --limit 1000 | jq length
1000
```

`total_count` for that workflow is 3265, so the 1000 is the endpoint's ceiling and not the window running out. The last line is the guard firing condition met at `RUN_LIMIT=1000` — unreachable at 2000. Patched script runs clean end to end (`token-report.sh 2 "review-"`, exit 0, 48 runs, no warnings), and `shellcheck` is clean.

## Provenance and scope

Found by the review on #886 — that PR fixes the same silent-truncation shape in `review-runs`' Step 1 census (30 of 110 runs, a 68-minute view of a 24-hour window), and the reviewer measured this adjacent case in Step 2 while checking it. Kept separate because it's a different file and a different fetcher.

#838 is doing the equivalent work for `list-recent-runs.sh` — raise the bound, warn at the boundary — so this is the third instance of one pattern rather than a new idea. Not a dedup hit: different script, different call, no overlap in the diff.

## Gate assessment

- **Evidence level: High.** Reproduced directly against the API, twice, at two limits. Structural — `gh run list` truncates at the limit deterministically, no decision point.
- **Change type: targeted fix** — one constant and a four-line guard. Normal Gate 1 bar, cleared.
- **Verified**: every branch exercised against the live API, and the patched script run end to end.
- **Revised twice after review** on this PR. Round one caught the swallowed-fetch path on the line being edited and measured 500 against the 168 h default; both folded in as a second commit. Round two caught that the replacement constant, 2000, sat above the API's 1000-result pagination ceiling and so made the truncation guard dead code — the defect this PR fixes, relocated. Third commit caps at 1000 and names the ceiling as the reason, so the next raise hits the explanation first; a fourth carries that framing into the runtime warning, which had called 1000 "the fetch limit" — a tunable-sounding phrase inviting the same bump — and now names it as the API's pagination ceiling and points at narrowing `HOURS`, the lever that does work.


