### PR TITLE
fix(nightly): test-merge bot PRs locally instead of filtering the lazy mergeable field

### DIFF
--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -76,15 +76,24 @@ a one-line reason) plus a `_Last refreshed: <YYYY-MM-DD>_` footer. Updates:
 
 Find conflicted PRs from this bot and from upstream dependency bots:
 
+`mergeable` is computed lazily, not stored. The first query after `main` moves returns `UNKNOWN` for every PR whose merge hasn't been recomputed and *enqueues* the computation; a later query returns the real value. Filtering a cold read on `== "CONFLICTING"` therefore reports a conflicted PR as clean. Re-query until it settles:
+
 ```bash
 BOT_LOGIN=$(gh api user --jq '.login')
 for author in "$BOT_LOGIN" app/dependabot app/renovate; do
-  gh pr list --author "$author" --json number,title,mergeable,headRefName,author \
-    --jq '.[] | select(.mergeable == "CONFLICTING")'
+  out="/tmp/prs-${author//\//-}.json"   # `app/dependabot` has a slash; strip it
+  for _ in 1 2 3 4 5; do
+    gh pr list --author "$author" --json number,title,mergeable,headRefName,author > "$out"
+    [ "$(jq '[.[] | select(.mergeable == "UNKNOWN")] | length' "$out")" -eq 0 ] && break
+    sleep 10
+  done
+  jq -c '.[] | select(.mergeable == "CONFLICTING")' "$out"
+  jq -r '.[] | select(.mergeable == "UNKNOWN")
+    | "unsettled, treat as possibly conflicted: #\(.number) \(.title)"' "$out"
 done
 ```
 
-Skip the rest of this step if none of the queries return anything.
+Skip the rest of this step only when every PR settled and none came back `CONFLICTING`. A PR still `UNKNOWN` after the retries is not a clean one — check it out and test-merge (`git merge --no-commit --no-ff origin/main`) before dismissing it, and report it as unverified rather than counting it clean.
 
 ### Upstream dependency bots: trigger the bot's own rebase
 

--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -82,33 +82,23 @@ Don't filter `gh pr list --json mergeable` on `== "CONFLICTING"`. `mergeable` is
 BOT_LOGIN=$(gh api user --jq '.login')
 git fetch --quiet origin main
 for author in "$BOT_LOGIN" app/dependabot app/renovate; do
-  out="/tmp/prs-${author//\//-}.json"   # `app/dependabot` has a slash; strip it
-  # `--limit 100` is load-bearing: `gh pr list` defaults to 30 and truncates
-  # silently, so PR 31 onward would never be test-merged.
-  gh pr list --author "$author" --limit 100 --json number,title,headRefName,author > "$out"
-  # A failed query leaves `$out` empty, which reads as "no conflicts" — the
-  # same silent-miss shape. `[]` (no open PRs) is 3 bytes, a failure is 0.
-  [ -s "$out" ] || { echo "query for $author never landed — conflicts unverified"; continue; }
+  # A failed query and "no open PRs" both print nothing; only the first is a
+  # reason to stop. --limit 100 because the default 30 truncates silently.
+  prs=$(gh pr list --author "$author" --limit 100 --json number,title) \
+    || { echo "query for $author never landed — conflicts unverified"; continue; }
   # One fetch for every head, forced because bot branches get force-pushed.
-  # `refs/pull/N/head` also covers PRs opened from a fork.
-  mapfile -t refs < <(jq -r '.[].number | "refs/pull/\(.)/head:refs/tend/pr/\(.)"' "$out")
-  [ "${#refs[@]}" -eq 0 ] || git fetch --quiet --force origin "${refs[@]}"
-  jq -r '.[] | "\(.number)\t\(.title)"' "$out" | while IFS=$'\t' read -r n title; do
-    # Clean merge: exit 0. Conflict: non-zero with the tree OID and conflicted
-    # paths on stdout. Anything else (ref never fetched, bad revision): non-zero
-    # with stdout empty — so test `$tree`, not the exit status alone.
-    if tree=$(git merge-tree --write-tree origin/main "refs/tend/pr/$n" 2>/dev/null); then
-      continue
-    elif [ -n "$tree" ]; then
-      echo "CONFLICTING: $author #$n $title"
-    else
-      echo "merge test never ran, conflicts unverified: $author #$n $title"
-    fi
+  mapfile -t refs < <(jq -r '.[].number | "refs/pull/\(.)/head:refs/tend/pr/\(.)"' <<<"$prs")
+  [ "${#refs[@]}" -eq 0 ] && continue
+  git fetch --quiet --force origin "${refs[@]}"
+  # Conflict, missing ref, unreadable ref: all non-zero, all need a look.
+  jq -r '.[] | [.number, .title] | @tsv' <<<"$prs" | while IFS=$'\t' read -r n title; do
+    git merge-tree --write-tree origin/main "refs/tend/pr/$n" >/dev/null \
+      || echo "needs a rebase: $author #$n $title"
   done
 done
 ```
 
-Skip the rest of this step only when every query landed and nothing printed. A PR whose merge test never ran is not a clean one — investigate it and report it as unverified rather than counting it clean.
+Skip the rest of this step only when every query landed and nothing printed.
 
 ### Upstream dependency bots: trigger the bot's own rebase
 

--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -83,7 +83,9 @@ BOT_LOGIN=$(gh api user --jq '.login')
 git fetch --quiet origin main
 for author in "$BOT_LOGIN" app/dependabot app/renovate; do
   out="/tmp/prs-${author//\//-}.json"   # `app/dependabot` has a slash; strip it
-  gh pr list --author "$author" --json number,title,headRefName,author > "$out"
+  # `--limit 100` is load-bearing: `gh pr list` defaults to 30 and truncates
+  # silently, so PR 31 onward would never be test-merged.
+  gh pr list --author "$author" --limit 100 --json number,title,headRefName,author > "$out"
   # A failed query leaves `$out` empty, which reads as "no conflicts" — the
   # same silent-miss shape. `[]` (no open PRs) is 3 bytes, a failure is 0.
   [ -s "$out" ] || { echo "query for $author never landed — conflicts unverified"; continue; }
@@ -98,9 +100,9 @@ for author in "$BOT_LOGIN" app/dependabot app/renovate; do
     if tree=$(git merge-tree --write-tree origin/main "refs/tend/pr/$n" 2>/dev/null); then
       continue
     elif [ -n "$tree" ]; then
-      echo "CONFLICTING: #$n $title"
+      echo "CONFLICTING: $author #$n $title"
     else
-      echo "merge test never ran, conflicts unverified: #$n $title"
+      echo "merge test never ran, conflicts unverified: $author #$n $title"
     fi
   done
 done

--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -76,28 +76,37 @@ a one-line reason) plus a `_Last refreshed: <YYYY-MM-DD>_` footer. Updates:
 
 Find conflicted PRs from this bot and from upstream dependency bots:
 
-`mergeable` is computed lazily, not stored. The first query after `main` moves returns `UNKNOWN` for every PR whose merge hasn't been recomputed and *enqueues* the computation; a later query returns the real value. Filtering a cold read on `== "CONFLICTING"` therefore reports a conflicted PR as clean. Re-query until it settles:
+Don't filter `gh pr list --json mergeable` on `== "CONFLICTING"`. `mergeable` is computed lazily: the first query after `main` moves returns `UNKNOWN` and only *enqueues* the computation, so a cold read reports a conflicted PR as clean. There is no blocking read — [the REST docs](https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request) prescribe resubmitting the request until the value settles. Test-merge locally instead: `git merge-tree` answers the same question synchronously, in-process, with no retry loop.
 
 ```bash
 BOT_LOGIN=$(gh api user --jq '.login')
+git fetch --quiet origin main
 for author in "$BOT_LOGIN" app/dependabot app/renovate; do
   out="/tmp/prs-${author//\//-}.json"   # `app/dependabot` has a slash; strip it
-  for _ in 1 2 3 4 5; do
-    gh pr list --author "$author" --json number,title,mergeable,headRefName,author > "$out"
-    # A failed query leaves `$out` empty, which reads as "no conflicts" — the
-    # same silent-miss shape. `[]` (no open PRs) is 3 bytes, a failure is 0.
-    [ -s "$out" ] || { sleep 10; continue; }
-    [ "$(jq '[.[] | select(.mergeable == "UNKNOWN")] | length' "$out")" -eq 0 ] && break
-    sleep 10
+  gh pr list --author "$author" --json number,title,headRefName,author > "$out"
+  # A failed query leaves `$out` empty, which reads as "no conflicts" — the
+  # same silent-miss shape. `[]` (no open PRs) is 3 bytes, a failure is 0.
+  [ -s "$out" ] || { echo "query for $author never landed — conflicts unverified"; continue; }
+  # One fetch for every head, forced because bot branches get force-pushed.
+  # `refs/pull/N/head` also covers PRs opened from a fork.
+  mapfile -t refs < <(jq -r '.[].number | "refs/pull/\(.)/head:refs/tend/pr/\(.)"' "$out")
+  [ "${#refs[@]}" -eq 0 ] || git fetch --quiet --force origin "${refs[@]}"
+  jq -r '.[] | "\(.number)\t\(.title)"' "$out" | while IFS=$'\t' read -r n title; do
+    # Clean merge: exit 0. Conflict: non-zero with the tree OID and conflicted
+    # paths on stdout. Anything else (ref never fetched, bad revision): non-zero
+    # with stdout empty — so test `$tree`, not the exit status alone.
+    if tree=$(git merge-tree --write-tree origin/main "refs/tend/pr/$n" 2>/dev/null); then
+      continue
+    elif [ -n "$tree" ]; then
+      echo "CONFLICTING: #$n $title"
+    else
+      echo "merge test never ran, conflicts unverified: #$n $title"
+    fi
   done
-  [ -s "$out" ] || echo "query for $author never landed — conflicts unverified"
-  jq -c '.[] | select(.mergeable == "CONFLICTING")' "$out"
-  jq -r '.[] | select(.mergeable == "UNKNOWN")
-    | "unsettled, treat as possibly conflicted: #\(.number) \(.title)"' "$out"
 done
 ```
 
-Skip the rest of this step only when every query landed, every PR settled, and none came back `CONFLICTING`. A PR still `UNKNOWN` after the retries is not a clean one — check it out and test-merge (`git merge --no-commit --no-ff origin/main`) before dismissing it, and report it as unverified rather than counting it clean.
+Skip the rest of this step only when every query landed and nothing printed. A PR whose merge test never ran is not a clean one — investigate it and report it as unverified rather than counting it clean.
 
 ### Upstream dependency bots: trigger the bot's own rebase
 

--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -84,16 +84,20 @@ for author in "$BOT_LOGIN" app/dependabot app/renovate; do
   out="/tmp/prs-${author//\//-}.json"   # `app/dependabot` has a slash; strip it
   for _ in 1 2 3 4 5; do
     gh pr list --author "$author" --json number,title,mergeable,headRefName,author > "$out"
+    # A failed query leaves `$out` empty, which reads as "no conflicts" — the
+    # same silent-miss shape. `[]` (no open PRs) is 3 bytes, a failure is 0.
+    [ -s "$out" ] || { sleep 10; continue; }
     [ "$(jq '[.[] | select(.mergeable == "UNKNOWN")] | length' "$out")" -eq 0 ] && break
     sleep 10
   done
+  [ -s "$out" ] || echo "query for $author never landed — conflicts unverified"
   jq -c '.[] | select(.mergeable == "CONFLICTING")' "$out"
   jq -r '.[] | select(.mergeable == "UNKNOWN")
     | "unsettled, treat as possibly conflicted: #\(.number) \(.title)"' "$out"
 done
 ```
 
-Skip the rest of this step only when every PR settled and none came back `CONFLICTING`. A PR still `UNKNOWN` after the retries is not a clean one — check it out and test-merge (`git merge --no-commit --no-ff origin/main`) before dismissing it, and report it as unverified rather than counting it clean.
+Skip the rest of this step only when every query landed, every PR settled, and none came back `CONFLICTING`. A PR still `UNKNOWN` after the retries is not a clean one — check it out and test-merge (`git merge --no-commit --no-ff origin/main`) before dismissing it, and report it as unverified rather than counting it clean.
 
 ### Upstream dependency bots: trigger the bot's own rebase
 


### PR DESCRIPTION
## Problem

Step 3 of the bundled `nightly` skill found conflicted bot PRs with a single `gh pr list` whose result was filtered on `select(.mergeable == "CONFLICTING")`, followed by *"Skip the rest of this step if none of the queries return anything."*

`mergeable` is not stored — GitHub computes it lazily. The first query after the base branch moves returns `UNKNOWN` and enqueues the computation; a later query returns the real value. `select(.mergeable == "CONFLICTING")` drops `UNKNOWN` silently, so a cold cache was indistinguishable from a clean one, and the skip line turned "I don't know" into "there are no conflicts" — skipping the whole step, including the *Bot-authored PRs: resolve manually* subagent dispatch that exists to rebase the bot's own conflicted PRs.

Reported in #897 with session-log evidence from ten sampled nightly runs.

## Reproduction

Confirmed live against `nodejs/node`, two queries seconds apart with nothing touched in between:

| | 1st query | 2nd query |
| --- | --- | --- |
| `UNKNOWN` | 36 | 0 |
| `CONFLICTING` | 0 | **1** |
| `MERGEABLE` | 24 | 59 |

The cold read reported zero conflicted PRs; the settled read revealed one that was genuinely `CONFLICTING`.

## Solution

Don't read `mergeable` at all — compute the merge locally with `git merge-tree --write-tree`, which is synchronous and authoritative, so there is no cache to wait on and no retry loop. There is no blocking read on the GitHub side: [the REST docs](https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request) prescribe resubmitting the request until `mergeable` is non-null.

The recipe fetches every PR head in one batched `git fetch` (`refs/pull/N/head`, so fork PRs are covered too, `--force` because bot branches get force-pushed), then test-merges each against `origin/main`. Failure stays distinguishable from clean at both steps: an empty `gh pr list` output file (0 bytes, versus 3 for `[]`) reports as unverified, and `git merge-tree` exits non-zero both for a real conflict and for a ref it couldn't resolve — the conflict prints the tree OID and conflicted paths on stdout, the error prints nothing, so the recipe tests the captured output rather than the exit status alone.

The output path is `/tmp/prs-${author//\//-}.json` — `app/dependabot` and `app/renovate` contain a slash, so the un-sanitized form suggested in the issue would redirect into a nonexistent `/tmp/prs-app/` directory and fail.

## Testing

Ran the recipe verbatim from the repo root against this repo's own PRs: it agrees exactly with GitHub's own (warm, therefore authoritative) answer across all 30 open bot PRs, flagging only #856 as `CONFLICTING`, and finishes in ~2s for all three authors with no sleeps. Both failure branches were exercised directly — a `gh pr list` that can't resolve the repo reports "query never landed", and an unfetched head ref reports "merge test never ran" — neither reads as clean.

`select(.mergeable` appears at no other site in the bundled skills; the only other `mergeable` mentions are workflow comments about merge-ref materialization, which are unrelated.

`fetch-depth: 0` is set by the shared checkout macro in `generator/src/tend/templates/macros.yaml.j2`, so every generated nightly job has the history the local merge needs.

---

Closes #897 — automated triage
