### PR TITLE
fix(running-in-ci): read a recipe before running it, and never extract one by position

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -618,15 +618,6 @@ Two paths, in order of preference:
 
 If both paths fail (GUI-only tool, private repo, environment-specific behavior), cite what you found, name the remaining gap honestly, and follow **Who to ask when you can't do it yourself** below — don't hand the verification to an outside party, least of all an upstream maintainer reviewing your change.
 
-**Path 1 runs against the live repo.** Verifying a skill's own recipe is the common case, and those recipes write: `gh issue close`, `gh pr comment`, `git push`. Read a block before running it, and never select one by position — `awk` on the Nth fence, `sed` on a line range — because the ordinal moves with every edit to the file, so the block that runs is not the one you meant to test. Match on the surrounding prose or the command instead. Run the read half and stop before the pipe into the write:
-
-```bash
-gh issue list --state open --author '@me' --search '"..." in:title' --json number --jq '.[].number'
-# ...and read that, rather than piping it into `xargs gh issue close`.
-```
-
-If the write is the part in question, point it at a scratch object you own. A wrong write is only partly recoverable: reopening an issue leaves the close in its timeline, and a deleted comment has already fired its `issue_comment` event, so any workflow it triggered ran and is still in the run list.
-
 <example>
 <bad reason="Trusted upstream docs for a fast-moving external CLI and shipped a broken recipe">
 
@@ -639,6 +630,15 @@ Good: Same question. Cloned cmux's source repo → grepped the CLI parser for `l
 
 </good>
 </example>
+
+**Path 1 runs against the live repo.** Verifying a skill's own recipe is the common case, and those recipes write: `gh issue close`, `gh pr comment`, `git push`. Never extract a block programmatically to run it — not by position (`awk` on the Nth fence, `sed` on a line range), and not by anchor either: both hand you a block you haven't read, and the ordinal additionally moves with every edit to the file, so what runs isn't even the block you meant to test. Read the file, then run the commands directly. Run the read half and stop before the pipe into the write:
+
+```bash
+gh issue list --state open --author '@me' --search '"..." in:title' --json number --jq '.[].number'
+# ...and read that, rather than piping it into `xargs gh issue close`.
+```
+
+If the write is the part in question, point it at a scratch object you own. A wrong write is only partly recoverable: reopening an issue leaves the close in its timeline, and a deleted comment has already fired its `issue_comment` event, so any workflow it triggered ran and is still in the run list.
 
 ### Who to ask when you can't do it yourself
 

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -618,6 +618,15 @@ Two paths, in order of preference:
 
 If both paths fail (GUI-only tool, private repo, environment-specific behavior), cite what you found, name the remaining gap honestly, and follow **Who to ask when you can't do it yourself** below — don't hand the verification to an outside party, least of all an upstream maintainer reviewing your change.
 
+**Path 1 runs against the live repo.** Verifying a skill's own recipe is the common case, and those recipes write: `gh issue close`, `gh pr comment`, `git push`. Read a block before running it, and never select one by position — `awk` on the Nth fence, `sed` on a line range — because the ordinal moves with every edit to the file, so the block that runs is not the one you meant to test. Match on the surrounding prose or the command instead. Run the read half and stop before the pipe into the write:
+
+```bash
+gh issue list --state open --author '@me' --search '"..." in:title' --json number --jq '.[].number'
+# ...and read that, rather than piping it into `xargs gh issue close`.
+```
+
+If the write is the part in question, point it at a scratch object you own. A wrong write is only partly recoverable: reopening an issue leaves the close in its timeline, and a deleted comment has already fired its `issue_comment` event, so any workflow it triggered ran and is still in the run list.
+
 <example>
 <bad reason="Trusted upstream docs for a fast-moving external CLI and shipped a broken recipe">
 


### PR DESCRIPTION
A session verifying its own skill edit closed a live maintainer-facing issue and posted a false status comment. The bot caught it and self-healed within ~2.5 minutes, but the close/reopen is permanent in the timeline and the deleted comment had already fired a workflow run. The guidance that produced the behaviour is still unguarded, so the next session hits the same shape.

## What happened

Run [31257558939](https://github.com/max-sixty/tend/actions/runs/31257558939) (`tend-mention`, `repository_dispatch`) was answering a review question on #898 — a change to `plugins/tend-ci-runner/skills/nightly/SKILL.md`. To verify the edit it extracted a code block from that file **by fence ordinal** and ran it:

````bash
awk '/^```bash$/{n++} n==3 && !/^```/{print} /^```$/{if(n==3) exit}' \
  plugins/tend-ci-runner/skills/nightly/SKILL.md > /tmp/step3.sh
bash /tmp/step3.sh
````

The third `bash` fence in that file is not the step-3 recipe it was aiming at. It is the drift-issue closer:

```bash
gh issue list --state open --author '@me' \
  --search '"configuration drift" in:title' \
  --json number --jq '.[].number' \
  | xargs -r -I {} gh issue close {} --comment 'tend check now passes.'
```

Issue #822 (`tend check: configuration drift on max-sixty/tend`) matched. It was closed at `12:38:56Z` with the comment `tend check now passes.` — false; the check still fails. The session noticed, reopened at `12:39:04Z`, deleted the comment, and [left a correction on the thread](https://github.com/max-sixty/tend/issues/822#issuecomment-5226147050) plus a flag in its PR reply. Its own words from the session log: *"My mistake — I ran an extracted block without reading it first."*

What did not recover: `#822`'s timeline still shows `closed by tend-agent` / `reopened by tend-agent`, and the deleted comment had already fired `issue_comment`, so run [31257716552](https://github.com/max-sixty/tend/actions/runs/31257716552) exists and always will.

## Root cause

Two things compose, and only the second is a slip:

1. **Structural — the verification mandate has no write carve-out.** [`running-in-ci`'s "Verifying external-tool behavior"](https://github.com/max-sixty/tend/blob/03f8e0d/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md#L610) says *"verify by running the code"* and ranks running the tool above reading the source, with an example scolding a session for trusting docs instead of running the thing. That instruction is right, and the session was obeying it. Nothing anywhere says the recipes it points at include `gh issue close`, `gh pr comment`, and `git push`, or that "run it" needs to mean something different when the recipe writes. Every adopter's `nightly` skill ships that same closer, so this is a bundled gap, not a tend-local one.
2. **Stochastic — selecting the block by ordinal and not reading it.** A different session might have read it. But the ordinal is a trap independent of judgment: it moves with every edit to the file, so the block that runs is by construction not guaranteed to be the one under test.

## The change

One paragraph plus a two-line example in the section that created the pressure. It names the write surface, kills positional extraction, and gives the read-half recipe. No new section, no reorganisation.

## Gate assessment

- **Evidence level: Critical, 1 occurrence** — this is the gate table's own example, *"clearly wrong outcome (closed wrong issue)"*, which acts at 1. It is also genuinely new: every one of the 124 prior windows in the evidence log records `0 reopened issue` under negative signals, so there is no historical count to add to.
- **Classification: structural pressure, stochastic trigger.** I'm not claiming the failure is fully structural — a session that read the block first would have avoided it. What is structural is the instruction that sent it there with no mention of side effects, and the ordinal extraction that makes "the block I meant" unknowable.
- **Magnitude: targeted fix.** Gate 2 would put a *new* section at the 3+ bar. This is a guard attached to an existing instruction that demonstrably produced a public wrong write, held to one paragraph to stay proportionate. Flagging the tension rather than hiding it: if you read this as a new-paragraph change wanting 3 occurrences, the counter-argument is that the three occurrences would each be another wrongly-closed issue.
- **Dedup:** no open or closed issue/PR covers it. The three open `running-in-ci` PRs (#837, #870, #876) are all the CI-monitor poll, a different section.

## Verified, not inferred

- Both claims in the new text were checked against this incident rather than assumed: `#822`'s events API shows the close and the reopen both retained; run `31257716552` fired from the since-deleted comment and is still listed.
- The extraction command and `bash /tmp/step3.sh` are read verbatim from the session log's `tool_use` entries, not reconstructed from the bot's summary.
- The third-fence block is reproduced by re-running the same `awk` against `nightly/SKILL.md` at `03f8e0d`.

Evidence log: https://gist.github.com/e08f6e62d6478163cb425a75648eb7e4
