### PR TITLE
chore: refresh consumers.json

### DIFF
--- a/data/consumers.json
+++ b/data/consumers.json
@@ -4,6 +4,10 @@
     "bot_name": "prql-bot"
   },
   {
+    "repo": "jakobtfaber/Faber2026",
+    "bot_name": "tend-jakobtfaber"
+  },
+  {
     "repo": "max-sixty/cargo-affected",
     "bot_name": "cargo-affected-bot"
   },


### PR DESCRIPTION
Weekly refresh of the consumer list the site's data Worker reads.

One new public repo has tend installed since the last refresh: `jakobtfaber/Faber2026` (bot `tend-jakobtfaber`). The other five entries are unchanged.

Discovered with the code-search recipe in `running-tend` (`max-sixty/tend`, `--extension yaml`, filtered to `.github/workflows/tend-*`), then each repo's `bot_name` resolved from its `.config/tend.yaml`.
