### PR TITLE
revert(generator): restore the slash-command prompt, and record why

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,8 @@ resolve bot identity. They differ in how the agent runs:
 - **Claude harness** — runs the official `claude` binary headless
   (`claude -p`) as a non-sudo sandbox user behind a local
   credential-injecting proxy, so the bot token and Anthropic credential
-  never enter the agent's environment. Each workflow's prompt names the
-  skill to run in prose rather than as a leading slash command, which
-  keeps the built-in `/code-review` reachable during the run.
+  never enter the agent's environment. Each workflow's prompt is a slash
+  command (`/tend-ci-runner:review`) that loads the matching skill.
 - **Codex harness** — installs the `@openai/codex` CLI on the runner and
   shells out to `codex exec`. An AGENTS.md staged into `$CODEX_HOME`
   teaches Codex to resolve `/tend-ci-runner:NAME` references to the

--- a/TODO.md
+++ b/TODO.md
@@ -277,6 +277,37 @@ back" to "the recovery workflow ran and my review still never came back".
 The same gap covers `tend-outage`; #816 tracks it from that side, and the
 `review-runs` skill's drain recipe reads the same table format.
 
+## Decide whether the built-in `/code-review` replaces the vendored port
+
+`plugins/tend-ci-runner/skills/code-review/` is a copy of Claude Code's
+built-in `/code-review`, read out of the 2.1.220 binary `claude/action.yaml`
+pins. The two share their method almost verbatim — the same ten angles, the
+same three-verdict verify with "PLAUSIBLE by default", the same sweep — so the
+copy buys nothing on method and costs the usual: it drifts silently, and
+nothing re-checks it against the binary.
+
+Reaching the built-in is possible. It carries `disable-model-invocation`,
+which the `Skill` tool waives for a turn whose own user message names the
+command, so a prompt naming `/code-review` in prose rather than opening with a
+slash unlocks it for the run. That was built and reverted, because reading the
+built-in out of the 2.1.226 binary says it isn't worth reaching:
+
+- It is a model × effort matrix rather than one prompt, and `claude-opus-5` at
+  both `medium` and `high` — where tend lands, running `model: opus` with no
+  effort set — renders a minimal cell: one careful diff pass, no angles, no
+  verify, no sweep. That cell is marked as externally measured, so it is a
+  deliberate upstream choice rather than an oversight. The port's core-logic
+  band is broader than it, and broader than the `default` row's 3+5 angles.
+- It reports through `ReportFindings`, which `claude/action.yaml` does not
+  allowlist.
+- The Codex harness has no built-in at all, so the port stays the only
+  implementation there regardless.
+
+Revisit when one of those moves: a pinned version whose Opus row is
+angle-based again, `ReportFindings` in the allowlist, or a Codex equivalent.
+Cutting over then costs a prompt reshape plus a per-harness branch in the
+`review` skill's step 4, which only pays once the built-in is the better pass.
+
 ## Worker: Phase 2 LLM summary of `/activity`
 
 A consumer (scheduled job or the Worker calling Claude) reads `/activity`

--- a/generator/src/tend/config.py
+++ b/generator/src/tend/config.py
@@ -200,53 +200,18 @@ class Config:
     sandbox_env: dict[str, str] = field(default_factory=dict)
     sandbox_setup: list[str] = field(default_factory=list)
 
-    @property
-    def code_review_notice(self) -> str:
-        """Sentence declaring the built-in `/code-review`; empty off the Claude harness.
-
-        Every generated Claude prompt carries it, including `mention`, whose prompt
-        `mention.yaml.j2` builds rather than `default_prompt` — but not an adopter's
-        `workflows.<name>.prompt`, which replaces the whole prompt. One definition, so
-        the two can't drift — and the token's regex (see `default_prompt`) is
-        fragile enough that a second copy is a second way to break it.
-        """
-        if self.harness != "claude":
-            return ""
-        return "Beyond the skills the Skill tool lists, /code-review is available too."
-
     def default_prompt(self, skill: str, args: str = "") -> str:
         """Default prompt invoking a tend-ci-runner skill in harness-native syntax.
 
-        Codex resolves `$NAME` as a skill mention (or matches by description); the
+        Claude resolves `/tend-ci-runner:NAME` as a slash command. Codex resolves
+        `$NAME` as a skill mention (or matches by description); the
         `tend-ci-runner` namespace prefix isn't needed at the prompt site because
         skill names within the plugin are unique. `args` is appended raw so
         callers can splice their own placeholders (`{pr_number}` etc.) and run
         the existing replace step.
-
-        Claude's prompt is prose naming the skill, rather than the bare
-        `/tend-ci-runner:NAME` slash command it also resolves, so that the
-        built-in `/code-review` is reachable. That skill carries
-        `disable-model-invocation`, which the `Skill` tool waives only for a turn
-        whose own user message names the command; a prompt *starting* with `/` is
-        stored wrapped in `<command-message>` and is skipped by that scan, so no
-        eligible message ever exists. Prose leaves the prompt eligible, and the
-        `/code-review` token in it unlocks the skill for the whole run.
-
-        Only the leading position routes a prompt to the slash-command path, so
-        the skill mention keeps its own `/` — the invocable form, and the same
-        shape as the `/code-review` beside it.
-
-        The token has to survive that scan's regex, `(?<!\\S)/code-review(?=$|\\s)`:
-        whitespace on both sides, so a trailing period or a backtick silently
-        costs the run its second pass. `test_default_prompt_unlocks_code_review`
-        pins it.
         """
-        if self.harness != "claude":
-            return f"${skill} {args}".rstrip()
-        invocation = f"Run the /tend-ci-runner:{skill} skill"
-        if args:
-            invocation += f" for {args}"
-        return f"{invocation}. {self.code_review_notice}"
+        prefix = f"/tend-ci-runner:{skill}" if self.harness == "claude" else f"${skill}"
+        return f"{prefix} {args}".rstrip()
 
     @classmethod
     def load(cls, path: Path | None = None) -> Config:

--- a/generator/src/tend/templates/mention.yaml.j2
+++ b/generator/src/tend/templates/mention.yaml.j2
@@ -18,9 +18,7 @@
               || (contains(github.event.comment.body, '@<<cfg.bot_name>>')
                 && format('You were mentioned in a comment ({0}). Read the full context and respond. If changes are requested, make them, commit, and push.', github.event.comment.html_url))
               || format('A user commented on an issue/PR where you previously participated ({0}). Read the full context. Only respond if the comment is directed at you, asks a question you can help with, or requests changes you can make. If the conversation is between other participants, exit silently.', github.event.comment.html_url)
-            }}{% if cfg.code_review_notice %}
-
-            <<cfg.code_review_notice>>{% endif %}{%- endset -%}
+            }}{%- endset -%}
 <<header>>
 name: tend-mention
 on:

--- a/generator/tests/_regtest_outputs/test_generate.test_extras_apply_path_regtest.out
+++ b/generator/tests/_regtest_outputs/test_generate.test_extras_apply_path_regtest.out
@@ -60,7 +60,7 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: >-
-            ${{ format('Run the /tend-ci-runner:review skill for {0}. Beyond the skills the Skill tool lists, /code-review is available too.', github.event.pull_request.number) }}
+            ${{ format('/tend-ci-runner:review {0}', github.event.pull_request.number) }}
     timeout-minutes: 240
 env:
   FOO: bar

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-ci-fix.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-ci-fix.yaml].out
@@ -40,7 +40,7 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the /tend-ci-runner:ci-fix skill for ${{ github.event.workflow_run.id }}. Beyond the skills the Skill tool lists, /code-review is available too.
+            /tend-ci-runner:ci-fix ${{ github.event.workflow_run.id }}
             - Run URL: ${{ github.event.workflow_run.html_url }}
             - Commit: ${{ github.event.workflow_run.head_sha }}
             - Commit message: ${{ github.event.workflow_run.head_commit.message }}

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-nightly.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-nightly.yaml].out
@@ -40,4 +40,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the /tend-ci-runner:nightly skill. Beyond the skills the Skill tool lists, /code-review is available too.
+            /tend-ci-runner:nightly

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
@@ -144,4 +144,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the /tend-ci-runner:notifications skill. Beyond the skills the Skill tool lists, /code-review is available too.
+            /tend-ci-runner:notifications

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-review-runs.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-review-runs.yaml].out
@@ -40,4 +40,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the /tend-ci-runner:review-runs skill. Beyond the skills the Skill tool lists, /code-review is available too.
+            /tend-ci-runner:review-runs

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-triage.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-triage.yaml].out
@@ -43,4 +43,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the /tend-ci-runner:triage skill for ${{ github.event.issue.number }}. Beyond the skills the Skill tool lists, /code-review is available too.
+            /tend-ci-runner:triage ${{ github.event.issue.number }}

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-weekly.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-weekly.yaml].out
@@ -40,4 +40,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the /tend-ci-runner:weekly skill. Beyond the skills the Skill tool lists, /code-review is available too.
+            /tend-ci-runner:weekly

--- a/generator/tests/_regtest_outputs/test_generate.test_sandbox_levers_regtest.out
+++ b/generator/tests/_regtest_outputs/test_generate.test_sandbox_levers_regtest.out
@@ -426,7 +426,6 @@ jobs:
                 && format('You were mentioned in a comment ({0}). Read the full context and respond. If changes are requested, make them, commit, and push.', github.event.comment.html_url))
               || format('A user commented on an issue/PR where you previously participated ({0}). Read the full context. Only respond if the comment is directed at you, asks a question you can help with, or requests changes you can make. If the conversation is between other participants, exit silently.', github.event.comment.html_url)
             }}
-            Beyond the skills the Skill tool lists, /code-review is available too.
 
       - name: Remove eyes reaction
         if: |

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[ci-fix].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[ci-fix].out
@@ -40,7 +40,7 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the /tend-ci-runner:ci-fix skill for ${{ github.event.workflow_run.id }}. Beyond the skills the Skill tool lists, /code-review is available too.
+            /tend-ci-runner:ci-fix ${{ github.event.workflow_run.id }}
             - Run URL: ${{ github.event.workflow_run.html_url }}
             - Commit: ${{ github.event.workflow_run.head_sha }}
             - Commit message: ${{ github.event.workflow_run.head_commit.message }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
@@ -417,7 +417,6 @@ jobs:
                 && format('You were mentioned in a comment ({0}). Read the full context and respond. If changes are requested, make them, commit, and push.', github.event.comment.html_url))
               || format('A user commented on an issue/PR where you previously participated ({0}). Read the full context. Only respond if the comment is directed at you, asks a question you can help with, or requests changes you can make. If the conversation is between other participants, exit silently.', github.event.comment.html_url)
             }}
-            Beyond the skills the Skill tool lists, /code-review is available too.
 
       - name: Remove eyes reaction
         if: |

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[nightly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[nightly].out
@@ -39,4 +39,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the /tend-ci-runner:nightly skill. Beyond the skills the Skill tool lists, /code-review is available too.
+            /tend-ci-runner:nightly

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
@@ -143,4 +143,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the /tend-ci-runner:notifications skill. Beyond the skills the Skill tool lists, /code-review is available too.
+            /tend-ci-runner:notifications

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review-runs].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review-runs].out
@@ -39,4 +39,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the /tend-ci-runner:review-runs skill. Beyond the skills the Skill tool lists, /code-review is available too.
+            /tend-ci-runner:review-runs

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review].out
@@ -59,4 +59,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: >-
-            ${{ format('Run the /tend-ci-runner:review skill for {0}. Beyond the skills the Skill tool lists, /code-review is available too.', github.event.pull_request.number) }}
+            ${{ format('/tend-ci-runner:review {0}', github.event.pull_request.number) }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[triage].out
@@ -43,4 +43,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the /tend-ci-runner:triage skill for ${{ github.event.issue.number }}. Beyond the skills the Skill tool lists, /code-review is available too.
+            /tend-ci-runner:triage ${{ github.event.issue.number }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[weekly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[weekly].out
@@ -39,4 +39,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the /tend-ci-runner:weekly skill. Beyond the skills the Skill tool lists, /code-review is available too.
+            /tend-ci-runner:weekly

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[ci-fix].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[ci-fix].out
@@ -42,7 +42,7 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the /tend-ci-runner:ci-fix skill for ${{ github.event.workflow_run.id }}. Beyond the skills the Skill tool lists, /code-review is available too.
+            /tend-ci-runner:ci-fix ${{ github.event.workflow_run.id }}
             - Run URL: ${{ github.event.workflow_run.html_url }}
             - Commit: ${{ github.event.workflow_run.head_sha }}
             - Commit message: ${{ github.event.workflow_run.head_commit.message }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
@@ -419,7 +419,6 @@ jobs:
                 && format('You were mentioned in a comment ({0}). Read the full context and respond. If changes are requested, make them, commit, and push.', github.event.comment.html_url))
               || format('A user commented on an issue/PR where you previously participated ({0}). Read the full context. Only respond if the comment is directed at you, asks a question you can help with, or requests changes you can make. If the conversation is between other participants, exit silently.', github.event.comment.html_url)
             }}
-            Beyond the skills the Skill tool lists, /code-review is available too.
 
       - name: Remove eyes reaction
         if: |

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[nightly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[nightly].out
@@ -41,4 +41,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the /tend-ci-runner:nightly skill. Beyond the skills the Skill tool lists, /code-review is available too.
+            /tend-ci-runner:nightly

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
@@ -146,4 +146,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the /tend-ci-runner:notifications skill. Beyond the skills the Skill tool lists, /code-review is available too.
+            /tend-ci-runner:notifications

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review-runs].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review-runs].out
@@ -41,4 +41,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the /tend-ci-runner:review-runs skill. Beyond the skills the Skill tool lists, /code-review is available too.
+            /tend-ci-runner:review-runs

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review].out
@@ -71,4 +71,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: >-
-            ${{ format('Run the /tend-ci-runner:review skill for {0}. Beyond the skills the Skill tool lists, /code-review is available too.', github.event.pull_request.number) }}
+            ${{ format('/tend-ci-runner:review {0}', github.event.pull_request.number) }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[triage].out
@@ -45,4 +45,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the /tend-ci-runner:triage skill for ${{ github.event.issue.number }}. Beyond the skills the Skill tool lists, /code-review is available too.
+            /tend-ci-runner:triage ${{ github.event.issue.number }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[weekly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[weekly].out
@@ -41,4 +41,4 @@ jobs:
           bot_name: test-bot
           model: opus
           prompt: |
-            Run the /tend-ci-runner:weekly skill. Beyond the skills the Skill tool lists, /code-review is available too.
+            /tend-ci-runner:weekly

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -393,53 +393,6 @@ def test_custom_prompt(tmp_path: Path) -> None:
     workflows = {wf.filename: wf for wf in generate_all(cfg)}
     triage = workflows["tend-triage.yaml"]
     assert "Custom triage:" in triage.content
-    # An adopter's prompt replaces the whole thing, `code_review_notice` included,
-    # so it carries no /code-review token — what that property's docstring claims.
-    assert "/code-review" not in triage.content
-
-
-def test_default_prompt_unlocks_code_review(tmp_path: Path) -> None:
-    """Claude prompts stay eligible for the `/code-review` waiver; Codex is untouched.
-
-    The `Skill` tool waives `disable-model-invocation` only for a turn whose own
-    user message names the command, and it finds that name with this regex. A
-    prompt starting with `/` is stored wrapped in `<command-message>` and skipped
-    by the scan, so prose is what keeps the message eligible at all — and the
-    token then has to clear the regex, which a trailing period or a backtick
-    silently fails.
-    """
-    user_typed_this_turn = re.compile(r"(?<!\S)/code-review(?=$|\s)")
-
-    cfg = Config.load(_minimal_config(tmp_path))
-    for skill, args in [("review", "{pr_number}"), ("nightly", "")]:
-        prompt = cfg.default_prompt(skill, args)
-        assert not prompt.startswith("/"), (
-            f"{skill} prompt starts with '/', so Claude Code stores it as a "
-            "slash command and the scan skips it"
-        )
-        assert user_typed_this_turn.search(prompt), (
-            f"{skill} prompt does not carry a bare /code-review token: {prompt!r}"
-        )
-        assert f"/tend-ci-runner:{skill}" in prompt
-
-    codex = Config.load(_minimal_config(tmp_path, "harness: codex\n"))
-    assert codex.default_prompt("review", "{pr_number}") == "$review {pr_number}"
-    assert codex.code_review_notice == ""
-
-    # Rendering is where the token can lose its whitespace: the review prompt is
-    # the one that goes through `_escape_braces`, `''`-quoting and GHA `format()`,
-    # and `mention` is the one workflow whose prompt skips `default_prompt`.
-    claude = {wf.filename: wf for wf in generate_all(cfg)}
-    for name in ["tend-review.yaml", "tend-mention.yaml"]:
-        assert user_typed_this_turn.search(claude[name].content), (
-            f"{name} lost the bare /code-review token in rendering"
-        )
-
-    codex_workflows = {wf.filename: wf for wf in generate_all(codex)}
-    for name, wf in codex_workflows.items():
-        assert "/code-review" not in wf.content, (
-            f"{name} declares /code-review, which the Codex harness has no skill for"
-        )
 
 
 def test_watched_workflows(tmp_path: Path) -> None:

--- a/plugins/tend-ci-runner/skills/code-review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/code-review/SKILL.md
@@ -10,16 +10,6 @@ metadata:
 
 A structured pass over a diff that returns ranked findings. Ported from Claude Code's built-in `/code-review`, read out of the 2.1.220 binary `claude/action.yaml` pins. The Codex harness has no built-in equivalent, and on Claude the built-in carries `disable-model-invocation`, which no tend prompt lifts. This copy is tend-owned: reachable from the model on either harness.
 
-<!-- TODO(2026-08-08): decide whether the built-in `/code-review` should replace this
-     port. Making the prompt prose, so the `Skill` tool's waiver fires and the built-in
-     becomes reachable, was tried and reverted (#902). Measured against the 2.1.226
-     binary, the two share their angles, verify pass and sweep near-verbatim — but the
-     built-in resolves per model and effort, and `claude-opus-5` at medium/high renders
-     a minimal single-pass cell with no verify and no sweep, then reports through
-     `ReportFindings`, which `claude/action.yaml` does not allowlist. Codex has no
-     built-in at all. The port stays until one of those changes. -->
-
-
 **Return findings; don't act on them.** No review, comment, commit, or artifact from this skill — the caller folds the findings into its own single review.
 
 ## Phase 0 — Gather the diff

--- a/plugins/tend-ci-runner/skills/code-review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/code-review/SKILL.md
@@ -8,7 +8,17 @@ metadata:
 
 # Code review
 
-A structured pass over a diff that returns ranked findings. Ported from Claude Code's built-in `/code-review` (read out of the 2.1.220 binary), which carries `disable-model-invocation` and so cannot be reached with the `Skill` tool. This copy is tend-owned: reachable from the model, and it runs on both harnesses.
+A structured pass over a diff that returns ranked findings. Ported from Claude Code's built-in `/code-review`, read out of the 2.1.220 binary `claude/action.yaml` pins. The Codex harness has no built-in equivalent, and on Claude the built-in carries `disable-model-invocation`, which no tend prompt lifts. This copy is tend-owned: reachable from the model on either harness.
+
+<!-- TODO(2026-08-08): decide whether the built-in `/code-review` should replace this
+     port. Making the prompt prose, so the `Skill` tool's waiver fires and the built-in
+     becomes reachable, was tried and reverted (#902). Measured against the 2.1.226
+     binary, the two share their angles, verify pass and sweep near-verbatim — but the
+     built-in resolves per model and effort, and `claude-opus-5` at medium/high renders
+     a minimal single-pass cell with no verify and no sweep, then reports through
+     `ReportFindings`, which `claude/action.yaml` does not allowlist. Codex has no
+     built-in at all. The port stays until one of those changes. -->
+
 
 **Return findings; don't act on them.** No review, comment, commit, or artifact from this skill — the caller folds the findings into its own single review.
 

--- a/shared/steps/compose-system-prompt.sh
+++ b/shared/steps/compose-system-prompt.sh
@@ -15,7 +15,7 @@
 set -eo pipefail
 
 SHARED="$SYSTEM_PROMPT_FILE"
-CLAUDE_DIRECTIVE="If the prompt names a tend-ci-runner skill, invoke it — it drives the whole run, and a run that skips it exits clean having done nothing. Use /tend-ci-runner:running-in-ci before starting work."
+CLAUDE_DIRECTIVE="Use /tend-ci-runner:running-in-ci before starting work."
 AUTONOMY_DIRECTIVE="You are running in CI; no human is available to answer questions. Never prompt for clarification or approval. When uncertain, make the best reasonable choice from the available evidence and proceed. Permissions are pre-approved; tool calls execute without confirmation."
 BASE=$(BOT_NAME="$BOT_NAME" envsubst '$BOT_NAME' < "$SHARED")
 FULL="${CLAUDE_DIRECTIVE}"$'\n\n'"${AUTONOMY_DIRECTIVE}"$'\n\n'"${BASE}"


### PR DESCRIPTION
Reverts #902.

Making the Claude prompt prose existed only so the `Skill` tool's waiver could fire and the built-in `/code-review` become reachable during a run. Reading the built-in out of the 2.1.226 binary says it isn't worth reaching.

**The two share their method almost verbatim.** Same ten angles (A line-by-line, B removed-behavior, C cross-file, D language-pitfall, E wrapper/proxy, plus Reuse, Simplification, Efficiency, Altitude, Conventions), the same three-verdict verify with the same "PLAUSIBLE by default" rule, and the same Phase 3 sweep down to the same focus list.

**But the built-in isn't one prompt — it's a model × effort matrix, and Opus 5 gets a deliberately minimal cell.** For `claude-opus-5`, both `medium` and `high` resolve to a cell whose entire prompt is `minimal prompt → single careful diff pass → ≤15 findings`: no angles, no verify, no sweep, no fan-out. It carries `measuredExternal: true`, so that is a measured choice rather than an oversight. The angle-based versions are what `xhigh`/`max` and the `default` model row get.

tend CI runs `model: opus` and sets no effort, so it lands on whichever row model-id normalization yields — and both candidates point the same way. The `default` row at medium is 3+5 angles → verify → ≤8; the `claude-opus-5` row is the minimal single pass. The port's core-logic band is 5+5 angles → verify → sweep → ≤10, broader than either.

Two further costs: the built-in reports through `ReportFindings`, which `claude/action.yaml` does not allowlist, and the Codex harness has no built-in at all.

So the port stays, and the prompt goes back to the slash command the harness routes — which also retires the compensating `CLAUDE_DIRECTIVE` clause the prose form needed.

## What stays behind

`TODO.md` gains an entry holding those measurements, so the question can be reopened without re-reading a binary. It lives there rather than in the skill because it argues about whether the port should exist, which is maintainer work — a skill body is loaded into every session that runs the skill, so a note there is carried by every review run and acted on by none.

Its preamble changes too. It used to say the built-in "cannot be reached with the `Skill` tool", which #902 made false — and which was over-strong even before, since the gate is `disableModelInvocation && !userTypedThisTurn` and a prompt naming `/code-review` is exactly what lifts it. It now names the two durable reasons the port exists: Codex has no equivalent, and no tend prompt lifts the Claude gate.

<details><summary>How the built-in was read, and what is not verified</summary>

2.1.220 — the version `claude/action.yaml` pins, and the one the port was taken from — has been pruned from local disk, so the comparison is against 2.1.226. The angle, verify and sweep texts still match the port near-verbatim, so the method itself has not drifted; what moved is the parameterization around it.

Not verified: which matrix row `model: opus` resolves to at runtime, since that depends on model-id normalization inside the binary. The conclusion holds under both candidate rows, which is why it did not need pinning down.

</details>

> _This was written by Claude Code on behalf of max-sixty_
