### PR TITLE
chore: bump the workflow action pins we run ourselves

### DIFF
--- a/.config/tend.yaml
+++ b/.config/tend.yaml
@@ -1,7 +1,7 @@
 bot_name: tend-agent
 
 setup:
-  - uses: astral-sh/setup-uv@v6
+  - uses: astral-sh/setup-uv@v9.0.0
 
 workflows:
   ci-fix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,8 +11,8 @@ jobs:
       run:
         working-directory: generator
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v9.0.0
       - run: uv run pytest
 
   # Tests for the shared credential-injection proxy addon. Run standalone (no
@@ -24,8 +24,8 @@ jobs:
       run:
         working-directory: proxy
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v9.0.0
       # Read the version from the Claude action's mitmproxy_version default so
       # the test exercises the version the production proxy runs. The addon
       # imports mitmproxy.test (an internal helper), so a second copy of the pin
@@ -97,8 +97,8 @@ jobs:
       run:
         working-directory: plugins/install-tend/skills/install-tend/scripts
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v9.0.0
       - run: uv run --no-project --with pytest pytest
 
   test-worker:
@@ -107,8 +107,8 @@ jobs:
       run:
         working-directory: worker
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: "20"
           cache: npm
@@ -120,6 +120,6 @@ jobs:
   lint:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v9.0.0
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/publish-site.yaml
+++ b/.github/workflows/publish-site.yaml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: 📂 Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'max-sixty/tend'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
 
@@ -32,7 +32,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: generator/dist
@@ -44,13 +44,13 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.13.0
+        uses: pypa/gh-action-pypi-publish@v1.14.2
 
   github-release:
     needs: pypi
@@ -58,7 +58,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Create GitHub Release from CHANGELOG section
         env:

--- a/.github/workflows/review-reviewers.yaml
+++ b/.github/workflows/review-reviewers.yaml
@@ -76,7 +76,7 @@ jobs:
       issues: write
       actions: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/tend-ci-fix.yaml
+++ b/.github/workflows/tend-ci-fix.yaml
@@ -32,7 +32,7 @@ jobs:
           fetch-tags: true
           token: ${{ secrets.TEND_BOT_TOKEN }}
 
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v9.0.0
 
       - uses: max-sixty/tend/claude@0.1.14
         with:

--- a/.github/workflows/tend-mention.yaml
+++ b/.github/workflows/tend-mention.yaml
@@ -360,7 +360,7 @@ jobs:
           fetch-tags: true
           token: ${{ secrets.TEND_BOT_TOKEN }}
 
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v9.0.0
 
       - name: Check out PR branch
         if: |

--- a/.github/workflows/tend-nightly.yaml
+++ b/.github/workflows/tend-nightly.yaml
@@ -32,7 +32,7 @@ jobs:
           fetch-tags: true
           token: ${{ secrets.TEND_BOT_TOKEN }}
 
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v9.0.0
 
       - uses: max-sixty/tend/claude@0.1.14
         with:

--- a/.github/workflows/tend-notifications.yaml
+++ b/.github/workflows/tend-notifications.yaml
@@ -136,7 +136,7 @@ jobs:
           fetch-tags: true
           token: ${{ secrets.TEND_BOT_TOKEN }}
 
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v9.0.0
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'
       - uses: max-sixty/tend/claude@0.1.14
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/tend-review-runs.yaml
+++ b/.github/workflows/tend-review-runs.yaml
@@ -32,7 +32,7 @@ jobs:
           fetch-tags: true
           token: ${{ secrets.TEND_BOT_TOKEN }}
 
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v9.0.0
 
       - uses: max-sixty/tend/claude@0.1.14
         with:

--- a/.github/workflows/tend-review.yaml
+++ b/.github/workflows/tend-review.yaml
@@ -35,7 +35,7 @@ jobs:
           fetch-tags: true
           token: ${{ secrets.TEND_BOT_TOKEN }}
 
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v9.0.0
 
       # GitHub only materializes refs/pull/N/merge for mergeable PRs — on
       # conflicting PRs it 404s and every downstream step cascades as skipped.

--- a/.github/workflows/tend-triage.yaml
+++ b/.github/workflows/tend-triage.yaml
@@ -35,7 +35,7 @@ jobs:
           fetch-tags: true
           token: ${{ secrets.TEND_BOT_TOKEN }}
 
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v9.0.0
 
       - uses: max-sixty/tend/claude@0.1.14
         with:

--- a/.github/workflows/tend-weekly.yaml
+++ b/.github/workflows/tend-weekly.yaml
@@ -32,7 +32,7 @@ jobs:
           fetch-tags: true
           token: ${{ secrets.TEND_BOT_TOKEN }}
 
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v9.0.0
 
       - uses: max-sixty/tend/claude@0.1.14
         with:

--- a/.github/workflows/worker-deploy.yaml
+++ b/.github/workflows/worker-deploy.yaml
@@ -24,9 +24,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm


### PR DESCRIPTION
Weekly `uses:` drift sweep, "ours alone" half: the hand-maintained `.github/workflows/` files plus `.config/tend.yaml`. Nothing here ships to adopters — the adopter-facing refs are split into their own PRs.

| Ref | Was | Now | Where |
|---|---|---|---|
| `actions/checkout` | v6 | v7 | ci, publish-site, pypi-release, review-reviewers, worker-deploy |
| `actions/setup-node` | v4 | v7 | ci, publish-site, worker-deploy |
| `astral-sh/setup-uv` | v7 | v9.0.0 | ci, pypi-release |
| `astral-sh/setup-uv` | v6 | v9.0.0 | `.config/tend.yaml` `setup:` |
| `actions/upload-artifact` | v6 | v7 | pypi-release |
| `actions/download-artifact` | v7 | v8 | pypi-release |
| `pypa/gh-action-pypi-publish` | v1.13.0 | v1.14.2 | pypi-release |

The generated `tend-*.yaml` changes are the `setup:` bump landing through `uvx tend@0.1.14 init` — one `setup-uv` line per workflow, nothing else. Regenerating against the released 0.1.14 (not the in-tree generator) keeps the `max-sixty/tend/claude@0.1.14` pin resolvable. Nothing in CI checks that regen — `tend-install-test` only exists on an install PR (`init --with-install-test`) and the nightly regen deletes it — so it was verified by hand: `uvx tend@0.1.14 init` on this branch leaves the tree unchanged.

Two things worth knowing rather than just merging past:

**`setup-uv` no longer publishes floating major tags.** v8.0.0 was the first immutable release and dropped the moving `v8`/`v9` refs — `astral-sh/setup-uv@v9` does not resolve. Hence the exact `@v9.0.0` pin, which is a shape change from the `@v6`/`@v7` this repo used before; future bumps of this action are full-version edits.

**`setup-uv` v9.0.0 flips `prune-cache` to `false` by default** (astral-sh/setup-uv#967) to reduce load on PyPI infrastructure. Upstream marked it breaking because it can raise Actions cache usage. That lands in this repo's CI and in the generated tend workflows; the mitmproxy cache in `claude/action.yaml` is a separate `actions/cache` entry and is unaffected. If cache growth is unwelcome, `prune-cache: true` restores the old behavior — say the word and I'll add it to `.config/tend.yaml`'s `setup:` rather than hold the version back.

The other majors are routine: `checkout` v7 is dependency updates plus PR-checkout input hardening; `setup-node` v7 is an ESM migration with new `cache-primary-key`/`cache-matched-key` outputs and the dummy `NODE_AUTH_TOKEN` export removed; `upload-artifact` v7 and `download-artifact` v8 are runtime/dependency refreshes (v8 adds CJK artifact-name support); `gh-action-pypi-publish` v1.14.2 is a dependency-tree update whose visible piece is Twine 7, which is what lets an sdist or wheel carrying core-metadata 2.5 upload at all.

