### PR TITLE
chore: bump claude_version to 2.1.226

### DIFF
--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -54,7 +54,7 @@ inputs:
     default: "true"
     description: Include the rendered Claude transcript in the workflow step summary.
   claude_version:
-    default: "2.1.220"
+    default: "2.1.226"
     description: >-
       Version of the `claude` binary to install via
       `https://claude.ai/install.sh`, pinned to a specific


### PR DESCRIPTION
Weekly pin refresh: `claude_version` 2.1.220 → 2.1.226 (npm `dist-tags.latest`). A stale binary resolves `--model opus`/`sonnet` to a superseded alias target, so the pin is worth moving even on a run of quiet releases.

CHANGELOG skim across 2.1.221 → 2.1.226, restricted to the paths this action exercises (headless `-p`, the credential-injection proxy, plugin skills, OAuth-token auth):

- **2.1.225 — headless OAuth token.** "Fixed a transient 401 replacing a long-lived `CLAUDE_CODE_OAUTH_TOKEN` with a stored login's short-lived token, breaking headless sessions until restart." This is exactly tend's auth shape; the failure mode was a session that dies partway and can't recover without a restart the action never does.
- **2.1.222 — HTTPS proxy.** "Fixed the startup connectivity check hanging and then failing behind an HTTPS proxy; it now uses the same proxy-aware transport as API requests and times out with a clear message." Every tend session starts behind `mitmdump`, so this removes a hang class at the point where the proxy has just come up.
- **2.1.221 — sandbox proxy + non-interactive skills.** "Fixed sandboxed large uploads failing with TLS errors through the sandbox proxy", and "Fixed plugin- and org-delivered skills named after terminal-only built-ins (e.g. `/help`, `/feedback`) being un-invocable in non-interactive sessions" — tend ships its skills as a plugin and invokes them from a non-interactive run.
- **2.1.223 — `/review` is now an alias of `/code-review`.** No action needed, but the reason isn't which skill the review path calls — it's that `code_review_notice` in `generator/src/tend/config.py` puts a bare `/code-review` token into *every* generated Claude prompt, to trip the `Skill` tool's `disable-model-invocation` waiver. The scan reading that token lives in the binary, so a release touching `/code-review` handling is precisely the change class that could unhook it with nothing failing — the run would just lose its second pass. Verified against the 2.1.226 binary rather than the CHANGELOG: the scan still builds its regex from the command name (`(?<!\S)/${name}(?=$|\s)`), and the canonical name is still `code-review` — 2.1.223 added `/review` as an alias rather than renaming it. #926 folds this check into the weekly bump rule so the next bump doesn't have to re-derive it.
- **2.1.226** is bug fixes and reliability only; **2.1.224** is feature work on surfaces this action doesn't touch (self-hosted runners, Remote Control, VS Code).

Nothing in the range changes `-p` result events, `--model` alias resolution, first-run onboarding, or Stop-hook behavior.

`mitmproxy_version` is already at latest (12.2.3), so `uv_version` stays put too — per `running-tend`, uv moves with mitmproxy rather than on a stream of its own.

The pin resolves on the channel the install actually uses, not just npm: `2.1.226/manifest.json` exists in the release bucket and the downloaded `linux-x64` binary's sha256 matches its manifest entry. Note that it now sits ahead of that bucket's own `stable` marker, which currently reads 2.1.220 — the version this PR replaces. That's the rule as written ("track latest"), not a defect here; #927 raises whether `latest` is the marker we want to keep tracking.
