### PR TITLE
refactor(install): give both pre-agent installers one retry window

### DIFF
--- a/generator/tests/test_shared_steps.py
+++ b/generator/tests/test_shared_steps.py
@@ -1408,8 +1408,8 @@ def test_install_claude_binary_rides_out_a_403_burst(
 
     Observed in production: every attempt inside a ~15s window answered 403
     while sibling matrix legs installed fine seconds either side. Three
-    attempts is too few to cross a blip that short, and the step failing this
-    early leaves no outage row, so the run vanishes without a trace.
+    attempts is too few to cross a blip that short, and the step fails ahead of
+    the agent, so the run is lost having done none of the work it was for.
     """
     install_env["CURL_FAILURES"] = "4"
 
@@ -1520,8 +1520,8 @@ def test_install_proxy_uv_rides_out_a_403_burst(proxy_uv_env: dict[str, str]) ->
     """The uv install is as exposed as the claude one, and gets the same window.
 
     It runs in the same job and equally ahead of the agent step, so a blip that
-    exhausts its retries loses the run with no outage row — the sibling failure
-    mode, with astral.sh in place of claude.ai.
+    exhausts its retries costs the whole run — the sibling failure mode, with
+    astral.sh in place of claude.ai.
     """
     proxy_uv_env["CURL_FAILURES"] = "4"
 

--- a/shared/steps/install-claude-binary.sh
+++ b/shared/steps/install-claude-binary.sh
@@ -16,48 +16,31 @@
 # (exported by setup-sandbox.sh via $GITHUB_ENV).
 set -eo pipefail
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+# Retry transient 403s/5xxs from the installer CDN, on the window lib/retry.sh
+# holds for both pre-agent installers. The lib is concatenated onto the front
+# of the sandbox script rather than sourced from inside it: nothing grants the
+# sandbox UID read access to the action's own checkout — setup-sandbox.sh
+# grants traversal (o+x) on the workspace's ancestors only — whereas stdin is a
+# stream the runner, not the sandbox, reads the file into.
+#
 # XDG_* pinned under the sandbox home: the runner exports
 # XDG_CONFIG_HOME=/home/runner/.config (leaks through sudo), which the
 # sandbox UID can't write. Pin all four base dirs so the installer (and
 # any XDG-aware tool the agent later runs) lands under $AGENT_HOME.
 # Install fetches go direct (no proxy env here), so this step does not
 # source $AGENT_ENV_FILE.
-sudo -u "$SANDBOX" env HOME="$AGENT_HOME" CLAUDE_VERSION="$CLAUDE_VERSION" \
-  XDG_CONFIG_HOME="$AGENT_HOME/.config" \
-  XDG_CACHE_HOME="$AGENT_HOME/.cache" \
-  XDG_DATA_HOME="$AGENT_HOME/.local/share" \
-  XDG_STATE_HOME="$AGENT_HOME/.local/state" \
-  bash <<'EOF'
+cat "${SCRIPT_DIR}/lib/retry.sh" - <<'EOF' \
+  | sudo -u "$SANDBOX" env HOME="$AGENT_HOME" CLAUDE_VERSION="$CLAUDE_VERSION" \
+      XDG_CONFIG_HOME="$AGENT_HOME/.config" \
+      XDG_CACHE_HOME="$AGENT_HOME/.cache" \
+      XDG_DATA_HOME="$AGENT_HOME/.local/share" \
+      XDG_STATE_HOME="$AGENT_HOME/.local/state" \
+      bash
 set -euo pipefail
-# Retry transient 403s/5xxs from the installer CDN. The inner
-# `set -o pipefail` is required: without it a curl failure passes empty
-# stdin to the downstream `bash -s --`, which exits 0, masking the
-# failure so the loop breaks after one attempt without retrying.
-#
-# Five attempts backing off exponentially, not three at a flat 5s. The old
-# window spent all three attempts inside ~15s, which is short enough for one
-# CDN blip to take the whole run: the step goes red, and because `Report
-# failure` is gated on the agent step, a failure this early leaves no outage
-# row either, so the run disappears silently.
-#
-# Jittered, because the legs of a matrix workflow install concurrently from
-# one runner's egress address. A rate limit hits them together, and an
-# unjittered backoff has them retry together too — every leg reproducing the
-# burst that tripped it. The jitter spreads the retries out.
-ATTEMPTS=5
-for i in $(seq 1 "$ATTEMPTS"); do
-  if timeout 60 bash -c "set -o pipefail; \
-    curl -fsSL https://claude.ai/install.sh | bash -s -- '$CLAUDE_VERSION'"; then
-    break
-  fi
-  if [ "$i" -eq "$ATTEMPTS" ]; then
-    echo "::error::failed to install claude $CLAUDE_VERSION after $ATTEMPTS attempts"
-    exit 1
-  fi
-  BACKOFF=$((5 * 2 ** (i - 1) + RANDOM % 10))
-  echo "Install attempt $i failed; retrying in ${BACKOFF}s"
-  sleep "$BACKOFF"
-done
+retry_install "claude $CLAUDE_VERSION" \
+  "curl -fsSL https://claude.ai/install.sh | bash -s -- '$CLAUDE_VERSION'"
 EOF
 if ! sudo -u "$SANDBOX" test -x "$AGENT_HOME/.local/bin/claude"; then
   echo "::error::claude binary not found at $AGENT_HOME/.local/bin/claude after install"

--- a/shared/steps/install-proxy-uv.sh
+++ b/shared/steps/install-proxy-uv.sh
@@ -14,32 +14,14 @@
 # Inputs (env): UV_VERSION, TEND_UV_DIR.
 set -euo pipefail
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib/retry.sh
+. "${SCRIPT_DIR}/lib/retry.sh"
+
 url="https://astral.sh/uv/${UV_VERSION}/install.sh"
 # Retry transient CDN failures — every workflow now depends on this install,
 # where the previous "only if uv is missing" step short-circuited on most repos.
-#
-# Five attempts backing off exponentially, matching install-claude-binary.sh,
-# and for the same reasons. Three attempts at a flat 5s spend the whole window
-# inside ~15s, which a CDN blip has outlasted; and because this step runs ahead
-# of the agent, `Report failure` — gated on the agent step's own outcome —
-# files no outage row, so a run lost here leaves no trace.
-#
-# Jittered, because a matrix workflow's legs install concurrently from one
-# runner's egress address. A rate limit hits them together, and an unjittered
-# backoff has them retry together too.
-ATTEMPTS=5
-for i in $(seq 1 "$ATTEMPTS"); do
-  if timeout 60 bash -c "set -o pipefail; curl -LsSf '$url' \
-    | env UV_INSTALL_DIR='$TEND_UV_DIR' UV_NO_MODIFY_PATH=1 sh -s -- --quiet"; then
-    break
-  fi
-  if [ "$i" -eq "$ATTEMPTS" ]; then
-    echo "::error::failed to install uv ${UV_VERSION} after $ATTEMPTS attempts"
-    exit 1
-  fi
-  BACKOFF=$((5 * 2 ** (i - 1) + RANDOM % 10))
-  echo "uv install attempt $i failed; retrying in ${BACKOFF}s"
-  sleep "$BACKOFF"
-done
+retry_install "uv ${UV_VERSION}" "curl -LsSf '$url' \
+  | env UV_INSTALL_DIR='$TEND_UV_DIR' UV_NO_MODIFY_PATH=1 sh -s -- --quiet"
 
 "${TEND_UV_DIR}/uvx" --version

--- a/shared/steps/lib/retry.sh
+++ b/shared/steps/lib/retry.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# The retry window the pre-agent installers share: install-claude-binary.sh
+# and install-proxy-uv.sh both fetch from a CDN before the agent step exists,
+# so a blip that exhausts their retries loses the run with no outage row
+# (`Report failure` is gated on the agent step's own outcome).
+#
+# Sourced, not executed.
+
+# retry_install LABEL COMMAND — run COMMAND under a 60s timeout, up to five
+# times, backing off 5/10/20/40s plus jitter. Jittered because a matrix
+# workflow's legs install concurrently from one runner's egress address: a
+# rate limit hits them together, and an unjittered backoff has them retry
+# together too.
+#
+# The inner `set -o pipefail` is required by both callers' `curl | sh`
+# shape: without it a curl failure passes empty stdin to the downstream
+# shell, which exits 0, masking the failure so the loop breaks after one
+# attempt without retrying.
+retry_install() {
+  local label=$1 cmd=$2 attempts=5 i backoff
+  for i in $(seq 1 "$attempts"); do
+    if timeout 60 bash -c "set -o pipefail; $cmd"; then
+      return 0
+    fi
+    if [ "$i" -eq "$attempts" ]; then
+      echo "::error::failed to install ${label} after ${attempts} attempts"
+      return 1
+    fi
+    backoff=$((5 * 2 ** (i - 1) + RANDOM % 10))
+    echo "${label} install attempt $i failed; retrying in ${backoff}s"
+    sleep "$backoff"
+  done
+}

--- a/shared/steps/lib/retry.sh
+++ b/shared/steps/lib/retry.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # The retry window the pre-agent installers share: install-claude-binary.sh
 # and install-proxy-uv.sh both fetch from a CDN before the agent step exists,
-# so a blip that exhausts their retries loses the run with no outage row
-# (`Report failure` is gated on the agent step's own outcome).
+# so a blip that exhausts their retries costs the whole run — the step goes red
+# having done none of the work the trigger asked for. The lost run is what
+# justifies a window this wide, independent of how the failure is reported
+# afterwards.
 #
 # Sourced, not executed.
 


### PR DESCRIPTION
Stacked on #907 — based on its branch, so the diff here is only the extraction. GitHub retargets this as the stack merges.

## Problem

Raised in the review of #907: after #906 and #907 land, the same retry policy exists in two files with no shared source of truth. `install-claude-binary.sh` and `install-proxy-uv.sh` each carry `ATTEMPTS=5`, the same `5 * 2 ** (i - 1) + RANDOM % 10` backoff, the same `timeout 60`, and the same `set -o pipefail`-inside-`bash -c` requirement. The next adjustment to the window has to be found and applied twice, and the two rationale comments already differ in wording while describing one policy — which is how the windows drift apart.

The repo already has the mechanism: `shared/steps/lib/run-issue.sh` is sourced by both `rate-limit-preflight.sh` and `report-failure.sh`.

## Change

`shared/steps/lib/retry.sh` holds `retry_install LABEL COMMAND` — the loop, the backoff, the jitter, and the `set -o pipefail` that both callers' `curl | sh` shape depends on. Each caller keeps its own one-line rationale for *why it fetches what it fetches*; the window's rationale lives once, in the lib.

The review flagged the sandbox boundary as the unverified part, and it is real: `install-claude-binary.sh` runs its loop inside `sudo -u "$SANDBOX" env … bash <<'EOF'`, and nothing grants the sandbox UID read access to the action's own checkout — `setup-sandbox.sh` grants traversal (`o+x`) on the *workspace's* ancestors only, and the action lives elsewhere under `_actions/`. So the lib is not sourced by path from inside the heredoc. It is concatenated onto the front of the script the sandbox bash reads from stdin:

```bash
cat "${SCRIPT_DIR}/lib/retry.sh" - <<'EOF' \
  | sudo -u "$SANDBOX" env HOME="$AGENT_HOME" … bash
set -euo pipefail
retry_install "claude $CLAUDE_VERSION" \
  "curl -fsSL https://claude.ai/install.sh | bash -s -- '$CLAUDE_VERSION'"
EOF
```

The file is read on the runner side of the privilege drop, so sandbox read access never enters into it, and the privilege drop itself is unchanged — same `sudo -u`, same `env`, same pinned XDG dirs. `install-proxy-uv.sh` runs as the runner and sources the lib normally.

Behaviour is unchanged on both paths: five attempts, 5/10/20/40s plus 0–9s jitter, `::error::failed to install <label> after 5 attempts` on exhaustion, one fetch and no sleep on the happy path.

## Tests

No new tests — the eight added by #906 and #907 already pin the contract behaviourally on both callers (attempt count, backoff floors, the exhaustion message, the no-sleep happy path), and they pass unmodified against the extracted lib. That is the point of the pair: the shared window is now asserted twice, from opposite sides of the `sudo` boundary.

Full generator suite: 387 passed. `shellcheck -S warning` clean on both scripts and the lib.

## If you'd rather not review three

The end state is what matters, not the split — squashing this into #907 loses nothing.
