### PR TITLE
chore: bump actions/setup-node to v7 in the example config

### DIFF
--- a/docs/tend.example.yaml
+++ b/docs/tend.example.yaml
@@ -132,7 +132,7 @@ bot_name: my-project-bot
 # `uses` with action inputs and step-level env:
 #
 #     setup:
-#       - uses: actions/setup-node@v4
+#       - uses: actions/setup-node@v7
 #         name: Setup Node
 #         with:
 #           node-version-file: .node-version
@@ -140,7 +140,7 @@ bot_name: my-project-bot
 #           FORCE_COLOR: "1"
 #
 #     # renders as:
-#     #   - uses: actions/setup-node@v4
+#     #   - uses: actions/setup-node@v7
 #     #     name: Setup Node
 #     #     with:
 #     #       node-version-file: .node-version

--- a/plugins/install-tend/skills/install-tend/references/tend.example.yaml
+++ b/plugins/install-tend/skills/install-tend/references/tend.example.yaml
@@ -132,7 +132,7 @@ bot_name: my-project-bot
 # `uses` with action inputs and step-level env:
 #
 #     setup:
-#       - uses: actions/setup-node@v4
+#       - uses: actions/setup-node@v7
 #         name: Setup Node
 #         with:
 #           node-version-file: .node-version
@@ -140,7 +140,7 @@ bot_name: my-project-bot
 #           FORCE_COLOR: "1"
 #
 #     # renders as:
-#     #   - uses: actions/setup-node@v4
+#     #   - uses: actions/setup-node@v7
 #     #     name: Setup Node
 #     #     with:
 #     #       node-version-file: .node-version


### PR DESCRIPTION
Closes the adopter-facing half of this week's `uses:` sweep. `docs/tend.example.yaml` and the install skill's copy of it illustrate a `setup:` block with `actions/setup-node@v4`; latest is `v7.0.0`. Both are commented examples, but they're the text an adopter copies into their own `.config/tend.yaml`, and the weekly sweep's grep matches them — it excludes `generator/tests` and `*.md`, not commented lines in a `.yaml` — so leaving them behind means this line reappears in the drift report every week.

The refs this repo runs itself moved in #920; `astral-sh/setup-uv` in these same two files moved in #921. Separate PR per the one-PR-per-action convention for adopter-facing refs.

`setup-node` v4 → v7 crosses:

- **v5** — automatic package-manager caching. Doesn't change this example, which already passes `node-version-file` and no `cache` input.
- **v6** — Node 24 runtime.
- **v7.0.0** — ESM migration, new `cache-primary-key` / `cache-matched-key` outputs, and removal of the dummy `NODE_AUTH_TOKEN` export.

Nothing in the example's surface (`node-version-file`, step-level `env`) changes across the three.
