### PR TITLE
fix(install): give the proxy uv install the same retry window

### DIFF
--- a/generator/tests/test_shared_steps.py
+++ b/generator/tests/test_shared_steps.py
@@ -1467,3 +1467,109 @@ def test_install_claude_binary_installs_first_try_without_sleeping(
     assert _attempts(install_env) == 1, _attempts(install_env)
     assert _sleeps(install_env) == [], _sleeps(install_env)
     assert "claude 2.1.220" in result.stdout, result.stdout
+
+
+# ---------------------------------------------------------------------------
+# install-proxy-uv.sh — the same retry contract, on the proxy's own installer
+# ---------------------------------------------------------------------------
+
+INSTALL_PROXY_UV = REPO_ROOT / "shared" / "steps" / "install-proxy-uv.sh"
+
+# Same failure schedule as FAKE_CURL, emitting astral's installer shape instead:
+# read on stdin by `sh -s --`, so it stays POSIX rather than bash.
+FAKE_CURL_UV = """#!/usr/bin/env bash
+n=$(cat "$CURL_ATTEMPTS" 2>/dev/null || echo 0)
+n=$((n + 1))
+echo "$n" > "$CURL_ATTEMPTS"
+if [ "$n" -le "${CURL_FAILURES:-0}" ]; then
+  echo "curl: (22) The requested URL returned error: 403" >&2
+  exit 22
+fi
+cat <<'INSTALLER'
+mkdir -p "$UV_INSTALL_DIR"
+printf '#!/usr/bin/env bash\\necho uvx-fake\\n' > "$UV_INSTALL_DIR/uvx"
+chmod +x "$UV_INSTALL_DIR/uvx"
+INSTALLER
+"""
+
+
+@pytest.fixture
+def proxy_uv_env(tmp_path: Path) -> dict[str, str]:
+    """A fake curl/sleep on PATH plus the env the proxy-uv install step is given."""
+    bindir = _fake_bin(tmp_path, curl=FAKE_CURL_UV, sleep=FAKE_SLEEP_RECORDING)
+
+    return {
+        "PATH": f"{bindir}:/usr/bin:/bin",
+        "UV_VERSION": "0.9.9",
+        "TEND_UV_DIR": str(tmp_path / "tend-uv"),
+        "CURL_ATTEMPTS": str(tmp_path / "curl-attempts"),
+        "SLEEPS": str(tmp_path / "sleeps"),
+    }
+
+
+def _run_proxy_uv(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(INSTALL_PROXY_UV)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_install_proxy_uv_rides_out_a_403_burst(proxy_uv_env: dict[str, str]) -> None:
+    """The uv install is as exposed as the claude one, and gets the same window.
+
+    It runs in the same job and equally ahead of the agent step, so a blip that
+    exhausts its retries loses the run with no outage row — the sibling failure
+    mode, with astral.sh in place of claude.ai.
+    """
+    proxy_uv_env["CURL_FAILURES"] = "4"
+
+    result = _run_proxy_uv(proxy_uv_env)
+
+    assert result.returncode == 0, (
+        f"gave up on a blip it should have ridden out; stderr:\n{result.stderr}"
+    )
+    assert _attempts(proxy_uv_env) == 5, _attempts(proxy_uv_env)
+
+
+def test_install_proxy_uv_backs_off_exponentially(
+    proxy_uv_env: dict[str, str],
+) -> None:
+    """Each wait at least doubles; only the floors are pinned, jitter is free."""
+    proxy_uv_env["CURL_FAILURES"] = "99"
+
+    _run_proxy_uv(proxy_uv_env)
+
+    assert _sleeps(proxy_uv_env) == pytest.approx([5, 10, 20, 40], abs=9), (
+        f"backoff did not double: {_sleeps(proxy_uv_env)}"
+    )
+    assert all(
+        actual >= floor
+        for actual, floor in zip(_sleeps(proxy_uv_env), [5, 10, 20, 40], strict=True)
+    ), f"slept less than the backoff floor: {_sleeps(proxy_uv_env)}"
+
+
+def test_install_proxy_uv_reddens_when_every_attempt_fails(
+    proxy_uv_env: dict[str, str],
+) -> None:
+    """A CDN that stays down still fails the step, and says how hard it tried."""
+    proxy_uv_env["CURL_FAILURES"] = "99"
+
+    result = _run_proxy_uv(proxy_uv_env)
+
+    assert result.returncode != 0, result.stdout
+    assert "after 5 attempts" in result.stdout, result.stdout
+    assert _attempts(proxy_uv_env) == 5, _attempts(proxy_uv_env)
+
+
+def test_install_proxy_uv_installs_first_try_without_sleeping(
+    proxy_uv_env: dict[str, str],
+) -> None:
+    """The happy path is one fetch, no delay, and a uvx that answers."""
+    result = _run_proxy_uv(proxy_uv_env)
+
+    assert result.returncode == 0, result.stderr
+    assert _attempts(proxy_uv_env) == 1, _attempts(proxy_uv_env)
+    assert _sleeps(proxy_uv_env) == [], _sleeps(proxy_uv_env)
+    assert "uvx-fake" in result.stdout, result.stdout

--- a/shared/steps/install-proxy-uv.sh
+++ b/shared/steps/install-proxy-uv.sh
@@ -17,17 +17,29 @@ set -euo pipefail
 url="https://astral.sh/uv/${UV_VERSION}/install.sh"
 # Retry transient CDN failures — every workflow now depends on this install,
 # where the previous "only if uv is missing" step short-circuited on most repos.
-for i in 1 2 3; do
+#
+# Five attempts backing off exponentially, matching install-claude-binary.sh,
+# and for the same reasons. Three attempts at a flat 5s spend the whole window
+# inside ~15s, which a CDN blip has outlasted; and because this step runs ahead
+# of the agent, `Report failure` — gated on the agent step's own outcome —
+# files no outage row, so a run lost here leaves no trace.
+#
+# Jittered, because a matrix workflow's legs install concurrently from one
+# runner's egress address. A rate limit hits them together, and an unjittered
+# backoff has them retry together too.
+ATTEMPTS=5
+for i in $(seq 1 "$ATTEMPTS"); do
   if timeout 60 bash -c "set -o pipefail; curl -LsSf '$url' \
     | env UV_INSTALL_DIR='$TEND_UV_DIR' UV_NO_MODIFY_PATH=1 sh -s -- --quiet"; then
     break
   fi
-  if [ "$i" = 3 ]; then
-    echo "::error::failed to install uv ${UV_VERSION} after 3 attempts"
+  if [ "$i" -eq "$ATTEMPTS" ]; then
+    echo "::error::failed to install uv ${UV_VERSION} after $ATTEMPTS attempts"
     exit 1
   fi
-  echo "uv install attempt $i failed; retrying"
-  sleep $((i * 5))
+  BACKOFF=$((5 * 2 ** (i - 1) + RANDOM % 10))
+  echo "uv install attempt $i failed; retrying in ${BACKOFF}s"
+  sleep "$BACKOFF"
 done
 
 "${TEND_UV_DIR}/uvx" --version


### PR DESCRIPTION
Stacked on #906 — based on its branch, so the diff here is only the `install-proxy-uv.sh` half. GitHub retargets this to `main` when #906 merges.

## Problem

#906 widens the retry window on `install-claude-binary.sh` after a CDN 403 burst cost `review-reviewers` a matrix leg. Reviewing it surfaced that `shared/steps/install-proxy-uv.sh` carries the identical loop — `for i in 1 2 3`, `sleep $((i * 5))`, `after 3 attempts` — and shares every property the rationale rests on:

- It runs in the same job (`claude/action.yaml`), ~80 lines ahead of the claude install, so it is equally ahead of the agent step and equally invisible to `Report failure`, which is gated on `steps.claude.outcome == 'failure'`. A run lost here files no `tend-outage` row.
- It fetches over the same runner egress, on all five `review-reviewers` legs at once, so a rate limit hits them together and an unjittered backoff has them retry together.
- Its three attempts span the same ~15s window the observed blip outlasted.

A 403 from `astral.sh` instead of `claude.ai` loses the leg identically. Fixing only the claude half leaves the exposure roughly halved rather than closed.

## Change

Same shape as #906: five attempts, exponential backoff, jitter — 5, 10, 20, 40 seconds plus 0–9s each. Happy path unchanged (one fetch, no sleep).

Worth stating the same ceiling caveat: when `curl` fails fast the added cost to a doomed install is ~95s; when the CDN hangs, each attempt burns the full `timeout 60` and the worst case goes from ~195s to ~411s.

## Tests

`install-proxy-uv.sh` had no test coverage at all. Four tests added, reusing the fixture pattern #906 establishes (`_fake_bin`, `FAKE_SLEEP_RECORDING`, the attempt/sleep readers) with a `curl` fake that emits astral's installer shape — read on stdin by `sh -s --`, so it stays POSIX rather than bash. Reusing those helpers is why this is stacked rather than parallel; the alternative was a second copy of each fake and a conflict at the end of the file.

Three of the four fail against the pre-fix script:

| Test | Against the base branch |
|---|---|
| rides out a 403 burst (4 failures then success) | fails — gives up after 3 |
| backs off exponentially | fails — sleeps `[5, 10]` |
| reddens when every attempt fails, naming the count | fails — says "after 3 attempts" |
| installs first try without sleeping | passes (happy path is unchanged) |

Full generator suite: 387 passed. `shellcheck -S warning` clean on the modified script; `ruff check` and `ruff format --check` clean.
