### PR TITLE
chore: bump astral-sh/setup-uv to v9.0.0

### DIFF
--- a/docs/tend.example.yaml
+++ b/docs/tend.example.yaml
@@ -120,14 +120,14 @@ bot_name: my-project-bot
 # `uses`:
 #
 #     setup:
-#       - uses: astral-sh/setup-uv@v6
+#       - uses: astral-sh/setup-uv@v9.0.0
 #
 #     # renders as (in tend-notifications):
-#     #   - uses: astral-sh/setup-uv@v6
+#     #   - uses: astral-sh/setup-uv@v9.0.0
 #     #     if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'
 #     #
 #     # and in other workflows:
-#     #   - uses: astral-sh/setup-uv@v6
+#     #   - uses: astral-sh/setup-uv@v9.0.0
 #
 # `uses` with action inputs and step-level env:
 #

--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -468,7 +468,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v9.0.0
       - name: Verify generator output matches committed files
         env:
           GH_TOKEN: ${{{{ github.token }}}}

--- a/generator/tests/_regtest_outputs/test_generate.test_install_test_workflow_regtest[claude].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_install_test_workflow_regtest[claude].out
@@ -24,7 +24,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v9.0.0
       - name: Verify generator output matches committed files
         env:
           GH_TOKEN: ${{ github.token }}

--- a/generator/tests/_regtest_outputs/test_generate.test_install_test_workflow_regtest[codex].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_install_test_workflow_regtest[codex].out
@@ -24,7 +24,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v9.0.0
       - name: Verify generator output matches committed files
         env:
           GH_TOKEN: ${{ github.token }}

--- a/generator/tests/test_integration.py
+++ b/generator/tests/test_integration.py
@@ -756,7 +756,9 @@ def test_install_test_workflow_shape(
     # Version is pinned from the committed header (not `@latest`) so a release
     # mid-PR doesn't fail the drift check for an irrelevant reason.
     assert 'uvx "tend@$TEND_VERSION" init --with-install-test' in content
-    assert "astral-sh/setup-uv@v6" in content
+    # Version-agnostic: the exact pin is covered by the regtest output, and
+    # weekly bumps shouldn't have to edit two places.
+    assert "astral-sh/setup-uv@" in content
 
     # Default-branch probe: must not use `git remote set-head origin --auto`,
     # which errors on the default shallow `actions/checkout@v7` (only the PR

--- a/plugins/install-tend/skills/install-tend/references/tend.example.yaml
+++ b/plugins/install-tend/skills/install-tend/references/tend.example.yaml
@@ -120,14 +120,14 @@ bot_name: my-project-bot
 # `uses`:
 #
 #     setup:
-#       - uses: astral-sh/setup-uv@v6
+#       - uses: astral-sh/setup-uv@v9.0.0
 #
 #     # renders as (in tend-notifications):
-#     #   - uses: astral-sh/setup-uv@v6
+#     #   - uses: astral-sh/setup-uv@v9.0.0
 #     #     if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'
 #     #
 #     # and in other workflows:
-#     #   - uses: astral-sh/setup-uv@v6
+#     #   - uses: astral-sh/setup-uv@v9.0.0
 #
 # `uses` with action inputs and step-level env:
 #


### PR DESCRIPTION
Weekly `uses:` drift sweep, adopter-facing half for `astral-sh/setup-uv`: v6 → v9.0.0 in the generated `tend-install-test` workflow (`generator/src/tend/workflows.py`) and in the commented `setup:` example that both `docs/tend.example.yaml` and the install skill's copy show adopters. The refs this repo runs itself move separately in #920.

**No floating major tag.** v8.0.0 was `setup-uv`'s first immutable release and dropped the moving major/minor refs — `astral-sh/setup-uv@v9` does not resolve, only `@v9.0.0` does. That's a shape change for anyone copying the example: future bumps are full-version edits, not a major that drifts forward on its own.

What the three majors carry:

- **v7.0.0** — Node 20 → Node 24, hence "breaking" for self-hosted runners that don't auto-update. Also removes the long-deprecated `server-url` input, superseded by `manifest-file`. Neither the generated workflow nor the example uses it.
- **v8.0.0** — immutable releases, plus removal of the old `manifest-file` format (a new format replaces it) and the major/minor tags above.
- **v9.0.0** — `prune-cache` now defaults to `false`, to reduce load on PyPI infrastructure (astral-sh/setup-uv#967). Marked breaking because it can raise an adopter's Actions cache usage. It's the one change here an adopter might actually notice; `prune-cache: true` restores the old behavior.

`tend-install-test` is a one-shot workflow (`init --with-install-test`) that runs on PRs touching the generated files, so the exposure of the v9 cache change through *that* path is small — the wider surface is adopters who copied the example `setup:` block.

Also relaxes the `setup-uv` assertion in `test_install_test_workflow_shape` to be version-agnostic. The exact pin is already covered byte-for-byte by the regtest output; asserting it a second time meant every weekly bump edited two places to say the same thing.
