### PR TITLE
fix(review-gates): name people without `@` in the evidence store

### DIFF
--- a/plugins/tend-ci-runner/shared/review-gates.md
+++ b/plugins/tend-ci-runner/shared/review-gates.md
@@ -75,6 +75,6 @@ When composing the findings file, either interpolate the values with an unquoted
 
 Each run gets its own heading so future runs can count prior occurrences and trace incidents to session logs.
 
-**Name people without `@`.** Write `` `alice` ``, not `@alice`. The evidence store is an internal accounting log nobody asked to be in; every `@handle` in it — including one added by appending to an existing comment — notifies that person and auto-subscribes them to every later entry. Backticks keep the attribution and drop the ping. Same rule for a PR or issue body opened from a finding, and for any repo the handle belongs to.
+**Name people without `@`.** Write `` `alice` ``, not `@alice`. The evidence store is an internal accounting log nobody asked to be in; every `@handle` in it — including one added by appending to an existing comment — notifies that person and auto-subscribes them to every later entry. Backticks keep the attribution and drop the ping. Same rule for a PR or issue body opened from a finding, and it holds even when the person is a collaborator of the repo you're writing in.
 
 When a historical entry looks like it might match a current finding, **download and investigate the linked workflow's session logs** — don't rely on the summary text alone, which lacks sufficient context to judge relatedness. Trace the original decision chain in the session JSONL to confirm the historical case is genuinely the same pattern, not just superficially similar.

--- a/plugins/tend-ci-runner/shared/review-gates.md
+++ b/plugins/tend-ci-runner/shared/review-gates.md
@@ -75,4 +75,6 @@ When composing the findings file, either interpolate the values with an unquoted
 
 Each run gets its own heading so future runs can count prior occurrences and trace incidents to session logs.
 
+**Name people without `@`.** Write `` `alice` ``, not `@alice`. The evidence store is an internal accounting log nobody asked to be in; every `@handle` in it — including one added by appending to an existing comment — notifies that person and auto-subscribes them to every later entry. Backticks keep the attribution and drop the ping. Same rule for a PR or issue body opened from a finding, and for any repo the handle belongs to.
+
 When a historical entry looks like it might match a current finding, **download and investigate the linked workflow's session logs** — don't rely on the summary text alone, which lacks sufficient context to judge relatedness. Trace the original decision chain in the session JSONL to confirm the historical case is genuinely the same pattern, not just superficially similar.


### PR DESCRIPTION
The evidence-store format tells a run to name the actors in a window, and runs do — with `@handle`. GitHub reads that as a mention, so a log nobody asked to be in pings a human and auto-subscribes them to every later entry appended to it.

## Evidence

`PRQL/prql` issue [#6123](https://github.com/PRQL/prql/issues/6123) is the bot's own `review-runs-tracking: 2026-08` accounting issue. Its timeline carries two `mentioned` + `subscribed` pairs for the repo's collaborator `kgutwin`:

| When | Source |
|---|---|
| 2026-08-02T08:43:10Z | edit appending a run block to comment `5150672291` (3 `@kgutwin`) |
| 2026-08-07T08:33:29Z | edit appending run [31160847646](https://github.com/PRQL/prql/actions/runs/31160847646)'s block to comment `5202559614` (7 `@kgutwin`) |

Neither is a conversation — both blocks are internal accounting prose that happens to credit who did what in the window (*"The window is unusually human-dense: @kgutwin (COLLABORATOR) engaged on five threads"*). The information is worth recording; the notification is the accident. The second edit also fired a `tend-mention` run ([31162178997](https://github.com/PRQL/prql/actions/runs/31162178997)), correctly skipped at the verify gate.

Corroborating signal that this thread is unwanted in a human inbox: `eitsupi` unsubscribed from #6123 at 2026-08-01T08:45:14Z, 90 seconds after the bot created it.

The fix restores an intent the skill already states — `review-runs/SKILL.md`'s recording step appends to one comment rather than posting per-run specifically because it "avoids notification spam from frequent runs". Appending is what carries the mention, so the append path defeats the goal the append path exists to serve.

## Change

One paragraph in `shared/review-gates.md` (symlinked into both `review-runs` and `review-reviewers`), under **Finding format**: write `` `alice` ``, not `@alice`. Backticks keep the attribution and drop the ping. Extended to PR/issue bodies opened from a finding, which have the same shape.

## Gate assessment

- **Evidence level**: High — **structural**. No decision point: the format asks for actors by name, nothing tells a run to strip the `@`, so any window with human activity reproduces it.
- **Occurrences**: **2** (2026-08-02, 2026-08-07), both on `PRQL/prql`, from two independent `review-runs` sessions. High needs 2–3 → passes Gate 1.
- **Change type**: targeted fix, one paragraph in an existing section — normal bar → passes Gate 2.

Evidence log: https://gist.github.com/192514ea2c36586f9b7f842a482d62ab
