### PR TITLE
fix(review-runs,review-reviewers): dedup against merged PRs, and against tend before filing upstream

### DIFF
--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -343,9 +343,12 @@ Before creating issues or PRs, check exhaustively for existing ones:
 ```bash
 gh issue list --state open --label claude-behavior --json number,title,body
 gh issue list --state open --json number,title,body  # also check unlabeled issues
-gh pr list --state open --json number,title,headRefName,body
 gh issue list --state closed --label claude-behavior --json number,title,closedAt --limit 30
+# --state all: a merged PR is the most common way a finding is already fixed
+gh pr list --state all --limit 40 --json number,title,state,mergedAt,headRefName,body
 ```
+
+**A merged fix still reproduces on adopters.** Adopters call a pinned action ref, so a merged skill fix is dormant on their repos until the next release tags. Observing the bug is therefore not evidence the fix is missing — check merged PRs before filing, or the report is churn on something already landed.
 
 Search titles AND bodies for related keywords. Only comment on existing issues if you have material new cases that would change the approach or increase prioritization. Do not comment with progress updates, fix-PR status, or re-statements of evidence already in the issue.
 

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -198,11 +198,14 @@ Before creating issues or PRs, check for existing ones:
 
 ```bash
 gh issue list --state open --json number,title,body
-gh pr list --state open --json number,title,headRefName,body
 gh issue list --state closed --json number,title,closedAt --limit 30
+# --state all: a merged PR is the most common way a finding is already fixed
+gh pr list --state all --limit 40 --json number,title,state,mergedAt,headRefName,body
 ```
 
 Search titles AND bodies for related keywords.
+
+**A merged fix still reproduces on adopters.** Adopters call a pinned action ref, so a merged skill fix is dormant on their repos until the next release tags. Observing the bug is therefore not evidence the fix is missing — check merged PRs before filing, or the report is churn on something already landed.
 
 ## Step 6: Act on findings
 

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -201,11 +201,15 @@ gh issue list --state open --json number,title,body
 gh issue list --state closed --json number,title,closedAt --limit 30
 # --state all: a merged PR is the most common way a finding is already fixed
 gh pr list --state all --limit 40 --json number,title,state,mergedAt,headRefName,body
+# Bundled-skill defects are filed upstream (Step 6), and the queries above only
+# see this repo — dedup against tend before filing there.
+gh pr list --repo max-sixty/tend --state all --limit 40 --json number,title,state,mergedAt,body
+gh issue list --repo max-sixty/tend --state all --limit 40 --json number,title,body
 ```
 
 Search titles AND bodies for related keywords.
 
-**A merged fix still reproduces on adopters.** Adopters call a pinned action ref, so a merged skill fix is dormant on their repos until the next release tags. Observing the bug is therefore not evidence the fix is missing — check merged PRs before filing, or the report is churn on something already landed.
+**A fix merged upstream still reproduces here.** The action ref is pinned per release, so a skill fix that merged in `max-sixty/tend` stays dormant on this repo until the next release tags. Observing the bug is therefore not evidence the fix is missing — check tend's merged PRs before filing, or the report is churn on something already landed.
 
 ## Step 6: Act on findings
 


### PR DESCRIPTION
## Problem

Two dedup blocks were blind in two different ways, and the cited duplicate needed both fixed.

**State filter.** `review-runs` Step 5 and `review-reviewers` Step 4 both deduped against PRs with `gh pr list --state open`. A merged PR is never returned by that query, so a finding whose fix already landed reads as undeduped and gets filed again. `running-in-ci`'s PR-creation dedup recheck already gets this right ("with `--state all` so closed and merged siblings show up"); these two recipes contradicted it.

**Repo scope.** `review-runs` is a generated workflow ([`generator/src/tend/config.py:24`](https://github.com/max-sixty/tend/blob/f65f49f/generator/src/tend/config.py#L24) lists it in the enabled set), so it runs in each adopter's checkout and an unqualified `gh pr list` returns *the adopter's* PRs. Step 6 routes bundled-skill defects upstream to tend, but neither Step 5 nor any of `running-in-ci`'s dedup recipes — all local-repo — told the agent to dedup in the target repo before filing there. `--state all` alone does not close this: the adopter's PR list never contained the upstream fix at any state.

`review-reviewers` is unaffected by the second half. It runs in `max-sixty/tend` and files onto tend, so its unqualified `gh pr list` already resolves to the right repo; only the state filter was wrong there.

This bites hardest on tend specifically, because of the pinning model: adopters call `max-sixty/tend/<harness>@X.Y.Z`, so a merged skill fix stays dormant on their repos until the next release tags. The bug keeps reproducing after the fix merges — which is exactly the window in which the analysis legs are looking at it, and exactly when the dedup queries are blind to the fix.

## What happened

`max-sixty/cargo-affected`'s `tend-review-runs` run [31160677649](https://github.com/max-sixty/cargo-affected/actions/runs/31160677649) (08:11:33Z → 08:21:41Z) hit the `| last` evidence-log mis-selection: it appended ~12 KB of run evidence into the nightly's unrelated comment on target [#73](https://github.com/max-sixty/cargo-affected/issues/73), noticed on its post-verify read, restored comment `5188771252`, and re-appended to the real log `5150650688`. Good recovery. It then filed [#883](https://github.com/max-sixty/tend/issues/883) upstream, whose "Proposed fix" is a `## Run ` heading predicate on the comment selector.

[#875](https://github.com/max-sixty/tend/pull/875) merged that exact fix at 07:34:40Z — 46 minutes before the issue was filed — as `test("^## Run [0-9]")` on the same selector, in the same file. #883 is a duplicate of a merged PR.

The run made three dedup queries before filing (`gh issue list --state all --search "tracking issue comment append"`, a broader `gh issue list --state all` title regex, and a final `gh issue list --state open` recheck). All three were `gh issue list`, which never returns PRs — and all three ran against `max-sixty/cargo-affected`. Even had it run Step 5's PR line verbatim, it would not have returned #875, for both reasons: the state filter excluded merged PRs, and the query's repo was the adopter's, not tend's.

## The fix

- Both skills: `gh pr list --state open` → `--state all`, projecting `state,mergedAt` so a merged hit is legible.
- `review-runs` only: add the cross-repo pair (`gh pr list`/`gh issue list --repo max-sixty/tend --state all`) so a finding heading upstream under Step 6 is deduped against tend first.
- `review-runs` only: the pinning note is scoped to the upstream repo, since in that skill the reader is the adopter and the local `gh pr list` above it has nothing to do with pinned refs. `review-reviewers` keeps the original wording, where tend is the reader and "on adopters" is the correct direction.

Both added commands were run against this repo to confirm they parse and return the expected shape.

## Gate assessment

- **Evidence level**: High. **Occurrences: 1** direct, verified end to end (session log, both dedup query sets, #875's merge time and diff, #883's body).
- **Structural, not stochastic.** `gh pr list --state open` deterministically cannot return a merged PR, and a query scoped to the adopter's repo deterministically cannot return a tend PR; replayed ten times it misses #875 ten times. There is no decision point.
- **Change type**: targeted fix — query lines plus one sentence naming the pinning consequence. It brings both recipes into line with a rule the same plugin already states in `running-in-ci`, rather than introducing new policy.
- **Why act at one occurrence**: the six-PR batch merged at 07:34:40Z ([#875](https://github.com/max-sixty/tend/pull/875), [#834](https://github.com/max-sixty/tend/pull/834), [#868](https://github.com/max-sixty/tend/pull/868), [#818](https://github.com/max-sixty/tend/pull/818), [#877](https://github.com/max-sixty/tend/pull/877), [#858](https://github.com/max-sixty/tend/pull/858)) is all unreleased, so six distinct bugs remain observable on every adopter until the next release. The first analysis leg after that batch produced the first duplicate. The exposure is six-wide and standing, not one-off.

## Not covered by

No open PR touches either dedup block. [#845](https://github.com/max-sixty/tend/pull/845)/[#850](https://github.com/max-sixty/tend/pull/850)/[#838](https://github.com/max-sixty/tend/pull/838) are the run-window cluster; [#849](https://github.com/max-sixty/tend/pull/849), [#856](https://github.com/max-sixty/tend/pull/856), [#857](https://github.com/max-sixty/tend/pull/857), [#864](https://github.com/max-sixty/tend/pull/864), [#869](https://github.com/max-sixty/tend/pull/869), [#876](https://github.com/max-sixty/tend/pull/876), [#809](https://github.com/max-sixty/tend/pull/809), [#837](https://github.com/max-sixty/tend/pull/837), [#821](https://github.com/max-sixty/tend/pull/821), [#836](https://github.com/max-sixty/tend/pull/836) are elsewhere.

#883 stays open as a maintainer call — it is redundant with #875 but the option-2 half of its body (finish the gist migration for `review-runs`) is not.

Evidence: https://gist.github.com/dca23a6e6a0d8cae2665944ba31676fb
