### PR TITLE
fix(check): stop pointing credential-environments at the setting it rejects

### DIFF
--- a/generator/src/tend/checks.py
+++ b/generator/src/tend/checks.py
@@ -1088,9 +1088,12 @@ def check_credential_environments(
             False,
             "A run the bot can cause reaches a credential: "
             f"{'; '.join(ungated)}. Gate each environment with a required "
-            "reviewer that is not the bot, or a deployment policy naming only "
-            "verified refs (protected branches, or tags under an admin-only "
-            "all-tags ruleset); move an OIDC job into such an environment.",
+            "reviewer that is not the bot, or a deployment policy listing "
+            "only verified refs — branches this run confirmed the bot cannot "
+            "write, or tags under an admin-only all-tags ruleset. The "
+            "policy's 'protected branches' setting is not one of them: it "
+            "keys on a rule covering the branch, not on who may push it. "
+            "Move an OIDC job into such an environment.",
         )
     if surface.unresolved:
         return CheckResult(

--- a/generator/src/tend/checks.py
+++ b/generator/src/tend/checks.py
@@ -1090,10 +1090,9 @@ def check_credential_environments(
             f"{'; '.join(ungated)}. Gate each environment with a required "
             "reviewer that is not the bot, or a deployment policy listing "
             "only verified refs — branches this run confirmed the bot cannot "
-            "write, or tags under an admin-only all-tags ruleset. The "
-            "policy's 'protected branches' setting is not one of them: it "
-            "keys on a rule covering the branch, not on who may push it. "
-            "Move an OIDC job into such an environment.",
+            "write, or tags under an admin-only all-tags ruleset; move an "
+            "OIDC job into such an environment. The policy's 'protected "
+            "branches' setting is not one of them.",
         )
     if surface.unresolved:
         return CheckResult(


### PR DESCRIPTION
`credential-environments` failed with a remedy that named "protected branches" as an acceptable deployment policy — but `_policy_gate` refuses exactly that setting, since it keys on a rule covering the branch rather than on who may push it. So the failure message pointed at the one option in the GitHub UI that cannot resolve it. The phrase is doubly misleading here, because tend's own config has a `protected_branches` key meaning something else entirely.

The remedy now names the branch class the check does credit (the wording `docs/security-model.md` already uses), and rules the toggle out in a closing sentence — without repeating the explanation, which `_policy_gate` already supplies as the per-environment reason whenever that setting is the reason for the failure.

Message only — no behaviour change; 354 tests pass.

> _This was written by Claude Code on behalf of max-sixty_
