### PR TITLE
chore: lint every Python file, not just generator/

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,14 +5,16 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+  # No `files:` filter — every Python file in the repo is linted and formatted.
+  # Python lives in three places now (`generator/`, `proxy/`, and the
+  # install-tend OAuth wrapper), and a path filter only ever covered the first,
+  # so each new one arrived unlinted and stayed that way until someone noticed.
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.11
     hooks:
       - id: ruff-check
         args: ["--fix"]
-        files: ^generator/
       - id: ruff-format
-        files: ^generator/
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: 0.7.12
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,10 +5,9 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
-  # No `files:` filter — every Python file in the repo is linted and formatted.
-  # Python lives in three places now (`generator/`, `proxy/`, and the
-  # install-tend OAuth wrapper), and a path filter only ever covered the first,
-  # so each new one arrived unlinted and stayed that way until someone noticed.
+  # The hook already selects Python by type; the previous `^generator/` filter
+  # only meant that each new Python directory arrived unlinted and stayed that
+  # way until someone noticed.
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.11
     hooks:

--- a/proxy/test_inject_credentials.py
+++ b/proxy/test_inject_credentials.py
@@ -226,7 +226,9 @@ def test_anthropic_lookalike_host_is_untouched(injector: CredentialInjector) -> 
     assert "Authorization" not in flow.request.headers
 
 
-def test_anthropic_mixed_case_host_gets_credential(injector: CredentialInjector) -> None:
+def test_anthropic_mixed_case_host_gets_credential(
+    injector: CredentialInjector,
+) -> None:
     flow = _flow("Api.Anthropic.Com", {"Authorization": "Bearer sk-ant-oat01-dummy"})
     injector.request(flow)
     assert flow.request.headers["Authorization"] == "Bearer sk-ant-oat01-REAL"


### PR DESCRIPTION
Ruff's pre-commit hooks carry `files: ^generator/`, which was the whole of the repo's Python when they were added. It isn't any more — `proxy/` (3 files) and the install-tend OAuth wrapper merged yesterday (`oauth_token.py` + its tests, ~280 lines) are both outside the filter, so neither is linted or formatted by `pre-commit run --all-files` or by CI's `lint` job.

Dropping the filter rather than extending it: the hook already restricts itself to Python by type, and a path list is exactly what let two directories arrive unnoticed. Whatever Python lands next is covered without anyone remembering to add it.

Both new directories already pass `ruff check`. `ruff format` had one pending change, in `proxy/test_inject_credentials.py` — a signature over the line limit, split across three lines; it's in this PR so the hook is green on merge rather than failing the next contributor's unrelated commit. `proxy/` tests still pass (23 passed).

No regression test: the mechanism under change *is* the check. Running `pre-commit run --all-files` on this branch exercises it.

Found by the nightly review of the last 24 hours of commits.
