### PR TITLE
chore: bump actions/setup-node to v7

### DIFF
--- a/docs/tend.example.yaml
+++ b/docs/tend.example.yaml
@@ -132,7 +132,7 @@ bot_name: my-project-bot
 # `uses` with action inputs and step-level env:
 #
 #     setup:
-#       - uses: actions/setup-node@v4
+#       - uses: actions/setup-node@v7
 #         name: Setup Node
 #         with:
 #           node-version-file: .node-version
@@ -140,7 +140,7 @@ bot_name: my-project-bot
 #           FORCE_COLOR: "1"
 #
 #     # renders as:
-#     #   - uses: actions/setup-node@v4
+#     #   - uses: actions/setup-node@v7
 #     #     name: Setup Node
 #     #     with:
 #     #       node-version-file: .node-version

--- a/plugins/install-tend/skills/install-tend/references/tend.example.yaml
+++ b/plugins/install-tend/skills/install-tend/references/tend.example.yaml
@@ -132,7 +132,7 @@ bot_name: my-project-bot
 # `uses` with action inputs and step-level env:
 #
 #     setup:
-#       - uses: actions/setup-node@v4
+#       - uses: actions/setup-node@v7
 #         name: Setup Node
 #         with:
 #           node-version-file: .node-version
@@ -140,7 +140,7 @@ bot_name: my-project-bot
 #           FORCE_COLOR: "1"
 #
 #     # renders as:
-#     #   - uses: actions/setup-node@v4
+#     #   - uses: actions/setup-node@v7
 #     #     name: Setup Node
 #     #     with:
 #     #       node-version-file: .node-version


### PR DESCRIPTION
The adopter-facing half of this week's `uses:` sweep moved `astral-sh/setup-uv` in #921 (still open, as is #920 for the refs we run ourselves — nothing has landed on `main` yet) and skipped `actions/setup-node`, which sits a dozen lines below it in the same example block: `v4` → `v7`. It appears twice per file (the `setup:` snippet and the "renders as" output beside it), in `docs/tend.example.yaml` and its byte-identical mirror under the install skill's `references/`.

Both are commented examples, but they're the text an adopter copies into their own `.config/tend.yaml`, and the weekly sweep's grep matches them — it excludes `generator/tests` and `*.md`, not commented lines in a `.yaml` — so leaving them behind means this line reappears in the drift report every week. That's the motivation.

Bare major, not a full version: `actions/setup-node@v7` and `@v7.0.0` resolve to the same commit (`8207627`), so the moving major still tracks — unlike `setup-uv`, whose v8 dropped its major/minor refs and forced the full-version pin #921 explains. `@v7` matches how every other `actions/*` ref in this repo is pinned.

What the three majors carry, for an adopter copying the block:

- **v5.0.0** — automatic caching when `package.json` has a `packageManager` field (disable with `package-manager-cache: false`), and Node 20 → Node 24, which needs runner v2.327.1+.
- **v6.0.0** — narrows that automatic caching to npm only.
- **v7.0.0** — no breaking changes; adds `cache-primary-key` / `cache-matched-key` outputs, migrates to ESM, drops a dummy `NODE_AUTH_TOKEN` export.

The example passes `node-version-file` and no `cache` input, so nothing in it changes shape — the v5 auto-caching is the only behavior an adopter copying it verbatim would newly see, and only on a repo whose `package.json` declares `packageManager`.

`generator/tests/` keeps `setup-node@v4` in its fixtures; those are arbitrary inputs exercising `uses`-with-`with` rendering, not a pin anyone runs, and the sweep's grep excludes that path.

Comment-only change to two files; `cd generator && pytest` passes (379).

#925 was a byte-identical duplicate of this PR — two sibling weekly runs opened them 47 seconds apart, so neither saw the other in its pre-create dedup check. It has since been closed in favor of this one; its motivation paragraph is folded in above.
