### PR TITLE
chore: bump actions/cache to v6

### DIFF
--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -197,7 +197,7 @@ runs:
     # in seconds instead of a cold ~20s resolve. Scoped to the proxy's uv; a
     # skill that installs its own uv gets that uv's default cache, untouched.
     - name: Cache mitmproxy
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ${{ runner.temp }}/tend-mitmproxy-uv
         key: tend-mitmproxy-${{ runner.os }}-${{ inputs.mitmproxy_version }}


### PR DESCRIPTION
`actions/cache` in `claude/action.yaml` was two majors behind (v4 → v6). This one ships to adopters — it runs in every adopter's job from the next release — so it goes in a PR of its own.

The step caches the proxy's mitmproxy download, keyed on `mitmproxy_version`. Its inputs (`path`, `key`) are unchanged across both majors.

What the majors carry:

- **v5.0.0** — runtime moved to Node 24. Requires Actions Runner ≥ 2.327.1. GitHub-hosted runners are well past that; an adopter on a self-hosted runner that doesn't auto-update is the only exposure, and that runner would already be failing on `actions/checkout@v7` (Node 24 as well), which `macros.yaml.j2` renders into every generated workflow.
- **v5.x** — `@actions/cache` bumped to handle read-only cache access, so a job without cache-write permission logs the denial instead of failing the step. Relevant here: this step runs in `pull_request_target` jobs where cache writes can be scoped.
- **v6.0.0** — dependency updates and an ESM migration. No input or behavior change.

No breaking changes to the surface this step uses.
