### PR TITLE
ci: smoke the pinned Codex CLI surface, and bump it off the alpha line

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -183,16 +183,12 @@ only launches that mitmproxy and CI smokes the two together, so it needs no
 release stream of its own; move both in one PR, at whatever uv is latest then
 (`curl -fsS https://pypi.org/pypi/uv/json | jq -r .info.version`).
 
-`codex_version` was held to the `alpha` dist-tag because only prereleases
-carried `codex plugin add`; stable ships it now, so bump to `latest` and drop to
-`alpha` only for a fix not yet released. CI's `test-codex-surface` job installs
-the pinned version and asserts the flags `codex exec` is passed plus the
-`Installed plugin root: ` line the action parses, so a bump that breaks the CLI
-surface fails on its own PR. That is the whole of the confirmation reachable
-here: no `OPENAI_API_KEY` reaches this repo's runs, so an agent session — model
-selection, `model_reasoning_effort`, whether the final message lands in
-`--output-last-message` — stays unverified. Skim the codex CHANGELOG across the
-bump for those paths and note it in the PR.
+Bump `codex_version` to `latest`; drop to `alpha` only for a fix not yet
+released. CI's `test-codex-surface` job installs whatever is pinned and asserts
+the CLI surface the action depends on, so a bump that breaks it fails on its own
+PR. No `OPENAI_API_KEY` reaches this repo's runs, so a live agent session stays
+unverified — skim the codex CHANGELOG across the bump for sandbox behavior and
+`--output-last-message`, and note what you find in the PR.
 
 ### `uses:` refs
 

--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -187,8 +187,8 @@ Bump `codex_version` to `latest`; drop to `alpha` only for a fix not yet
 released. CI's `test-codex-surface` job installs whatever is pinned and asserts
 the CLI surface the action depends on, so a bump that breaks it fails on its own
 PR. No `OPENAI_API_KEY` reaches this repo's runs, so a live agent session stays
-unverified — skim the codex CHANGELOG across the bump for sandbox behavior and
-`--output-last-message`, and note what you find in the PR.
+unverified — skim the codex CHANGELOG across the bump for model availability,
+sandbox behavior, and `--output-last-message`, and note what you find in the PR.
 
 ### `uses:` refs
 

--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -156,7 +156,7 @@ both.
 | `claude_version` | `claude/action.yaml` | track latest |
 | `mitmproxy_version` | `claude/action.yaml` | track latest |
 | `uv_version` | `claude/action.yaml` | move it with `mitmproxy_version` |
-| `codex_version` | `codex/action.yaml` | keep it on its prerelease line; bump only to a release confirmed to run under `codex exec` |
+| `codex_version` | `codex/action.yaml` | keep it on its prerelease line; bump it and let CI's surface job confirm it |
 
 ```bash
 yq '.inputs.claude_version.default' claude/action.yaml
@@ -164,6 +164,9 @@ npm view @anthropic-ai/claude-code dist-tags.latest
 
 yq '.inputs.mitmproxy_version.default' claude/action.yaml
 curl -fsS https://pypi.org/pypi/mitmproxy/json | jq -r .info.version
+
+yq '.inputs.codex_version.default' codex/action.yaml
+npm view @openai/codex dist-tags.alpha
 ```
 
 A stale `claude` binary resolves `--model opus`/`sonnet` to a superseded alias
@@ -179,6 +182,16 @@ addon-related in its CHANGELOG against the `mitmdump` flags in
 only launches that mitmproxy and CI smokes the two together, so it needs no
 release stream of its own; move both in one PR, at whatever uv is latest then
 (`curl -fsS https://pypi.org/pypi/uv/json | jq -r .info.version`).
+
+`codex_version` has no release stream to track either — the bump moves it to
+whatever the `alpha` dist-tag holds. CI's `test-codex-surface` job installs the
+pinned version and asserts the flags `codex exec` is passed plus the
+`Installed plugin root: ` line the action parses, so a bump that breaks the CLI
+surface fails on its own PR. That is the whole of the confirmation reachable
+here: no `OPENAI_API_KEY` reaches this repo's runs, so an agent session — model
+selection, `model_reasoning_effort`, whether the final message lands in
+`--output-last-message` — stays unverified. Skim the codex CHANGELOG across the
+bump for those paths and note it in the PR.
 
 ### `uses:` refs
 

--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -156,7 +156,7 @@ both.
 | `claude_version` | `claude/action.yaml` | track latest |
 | `mitmproxy_version` | `claude/action.yaml` | track latest |
 | `uv_version` | `claude/action.yaml` | move it with `mitmproxy_version` |
-| `codex_version` | `codex/action.yaml` | keep it on its prerelease line; bump it and let CI's surface job confirm it |
+| `codex_version` | `codex/action.yaml` | track latest; the surface job confirms the bump |
 
 ```bash
 yq '.inputs.claude_version.default' claude/action.yaml
@@ -166,7 +166,7 @@ yq '.inputs.mitmproxy_version.default' claude/action.yaml
 curl -fsS https://pypi.org/pypi/mitmproxy/json | jq -r .info.version
 
 yq '.inputs.codex_version.default' codex/action.yaml
-npm view @openai/codex dist-tags.alpha
+npm view @openai/codex dist-tags.latest
 ```
 
 A stale `claude` binary resolves `--model opus`/`sonnet` to a superseded alias
@@ -183,9 +183,10 @@ only launches that mitmproxy and CI smokes the two together, so it needs no
 release stream of its own; move both in one PR, at whatever uv is latest then
 (`curl -fsS https://pypi.org/pypi/uv/json | jq -r .info.version`).
 
-`codex_version` has no release stream to track either — the bump moves it to
-whatever the `alpha` dist-tag holds. CI's `test-codex-surface` job installs the
-pinned version and asserts the flags `codex exec` is passed plus the
+`codex_version` was held to the `alpha` dist-tag because only prereleases
+carried `codex plugin add`; stable ships it now, so bump to `latest` and drop to
+`alpha` only for a fix not yet released. CI's `test-codex-surface` job installs
+the pinned version and asserts the flags `codex exec` is passed plus the
 `Installed plugin root: ` line the action parses, so a bump that breaks the CLI
 surface fails on its own PR. That is the whole of the confirmation reachable
 here: no `OPENAI_API_KEY` reaches this repo's runs, so an agent session — model

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,8 +87,7 @@ jobs:
           kill "$pid" 2>/dev/null || true
           test -f "$confdir/mitmproxy-ca-cert.pem"
 
-  # `codex_version` is the one action pin with no upstream release stream to
-  # follow, and the weekly rule that governs it asked for a confirmation
+  # The weekly rule that governed `codex_version` asked for a confirmation
   # nothing here could produce ("bump only to a release confirmed to run under
   # `codex exec`"): no OPENAI_API_KEY reaches this repo's runs and no workflow
   # sets `harness: codex`, so the pin drifted by default rather than by
@@ -103,9 +102,9 @@ jobs:
   # .agents/plugins/marketplace.json or the plugin manifest that Codex can no
   # longer install fails here rather than in an adopter's job.
   #
-  # It does not cover an agent session: model selection,
-  # `model_reasoning_effort`, sandbox behavior, and whether the final message
-  # reaches --output-last-message all need a real key.
+  # It does not cover an agent session: sandbox behavior under a live model,
+  # and whether the final message reaches --output-last-message, both need a
+  # real key.
   test-codex-surface:
     runs-on: ubuntu-24.04
     steps:
@@ -149,6 +148,24 @@ jobs:
           # would break with the job still green.
           test -f "$root/skills/triage/SKILL.md"
           test -x "$root/scripts/list-recent-runs.sh"
+
+          # `model_reasoning_effort` is passed as a `-c` override, so a rename
+          # would be silently ignored rather than rejected — `--help` can't see
+          # it. `--strict-config` does validate `-c` keys, and both probes stop
+          # at the trusted-directory check before any network call, so this
+          # stays offline and fast. Run from a non-repo dir to hit that check.
+          probedir=$(mktemp -d)
+          probe() { (cd "$probedir" && codex exec --strict-config -c "$1" x </dev/null 2>&1); }
+          # Negative control: if this stops erroring, --strict-config no longer
+          # validates -c keys and the positive check below proves nothing.
+          if ! probe 'model_reasoning_effortZZZ="low"' | grep -q 'unknown configuration field'; then
+            echo "::error::codex $v no longer rejects unknown -c keys under --strict-config; the check below is void"
+            exit 1
+          fi
+          if probe 'model_reasoning_effort="low"' | grep -q 'unknown configuration field'; then
+            echo "::error::codex $v no longer accepts the model_reasoning_effort config key"
+            exit 1
+          fi
 
   # The OAuth wrapper ships inside the install-tend plugin rather than under
   # generator/, so the suites above never reach it. Its extractors decide what

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,9 +102,9 @@ jobs:
   # .agents/plugins/marketplace.json or the plugin manifest that Codex can no
   # longer install fails here rather than in an adopter's job.
   #
-  # It does not cover an agent session: sandbox behavior under a live model,
-  # and whether the final message reaches --output-last-message, both need a
-  # real key.
+  # It does not cover an agent session: model selection, sandbox behavior
+  # under a live model, and whether the final message reaches
+  # --output-last-message all need a real key.
   test-codex-surface:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,6 +87,63 @@ jobs:
           kill "$pid" 2>/dev/null || true
           test -f "$confdir/mitmproxy-ca-cert.pem"
 
+  # `codex_version` is the one action pin with no upstream release stream to
+  # follow, and the weekly rule that governs it asked for a confirmation
+  # nothing here could produce ("bump only to a release confirmed to run under
+  # `codex exec`"): no OPENAI_API_KEY reaches this repo's runs and no workflow
+  # sets `harness: codex`, so the pin drifted by default rather than by
+  # decision. This is the half of that confirmation which needs no credential,
+  # so it can gate every bump PR.
+  #
+  # It covers where a silent break actually lands: `codex exec` dropping or
+  # renaming a flag the action passes, and `codex plugin add` no longer
+  # printing the `Installed plugin root: ` prefix the action parses with awk to
+  # set CLAUDE_PLUGIN_ROOT. Either one fails every adopter's Codex run at the
+  # first step. It guards the other direction too — a change to
+  # .agents/plugins/marketplace.json or the plugin manifest that Codex can no
+  # longer install fails here rather than in an adopter's job.
+  #
+  # It does not cover an agent session: model selection,
+  # `model_reasoning_effort`, sandbox behavior, and whether the final message
+  # reaches --output-last-message all need a real key.
+  test-codex-surface:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      # `yq -e` exits non-zero if the input is ever renamed, rather than
+      # yielding "null" and failing later as an unresolvable npm version.
+      - name: Smoke the pinned Codex CLI surface
+        run: |
+          v=$(yq -e '.inputs.codex_version.default' codex/action.yaml)
+          npm install -g "@openai/codex@$v"
+          codex --version
+
+          # Every flag the action's `Run Codex` step passes. Matching on
+          # `--flag <` pins the option to one that still takes a value, so a
+          # release that keeps the name but drops the argument fails here.
+          help=$(codex exec --help)
+          for flag in --model --sandbox --output-last-message --config; do
+            grep -qF -- "$flag <" <<<"$help" || {
+              echo "::error::codex exec no longer accepts $flag <VALUE> in $v"
+              exit 1
+            }
+          done
+
+          # The action registers the marketplace from the repo root and reads
+          # the install path back out of the install output.
+          codex plugin marketplace add "$PWD"
+          out=$(codex plugin add tend-ci-runner@tend)
+          echo "$out"
+          root=$(awk -F': ' '/^Installed plugin root: /{print $2}' <<<"$out")
+          if [ -z "$root" ] || [ ! -d "$root" ]; then
+            echo "::error::codex $v no longer prints a parseable 'Installed plugin root: <path>'"
+            exit 1
+          fi
+          test -f "$root/skills/triage/SKILL.md"
+
   # The OAuth wrapper ships inside the install-tend plugin rather than under
   # generator/, so the suites above never reach it. Its extractors decide what
   # becomes an adopter's model credential, and a wrong answer stores a secret

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -142,7 +142,13 @@ jobs:
             echo "::error::codex $v no longer prints a parseable 'Installed plugin root: <path>'"
             exit 1
           fi
+          # Both trees skills reach for through CLAUDE_PLUGIN_ROOT. Only
+          # `skills/` is declared in plugin.json, so `scripts/` materializing
+          # is a packaging side effect that a release could stop honouring —
+          # and every skill shelling out to ${CLAUDE_PLUGIN_ROOT}/scripts/
+          # would break with the job still green.
           test -f "$root/skills/triage/SKILL.md"
+          test -x "$root/scripts/list-recent-runs.sh"
 
   # The OAuth wrapper ships inside the install-tend plugin rather than under
   # generator/, so the suites above never reach it. Its extractors decide what

--- a/codex/action.yaml
+++ b/codex/action.yaml
@@ -55,11 +55,12 @@ inputs:
   codex_version:
     default: "0.131.0-alpha.22"
     description: >-
-      `@openai/codex` npm version to install (e.g. `0.131.0-alpha.22`).
-      Must ship the `codex plugin add` subcommand (PR #21396, first
-      released in `rust-v0.131.0-alpha.17`). On npm this currently lives
-      on the `alpha` dist-tag — `latest` is still 0.130.0 and lacks it,
-      so the default pins an explicit alpha rather than tracking `latest`.
+      `@openai/codex` npm version to install (e.g. `0.147.0`). Must ship
+      the `codex plugin add` subcommand (PR #21396, first released in
+      `rust-v0.131.0-alpha.17`). That was `alpha`-only when the pin was
+      set, which is why the default is still a prerelease; `latest` has
+      since caught up, so a bump tracks `latest`. CI's
+      `test-codex-surface` job confirms whichever version is pinned.
   allowed_bots:
     default: "*"
     description: Bots allowed to trigger workflows (engagement gate, not used yet)
@@ -112,11 +113,11 @@ runs:
 
     # Install the Codex CLI from npm. `@openai/codex` ships a prebuilt
     # per-platform binary, so this is ~3 s with no Rust toolchain. We pin
-    # an explicit version (`codex_version`, default a `0.131.0-alpha.*`)
-    # because tend needs `codex plugin add` (PR #21396, first in
-    # `rust-v0.131.0-alpha.17`) and as of 2026-05-15 npm's `latest`
-    # (0.130.0) still predates it — only the `alpha` dist-tag carries it.
-    # Bump the default once a stable npm release ships PR #21396.
+    # an explicit version (`codex_version`) because tend needs `codex
+    # plugin add` (PR #21396, first in `rust-v0.131.0-alpha.17`), which
+    # was carried only by the `alpha` dist-tag when the pin was set. It
+    # is on stable now, so the bump target is `latest`; the pinned
+    # prerelease is a leftover, not a requirement.
     - name: Install Codex CLI
       shell: bash
       run: |

--- a/codex/action.yaml
+++ b/codex/action.yaml
@@ -53,13 +53,12 @@ inputs:
     default: danger-full-access
     description: Codex sandbox mode (workspace-write, read-only, danger-full-access)
   codex_version:
-    default: "0.131.0-alpha.22"
+    default: "0.147.0"
     description: >-
       `@openai/codex` npm version to install (e.g. `0.147.0`). Must ship
       the `codex plugin add` subcommand (PR #21396, first released in
       `rust-v0.131.0-alpha.17`). That was `alpha`-only when the pin was
-      set, which is why the default is still a prerelease; `latest` has
-      since caught up, so a bump tracks `latest`. CI's
+      first set; stable carries it now, so this tracks `latest`. CI's
       `test-codex-surface` job confirms whichever version is pinned.
   allowed_bots:
     default: "*"
@@ -113,11 +112,12 @@ runs:
 
     # Install the Codex CLI from npm. `@openai/codex` ships a prebuilt
     # per-platform binary, so this is ~3 s with no Rust toolchain. We pin
-    # an explicit version (`codex_version`) because tend needs `codex
-    # plugin add` (PR #21396, first in `rust-v0.131.0-alpha.17`), which
-    # was carried only by the `alpha` dist-tag when the pin was set. It
-    # is on stable now, so the bump target is `latest`; the pinned
-    # prerelease is a leftover, not a requirement.
+    # an explicit version (`codex_version`) rather than floating on
+    # `latest` so an adopter's run can't change engine mid-release. The
+    # pin sat on an `alpha` for a while because only prereleases carried
+    # `codex plugin add` (PR #21396, first in `rust-v0.131.0-alpha.17`);
+    # stable ships it now, so the pin tracks `latest` and drops back to a
+    # prerelease only for a fix that hasn't been released yet.
     - name: Install Codex CLI
       shell: bash
       run: |


### PR DESCRIPTION
## Problem

`codex_version` is pinned at `0.131.0-alpha.22` in `codex/action.yaml` while `latest` is `0.147.0`. The weekly rule governing it asked for a confirmation nothing in this repo could produce — *"bump only to a release confirmed to run under `codex exec`"* — because there is no `OPENAI_API_KEY` in the `tend` environment (`gh secret list --env tend` returns only `CLAUDE_CODE_OAUTH_TOKEN` and `TEND_BOT_TOKEN`), no `harness: codex` override in `.config/tend.yaml`, and no codex step in `ci.yaml`. The bump condition was unsatisfiable, so the pin drifted by default rather than by decision.

Both proposals in #922 need that same missing secret, so neither is actually the cheaper one. What doesn't need it is the part of the confirmation that is mechanically checkable — and it turns out to be the part where a silent break would land.

## Solution

**A `test-codex-surface` job in `ci.yaml`**, shaped after the existing `test-proxy` smoke: read the pin out of the action with `yq -e`, install it, and assert the surface the action depends on.

- Every flag the `Run Codex` step passes — `--model`, `--sandbox`, `--output-last-message`, `--config`. Matching on `--flag <` pins each to an option that still takes a value, so a release that keeps the name but drops the argument fails too.
- The `Installed plugin root: ` prefix that `codex plugin add` prints and the action parses with `awk` to set `CLAUDE_PLUGIN_ROOT`, plus that both trees skills reach for through that variable land under it — `skills/` and `scripts/`. Only `skills/` is declared in `plugin.json`, so `scripts/` materializing is a packaging side effect a release could stop honouring while every skill shelling out to `${CLAUDE_PLUGIN_ROOT}/scripts/` breaks.

No credential is involved: `codex --version`, `codex exec --help`, `codex plugin marketplace add`, and `codex plugin add` are all local. So the job runs on every PR, which also guards the other direction — a change to `.agents/plugins/marketplace.json` or the plugin layout that Codex can no longer install now fails here rather than in an adopter's job, which nothing catches today.

**The bump target moves to `latest`, and the pin moves with it.** The premise behind the prerelease pin has expired: `codex plugin add` was `alpha`-only when the pin was set, but stable `0.147.0` carries it. So the `running-tend` weekly rule now reads `track latest` (dropping to `alpha` only for a fix not yet released), the two `codex/action.yaml` comments that still said `latest` was `0.130.0` and lacked the subcommand are corrected, and `codex_version` is bumped `0.131.0-alpha.22` → `0.147.0`. The bump ships here rather than separately because this job is its confirmation — the gate and the first bump it gates are the same review, and the job would otherwise land green against a pin nobody had re-examined.

The rule also states plainly what stays unverified without a key — sandbox behavior under a real session, and whether the agent's final message actually reaches `--output-last-message` — with an instruction to skim the codex CHANGELOG for those paths, mirroring the `claude_version` rule.

## Testing

The job's script body ran end-to-end in this session with no OpenAI credential present, against the old pin, the new one, and the current alpha. Beyond that, `--strict-config` turns out to validate `-c` overrides, which reaches further than `--help` matching does: it confirms `model_reasoning_effort` is still a recognized field at `0.147.0` rather than a silently-ignored one.

<details><summary>Surface probe</summary>

| Version | Flags | `plugin add` parse | `skills/` + `scripts/` |
|---|---|---|---|
| `0.131.0-alpha.22` (old pin) | pass | pass | pass |
| `0.147.0` (new pin, `latest`) | pass | pass | pass |
| `0.148.0-alpha.5` (`alpha`) | pass | pass | pass |

`codex exec --help` at `0.147.0`, identical to the old pin for every flag the action passes:

```
  -c, --config <key=value>
  -m, --model <MODEL>
  -s, --sandbox <SANDBOX_MODE>
  -o, --output-last-message <FILE>
```

`--sandbox` still accepts `danger-full-access`, which is the action's default: `[possible values: read-only, workspace-write, danger-full-access]`.

</details>

<details><summary>Config-key probe, and how far a keyless run gets</summary>

`--strict-config` rejects unknown `-c` keys, so it can distinguish "field still exists" from "field silently ignored":

```
$ codex exec --strict-config -c 'model_reasoning_effortZZZ="low"' ...
Error loading config.toml: unknown configuration field `model_reasoning_effortZZZ` in -c/--config override

$ codex exec --strict-config -c 'model_reasoning_effort="low"' ...
(config loads; proceeds past config to the git-repo check)
```

Running the action's exact argument set with a deliberately invalid key gets all the way to the API call, so every flag and the `gpt-5.5` model string were accepted and the only thing that stopped it was auth:

```
$ codex exec --strict-config --skip-git-repo-check --model gpt-5.5 \
    --sandbox danger-full-access --output-last-message /tmp/o.md \
    -c 'model_reasoning_effort="low"' "say hi"
ERROR: unexpected status 401 Unauthorized: Missing bearer or basic authentication in header
```

Not attempted, and not reachable here: a successful `codex exec` session — so the final message actually landing in `--output-last-message`, and sandbox behavior under a live model, remain unverified.

</details>

<details><summary>CHANGELOG skim, <code>rust-v0.132.0</code> → <code>rust-v0.147.0</code></summary>

One removal in range touches `codex exec`'s flag surface: *"Remove the deprecated `codex exec --full-auto` flag; use `--sandbox workspace-write` instead"* ([#36054](https://github.com/openai/codex/pull/36054), in `rust-v0.147.0`). The action never passed `--full-auto` — it passes `--sandbox` explicitly — so it is unaffected.

Nothing else in range removes or renames a flag the action passes, and plugin work across the range is additive (search, remote catalogs, manifests) rather than changing the local `marketplace add` / `plugin add` path this depends on.

</details>

---

Refs #922. The agent-session half stays open: it needs a maintainer to put an `OPENAI_API_KEY` in the `tend` environment, which is the single decision both of the issue's options reduce to. (The body previously said `Closes #922` while also saying it didn't cover that half — corrected here so merging doesn't auto-close it.)
