### PR TITLE
fix(review-runs): census the prefixes Step 2 prices, not just tend-*

### DIFF
--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -150,7 +150,7 @@ Then, for each run ID from above, pull its jobs and classify them:
 - **Long-running** (>30 min): Tend runs typically finish in single-digit minutes. Anything over 30 is worth a look — download session logs in Step 3 and diagnose where the time went (long background waits, push-wait-fix cycles, a stuck tool call).
 - **Near-timeout** (within 90% of the cap): A job that consumed most of its timeout budget is one slow external check away from being killed. These are **structural** failures: one occurrence is enough to act on.
 
-To determine the timeout cap for a workflow, read `timeout-minutes` from the workflow YAML file (`.github/workflows/tend-*.yaml`). Tend's generated workflows do not set `timeout-minutes`, so GitHub's 360-minute default applies unless the adopter has overridden it via `workflows.<name>.jobs.<job>.timeout-minutes` in `.config/tend.yaml`.
+To determine the timeout cap for a workflow, read `timeout-minutes` from that workflow's own file under `.github/workflows/` — the census admits workflows named outside the `tend-` prefix, so don't glob for one. Tend's generated workflows do not set `timeout-minutes`, so GitHub's 360-minute default applies unless the adopter has overridden it via `workflows.<name>.jobs.<job>.timeout-minutes` in `.config/tend.yaml`.
 
 ```bash
 # Flag long-running and near-timeout jobs

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -131,10 +131,9 @@ List tend CI runs that completed in the past 24 hours (the cron runs daily):
 ```bash
 REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
 SINCE=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)
-# Census every workflow that runs the tend action, not only the generated
-# `tend-*` ones — a workflow named outside that prefix is otherwise never
-# classified, never near-timeout-checked, and never reaches Step 3. The repo's
-# `running-tend` skill carries the extra prefixes; Step 2 takes the same list.
+# Add the repo's extra prefixes from its `running-tend` skill: any workflow
+# running the tend action is in scope, not just the generated `tend-*` ones.
+# Step 2 prices the same list.
 PREFIXES=("tend-")
 PREFIX_RE="^($(IFS='|'; echo "${PREFIXES[*]}"))"
 for workflow in $(gh api repos/$REPO/actions/workflows --jq ".workflows[] | select(.name | test(\"$PREFIX_RE\")) | .id"); do

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -131,7 +131,13 @@ List tend CI runs that completed in the past 24 hours (the cron runs daily):
 ```bash
 REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
 SINCE=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)
-for workflow in $(gh api repos/$REPO/actions/workflows --jq '.workflows[] | select(.name | startswith("tend-")) | .id'); do
+# Census every workflow that runs the tend action, not only the generated
+# `tend-*` ones — a workflow named outside that prefix is otherwise never
+# classified, never near-timeout-checked, and never reaches Step 3. The repo's
+# `running-tend` skill carries the extra prefixes; Step 2 takes the same list.
+PREFIXES=("tend-")
+PREFIX_RE="^($(IFS='|'; echo "${PREFIXES[*]}"))"
+for workflow in $(gh api repos/$REPO/actions/workflows --jq ".workflows[] | select(.name | test(\"$PREFIX_RE\")) | .id"); do
   gh api "repos/$REPO/actions/workflows/$workflow/runs?created=>=$SINCE&status=completed" \
     --jq '.workflow_runs[] | {databaseId: .id, conclusion, createdAt: .created_at, name: .name}'
 done
@@ -165,7 +171,7 @@ Run the token report script to get per-run token counts:
 "${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" 24 > /tmp/token-report.json
 ```
 
-Pass additional workflow prefixes to include non-`tend-*` workflows that use the tend action (e.g., `review-reviewers`). Check the repo's `running-tend` skill for the list.
+Pass the same extra prefixes Step 1 censuses, so the two steps agree on what the fleet is — the repo's `running-tend` skill is the source for both (e.g. `review-` for a `review-reviewers` workflow that uses the tend action but isn't named `tend-*`).
 
 Include the totals and per-workflow breakdown in the summary (Step 7). Flag any runs with unusually high token usage for closer inspection in Step 3.
 


### PR DESCRIPTION
Step 1 of `review-runs` enumerates the fleet with a hard-coded single prefix, while Step 2 documents the opposite — that non-`tend-*` workflows using the tend action are in scope and their prefixes come from the repo's `running-tend` skill. The two steps therefore disagree about what the fleet is, and Step 1 wins: a workflow outside the `tend-` prefix is never classified for duration, never near-timeout-checked, and never reaches Step 3's log analysis. Nothing in the output marks the omission.

## Measured on this repo

Over a 24 h window (`SINCE=2026-08-06T08:42:07Z`), `review-reviewers` — which runs the tend composite action but is not named `tend-*`, and which tend's own `running-tend` overlay already lists as an extra prefix for Step 2 — has 21 completed runs that Step 1 never sees:

```
$ gh api repos/max-sixty/tend/actions/workflows --jq '.workflows[] | select(.name | startswith("tend-")) | .name' | grep -c '^review-reviewers$'
0
$ gh api "repos/max-sixty/tend/actions/workflows/250009605/runs?created=>=$SINCE&status=completed&per_page=1" --jq '.total_count'
21
```

## Change

Replace the inline `startswith("tend-")` with a `PREFIXES` array defaulting to `("tend-")`, matched as an anchored alternation. Step 2's sentence now points at the same list rather than describing a parallel one, so a single repo-level source drives both steps.

Behaviour is unchanged for an adopter with no extra prefixes — the default array reproduces the old filter exactly. Running the edited Step 1 block verbatim:

```
# as written, default PREFIXES=("tend-")
tend-review 30, tend-mention 30, tend-notifications 26, tend-ci-fix 9, tend-triage 6, tend-nightly 1

# with tend's running-tend prefix list, PREFIXES=("tend-" "review-")
tend-review 30, tend-mention 30, tend-notifications 26, review-reviewers 20, tend-ci-fix 9, tend-triage 6, tend-nightly 1
```

The `30`s in that output are #886's separate bug (the unpaginated endpoint capping at a page), still live on `main` — this change doesn't address it and doesn't depend on it.

## Scope and conflict note

This is part 2 of #888. Part 1 of that issue — `token-report.sh` capping the same window at `--limit 100` — is already fixed by #887, so nothing here touches that script.

#886 edits the same two `gh api` lines in this block to add `--paginate`. The changes are independent in intent but overlap textually, so whichever lands second needs a trivial rebase; the two edits compose (a `PREFIXES`-driven filter on a paginated fetch).

Not included: an explicit prefix-list line in tend's own `.claude/skills/running-tend/SKILL.md`. Its "Usage analysis" section already names `review-` as the extra prefix, so this repo's Step 1 resolves correctly today; adding a dedicated line there is a separate overlay concern.

## Gate assessment

- **Structural.** The filter is fixed in the recipe text, so it excludes identically on every run. No decision point.
- **Evidence: High.** Exclusion reproduced directly against the API, and the fix verified by executing the edited block verbatim at both prefix lists.
- **Change type: targeted fix** — one code block plus one cross-reference sentence, no new sections.

---
Refs #888


## Follow-up commits

`3d4fcda` — review on this PR found the same disagreement one paragraph later: the near-timeout instruction resolved a workflow's `timeout-minutes` by globbing `.github/workflows/tend-*.yaml`, which doesn't match the very workflow the widened census now admits. It now reads the workflow's own file. `f823494` reworded the `PREFIXES` comment from rationale into an instruction.
