### PR TITLE
fix(run-issue): tell a failed issue-list read from "no issue exists"

### DIFF
--- a/generator/tests/test_shared_steps.py
+++ b/generator/tests/test_shared_steps.py
@@ -240,7 +240,13 @@ case "$1" in
   issue)
     case "$2" in
       list)
-        if [ -n "${FAIL_ISSUE_LIST:-}" ]; then exit 1; fi
+        # Fail from the Nth list call on, so the spike block's two reads can be
+        # failed independently: `1` fails both, `2` leaves the first standing.
+        if [ -n "${FAIL_ISSUE_LIST_FROM:-}" ]; then
+          n=$(( $(cat "$LIST_CALLS" 2>/dev/null || echo 0) + 1 ))
+          echo "$n" > "$LIST_CALLS"
+          if [ "$n" -ge "$FAIL_ISSUE_LIST_FROM" ]; then exit 1; fi
+        fi
         emit "$(cat "$PAUSE_ISSUES_JSON")"
         ;;
       create)
@@ -359,6 +365,7 @@ def rate_limit_env(tmp_path: Path) -> dict[str, str]:
     return {
         "PATH": f"{bindir}:{Path(jq).parent}:/usr/bin:/bin",
         "GH_CALLS": str(tmp_path / "gh-calls.log"),
+        "LIST_CALLS": str(tmp_path / "list-calls"),
         "TIMELINE_JSON": str(timeline),
         "PAUSE_ISSUES_JSON": str(pause_issues),
         "PROBE_ISSUES_JSON": str(probe_issues),
@@ -510,7 +517,7 @@ def test_rate_limit_files_nothing_when_the_issue_list_cannot_be_read(
     rate_limit_env["FAKE_TODAY_POSTS"] = "16"
     # An issue is already open; the point is that this run cannot see it.
     _approve(rate_limit_env)
-    rate_limit_env["FAIL_ISSUE_LIST"] = "1"
+    rate_limit_env["FAIL_ISSUE_LIST_FROM"] = "1"
 
     result = _run_preflight(rate_limit_env)
 
@@ -519,6 +526,30 @@ def test_rate_limit_files_nothing_when_the_issue_list_cannot_be_read(
     assert not any(c.startswith("issue create") for c in calls), calls
     assert "could not be read" in result.stdout
     assert "could not be filed" not in result.stdout
+
+
+def test_rate_limit_still_files_when_only_the_re_read_fails(
+    rate_limit_env: dict[str, str],
+) -> None:
+    """A failed re-read must not suppress the file the first read cleared.
+
+    The two reads rule out different things. The first excludes an already-open
+    issue of any age, which is the duplicate worth avoiding; the re-read after
+    the jitter only narrows the seconds-wide sibling race, and the reconcile's
+    downward probe catches that anyway. Holding off here would pause the bot
+    with no issue at all — the outcome opening one exists to avoid — and point
+    the maintainer at an issue this run's own first read established isn't
+    there.
+    """
+    rate_limit_env["FAKE_TODAY_POSTS"] = "16"
+    # Nothing open, so the first read is a clean "none"; only the re-read fails.
+    rate_limit_env["FAIL_ISSUE_LIST_FROM"] = "2"
+
+    result = _run_preflight(rate_limit_env)
+
+    assert result.returncode == 1
+    assert any(c.startswith("issue create") for c in _calls(rate_limit_env))
+    assert "could not be read" not in result.stdout
 
 
 def test_rate_limit_human_close_doubles_the_ceiling(
@@ -847,7 +878,11 @@ emit() {
 case "$1 $2" in
   "api user") emit '{"login":"tend-agent","id":4242}' ;;
   "issue list")
-    if [ -n "${FAIL_ISSUE_LIST:-}" ]; then exit 1; fi
+    if [ -n "${FAIL_ISSUE_LIST_FROM:-}" ]; then
+      n=$(( $(cat "$LIST_CALLS" 2>/dev/null || echo 0) + 1 ))
+      echo "$n" > "$LIST_CALLS"
+      if [ "$n" -ge "$FAIL_ISSUE_LIST_FROM" ]; then exit 1; fi
+    fi
     emit "$(cat "$OPEN_ISSUES_JSON")"
     ;;
   "issue create") echo "https://github.com/owner/repo/issues/${FAKE_NEW_ISSUE}" ;;
@@ -891,6 +926,7 @@ def report_failure_env(tmp_path: Path) -> dict[str, str]:
     return {
         "PATH": f"{bindir}:{Path(jq).parent}:/usr/bin:/bin",
         "GH_CALLS": str(tmp_path / "gh-calls.log"),
+        "LIST_CALLS": str(tmp_path / "list-calls"),
         "OPEN_ISSUES_JSON": str(tmp_path / "open-issues.json"),
         "PROBE_ISSUES_JSON": str(tmp_path / "probe-issues.json"),
         "KEEPER_JSON": str(tmp_path / "keeper.json"),
@@ -961,7 +997,7 @@ def test_report_failure_files_nothing_when_the_issue_list_cannot_be_read(
     Path(report_failure_env["OPEN_ISSUES_JSON"]).write_text(
         json.dumps([{"number": 8, "title": OUTAGE_TITLE}])
     )
-    report_failure_env["FAIL_ISSUE_LIST"] = "1"
+    report_failure_env["FAIL_ISSUE_LIST_FROM"] = "1"
 
     result = _run_report_failure(report_failure_env)
 

--- a/generator/tests/test_shared_steps.py
+++ b/generator/tests/test_shared_steps.py
@@ -240,12 +240,18 @@ case "$1" in
   issue)
     case "$2" in
       list)
-        # Fail from the Nth list call on, so the spike block's two reads can be
-        # failed independently: `1` fails both, `2` leaves the first standing.
+        # Fail the list calls in [FROM, UNTIL], so the spike block's two reads
+        # can be failed in any combination: FROM=1 alone fails both, FROM=2
+        # spares the first, and FROM=1 UNTIL=1 spares the re-read. UNTIL is
+        # unbounded by default, which keeps "the list is simply down" open
+        # ended rather than pinned to an exact call count.
         if [ -n "${FAIL_ISSUE_LIST_FROM:-}" ]; then
           n=$(( $(cat "$LIST_CALLS" 2>/dev/null || echo 0) + 1 ))
           echo "$n" > "$LIST_CALLS"
-          if [ "$n" -ge "$FAIL_ISSUE_LIST_FROM" ]; then exit 1; fi
+          if [ "$n" -ge "$FAIL_ISSUE_LIST_FROM" ] \
+            && { [ -z "${FAIL_ISSUE_LIST_UNTIL:-}" ] || [ "$n" -le "$FAIL_ISSUE_LIST_UNTIL" ]; }; then
+            exit 1
+          fi
         fi
         emit "$(cat "$PAUSE_ISSUES_JSON")"
         ;;
@@ -544,6 +550,28 @@ def test_rate_limit_still_files_when_only_the_re_read_fails(
     rate_limit_env["FAKE_TODAY_POSTS"] = "16"
     # Nothing open, so the first read is a clean "none"; only the re-read fails.
     rate_limit_env["FAIL_ISSUE_LIST_FROM"] = "2"
+
+    result = _run_preflight(rate_limit_env)
+
+    assert result.returncode == 1
+    assert any(c.startswith("issue create") for c in _calls(rate_limit_env))
+    assert "could not be read" not in result.stdout
+
+
+def test_rate_limit_files_when_only_the_first_read_fails(
+    rate_limit_env: dict[str, str],
+) -> None:
+    """The re-read's verdict counts when the first read never landed.
+
+    The mirror of the case above, and the reason the re-read raises the flag
+    rather than merely leaving it alone. Without that raise the run refuses,
+    files nothing, and points the maintainer at an open issue the re-read had
+    just established isn't there — the same dead end from the other side.
+    """
+    rate_limit_env["FAKE_TODAY_POSTS"] = "16"
+    # Only the first read fails; the re-read comes back clean and empty.
+    rate_limit_env["FAIL_ISSUE_LIST_FROM"] = "1"
+    rate_limit_env["FAIL_ISSUE_LIST_UNTIL"] = "1"
 
     result = _run_preflight(rate_limit_env)
 

--- a/generator/tests/test_shared_steps.py
+++ b/generator/tests/test_shared_steps.py
@@ -239,7 +239,10 @@ case "$1" in
     ;;
   issue)
     case "$2" in
-      list) emit "$(cat "$PAUSE_ISSUES_JSON")" ;;
+      list)
+        if [ -n "${FAIL_ISSUE_LIST:-}" ]; then exit 1; fi
+        emit "$(cat "$PAUSE_ISSUES_JSON")"
+        ;;
       create)
         # An `if` rather than `[ ... ] && exit 1`: with nothing after it, the
         # failed test would become the branch's status and every create would
@@ -490,6 +493,32 @@ def test_rate_limit_keeps_its_annotation_when_the_row_cannot_be_appended(
 
     assert result.returncode == 1
     assert "Refused runs are listed in #42" in result.stdout
+
+
+def test_rate_limit_files_nothing_when_the_issue_list_cannot_be_read(
+    rate_limit_env: dict[str, str],
+) -> None:
+    """A failed list read must not be taken for "no issue exists".
+
+    Both readings are the empty string, and acting on the wrong one files a
+    second pause issue. The reconcile cannot merge that one away: it probes the
+    ten numbers under the issue it just filed, and an already-open pause issue
+    is normally far older. The duplicate then costs an approval outright — the
+    lookup resolves to the lowest-numbered issue, so a maintainer closing the
+    newer one, which is the issue this run's annotation names, approves nothing.
+    """
+    rate_limit_env["FAKE_TODAY_POSTS"] = "16"
+    # An issue is already open; the point is that this run cannot see it.
+    _approve(rate_limit_env)
+    rate_limit_env["FAIL_ISSUE_LIST"] = "1"
+
+    result = _run_preflight(rate_limit_env)
+
+    assert result.returncode == 1
+    calls = _calls(rate_limit_env)
+    assert not any(c.startswith("issue create") for c in calls), calls
+    assert "could not be read" in result.stdout
+    assert "could not be filed" not in result.stdout
 
 
 def test_rate_limit_human_close_doubles_the_ceiling(
@@ -817,7 +846,10 @@ emit() {
 
 case "$1 $2" in
   "api user") emit '{"login":"tend-agent","id":4242}' ;;
-  "issue list") emit "$(cat "$OPEN_ISSUES_JSON")" ;;
+  "issue list")
+    if [ -n "${FAIL_ISSUE_LIST:-}" ]; then exit 1; fi
+    emit "$(cat "$OPEN_ISSUES_JSON")"
+    ;;
   "issue create") echo "https://github.com/owner/repo/issues/${FAKE_NEW_ISSUE}" ;;
   "issue view") emit "$(cat "$KEEPER_JSON")" ;;
   "issue comment") cat >> "$COMMENT_BODIES" ;;
@@ -914,6 +946,29 @@ def test_report_failure_appends_to_the_open_tracker(
     assert not any(c.startswith("issue create") for c in calls), (
         f"filed a second tracker while one was open: {calls}"
     )
+
+
+def test_report_failure_files_nothing_when_the_issue_list_cannot_be_read(
+    report_failure_env: dict[str, str],
+) -> None:
+    """The same conflation, from the other caller.
+
+    Two open trackers is the state that breaks the drain sweep: later rows
+    scatter across both and neither carries the complete set. The reconcile's
+    downward probe does not reach an older tracker, so the duplicate persists.
+    Skipping costs this one row, and the next failure records normally.
+    """
+    Path(report_failure_env["OPEN_ISSUES_JSON"]).write_text(
+        json.dumps([{"number": 8, "title": OUTAGE_TITLE}])
+    )
+    report_failure_env["FAIL_ISSUE_LIST"] = "1"
+
+    result = _run_report_failure(report_failure_env)
+
+    assert result.returncode == 0, result.stderr
+    calls = _calls(report_failure_env)
+    assert not any(c.startswith("issue create") for c in calls), calls
+    assert "::warning::" in result.stdout
 
 
 def test_report_failure_carries_its_row_onto_the_racing_sibling(

--- a/generator/tests/test_shared_steps.py
+++ b/generator/tests/test_shared_steps.py
@@ -199,7 +199,18 @@ case "$1" in
     ;;
   issue)
     case "$2" in
-      list) emit "$(cat "$PAUSE_ISSUES_JSON")" ;;
+      list)
+        # Fail from the Nth list call on. `1` fails every one; a higher number
+        # lets the caller's own lookup succeed and fails only the reconcile's
+        # read, which runs in a different caller context — the one where
+        # `set -e` is live.
+        if [ -n "${FAIL_ISSUE_LIST_FROM:-}" ]; then
+          n=$(( $(cat "$LIST_CALLS" 2>/dev/null || echo 0) + 1 ))
+          echo "$n" > "$LIST_CALLS"
+          if [ "$n" -ge "$FAIL_ISSUE_LIST_FROM" ]; then exit 1; fi
+        fi
+        emit "$(cat "$ISSUE_LIST_JSON")"
+        ;;
       create)
         # An `if` rather than `[ ... ] && exit 1`: with nothing after it, the
         # failed test would become the branch's status and every create would
@@ -256,9 +267,12 @@ def _closed_event(
     }
 
 
-@pytest.fixture
-def rate_limit_env(tmp_path: Path) -> dict[str, str]:
-    """Fake gh/date/sleep on PATH, plus the Actions env the preflight reads."""
+def _fakebin(tmp_path: Path) -> Path:
+    """gh/date/sleep stand-ins, in a directory ready to go on PATH.
+
+    Shared by the preflight and report-failure fixtures: both drive the same
+    `lib/run-issue.sh` helpers, so they need the same `gh` to exercise them.
+    """
     bindir = tmp_path / "fakebin"
     bindir.mkdir()
     for name, body in (
@@ -269,6 +283,13 @@ def rate_limit_env(tmp_path: Path) -> dict[str, str]:
         path = bindir / name
         path.write_text(body)
         path.chmod(0o755)
+    return bindir
+
+
+@pytest.fixture
+def rate_limit_env(tmp_path: Path) -> dict[str, str]:
+    """Fake gh/date/sleep on PATH, plus the Actions env the preflight reads."""
+    bindir = _fakebin(tmp_path)
 
     # Both the fake gh and the script itself shell out to jq.
     jq = shutil.which("jq")
@@ -285,8 +306,9 @@ def rate_limit_env(tmp_path: Path) -> dict[str, str]:
     return {
         "PATH": f"{bindir}:{Path(jq).parent}:/usr/bin:/bin",
         "GH_CALLS": str(tmp_path / "gh-calls.log"),
+        "LIST_CALLS": str(tmp_path / "list-calls"),
         "TIMELINE_JSON": str(timeline),
-        "PAUSE_ISSUES_JSON": str(pause_issues),
+        "ISSUE_LIST_JSON": str(pause_issues),
         # past=15 puts the base limit at 10 + 15/3 = 15.
         "FAKE_PAST_POSTS": "15",
         "FAKE_TODAY_POSTS": "10",
@@ -316,7 +338,7 @@ def _approve(
     labelled_at: str = LABELLED_AT,
 ) -> None:
     """Put a pause issue on the label, labelled then carrying `events`."""
-    Path(env["PAUSE_ISSUES_JSON"]).write_text(
+    Path(env["ISSUE_LIST_JSON"]).write_text(
         json.dumps([{"number": issue, "title": PAUSE_TITLE}])
     )
     labelled = {
@@ -384,7 +406,7 @@ def test_rate_limit_names_the_label_when_the_number_is_unknown(
     # The lag is the subject, so it is set here rather than left to the
     # fixture's default: the create succeeds, and the list it reconciles
     # against still does not show the issue.
-    Path(rate_limit_env["PAUSE_ISSUES_JSON"]).write_text("[]")
+    Path(rate_limit_env["ISSUE_LIST_JSON"]).write_text("[]")
 
     result = _run_preflight(rate_limit_env)
 
@@ -413,6 +435,31 @@ def test_rate_limit_keeps_its_annotation_when_the_row_cannot_be_appended(
 
     assert result.returncode == 1
     assert "Refused runs are listed in #42" in result.stdout
+
+
+def test_rate_limit_files_nothing_when_the_issue_list_cannot_be_read(
+    rate_limit_env: dict[str, str],
+) -> None:
+    """A failed list read must not be taken for "no issue exists".
+
+    Both readings are the empty string, and acting on the wrong one files a
+    second pause issue. That is the costly duplicate: the lookup resolves to
+    the lowest-numbered issue, so a maintainer closing the newer one — the one
+    the annotation names — approves nothing and never learns it. The reconcile
+    that would close the loser reads the same list that just failed.
+    """
+    rate_limit_env["FAKE_TODAY_POSTS"] = "16"
+    # An issue is already open; the point is that the run cannot see it.
+    _approve(rate_limit_env)
+    rate_limit_env["FAIL_ISSUE_LIST_FROM"] = "1"
+
+    result = _run_preflight(rate_limit_env)
+
+    assert result.returncode == 1
+    calls = _calls(rate_limit_env)
+    assert not any(c.startswith("issue create") for c in calls), calls
+    assert "could not be read" in result.stdout
+    assert "#?" not in result.stdout
 
 
 def test_rate_limit_human_close_doubles_the_ceiling(
@@ -479,7 +526,7 @@ def test_rate_limit_reconciler_keeps_only_what_the_preflight_filed(
     refused-run rows and the `::error::` end up pointing at different issues.
     """
     rate_limit_env["FAKE_TODAY_POSTS"] = "16"
-    Path(rate_limit_env["PAUSE_ISSUES_JSON"]).write_text(
+    Path(rate_limit_env["ISSUE_LIST_JSON"]).write_text(
         json.dumps(
             [
                 {"number": 7, "title": "Something a maintainer labelled"},
@@ -614,7 +661,7 @@ def test_rate_limit_foreign_issue_is_not_the_anchor(
     """
     rate_limit_env["FAKE_TODAY_POSTS"] = "16"
     _approve(rate_limit_env, _closed_event("maintainer"))
-    Path(rate_limit_env["PAUSE_ISSUES_JSON"]).write_text(
+    Path(rate_limit_env["ISSUE_LIST_JSON"]).write_text(
         json.dumps([{"number": 7, "title": "Something a maintainer labelled"}])
     )
 
@@ -649,3 +696,99 @@ def test_rate_limit_reopens_rather_than_refiling(
     assert not any(c.startswith("issue create") for c in calls), (
         f"filed a second pause issue instead of reopening #42: {calls}"
     )
+
+
+REPORT_FAILURE = REPO_ROOT / "shared" / "steps" / "report-failure.sh"
+OUTAGE_TITLE = "Bot temporarily unavailable"
+
+
+@pytest.fixture
+def report_failure_env(tmp_path: Path) -> dict[str, str]:
+    """The other caller of the shared lookup, on the same fake gh."""
+    bindir = _fakebin(tmp_path)
+
+    jq = shutil.which("jq")
+    assert jq, "jq is required for these tests"
+
+    event = tmp_path / "event.json"
+    event.write_text(json.dumps({"pull_request": {"number": 851}}))
+    issues = tmp_path / "issue-list.json"
+    issues.write_text("[]")
+
+    return {
+        "PATH": f"{bindir}:{Path(jq).parent}:/usr/bin:/bin",
+        "GH_CALLS": str(tmp_path / "gh-calls.log"),
+        "LIST_CALLS": str(tmp_path / "list-calls"),
+        "ISSUE_LIST_JSON": str(issues),
+        "GITHUB_REPOSITORY": "owner/repo",
+        "GITHUB_SERVER_URL": "https://github.com",
+        "GITHUB_RUN_ID": "12345",
+        "GITHUB_EVENT_NAME": "pull_request_target",
+        "GITHUB_EVENT_PATH": str(event),
+    }
+
+
+def _run_report_failure(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(REPORT_FAILURE)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_report_failure_appends_to_the_open_tracker(
+    report_failure_env: dict[str, str],
+) -> None:
+    """With a tracker open the row is a comment on it, not a second issue."""
+    Path(report_failure_env["ISSUE_LIST_JSON"]).write_text(
+        json.dumps([{"number": 7, "title": OUTAGE_TITLE}])
+    )
+
+    result = _run_report_failure(report_failure_env)
+
+    assert result.returncode == 0, result.stderr
+    calls = _calls(report_failure_env)
+    assert any(c.startswith("issue comment 7") for c in calls), calls
+    assert not any(c.startswith("issue create") for c in calls), calls
+
+
+def test_report_failure_files_nothing_when_the_issue_list_cannot_be_read(
+    report_failure_env: dict[str, str],
+) -> None:
+    """The duplicate-tracker path, from the other caller.
+
+    Two open trackers is the state that breaks the drain sweep: rows scatter
+    across both and neither carries the complete set. Skipping costs this one
+    row, and the next failure records normally.
+    """
+    Path(report_failure_env["ISSUE_LIST_JSON"]).write_text(
+        json.dumps([{"number": 7, "title": OUTAGE_TITLE}])
+    )
+    report_failure_env["FAIL_ISSUE_LIST_FROM"] = "1"
+
+    result = _run_report_failure(report_failure_env)
+
+    assert result.returncode == 0, result.stderr
+    calls = _calls(report_failure_env)
+    assert not any(c.startswith("issue create") for c in calls), calls
+    assert "::warning::" in result.stdout
+
+
+def test_report_failure_survives_a_reconcile_that_cannot_list(
+    report_failure_env: dict[str, str],
+) -> None:
+    """The issue is filed; a failed reconcile read must not then fail the step.
+
+    Here the helper runs as the last element of a top-level pipeline, where
+    `set -e` *does* apply — unlike the command substitutions the preflight
+    reads it through. So the reconcile's bare assignment aborts the script in
+    the gap between filing the issue and returning from it.
+    """
+    # Lookup succeeds and finds nothing; the reconcile's own read then fails.
+    report_failure_env["FAIL_ISSUE_LIST_FROM"] = "2"
+
+    result = _run_report_failure(report_failure_env)
+
+    assert result.returncode == 0, result.stderr
+    assert any(c.startswith("issue create") for c in _calls(report_failure_env))

--- a/shared/steps/lib/run-issue.sh
+++ b/shared/steps/lib/run-issue.sh
@@ -87,9 +87,17 @@ run_issue_matching() {
 # The one that counts: lowest-numbered, empty when there is none. Sliced in the
 # shell rather than piped to `head`, which would close the pipe under `pipefail`
 # and can take the whole script down with it.
+#
+# Returns non-zero, having printed nothing, when the list read itself fails.
+# That is a different fact from "there is none", though an empty string states
+# both, and every caller acts on the difference: filing a fresh record because
+# the read failed is how a repo ends up with two open ones, and the reconcile
+# that would close the loser reads the same list that just failed. `set -e`
+# does not reach inside the command substitutions the callers read this through,
+# so the status has to be carried out explicitly to be seen at all.
 run_issue_canonical() {
   local matching
-  matching=$(run_issue_matching "$1" "$2" "$3")
+  matching=$(run_issue_matching "$1" "$2" "$3") || return 1
   printf '%s' "${matching%%$'\n'*}"
 }
 
@@ -131,7 +139,16 @@ run_issue_create_and_reconcile() {
   # on the label alone would let an unrelated issue carrying it outrank this
   # one on lowest-number, and the record just filed would be closed as that
   # issue's duplicate.
-  open=$(run_issue_matching "$label" open "$title")
+  #
+  # A failed read here is not fatal: the issue is filed either way, and the
+  # contract already allows handing back no number. Tested rather than left
+  # bare, because a bare assignment *does* propagate its status — unlike the
+  # substitution-wrapped calls above — so `set -e` would take the caller down
+  # in the gap between the create and the caller's own reporting of it.
+  if ! open=$(run_issue_matching "$label" open "$title"); then
+    echo "Could not list ${label} issues to reconcile duplicates; leaving any in place." >&2
+    return 0
+  fi
   keep=${open%%$'\n'*}
   echo "$open" | tail -n +2 | while read -r dup; do
     [ -z "$dup" ] && continue

--- a/shared/steps/lib/run-issue.sh
+++ b/shared/steps/lib/run-issue.sh
@@ -87,9 +87,18 @@ run_issue_matching() {
 # The one that counts: lowest-numbered, empty when there is none. Sliced in the
 # shell rather than piped to `head`, which would close the pipe under `pipefail`
 # and can take the whole script down with it.
+#
+# Returns non-zero, having printed nothing, when the list read itself fails.
+# That is a different fact from "there is none", though an empty string states
+# both, and a caller that conflates them files a fresh record while one is
+# already open. The reconcile below will not catch that duplicate: it only
+# probes the ten numbers under the one it just created, and an existing record
+# is usually far older than that. `set -e` does not reach inside the command
+# substitutions the callers read this through, so the status has to be carried
+# out explicitly to be seen at all.
 run_issue_canonical() {
   local matching
-  matching=$(run_issue_matching "$1" "$2" "$3")
+  matching=$(run_issue_matching "$1" "$2" "$3") || return 1
   printf '%s' "${matching%%$'\n'*}"
 }
 

--- a/shared/steps/rate-limit-preflight.sh
+++ b/shared/steps/rate-limit-preflight.sh
@@ -100,7 +100,10 @@ fi
 # Everything below runs only once the base limit is already exceeded, so the
 # common path costs no extra API calls at all.
 if [ "$TODAY_POSTS" -gt "$SPIKE_LIMIT" ]; then
-  PAUSE=$(run_issue_canonical "$PAUSE_LABEL" all "$PAUSE_TITLE")
+  # A failed read costs nothing extra here: no issue and no way to see it both
+  # leave approvals at zero, which refuses the run either way. Where the two
+  # part company is whether to file, further down.
+  PAUSE=$(run_issue_canonical "$PAUSE_LABEL" all "$PAUSE_TITLE") || PAUSE=""
 
   APPROVALS=0
   if [ -n "$PAUSE" ]; then
@@ -162,13 +165,25 @@ if [ "$TODAY_POSTS" -gt "$SPIKE_LIMIT" ]; then
       # the create-create race — sibling jobs trip within seconds of each
       # other, and without it each files its own issue — so it buys nothing
       # once the issue is known to exist, and the lookup above is still good.
+      #
+      # This second read is also what decides whether filing is safe, so its
+      # status is kept: a failure here is not "no issue exists", though both
+      # are the empty string. Filing on the wrong reading is how a repo ends up
+      # with two pause issues, and this is the record where that does real
+      # damage — the lookup resolves to the lowest-numbered one, so a maintainer
+      # closing the newer issue, the one this run's annotation names, would
+      # approve nothing and never learn it.
+      PAUSE_LOOKUP_OK=true
       if [ -z "$PAUSE" ]; then
         sleep $((RANDOM % 30))
-        PAUSE=$(run_issue_canonical "$PAUSE_LABEL" all "$PAUSE_TITLE")
+        if ! PAUSE=$(run_issue_canonical "$PAUSE_LABEL" all "$PAUSE_TITLE"); then
+          PAUSE=""
+          PAUSE_LOOKUP_OK=false
+        fi
       fi
 
-      FILED=true
       if [ -n "$PAUSE" ]; then
+        NOTICE=numbered
         # A no-op when it is already open, which is the usual case for the
         # second and later runs refused in one incident.
         gh issue reopen "$PAUSE" >/dev/null 2>&1 || true
@@ -182,6 +197,10 @@ if [ "$TODAY_POSTS" -gt "$SPIKE_LIMIT" ]; then
         if ! printf '%s\n' "$ROW" | gh issue comment "$PAUSE" -F -; then
           echo "::warning::Could not append this run's row to #${PAUSE}."
         fi
+      elif [ "$PAUSE_LOOKUP_OK" = false ]; then
+        # Cannot tell whether an issue is already open, so file nothing: see
+        # the lookup above for why a second one is worse here than none.
+        NOTICE=lookup-failed
       else
         run_issue_ensure_label "$PAUSE_LABEL" "Bot paused on its own rate limit; close to approve" "fbca04"
         # Tested rather than assigned bare: `set -e` would take the script down
@@ -196,26 +215,37 @@ if [ "$TODAY_POSTS" -gt "$SPIKE_LIMIT" ]; then
           "$ROW" \
           "The runs listed above were refused and do not retry on their own; re-run them with \`gh run rerun <id> --failed\` once this is closed." \
           | run_issue_create_and_reconcile "$PAUSE_LABEL" "$PAUSE_TITLE"); then
-          FILED=false
+          NOTICE=create-failed
           PAUSE=""
+        elif [ -n "$PAUSE" ]; then
+          NOTICE=numbered
+        else
+          # Filed, but the issue index had not caught up in time to hand back
+          # a number.
+          NOTICE=unnumbered
         fi
       fi
 
-      # What the annotation can offer depends on whether an issue ended up
-      # existing, and on whether its number came back — three states that must
-      # not be collapsed. Saying "could not be filed" about an issue that was
-      # filed sends a maintainer away from the one thing that would restart the
-      # bot; the `#${PAUSE:-?}` this replaces sent them after a number that
-      # never existed.
-      if [ "$FILED" = false ]; then
-        RECOVERY="The pause issue could not be filed (see the error above), so there is nothing to close and the ceiling holds until the UTC rollover."
-      elif [ -n "$PAUSE" ]; then
-        RECOVERY="Refused runs are listed in #${PAUSE}; closing it doubles the ceiling."
-      else
-        # Filed, but the issue index had not caught up in time to hand back a
-        # number. The label names it just as uniquely.
-        RECOVERY="Refused runs are listed in the open \`${PAUSE_LABEL}\` issue; closing it doubles the ceiling."
-      fi
+      # What the annotation can offer depends on how the notice ended up, and
+      # the states must not be collapsed onto "is the number empty". Saying
+      # "could not be filed" about an issue that was filed sends a maintainer
+      # away from the one thing that would restart the bot; the `#${PAUSE:-?}`
+      # this replaces sent them after a number that never existed.
+      case "$NOTICE" in
+        numbered)
+          RECOVERY="Refused runs are listed in #${PAUSE}; closing it doubles the ceiling."
+          ;;
+        unnumbered)
+          # The label names the issue as uniquely as the number would.
+          RECOVERY="Refused runs are listed in the open \`${PAUSE_LABEL}\` issue; closing it doubles the ceiling."
+          ;;
+        create-failed)
+          RECOVERY="The pause issue could not be filed (see the error above), so there is nothing to close and the ceiling holds until the UTC rollover."
+          ;;
+        lookup-failed)
+          RECOVERY="This repo's issues could not be read (see the error above), so none was filed; if an open \`${PAUSE_LABEL}\` issue exists, closing it doubles the ceiling."
+          ;;
+      esac
 
       echo "::error::Rate limit: bot created ${TODAY_POSTS} items today, above the ceiling of ${CEILING} (base limit ${SPIKE_LIMIT}, ${APPROVALS} approval(s), baseline ${PAST_POSTS} over past 6 days). ${RECOVERY}"
     else

--- a/shared/steps/rate-limit-preflight.sh
+++ b/shared/steps/rate-limit-preflight.sh
@@ -100,7 +100,10 @@ fi
 # Everything below runs only once the base limit is already exceeded, so the
 # common path costs no extra API calls at all.
 if [ "$TODAY_POSTS" -gt "$SPIKE_LIMIT" ]; then
-  PAUSE=$(run_issue_canonical "$PAUSE_LABEL" all "$PAUSE_TITLE")
+  # A failed read costs nothing extra here: no issue and no way to see one both
+  # leave approvals at zero, which refuses the run either way. Where the two
+  # part company is whether to file, further down.
+  PAUSE=$(run_issue_canonical "$PAUSE_LABEL" all "$PAUSE_TITLE") || PAUSE=""
 
   APPROVALS=0
   if [ -n "$PAUSE" ]; then
@@ -162,9 +165,22 @@ if [ "$TODAY_POSTS" -gt "$SPIKE_LIMIT" ]; then
       # the create-create race — sibling jobs trip within seconds of each
       # other, and without it each files its own issue — so it buys nothing
       # once the issue is known to exist, and the lookup above is still good.
+      #
+      # This second read also decides whether filing is safe, so its status is
+      # kept: a failure is not "no issue exists", though both are the empty
+      # string. Filing on the wrong reading leaves two pause issues, and the
+      # reconcile below cannot merge them — it probes the ten numbers under the
+      # one it just filed, and an existing pause issue is normally far older.
+      # This is the record where that hurts most: the lookup resolves to the
+      # lowest-numbered issue, so a maintainer closing the newer one — the issue
+      # this run's annotation names — approves nothing and never learns it.
+      PAUSE_LOOKUP_OK=true
       if [ -z "$PAUSE" ]; then
         sleep $((RANDOM % 30))
-        PAUSE=$(run_issue_canonical "$PAUSE_LABEL" all "$PAUSE_TITLE")
+        if ! PAUSE=$(run_issue_canonical "$PAUSE_LABEL" all "$PAUSE_TITLE"); then
+          PAUSE=""
+          PAUSE_LOOKUP_OK=false
+        fi
       fi
 
       FILED=true
@@ -182,6 +198,10 @@ if [ "$TODAY_POSTS" -gt "$SPIKE_LIMIT" ]; then
         if ! printf '%s\n' "$ROW" | gh issue comment "$PAUSE" -F -; then
           echo "::warning::Could not append this run's row to #${PAUSE}."
         fi
+      elif [ "$PAUSE_LOOKUP_OK" = false ]; then
+        # Cannot tell whether an issue is already open, so file nothing: see
+        # the retry above for why a second one is worse here than none.
+        FILED=false
       else
         run_issue_ensure_label "$PAUSE_LABEL" "Bot paused on its own rate limit; close to approve" "fbca04"
         # Tested rather than assigned bare: `set -e` would take the script down
@@ -211,12 +231,18 @@ if [ "$TODAY_POSTS" -gt "$SPIKE_LIMIT" ]; then
       fi
 
       # What the annotation can offer depends on whether an issue ended up
-      # existing, and on whether its number came back — three states that must
-      # not be collapsed. Saying "could not be filed" about an issue that was
+      # existing, on whether its number came back, and on whether this run
+      # could see well enough to say — four states that must not be collapsed.
+      # Saying "could not be filed" about an issue that was
       # filed sends a maintainer away from the one thing that would restart the
       # bot; the `#${PAUSE:-?}` this replaces sent them after a number that
       # never existed.
-      if [ "$FILED" = false ]; then
+      if [ "$PAUSE_LOOKUP_OK" = false ]; then
+        # Nothing was filed, and the reason is the read rather than the write —
+        # so unlike the next branch, an issue may well be open and worth
+        # closing. Naming the label is all this run can offer toward it.
+        RECOVERY="This repo's issues could not be read (see the error above), so none was filed; if an open \`${PAUSE_LABEL}\` issue exists, closing it doubles the ceiling."
+      elif [ "$FILED" = false ]; then
         RECOVERY="The pause issue could not be filed (see the error above), so there is nothing to close and the ceiling holds until the UTC rollover."
       elif [ -n "$PAUSE" ]; then
         RECOVERY="Refused runs are listed in #${PAUSE}; closing it doubles the ceiling."

--- a/shared/steps/rate-limit-preflight.sh
+++ b/shared/steps/rate-limit-preflight.sh
@@ -100,10 +100,15 @@ fi
 # Everything below runs only once the base limit is already exceeded, so the
 # common path costs no extra API calls at all.
 if [ "$TODAY_POSTS" -gt "$SPIKE_LIMIT" ]; then
-  # A failed read costs nothing extra here: no issue and no way to see one both
-  # leave approvals at zero, which refuses the run either way. Where the two
-  # part company is whether to file, further down.
-  PAUSE=$(run_issue_canonical "$PAUSE_LABEL" all "$PAUSE_TITLE") || PAUSE=""
+  # Whether the read succeeded is kept, not just what it returned: a failure
+  # and "none open" are both the empty string, and further down that difference
+  # decides whether filing is safe. For the approval count just below the two
+  # are equivalent — both leave it at zero, which refuses the run either way.
+  PAUSE_LOOKUP_OK=true
+  if ! PAUSE=$(run_issue_canonical "$PAUSE_LABEL" all "$PAUSE_TITLE"); then
+    PAUSE=""
+    PAUSE_LOOKUP_OK=false
+  fi
 
   APPROVALS=0
   if [ -n "$PAUSE" ]; then
@@ -166,20 +171,23 @@ if [ "$TODAY_POSTS" -gt "$SPIKE_LIMIT" ]; then
       # other, and without it each files its own issue — so it buys nothing
       # once the issue is known to exist, and the lookup above is still good.
       #
-      # This second read also decides whether filing is safe, so its status is
-      # kept: a failure is not "no issue exists", though both are the empty
-      # string. Filing on the wrong reading leaves two pause issues, and the
-      # reconcile below cannot merge them — it probes the ten numbers under the
-      # one it just filed, and an existing pause issue is normally far older.
-      # This is the record where that hurts most: the lookup resolves to the
-      # lowest-numbered issue, so a maintainer closing the newer one — the issue
-      # this run's annotation names — approves nothing and never learns it.
-      PAUSE_LOOKUP_OK=true
+      # A failed re-read leaves the first read's verdict standing rather than
+      # clearing it, because the two rule out different things. The first
+      # excludes an already-open issue of any age — the duplicate that matters
+      # here, since the lookup resolves to the lowest-numbered issue, so a
+      # maintainer closing the newer one, the issue this run's annotation
+      # names, would approve nothing and never learn it. The re-read only
+      # narrows the seconds-wide sibling race, and that race is what
+      # run_issue_create_and_reconcile's downward probe already catches. So
+      # only a run that never managed a good read has to hold off filing;
+      # holding off on a failed re-read would pause the bot with no issue at
+      # all, which is the outcome opening one exists to avoid.
       if [ -z "$PAUSE" ]; then
         sleep $((RANDOM % 30))
-        if ! PAUSE=$(run_issue_canonical "$PAUSE_LABEL" all "$PAUSE_TITLE"); then
+        if PAUSE=$(run_issue_canonical "$PAUSE_LABEL" all "$PAUSE_TITLE"); then
+          PAUSE_LOOKUP_OK=true
+        else
           PAUSE=""
-          PAUSE_LOOKUP_OK=false
         fi
       fi
 
@@ -199,8 +207,9 @@ if [ "$TODAY_POSTS" -gt "$SPIKE_LIMIT" ]; then
           echo "::warning::Could not append this run's row to #${PAUSE}."
         fi
       elif [ "$PAUSE_LOOKUP_OK" = false ]; then
-        # Cannot tell whether an issue is already open, so file nothing: see
-        # the retry above for why a second one is worse here than none.
+        # Neither read succeeded, so whether an issue is already open is
+        # unknown; file nothing. See the re-read above for why a second issue
+        # is worse here than none.
         FILED=false
       else
         run_issue_ensure_label "$PAUSE_LABEL" "Bot paused on its own rate limit; close to approve" "fbca04"
@@ -240,7 +249,8 @@ if [ "$TODAY_POSTS" -gt "$SPIKE_LIMIT" ]; then
       if [ "$PAUSE_LOOKUP_OK" = false ]; then
         # Nothing was filed, and the reason is the read rather than the write —
         # so unlike the next branch, an issue may well be open and worth
-        # closing. Naming the label is all this run can offer toward it.
+        # closing, this run just never managed to see. Naming the label is all
+        # it can offer toward it.
         RECOVERY="This repo's issues could not be read (see the error above), so none was filed; if an open \`${PAUSE_LABEL}\` issue exists, closing it doubles the ceiling."
       elif [ "$FILED" = false ]; then
         RECOVERY="The pause issue could not be filed (see the error above), so there is nothing to close and the ceiling holds until the UTC rollover."

--- a/shared/steps/report-failure.sh
+++ b/shared/steps/report-failure.sh
@@ -34,7 +34,16 @@ run_issue_ensure_label "$LABEL" "Tracks bot outage incidents" "d93f0b"
 # seconds). Without this, every leg reads $EXISTING as empty in parallel and
 # each files its own outage issue.
 sleep $((RANDOM % 30))
-EXISTING=$(run_issue_canonical "$LABEL" open "$TITLE")
+# A failed read is not "nothing is open". Filing on it is how a repo ends up
+# with two open trackers: the reconcile that would close the loser reads the
+# same list that just failed, so the duplicate survives and every later failure
+# scatters its rows across both, leaving no tracker with the complete set the
+# drain sweep needs. Skipping costs this one row on a transient failure, and
+# the next failure records normally.
+if ! EXISTING=$(run_issue_canonical "$LABEL" open "$TITLE"); then
+  echo "::warning::Could not read this repo's ${LABEL} issues, so this run was not recorded on the outage tracker."
+  exit 0
+fi
 
 if [ -n "$EXISTING" ]; then
   printf '%s\n' "$ROW" | gh issue comment "$EXISTING" -F -

--- a/shared/steps/report-failure.sh
+++ b/shared/steps/report-failure.sh
@@ -34,7 +34,16 @@ run_issue_ensure_label "$LABEL" "Tracks bot outage incidents" "d93f0b"
 # seconds). Without this, every leg reads $EXISTING as empty in parallel and
 # each files its own outage issue.
 sleep $((RANDOM % 30))
-EXISTING=$(run_issue_canonical "$LABEL" open "$TITLE")
+# A failed read is not "nothing is open". Filing on it is how a repo ends up
+# with two open trackers, and the reconcile does not clean this one up — it
+# probes the ten numbers below the issue it just filed, and an already-open
+# tracker is normally much older. Two of them scatter later rows across both,
+# so no tracker carries the complete set the drain sweep needs. Skipping costs
+# this one row on a transient failure, and the next failure records normally.
+if ! EXISTING=$(run_issue_canonical "$LABEL" open "$TITLE"); then
+  echo "::warning::Could not read this repo's ${LABEL} issues, so this run was not recorded on the outage tracker."
+  exit 0
+fi
 
 if [ -n "$EXISTING" ]; then
   printf '%s\n' "$ROW" | gh issue comment "$EXISTING" -F -


### PR DESCRIPTION
`run_issue_canonical` returns an empty string whether the `gh issue list` behind it failed or genuinely matched nothing, and status 0 either way. `set -e` does not reach inside a command substitution, and both callers read the number back through one, so a transient list failure has no way to be seen at all — it simply reads as "nothing is open".

Both callers then file a record while one is already open. #836's reconcile does not catch this duplicate: it probes the ten numbers below the issue it just created, which is the right window for a racing sibling but not for an existing record, which is normally far older.

On the outage tracker that leaves two open — the state that breaks the drain sweep, since later rows scatter across both and neither carries the complete set. On the rate-limit record it costs an approval outright: the lookup resolves to the lowest-numbered issue, so a maintainer closing the newer one, which is the issue the run's own annotation names, approves nothing and never learns it.

The lookup now carries the failure out and each caller acts on it. `report-failure.sh` records nothing and warns rather than filing a rival tracker — one row is the cheaper loss, and the next failure records normally. `rate-limit-preflight.sh` refuses without filing and names the label instead of a number. That is a fourth annotation state beside the three already distinguished, and it is genuinely distinct from a failed create: there the write failed and there is nothing open to close, whereas here an issue may well be open and worth closing.

The preflight reads twice, and only a run that never managed a good read holds off filing. The first read excludes an already-open issue of any age; the re-read after the jitter only narrows the seconds-wide sibling race, which the reconcile's downward probe catches anyway. So a failed re-read leaves the first read's verdict standing — otherwise the run would pause with no issue at all, which is the outcome opening one exists to avoid.

<details>
<summary>Reproducer, before and after</summary>

A fake `gh` whose `issue list` fails with a 502 while a `tend-outage` tracker is open:

```
--- run_issue_canonical's own status when the list read fails ---
before:  status=0 output=''      <- "no issue exists"
after:   status=1 output=''

--- report-failure.sh with an open tracker it cannot see ---
before:  issue-create calls: 1   <- duplicate tracker filed
after:   issue-create calls: 0   <- warns, records nothing
```

</details>

## Testing

Four tests: one per caller asserting no `issue create` happens when the list read fails, and one for each side of the preflight's two reads — still files when only the re-read fails, still files when only the first read fails. The harness fails `issue list` over a `[FROM, UNTIL]` call range, so either read can be failed alone and the unbounded form still means "the list is simply down".

Verified by mutation, each killing a different test: dropping the status propagation kills both callers' tests, reverting `report-failure.sh`'s guard kills its no-duplicate test, removing the preflight's branch kills its no-duplicate test, letting the re-read clear the verdict kills the re-read test, and dropping the re-read's raise of it kills the first-read test. 370 tests pass; pre-commit clean.

Not exercised against real GitHub — the failure is simulated with `exit 1`, so whether real `gh` exits non-zero on a secondary rate limit during a list read is still untested.

> _This was written by Claude Code on behalf of max-sixty_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
