### PR TITLE
test: wt test runs every suite, not just generator/

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -32,6 +32,7 @@ url = "http://localhost:{{ branch | hash_port }}"
 [[pre-remove]]
 server = "lsof -ti :{{ branch | hash_port }} -sTCP:LISTEN | xargs kill 2>/dev/null || true"
 
-# The Python package lives under generator/; this alias runs pytest from the right cwd.
+# Tests live in four places (generator/, proxy/, the install-tend scripts,
+# worker/); dev/test.sh runs the lot, mirroring ci.yaml's test jobs.
 [aliases]
-test = "cd generator && uv run pytest {{ args }}"
+test = "dev/test.sh {{ args }}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,13 +30,14 @@ repos:
   # The composite actions' shared step bodies live in standalone scripts
   # (shared/steps/, proxy/) rather than inline `run:` blocks, so
   # actionlint's built-in shellcheck doesn't see them. Run shellcheck directly
-  # to keep that coverage. -S warning matches actionlint's default severity.
+  # to keep that coverage — and over dev/, which actionlint never sees at all.
+  # -S warning matches actionlint's default severity.
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.11.0.1
     hooks:
       - id: shellcheck
         args: ["-S", "warning"]
-        files: ^(shared/steps/.*\.sh|proxy/setup-sandbox\.sh)$
+        files: ^(shared/steps/.*\.sh|proxy/setup-sandbox\.sh|dev/.*\.sh)$
   - repo: local
     hooks:
       # The Claude Code slash-command preprocessor treats a backticked token

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ pre-commit run --all-files         # lint: ruff, typos, actionlint, shellcheck, 
 ```
 
 `wt test` covers `generator/` only. Two more pytest suites live beside the code
-they test and have CI jobs of their own — run them from their own directory:
+they test and have CI jobs of their own — run each from the repo root:
 
 ```bash
 # proxy addon — pin mitmproxy the way CI does, to the version production runs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,18 @@ wt test                            # run pytest in generator/
 uvx tend@latest init               # regenerate workflows from .config/tend.yaml
 uvx tend@latest init --dry-run     # preview without writing
 uvx tend@latest check              # verify branch protection, secrets, bot access
-pre-commit run --all-files         # lint: ruff, typos, actionlint, uv-lock
+pre-commit run --all-files         # lint: ruff, typos, actionlint, shellcheck, uv-lock
+```
+
+`wt test` covers `generator/` only. Two smaller suites live beside the code
+they test and have CI jobs of their own — run them from their own directory:
+
+```bash
+# proxy addon — pin mitmproxy the way CI does, to the version production runs
+cd proxy && uv run --no-project --with pytest \
+  --with "mitmproxy==$(yq -e '.inputs.mitmproxy_version.default' ../claude/action.yaml)" pytest
+# install-tend OAuth wrapper
+cd plugins/install-tend/skills/install-tend/scripts && uv run --no-project --with pytest pytest
 ```
 
 ## Architecture
@@ -106,8 +117,8 @@ from `.config/tend.yaml`. Edit the generator or config, not the workflow files
 directly.
 
 The generator is a Python package under `generator/` — uses the uv_build
-backend, requires Python 3.11+. Runtime dependencies: click, ruamel.yaml.
-Dev dependencies: pytest, pytest-regtest.
+backend, requires Python 3.11+. Runtime dependencies: click, jinja2,
+ruamel.yaml. Dev dependencies: pytest, pytest-regtest.
 
 Consuming repos regenerate their `tend-*.yaml` workflows nightly (tend itself
 included — it dogfoods its own workflows). Changes to the generator do not

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,26 +11,15 @@ completely — old formats should fail with a clear error, not silently parse.
 ## Commands
 
 ```bash
-wt test                            # run pytest in generator/
+wt test                            # every suite (generator/, proxy/, install-tend scripts, worker/)
 uvx tend@latest init               # regenerate workflows from .config/tend.yaml
 uvx tend@latest init --dry-run     # preview without writing
 uvx tend@latest check              # verify branch protection, secrets, bot access
 pre-commit run --all-files         # lint: ruff, typos, actionlint, shellcheck, uv-lock
 ```
 
-`wt test` covers `generator/` only. Two more pytest suites live beside the code
-they test and have CI jobs of their own — run each from the repo root:
-
-```bash
-# proxy addon — pin mitmproxy the way CI does, to the version production runs
-(cd proxy && uv run --no-project --with pytest \
-  --with "mitmproxy==$(yq -e '.inputs.mitmproxy_version.default' ../claude/action.yaml)" pytest)
-# install-tend OAuth wrapper
-(cd plugins/install-tend/skills/install-tend/scripts && uv run --no-project --with pytest pytest)
-```
-
-`worker/` is a third suite outside `wt test`, vitest rather than pytest, with
-its own CI job — see [`worker/README.md`](worker/README.md).
+`wt test` runs [`dev/test.sh`](dev/test.sh), which mirrors the test jobs in
+`ci.yaml`; arguments go to the pytest suites (`wt test -k render`).
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,16 +18,19 @@ uvx tend@latest check              # verify branch protection, secrets, bot acce
 pre-commit run --all-files         # lint: ruff, typos, actionlint, shellcheck, uv-lock
 ```
 
-`wt test` covers `generator/` only. Two smaller suites live beside the code
+`wt test` covers `generator/` only. Two more pytest suites live beside the code
 they test and have CI jobs of their own — run them from their own directory:
 
 ```bash
 # proxy addon — pin mitmproxy the way CI does, to the version production runs
-cd proxy && uv run --no-project --with pytest \
-  --with "mitmproxy==$(yq -e '.inputs.mitmproxy_version.default' ../claude/action.yaml)" pytest
+(cd proxy && uv run --no-project --with pytest \
+  --with "mitmproxy==$(yq -e '.inputs.mitmproxy_version.default' ../claude/action.yaml)" pytest)
 # install-tend OAuth wrapper
-cd plugins/install-tend/skills/install-tend/scripts && uv run --no-project --with pytest pytest
+(cd plugins/install-tend/skills/install-tend/scripts && uv run --no-project --with pytest pytest)
 ```
+
+`worker/` is a third suite outside `wt test`, vitest rather than pytest, with
+its own CI job — see [`worker/README.md`](worker/README.md).
 
 ## Architecture
 

--- a/dev/test.sh
+++ b/dev/test.sh
@@ -18,9 +18,13 @@ suite() {
   shift
   printf '\n==> %s: %s\n' "$dir" "$*"
   (cd "$dir" && "$@") || rc=$?
-  # pytest exits 5 for "no tests collected" — what a -k aimed at one suite looks
-  # like from the others. Only a filtered run gets to treat that as a pass.
-  if [ "$rc" -eq 5 ] && [ ${#pytest_args[@]} -gt 0 ]; then rc=0; fi
+  # A filtered run gets slack: pytest exits 5 for "no tests collected" and 4 for
+  # a path that only exists in another suite. generator/ stays strict, so a bad
+  # flag — 4 everywhere — still fails the run.
+  if [ ${#pytest_args[@]} -gt 0 ] &&
+    { [ "$rc" -eq 5 ] || { [ "$rc" -eq 4 ] && [ "$dir" != generator ]; }; }; then
+    rc=0
+  fi
   if [ "$rc" -ne 0 ]; then failed+=("$dir"); fi
 }
 
@@ -43,11 +47,12 @@ suite plugins/install-tend/skills/install-tend/scripts \
   uv run --no-project --with pytest pytest "${pytest_args[@]}"
 
 if [ ${#pytest_args[@]} -eq 0 ]; then
-  # Install only when the tree is missing, and with `npm ci` rather than
-  # `npm install` — an older local npm reruns resolution and rewrites
-  # package-lock.json, leaving churn in the diff that has nothing to do with the
-  # change under test.
-  if [ ! -d worker/node_modules ]; then
+  # Install when the tree is missing or older than the lockfile (`npm ci` writes
+  # node_modules/.package-lock.json), and with `npm ci` rather than `npm install`
+  # — an older local npm reruns resolution and rewrites package-lock.json,
+  # leaving churn in the diff that has nothing to do with the change under test.
+  if [ ! -d worker/node_modules ] ||
+    [ worker/package-lock.json -nt worker/node_modules/.package-lock.json ]; then
     suite worker npm ci --prefer-offline --no-audit --no-fund
   fi
   suite worker npm run typecheck

--- a/dev/test.sh
+++ b/dev/test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Every test suite in the repo, mirroring the test jobs in
+# .github/workflows/ci.yaml. `wt test` runs this (see .config/wt.toml), so one
+# command covers generator/, proxy/, the install-tend scripts, and worker/.
+#
+# Arguments are forwarded to the pytest suites (`wt test -k render`); a filtered
+# run skips worker/, whose vitest CLI takes different flags. Every suite runs
+# even if an earlier one fails, and the failures are listed at the end.
+set -o pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 1
+
+failed=()
+
+# suite <dir> <cmd>...
+suite() {
+  local dir=$1 rc=0
+  shift
+  printf '\n==> %s: %s\n' "$dir" "$*"
+  (cd "$dir" && "$@") || rc=$?
+  # pytest exits 5 for "no tests collected" — what a -k aimed at one suite looks
+  # like from the others. Only a filtered run gets to treat that as a pass.
+  if [ "$rc" -eq 5 ] && [ ${#pytest_args[@]} -gt 0 ]; then rc=0; fi
+  if [ "$rc" -ne 0 ]; then failed+=("$dir"); fi
+}
+
+pytest_args=("$@")
+
+suite generator uv run pytest "${pytest_args[@]}"
+
+# The proxy addon isn't part of the generator package, and it imports
+# mitmproxy.test, so it runs standalone against the version production runs
+# rather than whatever mitmproxy is latest.
+if mitmproxy_version=$(yq -e '.inputs.mitmproxy_version.default' claude/action.yaml); then
+  suite proxy uv run --no-project --with pytest \
+    --with "mitmproxy==$mitmproxy_version" pytest "${pytest_args[@]}"
+else
+  echo "==> proxy: cannot read mitmproxy_version from claude/action.yaml (yq installed?)" >&2
+  failed+=(proxy)
+fi
+
+suite plugins/install-tend/skills/install-tend/scripts \
+  uv run --no-project --with pytest pytest "${pytest_args[@]}"
+
+if [ ${#pytest_args[@]} -eq 0 ]; then
+  # Install only when the tree is missing, and with `npm ci` rather than
+  # `npm install` — an older local npm reruns resolution and rewrites
+  # package-lock.json, leaving churn in the diff that has nothing to do with the
+  # change under test.
+  if [ ! -d worker/node_modules ]; then
+    suite worker npm ci --prefer-offline --no-audit --no-fund
+  fi
+  suite worker npm run typecheck
+  suite worker npm test
+fi
+
+if [ ${#failed[@]} -gt 0 ]; then
+  printf '\nfailed: %s\n' "${failed[*]}" >&2
+  exit 1
+fi


### PR DESCRIPTION
`wt test` ran `cd generator && uv run pytest`, so three of the four suites CI runs were reachable only by hand: `proxy/`, the install-tend OAuth scripts, and `worker/`. A contributor who touched any of them got a green `wt test` and found out in CI.

The alias now points at `dev/test.sh`, which runs all four in the order `ci.yaml` does — including the `proxy/` pin read out of `claude/action.yaml`, so the addon is tested against the mitmproxy version production runs rather than whatever is latest. Every suite runs even if an earlier one fails, and the failures are listed at the end.

Arguments still forward to the pytest suites, so both `wt test -k render` and `wt test tests/test_migrate.py` keep working. A filtered run gets slack in the suites the filter wasn't aimed at: pytest exits 5 there for "no tests collected" and 4 for a path that only exists in another suite, and both count as a pass. `generator/` stays strict, so a genuine bad flag — 4 everywhere — still fails the run. A filtered run skips `worker/`, whose vitest CLI takes different flags.

`worker/` needs `node_modules`, so a cold tree gets `npm ci` first — as does a tree older than the lockfile, which `npm ci` records at `node_modules/.package-lock.json`. Otherwise a dependency bump or a branch switch leaves tsc and vitest running against the last install while CI reruns `npm ci` and can go red: the same green-locally-red-in-CI shape this PR is closing, one directory over. `npm ci` rather than `npm install`, because on an older local npm the latter reruns resolution and leaves `package-lock.json` churn in the diff.

Also in here: shellcheck's file pattern picks up `dev/`, and two CLAUDE.md corrections that stand on their own — `shellcheck` was missing from the `pre-commit` line, and `jinja2` was missing from the generator's runtime dependencies.

<details><summary>Verification</summary>

From a cold checkout (`rm -rf worker/node_modules`):

- `./dev/test.sh` → exit 0; `generator` 354 passed, `proxy` 23 passed (mitmproxy 12.2.3, resolved from `claude/action.yaml`), install-tend scripts 9 passed, `worker` typecheck + 31 vitest tests passed. `git status worker/package-lock.json` clean afterwards.
- `./dev/test.sh tests/test_migrate.py` → exit 0; 8 passed in `generator`, the other two suites report the missing path and are tolerated.
- `./dev/test.sh -k render` → exit 0; 9 selected in `generator`, the other two suites deselect everything and are tolerated.
- `./dev/test.sh -k zzz_no_such_test` → exit 0 (nothing matched anywhere).
- `./dev/test.sh --bogus-flag` → exit 1, `failed: generator`.
- `touch worker/package-lock.json && ./dev/test.sh` → `==> worker: npm ci` reappears on the already-populated tree; the run right after skips it.
- `pre-commit run --files dev/test.sh .config/wt.toml CLAUDE.md .pre-commit-config.yaml` → all hooks pass, shellcheck included.

</details>
