### PR TITLE
fix(weekly): don't trust a re-anchored approval on a rebased dependency PR

### DIFF
--- a/plugins/tend-ci-runner/skills/weekly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/weekly/SKILL.md
@@ -57,6 +57,25 @@ If no dependency PRs are open, note "0 dependency PRs to process" and continue t
    ```
 4. If CI is failing, comment with the failure summary and skip
 5. If a major version bump, comment noting it needs manual review and skip
+6. On either skip path (4 or 5), dismiss an approval that predates the newest rewrite before you leave. Both paths are reachable *because* a rebase changed something, and neither passes through item 3's guard — so the pre-rewrite approval stays the bot's latest review, re-anchored onto the current head, and the PR still reads as bot-approved while you comment that it isn't mergeable:
+   ```bash
+   BOT_LOGIN=$(gh api user --jq '.login')
+   REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+   LAST_FORCE_PUSH_AT=$(gh api --paginate "repos/$REPO/issues/<number>/timeline" \
+     | jq -rs 'add | [.[] | select(.event == "head_ref_force_pushed") | .created_at] | max // ""')
+   STALE_APPROVAL_ID=$(gh api --paginate "repos/$REPO/pulls/<number>/reviews" \
+     | jq -rs --arg bot "$BOT_LOGIN" --arg fp "$LAST_FORCE_PUSH_AT" \
+       'add | [.[] | select(.user.login == $bot and .state == "APPROVED")
+                   | select($fp != "" and .submitted_at < $fp)]
+            | last | .id // empty')
+
+   if [ -n "$STALE_APPROVAL_ID" ]; then
+     # PUT, not POST — the dismiss endpoint requires it.
+     gh api "repos/$REPO/pulls/<number>/reviews/$STALE_APPROVAL_ID/dismissals" \
+       -X PUT -f message="Rebased since this approval; re-reviewing."
+   fi
+   ```
+   A dismissed review reports `DISMISSED` rather than `APPROVED`, so the filter stops matching it and a later run re-dismisses nothing.
 
 ## Step 3: Repo-specific weekly tasks
 

--- a/plugins/tend-ci-runner/skills/weekly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/weekly/SKILL.md
@@ -63,16 +63,23 @@ If no dependency PRs are open, note "0 dependency PRs to process" and continue t
    REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
    LAST_FORCE_PUSH_AT=$(gh api --paginate "repos/$REPO/issues/<number>/timeline" \
      | jq -rs 'add | [.[] | select(.event == "head_ref_force_pushed") | .created_at] | max // ""')
+   # `last` BEFORE the staleness test, not after: the question is whether the
+   # newest approval is stale, not whether some stale approval exists. Filtering
+   # first would return the pre-rewrite id even when a later approval already
+   # superseded it — dismissing a review that no longer sets the PR's state
+   # while the one that does stands untouched.
    STALE_APPROVAL_ID=$(gh api --paginate "repos/$REPO/pulls/<number>/reviews" \
      | jq -rs --arg bot "$BOT_LOGIN" --arg fp "$LAST_FORCE_PUSH_AT" \
-       'add | [.[] | select(.user.login == $bot and .state == "APPROVED")
-                   | select($fp != "" and .submitted_at < $fp)]
-            | last | .id // empty')
+       'add | [.[] | select(.user.login == $bot and .state == "APPROVED")]
+            | last
+            | select(. != null and $fp != "" and .submitted_at < $fp)
+            | .id')
 
    if [ -n "$STALE_APPROVAL_ID" ]; then
-     # PUT, not POST — the dismiss endpoint requires it.
+     # PUT, not POST — the dismiss endpoint requires it. Keep the message to what
+     # these paths actually do: they comment and stop, so don't promise a re-review.
      gh api "repos/$REPO/pulls/<number>/reviews/$STALE_APPROVAL_ID/dismissals" \
-       -X PUT -f message="Rebased since this approval; re-reviewing."
+       -X PUT -f message="Rebased since this approval; the new head is unreviewed."
    fi
    ```
    A dismissed review reports `DISMISSED` rather than `APPROVED`, so the filter stops matching it and a later run re-dismisses nothing.

--- a/plugins/tend-ci-runner/skills/weekly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/weekly/SKILL.md
@@ -28,10 +28,26 @@ If no dependency PRs are open, note "0 dependency PRs to process" and continue t
    ```bash
    HEAD_SHA=$(gh pr view <number> --json commits --jq '.commits[-1].oid')
    BOT_LOGIN=$(gh api user --jq '.login')
-   LAST_APPROVAL_SHA=$(gh pr view <number> --json reviews \
-     --jq "[.reviews[] | select(.author.login == \"$BOT_LOGIN\" and .state == \"APPROVED\")] | last | .commit.oid // empty")
+   REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
 
-   if [ "$LAST_APPROVAL_SHA" = "$HEAD_SHA" ]; then
+   # A force-push re-points an existing review's commit anchor at the NEW head,
+   # so an approval of the pre-rebase code reports the current `$HEAD_SHA` and
+   # this guard skips a commit the bot never read — leaving the rebased PR
+   # carrying an approval it never earned. Dependency PRs are the population
+   # tend rewrites on purpose (`nightly` posts `@dependabot recreate` and ticks
+   # renovate's rebase-check), so ignore approvals older than the newest
+   # rewrite. REST reviews carry `.commit_id`/`.submitted_at`, NOT the
+   # `.commit.oid` that `gh pr view --json reviews` returns; `gh api --jq`
+   # accepts no `--arg`, so pipe to `jq`.
+   LAST_FORCE_PUSH_AT=$(gh api --paginate "repos/$REPO/issues/<number>/timeline" \
+     | jq -rs 'add | [.[] | select(.event == "head_ref_force_pushed") | .created_at] | max // ""')
+   LAST_APPROVAL_SHA=$(gh api --paginate "repos/$REPO/pulls/<number>/reviews" \
+     | jq -rs --arg bot "$BOT_LOGIN" --arg fp "$LAST_FORCE_PUSH_AT" \
+       'add | [.[] | select(.user.login == $bot and .state == "APPROVED")
+                   | select($fp == "" or .submitted_at > $fp)]
+            | last | .commit_id // empty')
+
+   if [ -n "$LAST_APPROVAL_SHA" ] && [ "$LAST_APPROVAL_SHA" = "$HEAD_SHA" ]; then
      echo "Already approved on this commit; skipping."
    else
      # Compose a one-line review body naming the package, bump type, and what you

--- a/plugins/tend-ci-runner/skills/weekly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/weekly/SKILL.md
@@ -67,7 +67,9 @@ If no dependency PRs are open, note "0 dependency PRs to process" and continue t
    # newest approval is stale, not whether some stale approval exists. Filtering
    # first would return the pre-rewrite id even when a later approval already
    # superseded it — dismissing a review that no longer sets the PR's state
-   # while the one that does stands untouched.
+   # while the one that does stands untouched. Item 3 keeps the opposite order
+   # and is still correct: `submitted_at` is monotonic here, so its `> $fp` keeps
+   # a suffix (last-of-suffix == last-of-list) while this `< $fp` keeps a prefix.
    STALE_APPROVAL_ID=$(gh api --paginate "repos/$REPO/pulls/<number>/reviews" \
      | jq -rs --arg bot "$BOT_LOGIN" --arg fp "$LAST_FORCE_PUSH_AT" \
        'add | [.[] | select(.user.login == $bot and .state == "APPROVED")]


### PR DESCRIPTION
`weekly`'s dependency-PR step skips approving when `LAST_APPROVAL_SHA == HEAD_SHA`. A force-push doesn't just move the head — GitHub re-points the prior review's commit anchor at the **new** head, so after a rebase that comparison reads true for a commit the bot never read. The PR is left carrying an `APPROVED` it never earned, and the one step that would have re-checked it declines to run.

Dependency PRs are the population tend rewrites on purpose: `nightly` posts `@dependabot recreate` and ticks renovate's `rebase-check` on conflicted bot PRs, both of which force-push.

## Observed

[`PRQL/prql#6158`](https://github.com/PRQL/prql/pull/6158) (dependabot, `js-yaml` bump). `prql-bot` approved at 06:09:36Z; dependabot rebased at 07:40:18Z. Running the current snippet against it now:

```
HEAD_SHA=cc0207205f99c5481b8404c805a16a43c91fb3af
LAST_APPROVAL_SHA=cc0207205f99c5481b8404c805a16a43c91fb3af
-> "Already approved on this commit; skipping."
```

`cc020720` was created 90 minutes after that approval.

## Fix

Take the newest `head_ref_force_pushed` off the timeline and drop approvals older than it, mirroring the probe [#884](https://github.com/max-sixty/tend/pull/884) adds to `review`'s three anchor sites. Switching from `gh pr view --json reviews` to the REST endpoint is what makes the filter expressible: `submitted_at` isn't in the GraphQL projection, and `gh api --jq` takes no `--arg`, so the comparison pipes to `jq`. Note the field rename that comes with it — REST carries `.commit_id`, not `.commit.oid`.

The equality test also gains an `-n` guard: with no surviving approval both sides can now be empty, and `[ "" = "" ]` would skip.

Fixing the approve path alone would leave the stale `APPROVED` standing on the two paths that *don't* reach it — step 2's "CI is failing, comment and skip" and "major version bump, comment and skip". Both are reachable precisely because a rebase changed something, so a rebased-into-red dependency PR would get a failure comment while still reading as bot-approved. A new item 6 dismisses any approval older than the newest rewrite on those paths, using the same `reviews/$REVIEW_ID/dismissals` call #884 gives `review`. It's idempotent — a dismissed review reports `DISMISSED`, so the filter stops matching it.

## Verified live

| PR | shape | before | after |
|---|---|---|---|
| [`#6158`](https://github.com/PRQL/prql/pull/6158) | approved, then force-pushed | skip | **proceed** |
| [`#6157`](https://github.com/PRQL/prql/pull/6157) | approved, no rewrite | skip | skip |
| [`#6156`](https://github.com/PRQL/prql/pull/6156) | approved, no rewrite | skip | skip |

The two controls confirm the redundant-approval suppression the guard exists for is intact; only the rewritten case flips.

The dismissal filter resolves against the same three: `#6158` selects review `4880377370` (`prql-bot`, `APPROVED`, `submitted_at` 06:09:36Z, `commit_id` `cc020720` — the post-rewrite head, re-anchored), and both controls select nothing.

Flagged in the [review of #884](https://github.com/max-sixty/tend/pull/884#pullrequestreview-4881338227) as a separate concern from that diff, which patches `review` only.
