### PR TITLE
skills(running-in-ci): open the PR instead of filing an issue triage will convert

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -88,6 +88,14 @@ Corollary: don't background anything whose output gates the deliverable. If a fu
 
 A pushed fix isn't done until its required checks are terminal — see **CI Monitoring**.
 
+## Filing Issues in This Repo
+
+An issue here is not a note to a maintainer — `tend-triage` fires on `issues` and does the work. Filing one for a fix you have already scoped hands your own analysis to a second agent run, which re-derives it from your issue body and opens the PR minutes later at full session cost, on a thread nobody needed.
+
+So if you can open the PR in this run, open the PR. Reserve an issue for what you genuinely can't finish here: a problem too large or ambiguous to fix, one that needs a maintainer decision, or one whose verification is out of reach from CI.
+
+This governs your own repo only; filing into another repo follows the section below.
+
 ## Filing Issues in Other Repos
 
 Default: file an issue in the current repo asking for permission to file in the target. On maintainer approval, file in the target.

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -90,9 +90,9 @@ A pushed fix isn't done until its required checks are terminal — see **CI Moni
 
 ## Filing Issues in This Repo
 
-An issue here is not a note to a maintainer — `tend-triage` fires on `issues` and does the work. Filing one for a fix you have already scoped hands your own analysis to a second agent run, which re-derives it from your issue body and opens the PR minutes later at full session cost, on a thread nobody needed.
+An issue here is not a note to a maintainer — where `tend-triage` is enabled (the default), it fires on `issues` and does the work. Filing one for a fix you have already scoped hands your own analysis to a second agent run, which re-derives it from your issue body and opens the PR minutes later at full session cost, on a thread nobody needed.
 
-So if you can open the PR in this run, open the PR. Reserve an issue for what you genuinely can't finish here: a problem too large or ambiguous to fix, one that needs a maintainer decision, or one whose verification is out of reach from CI.
+So if you can open the PR in this run, open the PR. Reserve an issue for what you genuinely can't finish here: a problem too large or ambiguous to fix, one that needs a maintainer decision, or one whose verification is out of reach from CI. Bookkeeping issues are a separate case, not this trade-off: `ci-fix`'s transient-diagnosis tracker carries `tend-outage`, which the generated `tend-triage` and `tend-mention` `if:` skip, so no conversion run fires.
 
 This governs your own repo only; filing into another repo follows the section below.
 


### PR DESCRIPTION
## Problem

Filing an issue in this repo is not a note to a maintainer — `tend-triage` fires on `issues`. Twice in 66 minutes this morning a run filed an issue describing a fix it had already fully scoped, and triage then re-derived that fix from the issue body and opened the PR:

| Issue filed | Triage boots | Turns / cost | PR opened |
|---|---|---|---|
| [#909](https://github.com/max-sixty/tend/issues/909) 07:18:53Z | [31300864191](https://github.com/max-sixty/tend/actions/runs/31300864191) 07:18:56Z | 64 / $4.08 | [#910](https://github.com/max-sixty/tend/pull/910) `fix/issue-909` 07:25:17Z |
| [#911](https://github.com/max-sixty/tend/issues/911) 07:39:37Z | [31301666194](https://github.com/max-sixty/tend/actions/runs/31301666194) 07:39:40Z | 58 / $4.20 | [#912](https://github.com/max-sixty/tend/pull/912) `fix/issue-911` 07:49:37Z |

Three seconds from issue to triage boot in both cases. Neither issue was under-specified: #909 named `codex/action.yaml:120-124` and proposed extracting to `shared/steps/install-codex-cli.sh` sourcing `lib/retry.sh`; #911 named `proxy/setup-sandbox.sh:319` and proposed the same treatment. Both PRs implemented exactly the proposal. Triage's own session log confirms the conversion — run 31300864191's artifact is `claude-session-logs-n909`, and it ran `gh pr create --head fix/issue-909`, classifying the reporter as "the bot's own review of #908".

So the issue bought nothing and cost $8.28 of agent time plus two threads. The filing run could have opened both PRs itself.

<details><summary>Wider context — the cascade this sat inside</summary>

A single transient CDN 403 lost one matrix leg of `review-reviewers` run [31297986524](https://github.com/max-sixty/tend/actions/runs/31297986524) at 06:03Z (`curl: (22) ... 403`, three attempts inside 15.7 s, the other four legs installing the same version from the same runner at the same moment succeeded). Between 06:29Z and 07:56Z that produced #906, #907, #908, #909, #910, #911 and #912 — five stacked PRs and two issues, none merged, across ~14 agent runs and roughly $30 at list prices.

The engineering is sound and correctly atomic; this PR does not argue with any of it. Only the two issue hops are pure overhead, and they are the part with a mechanical fix.

</details>

## Solution

A short section in `running-in-ci` — the skill every workflow loads — stating that an issue in this repo is picked up by triage, so a fix you can already scope should be opened as a PR in the same run. The escape hatches stay: too large or ambiguous to fix, needs a maintainer decision, or verification is out of reach from CI.

This generalizes a rule that already exists but only in two skills: `review-runs` ("Issue (fallback): Only for problems too large or ambiguous to fix directly") and `review-reviewers` carry it, so the runs that have it don't do this. The runs that did — a `tend-review` session and a `tend-mention` session — load neither.

## Gate assessment

- **Evidence level**: High — 2 occurrences this window, and the self-amplifying-output family has been recorded in prior windows (2026-08-04: review→fix ping-pong over five rounds; two bot PRs seven minutes apart on one root cause).
- **Structural**: yes for the costly half. The bot's choice to file rather than fix is stochastic, but once an issue exists the triage conversion has no decision point — it fires on the `issues` event every time.
- **Change type**: targeted fix (one short section), normal evidence bar.
- **Both gates**: pass.

Found by `/tend-ci-runner:review-runs` on run [31302531474](https://github.com/max-sixty/tend/actions/runs/31302531474).
