### PR TITLE
feat(review): queue pushes behind an examined-HEAD gate instead of cancelling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
     hooks:
       - id: shellcheck
         args: ["-S", "warning"]
-        files: ^(shared/steps/.*\.sh|proxy/setup-sandbox\.sh)$
+        files: ^(shared/steps/.*\.sh|generator/src/tend/templates/.*\.sh|proxy/setup-sandbox\.sh)$
   - repo: local
     hooks:
       # The Claude Code slash-command preprocessor treats a backticked token

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,15 +222,17 @@ Events pass through three layers before the bot does work:
 1. **GHA `if:` conditions** — evaluated by Actions before the job starts.
    A false condition skips the job entirely (never enters the concurrency
    group, never queues).
-2. **Custom `should_run` logic** (mention only) — a lightweight verify job
-   checks engagement before the expensive handle job runs.
+2. **Custom `should_run` pre-checks** — cheap deterministic steps that decide
+   whether the agent boots: mention's verify job checks engagement, review's
+   gate skips a live HEAD already stamped as examined, notifications' check
+   exits when the inbox is clear.
 3. **Concurrency groups** — at most one running job per group.
 
 Concurrency groups:
 
 | Workflow | Group key | Cancel-in-progress |
 |---|---|---|
-| review | `workflow-PR#` | yes — new push invalidates a review |
+| review | `workflow-PR#` | **no** — the session folds pushes in and stamps examined commits (`tend-review/<pr>` status); a pre-check skips the queued run when the live HEAD is stamped |
 | mention/relay | none | stateless — secretless job that re-posts review events as a `repository_dispatch` |
 | mention/verify | none | stateless |
 | mention/handle | `workflow-handle-issue#\|PR#` | **no** — each mention runs to completion |
@@ -248,14 +250,16 @@ repo only) and `tend-mention`'s review-event paths already filter forks
 via `head.repo.full_name == github.repository`, so neither needs the
 guard.
 
-**GHA queue depth = 1.** With `cancel-in-progress: false` (mention/handle),
-when a third job arrives while one runs and one queues, the pending job is
-replaced. Mitigation lives in the skill prompts: dedup if the bot already
-responded to the triggering comment; self-heal earlier comments without a
-bot reply (oldest first). The workflow injects the queue-to-run time delta
-(seconds between event timestamp and job start) into the prompt — over
-~40 s indicates the job was queued behind another run, making conversation
-drift more likely.
+**GHA queue depth = 1.** With `cancel-in-progress: false` (mention/handle,
+review), when a third job arrives while one runs and one queues, the pending
+job is replaced. For mention, mitigation lives in the skill prompts: dedup if
+the bot already responded to the triggering comment; self-heal earlier
+comments without a bot reply (oldest first). The workflow injects the
+queue-to-run time delta (seconds between event timestamp and job start) into
+the prompt — over ~40 s indicates the job was queued behind another run,
+making conversation drift more likely. For review, replacement is loss-free
+by construction: the pre-check and the skill both judge the live HEAD, so
+whichever run executes covers the replaced event's commits.
 
 ## Skill design: bundled for everyone, overlay for one
 

--- a/generator/src/tend/templates/notifications-check.sh
+++ b/generator/src/tend/templates/notifications-check.sh
@@ -1,0 +1,106 @@
+# shellcheck shell=bash
+# Pre-check for tend-notifications: decide whether the agent needs to boot at
+# all, and clear inbox noise no agent run is needed for.
+#
+# Inlined into the generated workflow (adopter repos have no copy of this
+# file), so it stays self-contained: env in, GITHUB_OUTPUT out.
+#
+# env: BOT_NAME, GITHUB_REPOSITORY, GITHUB_OUTPUT, GITHUB_TOKEN
+
+# Fetch notifications once, tolerating transient non-JSON responses.
+# GitHub occasionally returns an HTML error page (even with a 200)
+# during a brief API blip; under `bash -e` an untolerated `gh api`
+# failure would abort the whole step red. A failed fetch just means
+# this cycle can't enumerate — the next scheduled cycle picks up
+# anything missed — so retry briefly, then skip cleanly.
+#
+# On every failed attempt, log what actually came back: the plain
+# fetch hides the body behind `2>/dev/null`, and a transient blip
+# that recovers on retry would otherwise leave no trace of the bad
+# response. `gh api -i` re-fetches with the HTTP status line +
+# headers ahead of the body, so a recurring failure shows the real
+# status code and body — not just jq's parse complaint. It exits
+# non-zero on an error status, hence `|| true`. The extra call runs
+# only on the (rare) failing attempt; the happy path is one fetch.
+NOTIFS=""
+for attempt in 1 2 3; do
+  if NOTIFS=$(gh api notifications 2>/dev/null) && echo "$NOTIFS" | jq -e . >/dev/null 2>&1; then
+    break
+  fi
+  NOTIFS=""
+  echo "--- notifications fetch attempt $attempt failed; actual response (status + body head) ---"
+  gh api notifications -i 2>&1 | head -c 1000 || true
+  echo
+  [ "$attempt" -lt 3 ] && sleep "$attempt"
+done
+if [ -z "$NOTIFS" ]; then
+  echo "count=0" >> "$GITHUB_OUTPUT"
+  echo "notifications fetch failed after retries — skipping this cycle"
+  exit 0
+fi
+
+COUNT=$(echo "$NOTIFS" | jq 'length')
+if [ "$COUNT" = "0" ]; then
+  echo "count=0" >> "$GITHUB_OUTPUT"
+  echo "No unread notifications — skipping"
+  exit 0
+fi
+
+# --- Layer B: drop notifications shadowed by recent dedicated runs ---
+# Event workflows mark their own notifications read via the harness
+# action's post-step on success; this sweeps the case where Claude failed
+# (post-step is gated by `if: success()`) so the notification still
+# gets cleared without burning Claude turns to rediscover it.
+SINCE=$(date -u -d '30 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
+RECENT_PRS=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs?created=>=$SINCE&per_page=50" --jq '[.workflow_runs[] | select(.name | test("^(tend-review|tend-mention|tend-triage|tend-ci-fix)$")) | .pull_requests[]?.number] | unique | .[]' || true)
+
+if [ -n "$RECENT_PRS" ]; then
+  for pr in $RECENT_PRS; do
+    echo "$NOTIFS" | jq -r --arg repo "$GITHUB_REPOSITORY" --arg pr "$pr" '.[] | select(.subject.url == "https://api.github.com/repos/" + $repo + "/pulls/" + $pr or .subject.url == "https://api.github.com/repos/" + $repo + "/issues/" + $pr) | .id' | while read -r tid; do
+      [ -n "$tid" ] || continue
+      gh api "notifications/threads/$tid" -X PATCH || true
+    done
+  done
+fi
+
+# --- Layer C: drop notifications on bot-authored closed PRs ---
+# The bot auto-subscribes to its own PRs. After merge/close, leftover
+# subscription notifications are pure noise — no action needed.
+# Reuses the snapshot fetched above; marking a thread read is
+# idempotent, so a stale snapshot at worst re-PATCHes a read thread.
+echo "$NOTIFS" | jq -r --arg repo "$GITHUB_REPOSITORY" '.[] | select(.repository.full_name == $repo and .subject.type == "PullRequest") | .id' | while read -r tid; do
+  [ -n "$tid" ] || continue
+  PR_NUM=$(echo "$NOTIFS" | jq -r --arg tid "$tid" '.[] | select(.id == $tid) | .subject.url | split("/") | last')
+  PR_INFO=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUM" --jq '"\(.user.login) \(.state)"' 2>/dev/null) || continue
+  PR_AUTHOR=${PR_INFO%% *}
+  PR_STATE=${PR_INFO##* }
+  if [ "$PR_AUTHOR" = "$BOT_NAME" ] && [ "$PR_STATE" = "closed" ]; then
+    gh api "notifications/threads/$tid" -X PATCH || true
+  fi
+done
+
+# --- Layer D: count processable notifications ---
+# Same-repo notifications younger than 10 minutes are deferred: a
+# dedicated workflow (tend-review/mention/triage/ci-fix) is likely
+# still starting up or mid-flight and hasn't posted its response yet.
+# Processing them now risks duplicating work. Cross-repo notifications
+# are exempt — no dedicated workflow handles them.
+CUTOFF=$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
+# Re-fetch so the count reflects threads marked read in Layers B/C.
+# Tolerate a transient failure by falling back to the pre-mutation
+# snapshot — an over-count at worst spends one agent run, never fails.
+if ! REMAINING=$(gh api notifications 2>/dev/null) || ! echo "$REMAINING" | jq -e . >/dev/null 2>&1; then
+  REMAINING="$NOTIFS"
+fi
+COUNT=$(echo "$REMAINING" | jq --arg repo "$GITHUB_REPOSITORY" --arg cutoff "$CUTOFF" '[.[] | select(.repository.full_name != $repo or .updated_at <= $cutoff)] | length')
+echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+if [ "$COUNT" = "0" ]; then
+  TOTAL=$(echo "$REMAINING" | jq 'length')
+  if [ "$TOTAL" = "0" ]; then
+    echo "All notifications handled by pre-checks — skipping"
+  else
+    echo "$TOTAL notification(s) remain but all are fresh same-repo (deferred) — skipping"
+  fi
+else
+  echo "$COUNT processable notification(s) — proceeding"
+fi

--- a/generator/src/tend/templates/notifications.yaml.j2
+++ b/generator/src/tend/templates/notifications.yaml.j2
@@ -14,106 +14,11 @@ jobs:
     steps:
       - name: Check for unread notifications
         id: check
-        run: |
-          # Fetch notifications once, tolerating transient non-JSON responses.
-          # GitHub occasionally returns an HTML error page (even with a 200)
-          # during a brief API blip; under `bash -e` an untolerated `gh api`
-          # failure would abort the whole step red. A failed fetch just means
-          # this cycle can't enumerate — the next scheduled cycle picks up
-          # anything missed — so retry briefly, then skip cleanly.
-          #
-          # On every failed attempt, log what actually came back: the plain
-          # fetch hides the body behind `2>/dev/null`, and a transient blip
-          # that recovers on retry would otherwise leave no trace of the bad
-          # response. `gh api -i` re-fetches with the HTTP status line +
-          # headers ahead of the body, so a recurring failure shows the real
-          # status code and body — not just jq's parse complaint. It exits
-          # non-zero on an error status, hence `|| true`. The extra call runs
-          # only on the (rare) failing attempt; the happy path is one fetch.
-          NOTIFS=""
-          for attempt in 1 2 3; do
-            if NOTIFS=$(gh api notifications 2>/dev/null) && echo "$NOTIFS" | jq -e . >/dev/null 2>&1; then
-              break
-            fi
-            NOTIFS=""
-            echo "--- notifications fetch attempt $attempt failed; actual response (status + body head) ---"
-            gh api notifications -i 2>&1 | head -c 1000 || true
-            echo
-            [ "$attempt" -lt 3 ] && sleep "$attempt"
-          done
-          if [ -z "$NOTIFS" ]; then
-            echo "count=0" >> "$GITHUB_OUTPUT"
-            echo "notifications fetch failed after retries — skipping this cycle"
-            exit 0
-          fi
-
-          COUNT=$(echo "$NOTIFS" | jq 'length')
-          if [ "$COUNT" = "0" ]; then
-            echo "count=0" >> "$GITHUB_OUTPUT"
-            echo "No unread notifications — skipping"
-            exit 0
-          fi
-
-          # --- Layer B: drop notifications shadowed by recent dedicated runs ---
-          # Event workflows mark their own notifications read via the harness
-          # action's post-step on success; this sweeps the case where Claude failed
-          # (post-step is gated by `if: success()`) so the notification still
-          # gets cleared without burning Claude turns to rediscover it.
-          SINCE=$(date -u -d '30 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
-          RECENT_PRS=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs?created=>=$SINCE&per_page=50" --jq '[.workflow_runs[] | select(.name | test("^(tend-review|tend-mention|tend-triage|tend-ci-fix)$")) | .pull_requests[]?.number] | unique | .[]' || true)
-
-          if [ -n "$RECENT_PRS" ]; then
-            for pr in $RECENT_PRS; do
-              echo "$NOTIFS" | jq -r --arg repo "$GITHUB_REPOSITORY" --arg pr "$pr" '.[] | select(.subject.url == "https://api.github.com/repos/" + $repo + "/pulls/" + $pr or .subject.url == "https://api.github.com/repos/" + $repo + "/issues/" + $pr) | .id' | while read -r tid; do
-                [ -n "$tid" ] || continue
-                gh api "notifications/threads/$tid" -X PATCH || true
-              done
-            done
-          fi
-
-          # --- Layer C: drop notifications on bot-authored closed PRs ---
-          # The bot auto-subscribes to its own PRs. After merge/close, leftover
-          # subscription notifications are pure noise — no action needed.
-          # Reuses the snapshot fetched above; marking a thread read is
-          # idempotent, so a stale snapshot at worst re-PATCHes a read thread.
-          echo "$NOTIFS" | jq -r --arg repo "$GITHUB_REPOSITORY" '.[] | select(.repository.full_name == $repo and .subject.type == "PullRequest") | .id' | while read -r tid; do
-            [ -n "$tid" ] || continue
-            PR_NUM=$(echo "$NOTIFS" | jq -r --arg tid "$tid" '.[] | select(.id == $tid) | .subject.url | split("/") | last')
-            PR_INFO=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUM" --jq '"\(.user.login) \(.state)"' 2>/dev/null) || continue
-            PR_AUTHOR=${PR_INFO%% *}
-            PR_STATE=${PR_INFO##* }
-            if [ "$PR_AUTHOR" = "<<cfg.bot_name>>" ] && [ "$PR_STATE" = "closed" ]; then
-              gh api "notifications/threads/$tid" -X PATCH || true
-            fi
-          done
-
-          # --- Layer D: count processable notifications ---
-          # Same-repo notifications younger than 10 minutes are deferred: a
-          # dedicated workflow (tend-review/mention/triage/ci-fix) is likely
-          # still starting up or mid-flight and hasn't posted its response yet.
-          # Processing them now risks duplicating work. Cross-repo notifications
-          # are exempt — no dedicated workflow handles them.
-          CUTOFF=$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
-          # Re-fetch so the count reflects threads marked read in Layers B/C.
-          # Tolerate a transient failure by falling back to the pre-mutation
-          # snapshot — an over-count at worst spends one agent run, never fails.
-          if ! REMAINING=$(gh api notifications 2>/dev/null) || ! echo "$REMAINING" | jq -e . >/dev/null 2>&1; then
-            REMAINING="$NOTIFS"
-          fi
-          COUNT=$(echo "$REMAINING" | jq --arg repo "$GITHUB_REPOSITORY" --arg cutoff "$CUTOFF" '[.[] | select(.repository.full_name != $repo or .updated_at <= $cutoff)] | length')
-          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
-          if [ "$COUNT" = "0" ]; then
-            TOTAL=$(echo "$REMAINING" | jq 'length')
-            if [ "$TOTAL" = "0" ]; then
-              echo "All notifications handled by pre-checks — skipping"
-            else
-              echo "$TOTAL notification(s) remain but all are fresh same-repo (deferred) — skipping"
-            fi
-          else
-            echo "$COUNT processable notification(s) — proceeding"
-          fi
         env:
           GITHUB_TOKEN: ${{ secrets.<<bot_token_secret>> }}
+          BOT_NAME: <<cfg.bot_name>>
+        run: |
+<<check_script|indent(10, first=True)>>
 
 <<checkout(cfg, ref=cfg.default_branch, if_condition=skip_condition)>>
 <<setup>><<agent_step(cfg, block_prompt(prompt), if_condition=skip_condition)>>

--- a/generator/src/tend/templates/review-gate.sh
+++ b/generator/src/tend/templates/review-gate.sh
@@ -1,0 +1,57 @@
+# shellcheck shell=bash
+# Pre-check for tend-review: decide whether the agent needs to boot at all.
+#
+# The review job runs without cancel-in-progress, so a push mid-review queues
+# a replacement run while the live session keeps going, folds the push in, and
+# stamps each commit it examined with a `tend-review/<pr>` commit status (review
+# skill, "Stamp examined HEADs"). The concurrency group holds this run until
+# that session ends; by then the live HEAD is usually stamped and there is
+# nothing left to do. Judged against the live PR, not the event payload — a
+# queued run's payload is stale by construction.
+#
+# Inlined into the generated workflow (adopter repos have no copy of this
+# file), so it stays self-contained: env in, GITHUB_OUTPUT out. Any write-scoped
+# actor could forge the stamp to suppress a review; that actor can already
+# cancel the run itself, so the merge gate — not this check — remains the
+# security boundary.
+#
+# env: PR, EVENT_ACTION, GITHUB_REPOSITORY, GITHUB_OUTPUT, GITHUB_TOKEN
+
+# Only `synchronize` can be a stale duplicate of an examination that already
+# happened: `opened` has no prior run, and `reopened` / `ready_for_review`
+# ask for a fresh pass even on a stamped commit.
+if [ "$EVENT_ACTION" != "synchronize" ]; then
+  echo "should_run=true" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+# Fail open on API errors: a redundant agent run beats a silently skipped
+# review.
+if ! PR_INFO=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR" 2>/dev/null); then
+  echo "PR #$PR fetch failed — proceeding without the pre-check"
+  echo "should_run=true" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+STATE=$(echo "$PR_INFO" | jq -r '.state')
+if [ "$STATE" != "open" ]; then
+  echo "PR #$PR is $STATE — skipping"
+  echo "should_run=false" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+# The stamp context carries the PR number: one branch can be two open PRs
+# (same head, different base), and each base means a different diff, so an
+# examination of one must not gate the other.
+HEAD=$(echo "$PR_INFO" | jq -r '.head.sha')
+STAMPED=$(gh api "repos/$GITHUB_REPOSITORY/commits/$HEAD/status?per_page=100" 2>/dev/null \
+  | jq --arg ctx "tend-review/$PR" \
+    '[.statuses[]? | select(.context == $ctx and .state == "success")] | length' \
+  || echo 0)
+if [ "${STAMPED:-0}" -gt 0 ]; then
+  echo "HEAD $HEAD already examined (tend-review/$PR) — skipping"
+  echo "should_run=false" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+echo "should_run=true" >> "$GITHUB_OUTPUT"

--- a/generator/src/tend/templates/review-gate.sh
+++ b/generator/src/tend/templates/review-gate.sh
@@ -26,14 +26,16 @@ if [ "$EVENT_ACTION" != "synchronize" ]; then
 fi
 
 # Fail open on API errors: a redundant agent run beats a silently skipped
-# review.
-if ! PR_INFO=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR" 2>/dev/null); then
+# review. The parse belongs inside the guard — GitHub sometimes returns an
+# HTML error page with a 200 during a blip, so a zero `gh` exit doesn't mean
+# the body is JSON, and an unguarded `jq` under the run block's `bash -e`
+# would fail the step (fail-closed) instead.
+if ! PR_INFO=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR" 2>/dev/null) \
+  || ! STATE=$(echo "$PR_INFO" | jq -re '.state'); then
   echo "PR #$PR fetch failed — proceeding without the pre-check"
   echo "should_run=true" >> "$GITHUB_OUTPUT"
   exit 0
 fi
-
-STATE=$(echo "$PR_INFO" | jq -r '.state')
 if [ "$STATE" != "open" ]; then
   echo "PR #$PR is $STATE — skipping"
   echo "should_run=false" >> "$GITHUB_OUTPUT"

--- a/generator/src/tend/templates/review.yaml.j2
+++ b/generator/src/tend/templates/review.yaml.j2
@@ -15,17 +15,29 @@ jobs:
   review:
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
+      # A push mid-review queues a replacement run rather than killing the
+      # session: the running review folds the push in and stamps the commits
+      # it examined, and the gate step below lets the queued run exit without
+      # booting an agent when its HEAD is already covered.
+      cancel-in-progress: false
     runs-on: ubuntu-24.04
 <<environment()>>
     permissions:
 <<permissions()>>
     steps:
+      - name: Skip when the live HEAD is already examined
+        id: gate
+        env:
+          GITHUB_TOKEN: ${{ secrets.<<bot_token_secret>> }}
+          PR: ${{ github.event.pull_request.number }}
+          EVENT_ACTION: ${{ github.event.action }}
+        run: |
+<<gate_script|indent(10, first=True)>>
 {% if has_setup %}
       # Two checkouts: `setup:` runs against the base tree, and the PR's own
       # tree lands after it. Setup executes as the runner user, outside the
       # containment the harness builds for the contributor's code.
-<<checkout(cfg)>>
+<<checkout(cfg, if_condition=skip_condition)>>
 <<setup>>
 {% endif %}
       # GitHub only materializes refs/pull/N/merge for mergeable PRs — on
@@ -35,6 +47,7 @@ jobs:
       # tree.
       - name: Resolve PR checkout ref
         id: pr_ref
+        if: <<skip_condition>>
         env:
           GITHUB_TOKEN: ${{ secrets.<<bot_token_secret>> }}
           PR: ${{ github.event.pull_request.number }}
@@ -45,6 +58,6 @@ jobs:
             echo "ref=refs/pull/$PR/head" >> "$GITHUB_OUTPUT"
             echo "::notice::refs/pull/$PR/merge unavailable (likely merge conflict); falling back to /head"
           fi
-<<checkout(cfg, ref='${{ steps.pr_ref.outputs.ref }}', allow_unsafe_pr_checkout=True, clean=not has_setup)>>
+<<checkout(cfg, ref='${{ steps.pr_ref.outputs.ref }}', if_condition=skip_condition, allow_unsafe_pr_checkout=True, clean=not has_setup)>>
 
-<<agent_step(cfg, prompt_body)>>
+<<agent_step(cfg, prompt_body, if_condition=skip_condition)>>

--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import dataclasses
+import importlib.resources
 import io
 import textwrap
 from collections.abc import Callable
@@ -152,7 +153,7 @@ def _setup_yaml(cfg: Config, condition: str = "") -> str:
             if "if" in fields:
                 click.echo(
                     "Warning: setup step has an explicit `if:`; the "
-                    "notifications pre-check guard will not be added. "
+                    "workflow's pre-check guard will not be added. "
                     "The step runs based on your condition alone.",
                     err=True,
                 )
@@ -227,10 +228,17 @@ def generate_review(cfg: Config) -> GeneratedWorkflow:
     else:
         prompt_expr = f"'{escaped}'"
 
+    skip_condition = "steps.gate.outputs.should_run == 'true'"
+    gate_script = (
+        importlib.resources.files("tend") / "templates" / "review-gate.sh"
+    ).read_text()
+
     content = _REVIEW_TMPL.render(
         cfg=eff,
-        setup=_setup_yaml(eff),
+        setup=_setup_yaml(eff, condition=skip_condition),
         prompt_expr=prompt_expr,
+        skip_condition=skip_condition,
+        gate_script=gate_script.rstrip("\n"),
     )
     return GeneratedWorkflow(filename="tend-review.yaml", content=content)
 
@@ -348,6 +356,9 @@ def generate_notifications(cfg: Config) -> GeneratedWorkflow:
     skip_condition = (
         "steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'"
     )
+    check_script = (
+        importlib.resources.files("tend") / "templates" / "notifications-check.sh"
+    ).read_text()
 
     content = _NOTIFICATIONS_TMPL.render(
         cfg=eff,
@@ -355,6 +366,7 @@ def generate_notifications(cfg: Config) -> GeneratedWorkflow:
         skip_condition=skip_condition,
         setup=_setup_yaml(eff, condition=skip_condition),
         prompt=prompt,
+        check_script=check_script.rstrip("\n"),
     )
     return GeneratedWorkflow(filename="tend-notifications.yaml", content=content)
 

--- a/generator/tests/_regtest_outputs/test_generate.test_extras_apply_path_regtest.out
+++ b/generator/tests/_regtest_outputs/test_generate.test_extras_apply_path_regtest.out
@@ -66,14 +66,16 @@ jobs:
           fi
 
           # Fail open on API errors: a redundant agent run beats a silently skipped
-          # review.
-          if ! PR_INFO=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR" 2>/dev/null); then
+          # review. The parse belongs inside the guard ? GitHub sometimes returns an
+          # HTML error page with a 200 during a blip, so a zero `gh` exit doesn't mean
+          # the body is JSON, and an unguarded `jq` under the run block's `bash -e`
+          # would fail the step (fail-closed) instead.
+          if ! PR_INFO=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR" 2>/dev/null) \
+            || ! STATE=$(echo "$PR_INFO" | jq -re '.state'); then
             echo "PR #$PR fetch failed ? proceeding without the pre-check"
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-
-          STATE=$(echo "$PR_INFO" | jq -r '.state')
           if [ "$STATE" != "open" ]; then
             echo "PR #$PR is $STATE ? skipping"
             echo "should_run=false" >> "$GITHUB_OUTPUT"

--- a/generator/tests/_regtest_outputs/test_generate.test_extras_apply_path_regtest.out
+++ b/generator/tests/_regtest_outputs/test_generate.test_extras_apply_path_regtest.out
@@ -15,7 +15,11 @@ jobs:
   review:
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
+      # A push mid-review queues a replacement run rather than killing the
+      # session: the running review folds the push in and stamps the commits
+      # it examined, and the gate step below lets the queued run exit without
+      # booting an agent when its HEAD is already covered.
+      cancel-in-progress: false
     runs-on: ubuntu-24.04
     environment:
       name: tend
@@ -27,6 +31,70 @@ jobs:
       issues: write
       packages: read
     steps:
+      - name: Skip when the live HEAD is already examined
+        id: gate
+        env:
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          EVENT_ACTION: ${{ github.event.action }}
+        run: |
+          # shellcheck shell=bash
+          # Pre-check for tend-review: decide whether the agent needs to boot at all.
+          #
+          # The review job runs without cancel-in-progress, so a push mid-review queues
+          # a replacement run while the live session keeps going, folds the push in, and
+          # stamps each commit it examined with a `tend-review/<pr>` commit status (review
+          # skill, "Stamp examined HEADs"). The concurrency group holds this run until
+          # that session ends; by then the live HEAD is usually stamped and there is
+          # nothing left to do. Judged against the live PR, not the event payload ? a
+          # queued run's payload is stale by construction.
+          #
+          # Inlined into the generated workflow (adopter repos have no copy of this
+          # file), so it stays self-contained: env in, GITHUB_OUTPUT out. Any write-scoped
+          # actor could forge the stamp to suppress a review; that actor can already
+          # cancel the run itself, so the merge gate ? not this check ? remains the
+          # security boundary.
+          #
+          # env: PR, EVENT_ACTION, GITHUB_REPOSITORY, GITHUB_OUTPUT, GITHUB_TOKEN
+
+          # Only `synchronize` can be a stale duplicate of an examination that already
+          # happened: `opened` has no prior run, and `reopened` / `ready_for_review`
+          # ask for a fresh pass even on a stamped commit.
+          if [ "$EVENT_ACTION" != "synchronize" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Fail open on API errors: a redundant agent run beats a silently skipped
+          # review.
+          if ! PR_INFO=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR" 2>/dev/null); then
+            echo "PR #$PR fetch failed ? proceeding without the pre-check"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          STATE=$(echo "$PR_INFO" | jq -r '.state')
+          if [ "$STATE" != "open" ]; then
+            echo "PR #$PR is $STATE ? skipping"
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # The stamp context carries the PR number: one branch can be two open PRs
+          # (same head, different base), and each base means a different diff, so an
+          # examination of one must not gate the other.
+          HEAD=$(echo "$PR_INFO" | jq -r '.head.sha')
+          STAMPED=$(gh api "repos/$GITHUB_REPOSITORY/commits/$HEAD/status?per_page=100" 2>/dev/null \
+            | jq --arg ctx "tend-review/$PR" \
+              '[.statuses[]? | select(.context == $ctx and .state == "success")] | length' \
+            || echo 0)
+          if [ "${STAMPED:-0}" -gt 0 ]; then
+            echo "HEAD $HEAD already examined (tend-review/$PR) ? skipping"
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
       # GitHub only materializes refs/pull/N/merge for mergeable PRs ? on
       # conflicting PRs it 404s and every downstream step cascades as skipped.
       # Probe first and fall back to /head so review always runs; on fallback
@@ -34,6 +102,7 @@ jobs:
       # tree.
       - name: Resolve PR checkout ref
         id: pr_ref
+        if: steps.gate.outputs.should_run == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
@@ -45,6 +114,7 @@ jobs:
             echo "::notice::refs/pull/$PR/merge unavailable (likely merge conflict); falling back to /head"
           fi
       - uses: actions/checkout@v7
+        if: steps.gate.outputs.should_run == 'true'
         with:
           ref: ${{ steps.pr_ref.outputs.ref }}
           allow-unsafe-pr-checkout: true
@@ -53,6 +123,7 @@ jobs:
           token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: max-sixty/tend/claude@X.Y.Z
+        if: steps.gate.outputs.should_run == 'true'
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
@@ -27,7 +27,19 @@ jobs:
     steps:
       - name: Check for unread notifications
         id: check
+        env:
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
+          BOT_NAME: test-bot
         run: |
+          # shellcheck shell=bash
+          # Pre-check for tend-notifications: decide whether the agent needs to boot at
+          # all, and clear inbox noise no agent run is needed for.
+          #
+          # Inlined into the generated workflow (adopter repos have no copy of this
+          # file), so it stays self-contained: env in, GITHUB_OUTPUT out.
+          #
+          # env: BOT_NAME, GITHUB_REPOSITORY, GITHUB_OUTPUT, GITHUB_TOKEN
+
           # Fetch notifications once, tolerating transient non-JSON responses.
           # GitHub occasionally returns an HTML error page (even with a 200)
           # during a brief API blip; under `bash -e` an untolerated `gh api`
@@ -95,7 +107,7 @@ jobs:
             PR_INFO=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUM" --jq '"\(.user.login) \(.state)"' 2>/dev/null) || continue
             PR_AUTHOR=${PR_INFO%% *}
             PR_STATE=${PR_INFO##* }
-            if [ "$PR_AUTHOR" = "test-bot" ] && [ "$PR_STATE" = "closed" ]; then
+            if [ "$PR_AUTHOR" = "$BOT_NAME" ] && [ "$PR_STATE" = "closed" ]; then
               gh api "notifications/threads/$tid" -X PATCH || true
             fi
           done
@@ -125,8 +137,6 @@ jobs:
           else
             echo "$COUNT processable notification(s) ? proceeding"
           fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: actions/checkout@v7
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[notifications].out
@@ -26,7 +26,19 @@ jobs:
     steps:
       - name: Check for unread notifications
         id: check
+        env:
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
+          BOT_NAME: test-bot
         run: |
+          # shellcheck shell=bash
+          # Pre-check for tend-notifications: decide whether the agent needs to boot at
+          # all, and clear inbox noise no agent run is needed for.
+          #
+          # Inlined into the generated workflow (adopter repos have no copy of this
+          # file), so it stays self-contained: env in, GITHUB_OUTPUT out.
+          #
+          # env: BOT_NAME, GITHUB_REPOSITORY, GITHUB_OUTPUT, GITHUB_TOKEN
+
           # Fetch notifications once, tolerating transient non-JSON responses.
           # GitHub occasionally returns an HTML error page (even with a 200)
           # during a brief API blip; under `bash -e` an untolerated `gh api`
@@ -94,7 +106,7 @@ jobs:
             PR_INFO=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUM" --jq '"\(.user.login) \(.state)"' 2>/dev/null) || continue
             PR_AUTHOR=${PR_INFO%% *}
             PR_STATE=${PR_INFO##* }
-            if [ "$PR_AUTHOR" = "test-bot" ] && [ "$PR_STATE" = "closed" ]; then
+            if [ "$PR_AUTHOR" = "$BOT_NAME" ] && [ "$PR_STATE" = "closed" ]; then
               gh api "notifications/threads/$tid" -X PATCH || true
             fi
           done
@@ -124,8 +136,6 @@ jobs:
           else
             echo "$COUNT processable notification(s) ? proceeding"
           fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: actions/checkout@v7
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[review].out
@@ -15,7 +15,11 @@ jobs:
   review:
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
+      # A push mid-review queues a replacement run rather than killing the
+      # session: the running review folds the push in and stamps the commits
+      # it examined, and the gate step below lets the queued run exit without
+      # booting an agent when its HEAD is already covered.
+      cancel-in-progress: false
     runs-on: ubuntu-24.04
     environment:
       name: tend
@@ -26,6 +30,70 @@ jobs:
       actions: read
       issues: write
     steps:
+      - name: Skip when the live HEAD is already examined
+        id: gate
+        env:
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          EVENT_ACTION: ${{ github.event.action }}
+        run: |
+          # shellcheck shell=bash
+          # Pre-check for tend-review: decide whether the agent needs to boot at all.
+          #
+          # The review job runs without cancel-in-progress, so a push mid-review queues
+          # a replacement run while the live session keeps going, folds the push in, and
+          # stamps each commit it examined with a `tend-review/<pr>` commit status (review
+          # skill, "Stamp examined HEADs"). The concurrency group holds this run until
+          # that session ends; by then the live HEAD is usually stamped and there is
+          # nothing left to do. Judged against the live PR, not the event payload ? a
+          # queued run's payload is stale by construction.
+          #
+          # Inlined into the generated workflow (adopter repos have no copy of this
+          # file), so it stays self-contained: env in, GITHUB_OUTPUT out. Any write-scoped
+          # actor could forge the stamp to suppress a review; that actor can already
+          # cancel the run itself, so the merge gate ? not this check ? remains the
+          # security boundary.
+          #
+          # env: PR, EVENT_ACTION, GITHUB_REPOSITORY, GITHUB_OUTPUT, GITHUB_TOKEN
+
+          # Only `synchronize` can be a stale duplicate of an examination that already
+          # happened: `opened` has no prior run, and `reopened` / `ready_for_review`
+          # ask for a fresh pass even on a stamped commit.
+          if [ "$EVENT_ACTION" != "synchronize" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Fail open on API errors: a redundant agent run beats a silently skipped
+          # review.
+          if ! PR_INFO=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR" 2>/dev/null); then
+            echo "PR #$PR fetch failed ? proceeding without the pre-check"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          STATE=$(echo "$PR_INFO" | jq -r '.state')
+          if [ "$STATE" != "open" ]; then
+            echo "PR #$PR is $STATE ? skipping"
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # The stamp context carries the PR number: one branch can be two open PRs
+          # (same head, different base), and each base means a different diff, so an
+          # examination of one must not gate the other.
+          HEAD=$(echo "$PR_INFO" | jq -r '.head.sha')
+          STAMPED=$(gh api "repos/$GITHUB_REPOSITORY/commits/$HEAD/status?per_page=100" 2>/dev/null \
+            | jq --arg ctx "tend-review/$PR" \
+              '[.statuses[]? | select(.context == $ctx and .state == "success")] | length' \
+            || echo 0)
+          if [ "${STAMPED:-0}" -gt 0 ]; then
+            echo "HEAD $HEAD already examined (tend-review/$PR) ? skipping"
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
       # GitHub only materializes refs/pull/N/merge for mergeable PRs ? on
       # conflicting PRs it 404s and every downstream step cascades as skipped.
       # Probe first and fall back to /head so review always runs; on fallback
@@ -33,6 +101,7 @@ jobs:
       # tree.
       - name: Resolve PR checkout ref
         id: pr_ref
+        if: steps.gate.outputs.should_run == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
@@ -44,6 +113,7 @@ jobs:
             echo "::notice::refs/pull/$PR/merge unavailable (likely merge conflict); falling back to /head"
           fi
       - uses: actions/checkout@v7
+        if: steps.gate.outputs.should_run == 'true'
         with:
           ref: ${{ steps.pr_ref.outputs.ref }}
           allow-unsafe-pr-checkout: true
@@ -52,6 +122,7 @@ jobs:
           token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: max-sixty/tend/codex@X.Y.Z
+        if: steps.gate.outputs.should_run == 'true'
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[review].out
@@ -65,14 +65,16 @@ jobs:
           fi
 
           # Fail open on API errors: a redundant agent run beats a silently skipped
-          # review.
-          if ! PR_INFO=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR" 2>/dev/null); then
+          # review. The parse belongs inside the guard ? GitHub sometimes returns an
+          # HTML error page with a 200 during a blip, so a zero `gh` exit doesn't mean
+          # the body is JSON, and an unguarded `jq` under the run block's `bash -e`
+          # would fail the step (fail-closed) instead.
+          if ! PR_INFO=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR" 2>/dev/null) \
+            || ! STATE=$(echo "$PR_INFO" | jq -re '.state'); then
             echo "PR #$PR fetch failed ? proceeding without the pre-check"
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-
-          STATE=$(echo "$PR_INFO" | jq -r '.state')
           if [ "$STATE" != "open" ]; then
             echo "PR #$PR is $STATE ? skipping"
             echo "should_run=false" >> "$GITHUB_OUTPUT"

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
@@ -26,7 +26,19 @@ jobs:
     steps:
       - name: Check for unread notifications
         id: check
+        env:
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
+          BOT_NAME: test-bot
         run: |
+          # shellcheck shell=bash
+          # Pre-check for tend-notifications: decide whether the agent needs to boot at
+          # all, and clear inbox noise no agent run is needed for.
+          #
+          # Inlined into the generated workflow (adopter repos have no copy of this
+          # file), so it stays self-contained: env in, GITHUB_OUTPUT out.
+          #
+          # env: BOT_NAME, GITHUB_REPOSITORY, GITHUB_OUTPUT, GITHUB_TOKEN
+
           # Fetch notifications once, tolerating transient non-JSON responses.
           # GitHub occasionally returns an HTML error page (even with a 200)
           # during a brief API blip; under `bash -e` an untolerated `gh api`
@@ -94,7 +106,7 @@ jobs:
             PR_INFO=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUM" --jq '"\(.user.login) \(.state)"' 2>/dev/null) || continue
             PR_AUTHOR=${PR_INFO%% *}
             PR_STATE=${PR_INFO##* }
-            if [ "$PR_AUTHOR" = "test-bot" ] && [ "$PR_STATE" = "closed" ]; then
+            if [ "$PR_AUTHOR" = "$BOT_NAME" ] && [ "$PR_STATE" = "closed" ]; then
               gh api "notifications/threads/$tid" -X PATCH || true
             fi
           done
@@ -124,8 +136,6 @@ jobs:
           else
             echo "$COUNT processable notification(s) ? proceeding"
           fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: actions/checkout@v7
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review].out
@@ -15,7 +15,11 @@ jobs:
   review:
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
+      # A push mid-review queues a replacement run rather than killing the
+      # session: the running review folds the push in and stamps the commits
+      # it examined, and the gate step below lets the queued run exit without
+      # booting an agent when its HEAD is already covered.
+      cancel-in-progress: false
     runs-on: ubuntu-24.04
     environment:
       name: tend
@@ -26,6 +30,70 @@ jobs:
       actions: read
       issues: write
     steps:
+      - name: Skip when the live HEAD is already examined
+        id: gate
+        env:
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          EVENT_ACTION: ${{ github.event.action }}
+        run: |
+          # shellcheck shell=bash
+          # Pre-check for tend-review: decide whether the agent needs to boot at all.
+          #
+          # The review job runs without cancel-in-progress, so a push mid-review queues
+          # a replacement run while the live session keeps going, folds the push in, and
+          # stamps each commit it examined with a `tend-review/<pr>` commit status (review
+          # skill, "Stamp examined HEADs"). The concurrency group holds this run until
+          # that session ends; by then the live HEAD is usually stamped and there is
+          # nothing left to do. Judged against the live PR, not the event payload ? a
+          # queued run's payload is stale by construction.
+          #
+          # Inlined into the generated workflow (adopter repos have no copy of this
+          # file), so it stays self-contained: env in, GITHUB_OUTPUT out. Any write-scoped
+          # actor could forge the stamp to suppress a review; that actor can already
+          # cancel the run itself, so the merge gate ? not this check ? remains the
+          # security boundary.
+          #
+          # env: PR, EVENT_ACTION, GITHUB_REPOSITORY, GITHUB_OUTPUT, GITHUB_TOKEN
+
+          # Only `synchronize` can be a stale duplicate of an examination that already
+          # happened: `opened` has no prior run, and `reopened` / `ready_for_review`
+          # ask for a fresh pass even on a stamped commit.
+          if [ "$EVENT_ACTION" != "synchronize" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Fail open on API errors: a redundant agent run beats a silently skipped
+          # review.
+          if ! PR_INFO=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR" 2>/dev/null); then
+            echo "PR #$PR fetch failed ? proceeding without the pre-check"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          STATE=$(echo "$PR_INFO" | jq -r '.state')
+          if [ "$STATE" != "open" ]; then
+            echo "PR #$PR is $STATE ? skipping"
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # The stamp context carries the PR number: one branch can be two open PRs
+          # (same head, different base), and each base means a different diff, so an
+          # examination of one must not gate the other.
+          HEAD=$(echo "$PR_INFO" | jq -r '.head.sha')
+          STAMPED=$(gh api "repos/$GITHUB_REPOSITORY/commits/$HEAD/status?per_page=100" 2>/dev/null \
+            | jq --arg ctx "tend-review/$PR" \
+              '[.statuses[]? | select(.context == $ctx and .state == "success")] | length' \
+            || echo 0)
+          if [ "${STAMPED:-0}" -gt 0 ]; then
+            echo "HEAD $HEAD already examined (tend-review/$PR) ? skipping"
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
       # GitHub only materializes refs/pull/N/merge for mergeable PRs ? on
       # conflicting PRs it 404s and every downstream step cascades as skipped.
       # Probe first and fall back to /head so review always runs; on fallback
@@ -33,6 +101,7 @@ jobs:
       # tree.
       - name: Resolve PR checkout ref
         id: pr_ref
+        if: steps.gate.outputs.should_run == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
@@ -44,6 +113,7 @@ jobs:
             echo "::notice::refs/pull/$PR/merge unavailable (likely merge conflict); falling back to /head"
           fi
       - uses: actions/checkout@v7
+        if: steps.gate.outputs.should_run == 'true'
         with:
           ref: ${{ steps.pr_ref.outputs.ref }}
           allow-unsafe-pr-checkout: true
@@ -52,6 +122,7 @@ jobs:
           token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: max-sixty/tend/claude@X.Y.Z
+        if: steps.gate.outputs.should_run == 'true'
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review].out
@@ -65,14 +65,16 @@ jobs:
           fi
 
           # Fail open on API errors: a redundant agent run beats a silently skipped
-          # review.
-          if ! PR_INFO=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR" 2>/dev/null); then
+          # review. The parse belongs inside the guard ? GitHub sometimes returns an
+          # HTML error page with a 200 during a blip, so a zero `gh` exit doesn't mean
+          # the body is JSON, and an unguarded `jq` under the run block's `bash -e`
+          # would fail the step (fail-closed) instead.
+          if ! PR_INFO=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR" 2>/dev/null) \
+            || ! STATE=$(echo "$PR_INFO" | jq -re '.state'); then
             echo "PR #$PR fetch failed ? proceeding without the pre-check"
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-
-          STATE=$(echo "$PR_INFO" | jq -r '.state')
           if [ "$STATE" != "open" ]; then
             echo "PR #$PR is $STATE ? skipping"
             echo "should_run=false" >> "$GITHUB_OUTPUT"

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
@@ -26,7 +26,19 @@ jobs:
     steps:
       - name: Check for unread notifications
         id: check
+        env:
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
+          BOT_NAME: test-bot
         run: |
+          # shellcheck shell=bash
+          # Pre-check for tend-notifications: decide whether the agent needs to boot at
+          # all, and clear inbox noise no agent run is needed for.
+          #
+          # Inlined into the generated workflow (adopter repos have no copy of this
+          # file), so it stays self-contained: env in, GITHUB_OUTPUT out.
+          #
+          # env: BOT_NAME, GITHUB_REPOSITORY, GITHUB_OUTPUT, GITHUB_TOKEN
+
           # Fetch notifications once, tolerating transient non-JSON responses.
           # GitHub occasionally returns an HTML error page (even with a 200)
           # during a brief API blip; under `bash -e` an untolerated `gh api`
@@ -94,7 +106,7 @@ jobs:
             PR_INFO=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUM" --jq '"\(.user.login) \(.state)"' 2>/dev/null) || continue
             PR_AUTHOR=${PR_INFO%% *}
             PR_STATE=${PR_INFO##* }
-            if [ "$PR_AUTHOR" = "test-bot" ] && [ "$PR_STATE" = "closed" ]; then
+            if [ "$PR_AUTHOR" = "$BOT_NAME" ] && [ "$PR_STATE" = "closed" ]; then
               gh api "notifications/threads/$tid" -X PATCH || true
             fi
           done
@@ -124,8 +136,6 @@ jobs:
           else
             echo "$COUNT processable notification(s) ? proceeding"
           fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: actions/checkout@v7
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review].out
@@ -15,7 +15,11 @@ jobs:
   review:
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
+      # A push mid-review queues a replacement run rather than killing the
+      # session: the running review folds the push in and stamps the commits
+      # it examined, and the gate step below lets the queued run exit without
+      # booting an agent when its HEAD is already covered.
+      cancel-in-progress: false
     runs-on: ubuntu-24.04
     environment:
       name: tend
@@ -26,16 +30,82 @@ jobs:
       actions: read
       issues: write
     steps:
+      - name: Skip when the live HEAD is already examined
+        id: gate
+        env:
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          EVENT_ACTION: ${{ github.event.action }}
+        run: |
+          # shellcheck shell=bash
+          # Pre-check for tend-review: decide whether the agent needs to boot at all.
+          #
+          # The review job runs without cancel-in-progress, so a push mid-review queues
+          # a replacement run while the live session keeps going, folds the push in, and
+          # stamps each commit it examined with a `tend-review/<pr>` commit status (review
+          # skill, "Stamp examined HEADs"). The concurrency group holds this run until
+          # that session ends; by then the live HEAD is usually stamped and there is
+          # nothing left to do. Judged against the live PR, not the event payload ? a
+          # queued run's payload is stale by construction.
+          #
+          # Inlined into the generated workflow (adopter repos have no copy of this
+          # file), so it stays self-contained: env in, GITHUB_OUTPUT out. Any write-scoped
+          # actor could forge the stamp to suppress a review; that actor can already
+          # cancel the run itself, so the merge gate ? not this check ? remains the
+          # security boundary.
+          #
+          # env: PR, EVENT_ACTION, GITHUB_REPOSITORY, GITHUB_OUTPUT, GITHUB_TOKEN
+
+          # Only `synchronize` can be a stale duplicate of an examination that already
+          # happened: `opened` has no prior run, and `reopened` / `ready_for_review`
+          # ask for a fresh pass even on a stamped commit.
+          if [ "$EVENT_ACTION" != "synchronize" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Fail open on API errors: a redundant agent run beats a silently skipped
+          # review.
+          if ! PR_INFO=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR" 2>/dev/null); then
+            echo "PR #$PR fetch failed ? proceeding without the pre-check"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          STATE=$(echo "$PR_INFO" | jq -r '.state')
+          if [ "$STATE" != "open" ]; then
+            echo "PR #$PR is $STATE ? skipping"
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # The stamp context carries the PR number: one branch can be two open PRs
+          # (same head, different base), and each base means a different diff, so an
+          # examination of one must not gate the other.
+          HEAD=$(echo "$PR_INFO" | jq -r '.head.sha')
+          STAMPED=$(gh api "repos/$GITHUB_REPOSITORY/commits/$HEAD/status?per_page=100" 2>/dev/null \
+            | jq --arg ctx "tend-review/$PR" \
+              '[.statuses[]? | select(.context == $ctx and .state == "success")] | length' \
+            || echo 0)
+          if [ "${STAMPED:-0}" -gt 0 ]; then
+            echo "HEAD $HEAD already examined (tend-review/$PR) ? skipping"
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
       # Two checkouts: `setup:` runs against the base tree, and the PR's own
       # tree lands after it. Setup executes as the runner user, outside the
       # containment the harness builds for the contributor's code.
       - uses: actions/checkout@v7
+        if: steps.gate.outputs.should_run == 'true'
         with:
           fetch-depth: 0
           fetch-tags: true
           token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: astral-sh/setup-uv@v6
+        if: steps.gate.outputs.should_run == 'true'
 
       # GitHub only materializes refs/pull/N/merge for mergeable PRs ? on
       # conflicting PRs it 404s and every downstream step cascades as skipped.
@@ -44,6 +114,7 @@ jobs:
       # tree.
       - name: Resolve PR checkout ref
         id: pr_ref
+        if: steps.gate.outputs.should_run == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
@@ -55,6 +126,7 @@ jobs:
             echo "::notice::refs/pull/$PR/merge unavailable (likely merge conflict); falling back to /head"
           fi
       - uses: actions/checkout@v7
+        if: steps.gate.outputs.should_run == 'true'
         with:
           ref: ${{ steps.pr_ref.outputs.ref }}
           allow-unsafe-pr-checkout: true
@@ -64,6 +136,7 @@ jobs:
           token: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: max-sixty/tend/claude@X.Y.Z
+        if: steps.gate.outputs.should_run == 'true'
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review].out
@@ -65,14 +65,16 @@ jobs:
           fi
 
           # Fail open on API errors: a redundant agent run beats a silently skipped
-          # review.
-          if ! PR_INFO=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR" 2>/dev/null); then
+          # review. The parse belongs inside the guard ? GitHub sometimes returns an
+          # HTML error page with a 200 during a blip, so a zero `gh` exit doesn't mean
+          # the body is JSON, and an unguarded `jq` under the run block's `bash -e`
+          # would fail the step (fail-closed) instead.
+          if ! PR_INFO=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR" 2>/dev/null) \
+            || ! STATE=$(echo "$PR_INFO" | jq -re '.state'); then
             echo "PR #$PR fetch failed ? proceeding without the pre-check"
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-
-          STATE=$(echo "$PR_INFO" | jq -r '.state')
           if [ "$STATE" != "open" ]; then
             echo "PR #$PR is $STATE ? skipping"
             echo "should_run=false" >> "$GITHUB_OUTPUT"

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -526,6 +526,32 @@ def test_review_without_setup_checks_out_once(tmp_path: Path) -> None:
     assert "clean" not in checkouts[0]["with"]
 
 
+def test_review_queues_pushes_behind_a_gate(tmp_path: Path) -> None:
+    """A push mid-review queues a replacement run; the gate step decides
+    whether it boots an agent.
+
+    The running session folds the push in and stamps examined commits, so the
+    queued run's work is usually already done. That only holds if the gate is
+    the first step and everything after it — checkouts, setup, the agent — is
+    conditioned on its verdict; an ungated step would run (and bill) on every
+    replaced event.
+    """
+    extra = "setup:\n  - run: npm ci\n"
+    cfg = Config.load(_minimal_config(tmp_path, extra))
+    workflows = {wf.filename: wf for wf in generate_all(cfg)}
+    data = yaml.safe_load(workflows["tend-review.yaml"].content)
+    job = data["jobs"]["review"]
+
+    assert job["concurrency"]["cancel-in-progress"] is False
+    steps = job["steps"]
+    assert steps[0].get("id") == "gate"
+    assert "tend-review/$PR" in steps[0]["run"]
+    for step in steps[1:]:
+        assert step.get("if") == "steps.gate.outputs.should_run == 'true'", (
+            f"ungated step after the gate: {step}"
+        )
+
+
 def test_setup_raw_rejected_with_migration_hint(tmp_path: Path) -> None:
     """`raw` was removed in favor of structured steps — the error message
     must point users at the two supported paths so they can migrate."""

--- a/generator/tests/test_shared_steps.py
+++ b/generator/tests/test_shared_steps.py
@@ -891,7 +891,7 @@ case "$2" in
     [ -n "${FAIL_PR:-}" ] && exit 1
     cat "$PR_JSON"
     ;;
-  repos/*/commits/*/status\?per_page=100)
+  repos/*/commits/*/status\\?per_page=100)
     [ -n "${FAIL_STATUS:-}" ] && exit 1
     cat "$STATUS_JSON"
     ;;
@@ -1004,6 +1004,20 @@ def test_review_gate_fails_open_on_api_errors(
     """An API error must boot the agent, not silently skip the review."""
     _stamp(gate_env, {"context": "tend-review/7", "state": "success"})
     gate_env[failure] = "1"
+
+    result = _run_gate(gate_env)
+
+    assert result.returncode == 0, result.stderr
+    assert _should_run(gate_env) == "true"
+
+
+def test_review_gate_fails_open_on_an_html_200(gate_env: dict[str, str]) -> None:
+    """A GitHub blip can return an HTML error page with a 200: `gh` exits zero
+    but the body isn't JSON. The parse must stay inside the fail-open guard —
+    unguarded under the run block's `bash -e` it fails the step, skipping the
+    whole review (fail-closed)."""
+    _stamp(gate_env, {"context": "tend-review/7", "state": "success"})
+    Path(gate_env["PR_JSON"]).write_text("<html>oops</html>")
 
     result = _run_gate(gate_env)
 

--- a/generator/tests/test_shared_steps.py
+++ b/generator/tests/test_shared_steps.py
@@ -1,10 +1,11 @@
-"""Tests for the composite actions' shared step bodies (shared/steps/*.sh).
+"""Tests for the workflow step bodies shipped as shell scripts.
 
-These scripts run as `bash <script>` inside both harness actions, so a
-non-zero exit fails the step and turns an otherwise-successful agent run red.
-They aren't part of the generator package; the tests live here because this is
-the repo's only Python suite, and shellcheck (pre-commit) can't catch runtime
-behaviour.
+Two homes, one testing need: the composite actions' shared steps
+(shared/steps/*.sh) run as `bash <script>` inside both harness actions, and
+the generator's template scripts (generator/src/tend/templates/*.sh) are
+inlined into generated workflows. In both, a non-zero exit fails the step, and
+shellcheck (pre-commit) can't catch runtime behaviour; this is the repo's only
+Python suite, so the tests live here.
 """
 
 from __future__ import annotations
@@ -18,6 +19,18 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 MARK_NOTIFICATION_READ = REPO_ROOT / "shared" / "steps" / "mark-notification-read.sh"
+
+
+def _fake_bin(tmp_path: Path, **scripts: str) -> Path:
+    """Write executable command stand-ins (gh, date, …); return the PATH dir."""
+    bindir = tmp_path / "fakebin"
+    bindir.mkdir()
+    for name, body in scripts.items():
+        path = bindir / name
+        path.write_text(body)
+        path.chmod(0o755)
+    return bindir
+
 
 # `gh api` stand-in. Records every invocation so a test can assert which calls
 # the script made, and fails the run-metadata fetch when FAIL_RUN_META is set.
@@ -43,11 +56,7 @@ esac
 @pytest.fixture
 def gh_env(tmp_path: Path) -> dict[str, str]:
     """A fake `gh` on PATH plus the Actions env the script reads."""
-    bindir = tmp_path / "fakebin"
-    bindir.mkdir()
-    gh = bindir / "gh"
-    gh.write_text(FAKE_GH)
-    gh.chmod(0o755)
+    bindir = _fake_bin(tmp_path, gh=FAKE_GH)
 
     event = tmp_path / "event.json"
     event.write_text(json.dumps({"issue": {"number": 7}}))
@@ -259,16 +268,9 @@ def _closed_event(
 @pytest.fixture
 def rate_limit_env(tmp_path: Path) -> dict[str, str]:
     """Fake gh/date/sleep on PATH, plus the Actions env the preflight reads."""
-    bindir = tmp_path / "fakebin"
-    bindir.mkdir()
-    for name, body in (
-        ("gh", FAKE_GH_RATE_LIMIT),
-        ("date", FAKE_DATE),
-        ("sleep", FAKE_SLEEP),
-    ):
-        path = bindir / name
-        path.write_text(body)
-        path.chmod(0o755)
+    bindir = _fake_bin(
+        tmp_path, gh=FAKE_GH_RATE_LIMIT, date=FAKE_DATE, sleep=FAKE_SLEEP
+    )
 
     # Both the fake gh and the script itself shell out to jq.
     jq = shutil.which("jq")
@@ -649,3 +651,136 @@ def test_rate_limit_reopens_rather_than_refiling(
     assert not any(c.startswith("issue create") for c in calls), (
         f"filed a second pause issue instead of reopening #42: {calls}"
     )
+
+
+# ---------------------------------------------------------------------------
+# review-gate.sh — the tend-review pre-check inlined into generated workflows
+# ---------------------------------------------------------------------------
+
+REVIEW_GATE = REPO_ROOT / "generator" / "src" / "tend" / "templates" / "review-gate.sh"
+
+FAKE_GH_REVIEW_GATE = """#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$GH_CALLS"
+case "$2" in
+  repos/*/pulls/*)
+    [ -n "${FAIL_PR:-}" ] && exit 1
+    cat "$PR_JSON"
+    ;;
+  repos/*/commits/*/status\?per_page=100)
+    [ -n "${FAIL_STATUS:-}" ] && exit 1
+    cat "$STATUS_JSON"
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+"""
+
+
+@pytest.fixture
+def gate_env(tmp_path: Path) -> dict[str, str]:
+    """A fake `gh` on PATH plus the workflow env the gate script reads."""
+    bindir = _fake_bin(tmp_path, gh=FAKE_GH_REVIEW_GATE)
+
+    pr = tmp_path / "pr.json"
+    pr.write_text(json.dumps({"state": "open", "head": {"sha": "abc123"}}))
+    status = tmp_path / "status.json"
+    status.write_text(json.dumps({"statuses": []}))
+
+    return {
+        "PATH": f"{bindir}:/usr/bin:/bin",
+        "GH_CALLS": str(tmp_path / "gh-calls.log"),
+        "GITHUB_OUTPUT": str(tmp_path / "output.txt"),
+        "GITHUB_REPOSITORY": "owner/repo",
+        "PR": "7",
+        "EVENT_ACTION": "synchronize",
+        "PR_JSON": str(pr),
+        "STATUS_JSON": str(status),
+    }
+
+
+def _run_gate(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    # `bash -e` mirrors the shell GitHub Actions gives a `run:` block.
+    return subprocess.run(
+        ["bash", "-e", str(REVIEW_GATE)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _should_run(env: dict[str, str]) -> str:
+    lines = Path(env["GITHUB_OUTPUT"]).read_text().splitlines()
+    values = [line.split("=", 1)[1] for line in lines if line.startswith("should_run=")]
+    assert len(values) == 1, f"expected exactly one should_run, got: {lines}"
+    return values[0]
+
+
+def _stamp(env: dict[str, str], *statuses: dict[str, str]) -> None:
+    Path(env["STATUS_JSON"]).write_text(json.dumps({"statuses": list(statuses)}))
+
+
+def test_review_gate_skips_a_stamped_head(gate_env: dict[str, str]) -> None:
+    """A `synchronize` whose live HEAD carries this PR's stamp is a no-op."""
+    _stamp(gate_env, {"context": "tend-review/7", "state": "success"})
+
+    result = _run_gate(gate_env)
+
+    assert result.returncode == 0, result.stderr
+    assert _should_run(gate_env) == "false"
+
+
+def test_review_gate_runs_when_head_is_unstamped(gate_env: dict[str, str]) -> None:
+    """Foreign contexts don't gate: another PR's stamp (one branch can be two
+    open PRs with different bases) and a non-success state both leave the
+    review to run."""
+    _stamp(
+        gate_env,
+        {"context": "tend-review/8", "state": "success"},
+        {"context": "tend-review/7", "state": "pending"},
+        {"context": "ci/tests", "state": "success"},
+    )
+
+    result = _run_gate(gate_env)
+
+    assert result.returncode == 0, result.stderr
+    assert _should_run(gate_env) == "true"
+
+
+def test_review_gate_only_gates_synchronize(gate_env: dict[str, str]) -> None:
+    """`opened`/`reopened`/`ready_for_review` always run — with no API calls,
+    so a GitHub blip can't fail the ungated path."""
+    gate_env["EVENT_ACTION"] = "ready_for_review"
+    _stamp(gate_env, {"context": "tend-review/7", "state": "success"})
+
+    result = _run_gate(gate_env)
+
+    assert result.returncode == 0, result.stderr
+    assert _should_run(gate_env) == "true"
+    assert not Path(gate_env["GH_CALLS"]).exists(), "ungated event still hit the API"
+
+
+def test_review_gate_skips_closed_prs(gate_env: dict[str, str]) -> None:
+    """A queued run whose PR was merged or closed while it waited is a no-op."""
+    Path(gate_env["PR_JSON"]).write_text(
+        json.dumps({"state": "closed", "head": {"sha": "abc123"}})
+    )
+
+    result = _run_gate(gate_env)
+
+    assert result.returncode == 0, result.stderr
+    assert _should_run(gate_env) == "false"
+
+
+@pytest.mark.parametrize("failure", ["FAIL_PR", "FAIL_STATUS"])
+def test_review_gate_fails_open_on_api_errors(
+    gate_env: dict[str, str], failure: str
+) -> None:
+    """An API error must boot the agent, not silently skip the review."""
+    _stamp(gate_env, {"context": "tend-review/7", "state": "success"})
+    gate_env[failure] = "1"
+
+    result = _run_gate(gate_env)
+
+    assert result.returncode == 0, result.stderr
+    assert _should_run(gate_env) == "true"

--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -239,7 +239,7 @@ Use a cheap subagent (e.g. Haiku / gpt-mini) and a prompt like:
 > **Negative outcome signals** — report any sign the bot's output was rejected, corrected, or ignored. Common shapes (use judgment for signals not listed):
 > - Human reviewer posted CHANGES_REQUESTED after bot approved
 > - PR closed without merge shortly after bot approved
-> - Bot posted no review despite a `tend-review` run completing on an open PR
+> - Bot posted no review despite a `tend-review` run completing on an open PR — first check the run wasn't gate-skipped (its pre-check found the live HEAD already stamped `tend-review/<pr>`; agent step skipped, no session-log artifacts). A gate-skipped run is expected silence: a sibling session covered the push.
 > - Subsequent commits reversed changes the bot approved
 > - Bot-closed issue was reopened
 > - Fix commit was reverted or CI still failing after bot pushed

--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -53,7 +53,7 @@ LAST_REVIEW_SHA=$(gh api --paginate "repos/$REPO/pulls/<number>/reviews" \
          | last | .commit_id // empty')
 ```
 
-If `LAST_REVIEW_SHA == HEAD_SHA`, this commit has already been reviewed — exit silently. Two exceptions: an unanswered conversation question directed at the bot (check below), or `EVENT_ACTION == "ready_for_review"` (the PR just transitioned out of draft, so any prior review was a draft-mode review and the author is now asking for a full one — proceed).
+If `LAST_REVIEW_SHA == HEAD_SHA`, this commit has already been reviewed — finish at step 9 without posting. Two exceptions: an unanswered conversation question directed at the bot (check below), or `EVENT_ACTION == "ready_for_review"` (the PR just transitioned out of draft, so any prior review was a draft-mode review and the author is now asking for a full one — proceed).
 
 If the bot reviewed a previous commit (`LAST_REVIEW_SHA` exists but differs from `HEAD_SHA`), judge what was pushed since. Read two signals, both leak-free against base-merges:
 
@@ -77,7 +77,7 @@ git fetch --no-tags --quiet origin "$BASE_SHA" 2>/dev/null || true
 git log --no-merges --numstat --format='%h %s' "$LAST_REVIEW_SHA..$HEAD_SHA" --not "$BASE_SHA"
 ```
 
-If the incremental changes are trivial, skip the full review — go directly to step 7 to resolve any bot threads addressed by the new changes. After resolving threads: if the most recent bot review was a COMMENT that flagged issues, and those issues are now addressed, submit an APPROVE with an empty body so the PR isn't left in limbo. Otherwise do not submit a new review — the existing one stands. Do NOT proceed to steps 2–6. Rough heuristic: changes under ~20 added+deleted lines that don't introduce new functions, types, or control flow are typically trivial.
+If the incremental changes are trivial, skip the full review — go directly to step 7 to resolve any bot threads addressed by the new changes. After resolving threads: if the most recent bot review was a COMMENT that flagged issues, and those issues are now addressed, submit an APPROVE with an empty body so the PR isn't left in limbo. Otherwise do not submit a new review — the existing one stands. Do NOT proceed to steps 2–6; finish at step 9. Rough heuristic: changes under ~20 added+deleted lines that don't introduce new functions, types, or control flow are typically trivial.
 
 **Commit and PR authorship do not affect review behavior.** Apply the same trivial-vs-substantive heuristic regardless of who pushed the new commits. When `tend-notifications` or `tend-ci-fix` pushes a fix to a human-authored PR, reviewing (and re-approving) the updated state is expected — the reviewer role is independent of commit authorship.
 
@@ -113,7 +113,7 @@ gh api graphql -F query=@/tmp/inline-prev.graphql -f owner="$OWNER" -f repo="$NA
         | {path, line, body}"
 ```
 
-**Apply the sibling-workflow dedup rule from `running-in-ci`** to both the review body and inline comments. If a prior bot comment in the conversation already covers a point — a previous review on this or an earlier commit, a `tend-mention` reply, a `tend-triage` post, anything from a tend workflow — omit it from this review and stick to diff-grounded findings. If that leaves no new diff-grounded finding on the incremental changes and the only outstanding concern is a still-unresolved thread from an earlier bot review, do not post a new review: that thread already blocks the PR, and restating "the prior thread still applies" on every push is noise. Resolve any bot threads the new commits addressed (step 7), then exit without posting. A fresh review is warranted only when the incremental diff introduces a new finding, or resolves the last open one (then approve with an empty body). When concurrent runs race (a new push while the first run is still responding), both see the same unanswered question — check whether a bot reply exists after the question's timestamp before answering. Address remaining unanswered questions in the review body (not via `gh pr comment`).
+**Apply the sibling-workflow dedup rule from `running-in-ci`** to both the review body and inline comments. If a prior bot comment in the conversation already covers a point — a previous review on this or an earlier commit, a `tend-mention` reply, a `tend-triage` post, anything from a tend workflow — omit it from this review and stick to diff-grounded findings. If that leaves no new diff-grounded finding on the incremental changes and the only outstanding concern is a still-unresolved thread from an earlier bot review, do not post a new review: that thread already blocks the PR, and restating "the prior thread still applies" on every push is noise. Resolve any bot threads the new commits addressed (step 7), then finish at step 9 without posting. A fresh review is warranted only when the incremental diff introduces a new finding, or resolves the last open one (then approve with an empty body). When concurrent runs race (a new push while the first run is still responding), both see the same unanswered question — check whether a bot reply exists after the question's timestamp before answering. Address remaining unanswered questions in the review body (not via `gh pr comment`).
 
 #### Draft mode
 
@@ -126,7 +126,7 @@ If `IS_DRAFT == "true"`, run a lighter review:
 - Skip step 6 (CI monitoring) — drafts churn; CI failures are the author's to chase.
 - Skip step 8 (push fixes) — never push to a WIP branch.
 
-Steps 1, 3, 4 (without duplication scan), 5 (COMMENT path), and 7 still apply. Stay silent if there's nothing actionable; don't post a "looks fine" comment.
+Steps 1, 3, 4 (without duplication scan), 5 (COMMENT path), 7, and 9 still apply. Stay silent if there's nothing actionable; don't post a "looks fine" comment.
 
 ### 2. Check for overlapping PRs
 
@@ -225,7 +225,7 @@ REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
 BOT_LOGIN=$(gh api user --jq '.login')
 read -r CURRENT_HEAD PR_STATE < <(gh pr view <number> --json commits,state \
   --jq '"\(.commits[-1].oid) \(.state)"')
-[ "$CURRENT_HEAD" != "$HEAD_SHA" ] && echo "HEAD moved — skipping" && exit 0
+[ "$CURRENT_HEAD" != "$HEAD_SHA" ] && echo "HEAD moved — fold in per step 9, then re-run these mechanics against $CURRENT_HEAD" && exit 0
 [ "$PR_STATE" != "OPEN" ] && echo "PR is $PR_STATE — skipping" && exit 0
 
 # Same substantive-review filter as step 1, and for the same reason: a synthetic
@@ -241,10 +241,12 @@ ALREADY_POSTED=$(gh api --paginate "repos/$REPO/pulls/<number>/reviews" \
     'add | [.[] | select(.user.login == $bot and .commit_id == $head)
                 | select((.body | length) > 0 or (.id | IN($sub[])) or .state == "APPROVED")]
          | last | .submitted_at // empty')
-[ -n "$ALREADY_POSTED" ] && echo "Already reviewed — skipping" && exit 0
+[ -n "$ALREADY_POSTED" ] && echo "Already reviewed — finish at step 9" && exit 0
 ```
 
 The state check matters because the maintainer may close (or another path may merge) the PR while a review is in flight — `pull_request_target` reviews routinely run for 5–10 minutes between fetching `HEAD_SHA` and posting the verdict, and HEAD doesn't move when the PR is closed. Approving a CLOSED or MERGED PR creates a confusing artifact (an approval timestamped after the close).
+
+When HEAD moved, don't discard the assembled review — no other run will pick it up: the concurrency group holds the queued replacement until this session ends, and the pre-check skips it once step 9 stamps what this session examined. Instead judge the new commits with step 1's incremental logic, drop findings they addressed, fold in any new ones, and post one review against `$CURRENT_HEAD` (re-run these mechanics against it first).
 
 **Before APPROVE specifically**, also peek the current check rollup on `HEAD_SHA`. If any check has reached terminal `FAILURE`, do not emit an empty-body APPROVE — the close-out reads as the bot rubber-stamping over the visibly red signal:
 
@@ -265,7 +267,7 @@ PENDING=$(gh pr view <number> --json statusCheckRollup \
 **Don't treat a mid-flight rollup as settled.** A `FAILURE` co-existing with checks still in flight (`$PENDING > 0`) is often a *stale cancellation-cascade* artifact, not a real failure: when several events fire near-simultaneously (e.g. Dependabot opening a PR), the `tests` concurrency group cancels all but the latest, and a cancelled contributor makes an `if: always()` merge-gate omnibus (like PRQL's `check-ok-to-merge`) resolve to conclusion `FAILURE` — *not* `cancelled`, so it slips past the post-approve cancellation awareness below and reads as red. A fresh replacement run is already in flight and will re-register the omnibus. So decide on the **settled** rollup:
 
 - **`$FAILED` set and `$PENDING > 0`** — the rollup hasn't settled. Foreground-poll until non-own checks are terminal (the Step 6 / `running-in-ci` CI-monitoring loop), then re-peek `$FAILED`. Judge the settled state, not the mid-flight snapshot — a stale cancellation-cascade `FAILURE` clears once the replacement run's omnibus goes green.
-- **`$FAILED` set and `$PENDING == 0`** — genuine terminal red. Skip the close-out (`exit 0`). But if **no prior substantive bot review** stands on this PR, don't exit fully silent or leave only a `+1` reaction — a clean external-dependency bump then carries zero review signal. Post a brief COMMENT recording the diff assessment and why approval is held (e.g. "Diff is a correct, mechanical dependency bump; holding APPROVE because `check-ok-to-merge` is red."). Any earlier substantive review (e.g. a COMMENT with inline suggestions) already stands as the active verdict — leave it. On a bot PR where you intend to push the fix yourself (step 8), post that COMMENT **before** pushing — the push cancels this session.
+- **`$FAILED` set and `$PENDING == 0`** — genuine terminal red. Skip the close-out and finish at step 9. But if **no prior substantive bot review** stands on this PR, don't exit fully silent or leave only a `+1` reaction — a clean external-dependency bump then carries zero review signal. Post a brief COMMENT recording the diff assessment and why approval is held (e.g. "Diff is a correct, mechanical dependency bump; holding APPROVE because `check-ok-to-merge` is red."). Any earlier substantive review (e.g. a COMMENT with inline suggestions) already stands as the active verdict — leave it. On a bot PR where you intend to push the fix yourself (step 8), post that COMMENT before pushing, while the rollup it describes is still the current one.
 - **`$FAILED` empty** — proceed with APPROVE.
 
 Step 6's "approve, foreground-poll CI, dismiss if a check fails" pattern only recovers while the session is still alive — the job timeout or a poll cap can leave a post-approve failure undismissed and the PR carrying a misleading APPROVED state. A synchronous pre-APPROVE peek catches the case where the failure is already in the rollup — including non-required checks like `codecov/patch` that an overlay treats as a merge gate. Waiting for the rollup to settle before this peek is what keeps a superseded red from being mistaken for a real one.
@@ -353,9 +355,9 @@ Prevention: before writing any inline comment, verify the target line falls insi
 
 ### 6. Monitor CI
 
-If you **stayed silent** (no review posted, nothing to dismiss), end the session — there's no follow-up gated on the CI result. Don't background-poll: per `/tend-ci-runner:running-in-ci` under "End the turn only when work is shipped", the completion notification isn't reliably delivered to a CI session.
+If you **stayed silent** (no review posted, nothing to dismiss), skip to step 9 — there's no follow-up gated on the CI result. Don't background-poll: per `/tend-ci-runner:running-in-ci` under "End the turn only when work is shipped", the completion notification isn't reliably delivered to a CI session.
 
-If you **approved**, the dismissal-on-failure is a gated follow-up. Foreground-poll using the recipe in `/tend-ci-runner:running-in-ci` under "CI Monitoring" (don't use `run_in_background`).
+If you **approved**, the dismissal-on-failure is a gated follow-up. Foreground-poll using the recipe in `/tend-ci-runner:running-in-ci` under "CI Monitoring" (don't use `run_in_background`). If the PR head moves while polling — a new push landed — stop polling the stale commit and fold the push in per step 9; resume monitoring on the new HEAD if it earns a verdict of its own.
 
 Then handle the outcome:
 
@@ -436,9 +438,7 @@ Outdated comments (null line) are best-effort — skip if the original context c
 
 ### 8. Push fixes
 
-**A push cancels this session — make it the last thing you do.** `tend-review` triggers on `synchronize` with `cancel-in-progress: true` on a per-PR group, so pushing to the branch under review starts a replacement run that cancels this one within seconds, mid-tool-call. The replacement run starts cold against the new HEAD and does not resume this review, so anything still pending at push time is lost. Submit the review (step 5) and resolve threads (step 7) **before** pushing, and say in the review body that the fix is coming rather than planning to review after.
-
-This is the one exception to `running-in-ci`'s "a pushed fix is always gated" rule: you cannot poll the pushed fix's CI, because the session ends before it settles — and nothing else reliably picks it up. The replacement run's pre-flight reads reviews and the diff, never the rollup, and a small fix commit takes the trivial-skip path that bypasses steps 2–6. So name the pushed fix as CI-unverified in the review body, which keeps the gap visible in the thread.
+Pushing to the branch under review fires `synchronize`, which queues a replacement run behind this session rather than cancelling it. Submit the review (step 5) and resolve threads (step 7) before pushing, so the review documents the code the fix responds to. Then treat your own push like any other fold-in (step 9): judge it with step 1's trivial-skip heuristic — you already know the increment — and poll its CI to green per `running-in-ci`'s "a pushed fix is always gated" before ending the session.
 
 **Bot PRs** (Dependabot, renovate, etc.): There is no human author to act on feedback, so a review that only describes the fix leaves the PR red and pushes the work onto a maintainer — the opposite of the point. If you can articulate the fix, apply it: commit and push it to the PR branch. "Not a one-token change" and "more than one syntactically valid form exists" are **not** reasons to defer — pick the option most consistent with the surrounding code and the repo's existing conventions, push it, and note any alternative in the review. The only bar for deferring is that *no defensible default exists*: a genuine semantic ambiguity that needs maintainer intent, not merely a fix that took thought to derive. If the review already worked out the answer, that answer is pushable. Rebase onto the latest target branch first if the branch is behind.
 
@@ -450,3 +450,24 @@ git add <files>
 git commit -m "fix: <description>"
 git push
 ```
+
+### 9. Stamp examined HEADs, then re-check for a new push
+
+Every session on an open PR ends here, whichever path it took — a posted review, an approval, a pushed fix, or silence. A PR found CLOSED or MERGED skips it: the workflow's pre-check already skips closed PRs, so a stamp there gates nothing.
+
+**Stamp each HEAD this session fully examined**, whatever the verdict was. Fully examined means the flow above ran against that commit; a stamp on a commit you only glanced at suppresses its review, which is worse than the redundant agent boot an unstamped examination costs.
+
+```bash
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+# HEAD_SHA: the commit this session examined — after a fold-in, re-point it at
+# the folded-in commit. Never derive it from the live head here: in the race
+# window a fresh push is a head this session hasn't reviewed.
+gh api "repos/$REPO/statuses/$HEAD_SHA" \
+  -f state=success -f context="tend-review/<number>" \
+  -f description="examined by tend-review" \
+  -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+```
+
+The generated workflow holds a replacement run queued by any mid-session push until this session ends; a pre-check then reads this stamp off the live HEAD and skips the agent when it's present. The context carries the PR number because one branch can be two open PRs with different bases — an examination of one must not gate the other.
+
+**Then re-fetch the live HEAD and draft state.** If the PR left draft mode during the session, run the full non-draft flow on the current HEAD before stamping it: the `ready_for_review` run that would have done so may sit queued behind this session and be replaced by a later push's run, which the stamp would gate out. If HEAD moved, fold the push in rather than leaving it to the queued run's cold start: judge the increment with step 1's incremental logic (the trivial-skip heuristic applies), act on the result — a review per step 5, thread resolution per step 7, or silence — stamp the commit, and re-check again. After three fold-ins, end the session leaving the newest HEAD unstamped; the queued run picks it up with a fresh view.

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -181,14 +181,14 @@ Always use `git push` without specifying a remote — `gh pr checkout` configure
 
 If pushing fails (fork PR with edits disabled), fall back to posting code snippets in a comment. Don't reference commit SHAs from temporary branches — post code inline.
 
-### Batch the push — every push restarts the reviewer
+### Batch the push — every push costs a reviewer round
 
-`tend-review` triggers on `synchronize` under a per-PR concurrency group at `cancel-in-progress: true`, so each push to a PR starts a fresh review run and cancels the one already running. Push twice in quick succession and the first reviewer is killed at startup having produced nothing; push after several minutes and it dies with whatever review it had assembled unsubmitted.
+`tend-review` triggers on `synchronize` under a per-PR concurrency group without cancel-in-progress: a push while a review session runs queues a replacement run, and the running session folds the push into its review before ending (review skill, step 9). Nothing is killed, but each push still costs a round — a fold-in extends the live session, and an unabsorbed push boots a fresh one.
 
 - **Commit everything before `gh pr create`.** Changelog entries, test pins, and formatting fixups belong in the initial push, not a follow-up thirty seconds later.
 - **Make the commits, then push once** — not a push after each commit. Amends and rebases count: a force-push fires `synchronize` too.
 
-A follow-up push that acts on information the session didn't have at push time — review feedback, a red check — *should* invalidate the running review; that one is correct. What's wasteful is splitting work you already have into several pushes.
+A follow-up push that acts on information the session didn't have at push time — review feedback, a red check — earns its round. What's wasteful is splitting work you already have into several pushes.
 
 ### Re-check PR state before pushing a follow-up commit
 


### PR DESCRIPTION
## Problem

A push to a PR under review cancels the in-flight `tend-review` run (`cancel-in-progress: true`), throwing away whatever the session had already read and assembled. On an active PR — e.g. one where a mention-handle session pushes a fix after each review round — this both wastes the partial review work and cold-starts a fresh session per push.

## Solution

Flip review to queue-instead-of-cancel, with a deterministic gate so the queued run is nearly free:

- **`cancel-in-progress: false`** on the review concurrency group: a mid-review push queues a replacement run while the live session keeps going.
- **Fold-in (review skill, new step 9)**: before ending, the session re-fetches the live HEAD and draft state; a push that landed mid-session is judged as an increment (the existing step-1 incremental logic), capped at three fold-ins before handing off to the queued run.
- **Examined-HEAD stamp**: the session stamps every fully-examined commit with a `tend-review/<pr>` commit status — including silent examinations, which previously left no machine-readable trace. The stamp is PR-scoped because one branch can be two open PRs with different bases.
- **Gate** (`review-gate.sh`, inlined into the generated workflow): a queued `synchronize` run exits before booting an agent when the live HEAD is stamped or the PR closed; fails open on API errors. `opened`/`reopened`/`ready_for_review` always run.

Consequences that fall out: the posting-mechanics "HEAD moved — discard" guard becomes a fold-in (nothing else will pick up the discarded review any more, since the queued run gates out), and step 8's pushed fixes are no longer CI-unverified — the session survives its own push and polls the fix to green, dissolving the documented exception to `running-in-ci`'s "a pushed fix is always gated".

Also folded in, from review: the notifications pre-check moves from inline template bash to `notifications-check.sh` consumed the same way as the gate (bot name via `BOT_NAME` env instead of a template substitution), so both workflow pre-checks ship as one mechanism — shellchecked and bash-tested; `review-reviewers` learns that a gate-skipped run is expected silence, not a missing review.

## Testing

Six bash tests drive `review-gate.sh` directly under `bash -e` with a fake `gh` (stamped/unstamped/foreign-context HEADs, non-`synchronize` events make no API calls, closed PRs, fail-open on API errors), plus a workflow-shape test asserting the gate is the first step and every later step is conditioned on it. Snapshot diffs for the notifications extraction verified to be exactly the env-parameterization. 378 tests, `shellcheck`, and `pre-commit` green.

Deferred, deliberately: an adopter `setup:` step carrying its own explicit `if:` still runs on gate-skipped runs (the pre-existing notifications warn-only behavior); AND-composing it with the gate changes semantics for `if: always()`-style steps, so that's left as a follow-up decision.

One property the flip makes strictly worse, accepted deliberately: with no cancel-in-progress, a wedged review session holds queued reviews on that PR until the action's own timeout (~5h50m) instead of being replaced by the next push — the same trade `tend-mention`'s handle job already makes.

The live queue → fold-in → stamp → skip cycle can only be observed after the next release (the action ref pins to a released tag), via tend's own dogfooding.

> _This was written by Claude Code on behalf of max-sixty_

