### PR TITLE
fix(running-in-ci): don't let a failed status probe read as no incident

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -591,10 +591,12 @@ Intermittent or inconsistent behavior — the same query returning different res
 # Fetch first, parse second. The endpoint sits behind an edge that sometimes
 # answers a CI runner with an HTML challenge page instead of JSON; piping that
 # straight into jq gives a parse error on stderr and an empty stdout, which
-# reads exactly like "no open incidents". `-f` turns the non-200 into a
-# non-zero exit, and capturing it means the pipeline's status is curl's, not
-# jq's (a bare `curl … | jq … || …` exits 0 on the challenge page).
-if ! INCIDENTS=$(curl -fsS 'https://www.githubstatus.com/api/v2/incidents/unresolved.json'); then
+# reads exactly like "no open incidents". `-f` catches a challenge served as a
+# non-200 and the `jq -e` probe catches one served as 200; capturing the body
+# means the status is curl's or jq's, not a pipeline's (a bare
+# `curl … | jq … || …` exits 0 on the challenge page).
+if ! INCIDENTS=$(curl -fsS 'https://www.githubstatus.com/api/v2/incidents/unresolved.json') \
+   || ! echo "$INCIDENTS" | jq -e . >/dev/null 2>&1; then
   echo 'STATUS PROBE FAILED — upstream state unknown, not clear'
 else
   echo "$INCIDENTS" \

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -588,9 +588,21 @@ If you can't find source evidence for a specific detail, say so ("I'm not sure o
 Intermittent or inconsistent behavior — the same query returning different results within seconds, an API silently returning empty when records demonstrably exist, a CLI flag working sometimes — points more strongly at an active upstream incident than at a CLI or skill bug. Reproducing the flake confirms the symptom but not the cause; the cause is often a current incident on the upstream service, in which case the right disposition is to wait for resolution rather than commit a code workaround that outlives the incident. Before designing a workaround, check upstream status. For GitHub-side symptoms:
 
 ```bash
-curl -s 'https://www.githubstatus.com/api/v2/incidents/unresolved.json' \
-  | jq '.incidents[] | {created_at, name, impact, components: [.components[].name]}'
+# Fetch first, parse second. The endpoint sits behind an edge that sometimes
+# answers a CI runner with an HTML challenge page instead of JSON; piping that
+# straight into jq gives a parse error on stderr and an empty stdout, which
+# reads exactly like "no open incidents". `-f` turns the non-200 into a
+# non-zero exit, and capturing it means the pipeline's status is curl's, not
+# jq's (a bare `curl … | jq … || …` exits 0 on the challenge page).
+if ! INCIDENTS=$(curl -fsS 'https://www.githubstatus.com/api/v2/incidents/unresolved.json'); then
+  echo 'STATUS PROBE FAILED — upstream state unknown, not clear'
+else
+  echo "$INCIDENTS" \
+    | jq '.incidents[] | {created_at, name, impact, components: [.components[].name]}'
+fi
 ```
+
+**A failed probe is `unknown`, never `clear`.** Empty output from a successful query means no open incident; a probe that errored means you didn't check. Both resolve the same way — record the symptom in the evidence log and skip the workaround PR — so an unreachable status endpoint is not a reason to file one.
 
 If the response is non-empty and the components/timing match the symptom (e.g. Issues / Pull Requests / Actions during a search-degradation incident), record the symptom in the run's evidence log and exit without a PR. Sibling matrix legs that hit different surface symptoms of the same incident otherwise each open their own near-duplicate workaround PR — title and file dedup don't catch them because each leg picks a different command to mitigate.
 


### PR DESCRIPTION
The upstream-incident probe in `running-in-ci` fails open: when the status endpoint doesn't answer with JSON, the recipe prints nothing, and "nothing" is the same output it prints when there are genuinely no open incidents. The agent reads the empty result as *clear* and proceeds to file the workaround PR that the check exists to prevent.

**Observed live this run.** `https://www.githubstatus.com/api/v2/incidents/unresolved.json` currently answers a GitHub Actions runner with HTTP 405 and a 2,519-byte `Human Verification` HTML page, reproducibly (3/3 attempts). The documented recipe on that body:

```
$ curl -s '…/incidents/unresolved.json' | jq '.incidents[] | {created_at, name, impact, components: [.components[].name]}'
jq: parse error: Invalid numeric literal at line 1, column 10
$ echo "stdout=[$OUT]"
stdout=[]
```

Empty stdout, and the paragraph right below the recipe keys off exactly that: *"If the response is non-empty and the components/timing match the symptom … exit without a PR."* Empty → no incident → file the PR. Egress is fine generally (`pypi.org` returns 200 from the same shell), so this is the status endpoint's edge challenging the runner, not a sandbox block.

**The fix.** Fetch first, parse second, and say so when the fetch fails. A bare `curl -f … | jq … || echo` does *not* work — the pipeline's exit status is jq's, and jq exits 0 on empty stdin, so the `||` branch never fires. Verified both halves against the live endpoint and against a reachable JSON endpoint as a positive control.

One added sentence draws the distinction the recipe can't draw on its own: a probe that errored is `unknown`, not `clear`, and `unknown` resolves the same way an open incident does — record the symptom, skip the workaround PR.

## Gate assessment

- **Evidence level / occurrences**: the *trigger* (endpoint unreachable from CI) is occurrence 1 — the evidence gist records 167 prior probes across ~45 legs, every one of them a clean `0 incidents`, so this is the first failure. The *defect* isn't occurrence-counted, though: that the recipe cannot distinguish a failed fetch from a clean result is provable by reading it, and was demonstrated end-to-end above rather than inferred.
- **Structural, not stochastic**: no model decision point. Any non-JSON body produces empty stdout every time.
- **Change type**: targeted fix — recipe hardening plus one clarifying sentence, no new section.
- **Passes both gates**: yes. The failure direction is what tips it — this fails *open*, toward filing a workaround for a transient, which is the specific outcome the surrounding guidance was written to stop. `list-recent-runs.sh` already treats the same class of silent-empty as worth failing loud ("refusing to report an empty run list that would read as a false all-clear"); this brings the incident probe onto that footing.

Evidence: https://gist.github.com/dca23a6e6a0d8cae2665944ba31676fb
