### PR TITLE
docs: point the release and consumers-search notes at the harness-scoped action ref

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -37,9 +37,10 @@ Draft the section from the commits since the last release (`git log <last-versio
 
 Tags are bare versions (`0.0.9`), not prefixed (`v0.0.9`).
 
-Generated workflows pin the action to the generator's own version
-(`max-sixty/tend@X.Y.Z`); there is no floating `v1`. Each `X.Y.Z` tag is the
-immutable ref consumers run, enforced by a tag ruleset on `max-sixty/tend`
+Generated workflows pin the harness action to the generator's own version
+(`max-sixty/tend/claude@X.Y.Z`, `max-sixty/tend/codex@X.Y.Z`); there is no
+bare-root action and no floating `v1`. Each `X.Y.Z` tag is the immutable ref
+consumers run, enforced by a tag ruleset on `max-sixty/tend`
 (`update`/`deletion` restricted). Never force-move or delete a published tag.
 Step 9 (tag) must precede step 11 (regenerate via `uvx tend@latest`) so the
 pinned ref resolves to an existing tag.

--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -111,9 +111,10 @@ because the workflow files are public.
 
 ```bash
 # 1. Discover consumer repos via code search. Generated workflows pin a
-#    version tag (`max-sixty/tend@X.Y.Z`, or `/codex@X.Y.Z`), so search the
-#    bare `max-sixty/tend` token (version-agnostic; GitHub code search does
-#    not index `@` or `/`, so this matches both the Claude and Codex refs).
+#    version tag (`max-sixty/tend/claude@X.Y.Z`, or `/codex@X.Y.Z`), so
+#    search the bare `max-sixty/tend` token (version-agnostic; GitHub code
+#    search does not index `@` or `/`, so this matches both the Claude and
+#    Codex refs).
 #    `--extension yaml` is required: without it, README/CLAUDE.md/TODO.md
 #    hits on `max-sixty/tend` itself crowd out tend's own workflow files
 #    past the 100-result cap, dropping tend from its own consumers.json.


### PR DESCRIPTION
Two repo-local skills still describe the action as living at the repo root. That path was removed when every harness moved under a harness-named directory — `CLAUDE.md` records it as "Every harness lives under a harness-named path; there is no bare-root default" — so `max-sixty/tend@X.Y.Z` names a ref that does not resolve, and a release run following the `release` skill's version-scheme note would be checking the wrong thing.

- `.claude/skills/release/SKILL.md` — names both harness refs and drops the bare-root form.
- `.claude/skills/running-tend/SKILL.md` — the consumers.json search recipe's parenthetical, which paired a bare-root Claude ref against `/codex@X.Y.Z`. The search token it documents (`max-sixty/tend`) is unchanged and still correct; only the example refs were stale.

Docs only, so no regression test. Verified against the tree: `ls action.yaml` finds nothing at the root, and the generated workflows all pin `max-sixty/tend/claude@0.1.14`.

Found by the nightly rolling survey (`.claude/skills/release/SKILL.md` was in today's bucket).
