### PR TITLE
feat(generator): make the Claude prompt prose, so /code-review is reachable

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ resolve bot identity. They differ in how the agent runs:
   (`claude -p`) as a non-sudo sandbox user behind a local
   credential-injecting proxy, so the bot token and Anthropic credential
   never enter the agent's environment. Each workflow's prompt names the
-  skill to run in prose, which also keeps the prompt eligible for the
-  waiver that makes the built-in `/code-review` invocable.
+  skill to run in prose rather than as a leading slash command, which
+  keeps the built-in `/code-review` reachable during the run.
 - **Codex harness** — installs the `@openai/codex` CLI on the runner and
   shells out to `codex exec`. An AGENTS.md staged into `$CODEX_HOME`
   teaches Codex to resolve `/tend-ci-runner:NAME` references to the

--- a/README.md
+++ b/README.md
@@ -105,8 +105,9 @@ resolve bot identity. They differ in how the agent runs:
 - **Claude harness** — runs the official `claude` binary headless
   (`claude -p`) as a non-sudo sandbox user behind a local
   credential-injecting proxy, so the bot token and Anthropic credential
-  never enter the agent's environment. Each workflow's prompt is a slash
-  command (`/tend-ci-runner:review`) that loads the matching skill.
+  never enter the agent's environment. Each workflow's prompt names the
+  skill to run in prose, which also keeps the prompt eligible for the
+  waiver that makes the built-in `/code-review` invocable.
 - **Codex harness** — installs the `@openai/codex` CLI on the runner and
   shells out to `codex exec`. An AGENTS.md staged into `$CODEX_HOME`
   teaches Codex to resolve `/tend-ci-runner:NAME` references to the

--- a/generator/src/tend/config.py
+++ b/generator/src/tend/config.py
@@ -203,15 +203,35 @@ class Config:
     def default_prompt(self, skill: str, args: str = "") -> str:
         """Default prompt invoking a tend-ci-runner skill in harness-native syntax.
 
-        Claude resolves `/tend-ci-runner:NAME` as a slash command. Codex resolves
-        `$NAME` as a skill mention (or matches by description); the
+        Codex resolves `$NAME` as a skill mention (or matches by description); the
         `tend-ci-runner` namespace prefix isn't needed at the prompt site because
         skill names within the plugin are unique. `args` is appended raw so
         callers can splice their own placeholders (`{pr_number}` etc.) and run
         the existing replace step.
+
+        Claude's prompt is prose naming the skill, rather than the
+        `/tend-ci-runner:NAME` slash command it also resolves, so that the
+        built-in `/code-review` is reachable. That skill carries
+        `disable-model-invocation`, which the `Skill` tool waives only for a turn
+        whose own user message names the command; a prompt starting with `/` is
+        stored wrapped in `<command-message>` and is skipped by that scan, so no
+        eligible message ever exists. Prose leaves the prompt eligible, and the
+        `/code-review` token in it unlocks the skill for the whole run.
+
+        The token has to survive that scan's regex, `(?<!\\S)/code-review(?=$|\\s)`:
+        whitespace on both sides, so a trailing period or a backtick silently
+        costs the run its second pass. `test_default_prompt_unlocks_code_review`
+        pins it.
         """
-        prefix = f"/tend-ci-runner:{skill}" if self.harness == "claude" else f"${skill}"
-        return f"{prefix} {args}".rstrip()
+        if self.harness != "claude":
+            return f"${skill} {args}".rstrip()
+        invocation = f"Run the tend-ci-runner:{skill} skill"
+        if args:
+            invocation += f" for {args}"
+        return (
+            f"{invocation}. Beyond the skills the Skill tool lists, "
+            "/code-review is available too."
+        )
 
     @classmethod
     def load(cls, path: Path | None = None) -> Config:

--- a/generator/src/tend/config.py
+++ b/generator/src/tend/config.py
@@ -204,8 +204,9 @@ class Config:
     def code_review_notice(self) -> str:
         """Sentence declaring the built-in `/code-review`; empty off the Claude harness.
 
-        Every Claude prompt carries it, including `mention`, whose prompt
-        `mention.yaml.j2` builds rather than `default_prompt`. One definition, so
+        Every generated Claude prompt carries it, including `mention`, whose prompt
+        `mention.yaml.j2` builds rather than `default_prompt` — but not an adopter's
+        `workflows.<name>.prompt`, which replaces the whole prompt. One definition, so
         the two can't drift — and the token's regex (see `default_prompt`) is
         fragile enough that a second copy is a second way to break it.
         """

--- a/generator/src/tend/config.py
+++ b/generator/src/tend/config.py
@@ -200,6 +200,19 @@ class Config:
     sandbox_env: dict[str, str] = field(default_factory=dict)
     sandbox_setup: list[str] = field(default_factory=list)
 
+    @property
+    def code_review_notice(self) -> str:
+        """Sentence declaring the built-in `/code-review`; empty off the Claude harness.
+
+        Every Claude prompt carries it, including `mention`, whose prompt
+        `mention.yaml.j2` builds rather than `default_prompt`. One definition, so
+        the two can't drift — and the token's regex (see `default_prompt`) is
+        fragile enough that a second copy is a second way to break it.
+        """
+        if self.harness != "claude":
+            return ""
+        return "Beyond the skills the Skill tool lists, /code-review is available too."
+
     def default_prompt(self, skill: str, args: str = "") -> str:
         """Default prompt invoking a tend-ci-runner skill in harness-native syntax.
 
@@ -232,10 +245,7 @@ class Config:
         invocation = f"Run the /tend-ci-runner:{skill} skill"
         if args:
             invocation += f" for {args}"
-        return (
-            f"{invocation}. Beyond the skills the Skill tool lists, "
-            "/code-review is available too."
-        )
+        return f"{invocation}. {self.code_review_notice}"
 
     @classmethod
     def load(cls, path: Path | None = None) -> Config:

--- a/generator/src/tend/config.py
+++ b/generator/src/tend/config.py
@@ -209,14 +209,18 @@ class Config:
         callers can splice their own placeholders (`{pr_number}` etc.) and run
         the existing replace step.
 
-        Claude's prompt is prose naming the skill, rather than the
+        Claude's prompt is prose naming the skill, rather than the bare
         `/tend-ci-runner:NAME` slash command it also resolves, so that the
         built-in `/code-review` is reachable. That skill carries
         `disable-model-invocation`, which the `Skill` tool waives only for a turn
-        whose own user message names the command; a prompt starting with `/` is
+        whose own user message names the command; a prompt *starting* with `/` is
         stored wrapped in `<command-message>` and is skipped by that scan, so no
         eligible message ever exists. Prose leaves the prompt eligible, and the
         `/code-review` token in it unlocks the skill for the whole run.
+
+        Only the leading position routes a prompt to the slash-command path, so
+        the skill mention keeps its own `/` — the invocable form, and the same
+        shape as the `/code-review` beside it.
 
         The token has to survive that scan's regex, `(?<!\\S)/code-review(?=$|\\s)`:
         whitespace on both sides, so a trailing period or a backtick silently
@@ -225,7 +229,7 @@ class Config:
         """
         if self.harness != "claude":
             return f"${skill} {args}".rstrip()
-        invocation = f"Run the tend-ci-runner:{skill} skill"
+        invocation = f"Run the /tend-ci-runner:{skill} skill"
         if args:
             invocation += f" for {args}"
         return (

--- a/generator/src/tend/templates/mention.yaml.j2
+++ b/generator/src/tend/templates/mention.yaml.j2
@@ -18,7 +18,9 @@
               || (contains(github.event.comment.body, '@<<cfg.bot_name>>')
                 && format('You were mentioned in a comment ({0}). Read the full context and respond. If changes are requested, make them, commit, and push.', github.event.comment.html_url))
               || format('A user commented on an issue/PR where you previously participated ({0}). Read the full context. Only respond if the comment is directed at you, asks a question you can help with, or requests changes you can make. If the conversation is between other participants, exit silently.', github.event.comment.html_url)
-            }}{%- endset -%}
+            }}{% if cfg.code_review_notice %}
+
+            <<cfg.code_review_notice>>{% endif %}{%- endset -%}
 <<header>>
 name: tend-mention
 on:

--- a/generator/tests/_regtest_outputs/test_generate.test_extras_apply_path_regtest.out
+++ b/generator/tests/_regtest_outputs/test_generate.test_extras_apply_path_regtest.out
@@ -60,7 +60,7 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: >-
-            ${{ format('Run the tend-ci-runner:review skill for {0}. Beyond the skills the Skill tool lists, /code-review is available too.', github.event.pull_request.number) }}
+            ${{ format('Run the /tend-ci-runner:review skill for {0}. Beyond the skills the Skill tool lists, /code-review is available too.', github.event.pull_request.number) }}
     timeout-minutes: 240
 env:
   FOO: bar

--- a/generator/tests/_regtest_outputs/test_generate.test_extras_apply_path_regtest.out
+++ b/generator/tests/_regtest_outputs/test_generate.test_extras_apply_path_regtest.out
@@ -60,7 +60,7 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: >-
-            ${{ format('/tend-ci-runner:review {0}', github.event.pull_request.number) }}
+            ${{ format('Run the tend-ci-runner:review skill for {0}. Beyond the skills the Skill tool lists, /code-review is available too.', github.event.pull_request.number) }}
     timeout-minutes: 240
 env:
   FOO: bar

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-ci-fix.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-ci-fix.yaml].out
@@ -40,7 +40,7 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the tend-ci-runner:ci-fix skill for ${{ github.event.workflow_run.id }}. Beyond the skills the Skill tool lists, /code-review is available too.
+            Run the /tend-ci-runner:ci-fix skill for ${{ github.event.workflow_run.id }}. Beyond the skills the Skill tool lists, /code-review is available too.
             - Run URL: ${{ github.event.workflow_run.html_url }}
             - Commit: ${{ github.event.workflow_run.head_sha }}
             - Commit message: ${{ github.event.workflow_run.head_commit.message }}

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-ci-fix.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-ci-fix.yaml].out
@@ -40,7 +40,7 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            /tend-ci-runner:ci-fix ${{ github.event.workflow_run.id }}
+            Run the tend-ci-runner:ci-fix skill for ${{ github.event.workflow_run.id }}. Beyond the skills the Skill tool lists, /code-review is available too.
             - Run URL: ${{ github.event.workflow_run.html_url }}
             - Commit: ${{ github.event.workflow_run.head_sha }}
             - Commit message: ${{ github.event.workflow_run.head_commit.message }}

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-nightly.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-nightly.yaml].out
@@ -40,4 +40,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the tend-ci-runner:nightly skill. Beyond the skills the Skill tool lists, /code-review is available too.
+            Run the /tend-ci-runner:nightly skill. Beyond the skills the Skill tool lists, /code-review is available too.

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-nightly.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-nightly.yaml].out
@@ -40,4 +40,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            /tend-ci-runner:nightly
+            Run the tend-ci-runner:nightly skill. Beyond the skills the Skill tool lists, /code-review is available too.

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
@@ -144,4 +144,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the tend-ci-runner:notifications skill. Beyond the skills the Skill tool lists, /code-review is available too.
+            Run the /tend-ci-runner:notifications skill. Beyond the skills the Skill tool lists, /code-review is available too.

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
@@ -144,4 +144,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            /tend-ci-runner:notifications
+            Run the tend-ci-runner:notifications skill. Beyond the skills the Skill tool lists, /code-review is available too.

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-review-runs.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-review-runs.yaml].out
@@ -40,4 +40,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            /tend-ci-runner:review-runs
+            Run the tend-ci-runner:review-runs skill. Beyond the skills the Skill tool lists, /code-review is available too.

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-review-runs.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-review-runs.yaml].out
@@ -40,4 +40,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the tend-ci-runner:review-runs skill. Beyond the skills the Skill tool lists, /code-review is available too.
+            Run the /tend-ci-runner:review-runs skill. Beyond the skills the Skill tool lists, /code-review is available too.

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-triage.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-triage.yaml].out
@@ -43,4 +43,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the tend-ci-runner:triage skill for ${{ github.event.issue.number }}. Beyond the skills the Skill tool lists, /code-review is available too.
+            Run the /tend-ci-runner:triage skill for ${{ github.event.issue.number }}. Beyond the skills the Skill tool lists, /code-review is available too.

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-triage.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-triage.yaml].out
@@ -43,4 +43,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            /tend-ci-runner:triage ${{ github.event.issue.number }}
+            Run the tend-ci-runner:triage skill for ${{ github.event.issue.number }}. Beyond the skills the Skill tool lists, /code-review is available too.

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-weekly.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-weekly.yaml].out
@@ -40,4 +40,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the tend-ci-runner:weekly skill. Beyond the skills the Skill tool lists, /code-review is available too.
+            Run the /tend-ci-runner:weekly skill. Beyond the skills the Skill tool lists, /code-review is available too.

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-weekly.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-weekly.yaml].out
@@ -40,4 +40,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            /tend-ci-runner:weekly
+            Run the tend-ci-runner:weekly skill. Beyond the skills the Skill tool lists, /code-review is available too.

--- a/generator/tests/_regtest_outputs/test_generate.test_sandbox_levers_regtest.out
+++ b/generator/tests/_regtest_outputs/test_generate.test_sandbox_levers_regtest.out
@@ -426,6 +426,7 @@ jobs:
                 && format('You were mentioned in a comment ({0}). Read the full context and respond. If changes are requested, make them, commit, and push.', github.event.comment.html_url))
               || format('A user commented on an issue/PR where you previously participated ({0}). Read the full context. Only respond if the comment is directed at you, asks a question you can help with, or requests changes you can make. If the conversation is between other participants, exit silently.', github.event.comment.html_url)
             }}
+            Beyond the skills the Skill tool lists, /code-review is available too.
 
       - name: Remove eyes reaction
         if: |

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[ci-fix].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[ci-fix].out
@@ -40,7 +40,7 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the tend-ci-runner:ci-fix skill for ${{ github.event.workflow_run.id }}. Beyond the skills the Skill tool lists, /code-review is available too.
+            Run the /tend-ci-runner:ci-fix skill for ${{ github.event.workflow_run.id }}. Beyond the skills the Skill tool lists, /code-review is available too.
             - Run URL: ${{ github.event.workflow_run.html_url }}
             - Commit: ${{ github.event.workflow_run.head_sha }}
             - Commit message: ${{ github.event.workflow_run.head_commit.message }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[ci-fix].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[ci-fix].out
@@ -40,7 +40,7 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            /tend-ci-runner:ci-fix ${{ github.event.workflow_run.id }}
+            Run the tend-ci-runner:ci-fix skill for ${{ github.event.workflow_run.id }}. Beyond the skills the Skill tool lists, /code-review is available too.
             - Run URL: ${{ github.event.workflow_run.html_url }}
             - Commit: ${{ github.event.workflow_run.head_sha }}
             - Commit message: ${{ github.event.workflow_run.head_commit.message }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
@@ -417,6 +417,7 @@ jobs:
                 && format('You were mentioned in a comment ({0}). Read the full context and respond. If changes are requested, make them, commit, and push.', github.event.comment.html_url))
               || format('A user commented on an issue/PR where you previously participated ({0}). Read the full context. Only respond if the comment is directed at you, asks a question you can help with, or requests changes you can make. If the conversation is between other participants, exit silently.', github.event.comment.html_url)
             }}
+            Beyond the skills the Skill tool lists, /code-review is available too.
 
       - name: Remove eyes reaction
         if: |

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[nightly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[nightly].out
@@ -39,4 +39,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the tend-ci-runner:nightly skill. Beyond the skills the Skill tool lists, /code-review is available too.
+            Run the /tend-ci-runner:nightly skill. Beyond the skills the Skill tool lists, /code-review is available too.

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[nightly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[nightly].out
@@ -39,4 +39,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            /tend-ci-runner:nightly
+            Run the tend-ci-runner:nightly skill. Beyond the skills the Skill tool lists, /code-review is available too.

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
@@ -143,4 +143,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the tend-ci-runner:notifications skill. Beyond the skills the Skill tool lists, /code-review is available too.
+            Run the /tend-ci-runner:notifications skill. Beyond the skills the Skill tool lists, /code-review is available too.

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
@@ -143,4 +143,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            /tend-ci-runner:notifications
+            Run the tend-ci-runner:notifications skill. Beyond the skills the Skill tool lists, /code-review is available too.

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review-runs].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review-runs].out
@@ -39,4 +39,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            /tend-ci-runner:review-runs
+            Run the tend-ci-runner:review-runs skill. Beyond the skills the Skill tool lists, /code-review is available too.

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review-runs].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review-runs].out
@@ -39,4 +39,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the tend-ci-runner:review-runs skill. Beyond the skills the Skill tool lists, /code-review is available too.
+            Run the /tend-ci-runner:review-runs skill. Beyond the skills the Skill tool lists, /code-review is available too.

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review].out
@@ -59,4 +59,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: >-
-            ${{ format('/tend-ci-runner:review {0}', github.event.pull_request.number) }}
+            ${{ format('Run the tend-ci-runner:review skill for {0}. Beyond the skills the Skill tool lists, /code-review is available too.', github.event.pull_request.number) }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review].out
@@ -59,4 +59,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: >-
-            ${{ format('Run the tend-ci-runner:review skill for {0}. Beyond the skills the Skill tool lists, /code-review is available too.', github.event.pull_request.number) }}
+            ${{ format('Run the /tend-ci-runner:review skill for {0}. Beyond the skills the Skill tool lists, /code-review is available too.', github.event.pull_request.number) }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[triage].out
@@ -43,4 +43,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the tend-ci-runner:triage skill for ${{ github.event.issue.number }}. Beyond the skills the Skill tool lists, /code-review is available too.
+            Run the /tend-ci-runner:triage skill for ${{ github.event.issue.number }}. Beyond the skills the Skill tool lists, /code-review is available too.

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[triage].out
@@ -43,4 +43,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            /tend-ci-runner:triage ${{ github.event.issue.number }}
+            Run the tend-ci-runner:triage skill for ${{ github.event.issue.number }}. Beyond the skills the Skill tool lists, /code-review is available too.

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[weekly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[weekly].out
@@ -39,4 +39,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            /tend-ci-runner:weekly
+            Run the tend-ci-runner:weekly skill. Beyond the skills the Skill tool lists, /code-review is available too.

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[weekly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[weekly].out
@@ -39,4 +39,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the tend-ci-runner:weekly skill. Beyond the skills the Skill tool lists, /code-review is available too.
+            Run the /tend-ci-runner:weekly skill. Beyond the skills the Skill tool lists, /code-review is available too.

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[ci-fix].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[ci-fix].out
@@ -42,7 +42,7 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            /tend-ci-runner:ci-fix ${{ github.event.workflow_run.id }}
+            Run the tend-ci-runner:ci-fix skill for ${{ github.event.workflow_run.id }}. Beyond the skills the Skill tool lists, /code-review is available too.
             - Run URL: ${{ github.event.workflow_run.html_url }}
             - Commit: ${{ github.event.workflow_run.head_sha }}
             - Commit message: ${{ github.event.workflow_run.head_commit.message }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[ci-fix].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[ci-fix].out
@@ -42,7 +42,7 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the tend-ci-runner:ci-fix skill for ${{ github.event.workflow_run.id }}. Beyond the skills the Skill tool lists, /code-review is available too.
+            Run the /tend-ci-runner:ci-fix skill for ${{ github.event.workflow_run.id }}. Beyond the skills the Skill tool lists, /code-review is available too.
             - Run URL: ${{ github.event.workflow_run.html_url }}
             - Commit: ${{ github.event.workflow_run.head_sha }}
             - Commit message: ${{ github.event.workflow_run.head_commit.message }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
@@ -419,6 +419,7 @@ jobs:
                 && format('You were mentioned in a comment ({0}). Read the full context and respond. If changes are requested, make them, commit, and push.', github.event.comment.html_url))
               || format('A user commented on an issue/PR where you previously participated ({0}). Read the full context. Only respond if the comment is directed at you, asks a question you can help with, or requests changes you can make. If the conversation is between other participants, exit silently.', github.event.comment.html_url)
             }}
+            Beyond the skills the Skill tool lists, /code-review is available too.
 
       - name: Remove eyes reaction
         if: |

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[nightly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[nightly].out
@@ -41,4 +41,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the tend-ci-runner:nightly skill. Beyond the skills the Skill tool lists, /code-review is available too.
+            Run the /tend-ci-runner:nightly skill. Beyond the skills the Skill tool lists, /code-review is available too.

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[nightly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[nightly].out
@@ -41,4 +41,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            /tend-ci-runner:nightly
+            Run the tend-ci-runner:nightly skill. Beyond the skills the Skill tool lists, /code-review is available too.

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
@@ -146,4 +146,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the tend-ci-runner:notifications skill. Beyond the skills the Skill tool lists, /code-review is available too.
+            Run the /tend-ci-runner:notifications skill. Beyond the skills the Skill tool lists, /code-review is available too.

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
@@ -146,4 +146,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            /tend-ci-runner:notifications
+            Run the tend-ci-runner:notifications skill. Beyond the skills the Skill tool lists, /code-review is available too.

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review-runs].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review-runs].out
@@ -41,4 +41,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the tend-ci-runner:review-runs skill. Beyond the skills the Skill tool lists, /code-review is available too.
+            Run the /tend-ci-runner:review-runs skill. Beyond the skills the Skill tool lists, /code-review is available too.

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review-runs].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review-runs].out
@@ -41,4 +41,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            /tend-ci-runner:review-runs
+            Run the tend-ci-runner:review-runs skill. Beyond the skills the Skill tool lists, /code-review is available too.

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review].out
@@ -71,4 +71,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: >-
-            ${{ format('/tend-ci-runner:review {0}', github.event.pull_request.number) }}
+            ${{ format('Run the tend-ci-runner:review skill for {0}. Beyond the skills the Skill tool lists, /code-review is available too.', github.event.pull_request.number) }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review].out
@@ -71,4 +71,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: >-
-            ${{ format('Run the tend-ci-runner:review skill for {0}. Beyond the skills the Skill tool lists, /code-review is available too.', github.event.pull_request.number) }}
+            ${{ format('Run the /tend-ci-runner:review skill for {0}. Beyond the skills the Skill tool lists, /code-review is available too.', github.event.pull_request.number) }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[triage].out
@@ -45,4 +45,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the tend-ci-runner:triage skill for ${{ github.event.issue.number }}. Beyond the skills the Skill tool lists, /code-review is available too.
+            Run the /tend-ci-runner:triage skill for ${{ github.event.issue.number }}. Beyond the skills the Skill tool lists, /code-review is available too.

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[triage].out
@@ -45,4 +45,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            /tend-ci-runner:triage ${{ github.event.issue.number }}
+            Run the tend-ci-runner:triage skill for ${{ github.event.issue.number }}. Beyond the skills the Skill tool lists, /code-review is available too.

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[weekly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[weekly].out
@@ -41,4 +41,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            /tend-ci-runner:weekly
+            Run the tend-ci-runner:weekly skill. Beyond the skills the Skill tool lists, /code-review is available too.

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[weekly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[weekly].out
@@ -41,4 +41,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the tend-ci-runner:weekly skill. Beyond the skills the Skill tool lists, /code-review is available too.
+            Run the /tend-ci-runner:weekly skill. Beyond the skills the Skill tool lists, /code-review is available too.

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -421,9 +421,22 @@ def test_default_prompt_unlocks_code_review(tmp_path: Path) -> None:
 
     codex = Config.load(_minimal_config(tmp_path, "harness: codex\n"))
     assert codex.default_prompt("review", "{pr_number}") == "$review {pr_number}"
+    assert codex.code_review_notice == ""
 
-    workflows = {wf.filename: wf for wf in generate_all(cfg)}
-    assert "/code-review" in workflows["tend-review.yaml"].content
+    # Rendering is where the token can lose its whitespace: the review prompt is
+    # the one that goes through `_escape_braces`, `''`-quoting and GHA `format()`,
+    # and `mention` is the one workflow whose prompt skips `default_prompt`.
+    claude = {wf.filename: wf for wf in generate_all(cfg)}
+    for name in ["tend-review.yaml", "tend-mention.yaml"]:
+        assert user_typed_this_turn.search(claude[name].content), (
+            f"{name} lost the bare /code-review token in rendering"
+        )
+
+    codex_workflows = {wf.filename: wf for wf in generate_all(codex)}
+    for name, wf in codex_workflows.items():
+        assert "/code-review" not in wf.content, (
+            f"{name} declares /code-review, which the Codex harness has no skill for"
+        )
 
 
 def test_watched_workflows(tmp_path: Path) -> None:

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -395,6 +395,37 @@ def test_custom_prompt(tmp_path: Path) -> None:
     assert "Custom triage:" in triage.content
 
 
+def test_default_prompt_unlocks_code_review(tmp_path: Path) -> None:
+    """Claude prompts stay eligible for the `/code-review` waiver; Codex is untouched.
+
+    The `Skill` tool waives `disable-model-invocation` only for a turn whose own
+    user message names the command, and it finds that name with this regex. A
+    prompt starting with `/` is stored wrapped in `<command-message>` and skipped
+    by the scan, so prose is what keeps the message eligible at all — and the
+    token then has to clear the regex, which a trailing period or a backtick
+    silently fails.
+    """
+    user_typed_this_turn = re.compile(r"(?<!\S)/code-review(?=$|\s)")
+
+    cfg = Config.load(_minimal_config(tmp_path))
+    for skill, args in [("review", "{pr_number}"), ("nightly", "")]:
+        prompt = cfg.default_prompt(skill, args)
+        assert not prompt.startswith("/"), (
+            f"{skill} prompt starts with '/', so Claude Code stores it as a "
+            "slash command and the scan skips it"
+        )
+        assert user_typed_this_turn.search(prompt), (
+            f"{skill} prompt does not carry a bare /code-review token: {prompt!r}"
+        )
+        assert f"tend-ci-runner:{skill}" in prompt
+
+    codex = Config.load(_minimal_config(tmp_path, "harness: codex\n"))
+    assert codex.default_prompt("review", "{pr_number}") == "$review {pr_number}"
+
+    workflows = {wf.filename: wf for wf in generate_all(cfg)}
+    assert "/code-review" in workflows["tend-review.yaml"].content
+
+
 def test_watched_workflows(tmp_path: Path) -> None:
     extra = dedent("""\
         workflows:

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -417,7 +417,7 @@ def test_default_prompt_unlocks_code_review(tmp_path: Path) -> None:
         assert user_typed_this_turn.search(prompt), (
             f"{skill} prompt does not carry a bare /code-review token: {prompt!r}"
         )
-        assert f"tend-ci-runner:{skill}" in prompt
+        assert f"/tend-ci-runner:{skill}" in prompt
 
     codex = Config.load(_minimal_config(tmp_path, "harness: codex\n"))
     assert codex.default_prompt("review", "{pr_number}") == "$review {pr_number}"

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -393,6 +393,9 @@ def test_custom_prompt(tmp_path: Path) -> None:
     workflows = {wf.filename: wf for wf in generate_all(cfg)}
     triage = workflows["tend-triage.yaml"]
     assert "Custom triage:" in triage.content
+    # An adopter's prompt replaces the whole thing, `code_review_notice` included,
+    # so it carries no /code-review token — what that property's docstring claims.
+    assert "/code-review" not in triage.content
 
 
 def test_default_prompt_unlocks_code_review(tmp_path: Path) -> None:

--- a/shared/steps/compose-system-prompt.sh
+++ b/shared/steps/compose-system-prompt.sh
@@ -15,7 +15,7 @@
 set -eo pipefail
 
 SHARED="$SYSTEM_PROMPT_FILE"
-CLAUDE_DIRECTIVE="Invoke the skill the prompt names — it drives the whole run, and a run that skips it exits clean having done nothing. Use /tend-ci-runner:running-in-ci before starting work."
+CLAUDE_DIRECTIVE="If the prompt names a tend-ci-runner skill, invoke it — it drives the whole run, and a run that skips it exits clean having done nothing. Use /tend-ci-runner:running-in-ci before starting work."
 AUTONOMY_DIRECTIVE="You are running in CI; no human is available to answer questions. Never prompt for clarification or approval. When uncertain, make the best reasonable choice from the available evidence and proceed. Permissions are pre-approved; tool calls execute without confirmation."
 BASE=$(BOT_NAME="$BOT_NAME" envsubst '$BOT_NAME' < "$SHARED")
 FULL="${CLAUDE_DIRECTIVE}"$'\n\n'"${AUTONOMY_DIRECTIVE}"$'\n\n'"${BASE}"

--- a/shared/steps/compose-system-prompt.sh
+++ b/shared/steps/compose-system-prompt.sh
@@ -15,7 +15,7 @@
 set -eo pipefail
 
 SHARED="$SYSTEM_PROMPT_FILE"
-CLAUDE_DIRECTIVE="Use /tend-ci-runner:running-in-ci before starting work."
+CLAUDE_DIRECTIVE="Invoke the skill the prompt names — it drives the whole run, and a run that skips it exits clean having done nothing. Use /tend-ci-runner:running-in-ci before starting work."
 AUTONOMY_DIRECTIVE="You are running in CI; no human is available to answer questions. Never prompt for clarification or approval. When uncertain, make the best reasonable choice from the available evidence and proceed. Permissions are pre-approved; tool calls execute without confirmation."
 BASE=$(BOT_NAME="$BOT_NAME" envsubst '$BOT_NAME' < "$SHARED")
 FULL="${CLAUDE_DIRECTIVE}"$'\n\n'"${AUTONOMY_DIRECTIVE}"$'\n\n'"${BASE}"


### PR DESCRIPTION
The built-in `/code-review` carries `disable-model-invocation`, and the `Skill` tool waives that only for a turn whose own user message names the command. The scan behind that waiver skips messages wrapped in `<command-message>` — which is exactly how Claude Code stores a prompt beginning with `/`. Since `default_prompt` built every Claude prompt as `/tend-ci-runner:<skill>`, no eligible message ever existed, so the waiver could never fire in any tend workflow.

The Claude prompt now names its skill in prose and declares `/code-review` alongside the skills the `Skill` tool lists:

```
Run the /tend-ci-runner:review skill for 891. Beyond the skills the Skill tool lists, /code-review is available too.
```

Codex prompts are unchanged, and a test asserts no Codex workflow declares a skill that harness hasn't got.

Only the *leading* position routes a prompt down the slash-command path, so the skill mention keeps its own `/`: it's the invocable form, and it matches the `/code-review` beside it rather than reading as a bare identifier.

The declaring sentence lives in `Config.code_review_notice`, because `mention` builds its prompt in `mention.yaml.j2` rather than through `default_prompt` — one definition, so the two producers can't drift on a token whose whitespace is load-bearing.

Prose relies on the model electing to call `Skill`, where the slash command was routed by the harness. `CLAUDE_DIRECTIVE` in `compose-system-prompt.sh` now covers that without touching the prompt shape: if the prompt names a tend-ci-runner skill, invoke it. The failure it guards is silent, since a run that never loads its skill still exits 0. The clause binds to a tend-ci-runner skill rather than to any skill because `mention`'s prompt names none — it's a task description — so an unconditional version would have pointed a mention run at the `/code-review` the notice had just added.

## What this does and doesn't buy

Nothing consumes the new availability yet. Step 4 of the `review` skill still mandates `/tend-ci-runner:code-review`, so as it stands the declaration is inert — and the prompt now advertises one code-review skill while the skill body mandates another. Resolving that is a separate call, because pointing step 4 at the built-in would cost the Codex harness the second pass it gained when the port landed.

This also changes nothing in CI until the next release: the committed workflows are regenerated by the published generator, not the in-tree one.

<details><summary>Verification, and what is not verified</summary>

Checked on the folded scalar the action actually receives, rather than the serialized file: all seven Claude workflows carry a `/code-review` token with whitespace on both sides, and none leads with a slash.

Verified against a real session log: a prompt of this shape is stored as a plain string user message — not `isMeta`, no `<command-message>` wrapper, no tool result — so it clears all four of the scan's skip rules, and both tokens clear their own regexes with the slash mid-string.

Not verified: the end-to-end unlock at a version that hardcodes the flag. That A/B needed a local 2.1.222 binary, which Claude Code pruned mid-session; the remaining local builds gate the flag open, where the test can't distinguish. The blocked half is confirmed — this PR's own review run reports the built-in returning `disable-model-invocation` under the old slash-command prompt.

The token must clear `(?<!\S)/code-review(?=$|\s)`, where a trailing period or a backtick silently costs the run its second pass. `test_default_prompt_unlocks_code_review` pins that at the rendered layer, along with the no-leading-slash invariant and the unchanged Codex form.

</details>

> _This was written by Claude Code on behalf of max-sixty_
