### PR TITLE
skills(running-tend): check the /code-review waiver scan when bumping claude_version

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -183,16 +183,23 @@ pass. Confirm both halves in the version being pinned and report them in the PR:
 ```bash
 V=<version being pinned>
 curl -fsSL "https://downloads.claude.ai/claude-code-releases/$V/linux-x64/claude" -o "/tmp/claude-$V"
-# Scan regex: whitespace on both sides of a token built from the command name.
+# Scan regex: whitespace on both sides of a token built from the invoked
+# skill's name, which the Skill tool passes in at runtime.
 grep -aoE '\(\?<!\\\\S\)/\$\{[^}]+\}\(\?=\$\|\\\\s\)' "/tmp/claude-$V"
-# Canonical command name, via its (minified, release-unstable) binding.
-grep -aoE 'CODE_REVIEW_WORKFLOW_NAME:\(\)=>[A-Za-z0-9_$]+.{0,60}' "/tmp/claude-$V"
+# Every binding of the name, with enough context to tell which is which.
+grep -aoE '.{90}"code-review".{40}' "/tmp/claude-$V"
 ```
 
-Empty output from either grep means the shape moved; read the surrounding code
-before concluding the waiver still fires. That URL is the path the install
-actually takes — `claude.ai/install.sh` redirects to the same release bucket —
-so a version resolving on npm but not there fails the install.
+The second grep prints several hits and only one is the half that matters: the
+bundled-skill name list, a run of `var` assignments with `dataviz` and
+`code-walkthrough` as neighbors. A `CODE_REVIEW_WORKFLOW_NAME` hit names the
+built-in code-review *workflow* instead — a skill-side rename need not move it,
+so reading that one as the answer reports "still fine" on exactly the failure
+this check exists to catch. Empty output from either grep means the shape
+moved; read the surrounding code before concluding the waiver still fires. That
+URL is the path the install actually takes — `claude.ai/install.sh` redirects
+to the same release bucket — so a version resolving on npm but not there fails
+the install.
 
 `mitmproxy_version` pins the process that holds the real PAT and model
 credential, so a security fix there matters here. Check anything security- or

--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -170,7 +170,29 @@ A stale `claude` binary resolves `--model opus`/`sonnet` to a superseded alias
 target, so drift silently downgrades the model. Skim the claude-code CHANGELOG
 between the two versions for anything touching the agent paths (first-run
 onboarding, `--model` alias resolution, headless `-p` result events, Stop-hook
-behavior) and note it in the PR.
+behavior, slash-command or `Skill`-tool handling) and note it in the PR.
+
+One of those paths has to be checked against the binary, not the CHANGELOG.
+Every generated Claude prompt carries a bare `/code-review` token
+(`code_review_notice` in `generator/src/tend/config.py`) to trip the `Skill`
+tool's `disable-model-invocation` waiver, and the scan reading it lives in the
+binary. `test_default_prompt_unlocks_code_review` pins only our side of that
+contract, so if the scan moves, nothing fails — every run just loses its second
+pass. Confirm both halves in the version being pinned and report them in the PR:
+
+```bash
+V=<version being pinned>
+curl -fsSL "https://downloads.claude.ai/claude-code-releases/$V/linux-x64/claude" -o "/tmp/claude-$V"
+# Scan regex: whitespace on both sides of a token built from the command name.
+grep -aoE '\(\?<!\\\\S\)/\$\{[^}]+\}\(\?=\$\|\\\\s\)' "/tmp/claude-$V"
+# Canonical command name, via its (minified, release-unstable) binding.
+grep -aoE 'CODE_REVIEW_WORKFLOW_NAME:\(\)=>[A-Za-z0-9_$]+.{0,60}' "/tmp/claude-$V"
+```
+
+Empty output from either grep means the shape moved; read the surrounding code
+before concluding the waiver still fires. That URL is the path the install
+actually takes — `claude.ai/install.sh` redirects to the same release bucket —
+so a version resolving on npm but not there fails the install.
 
 `mitmproxy_version` pins the process that holds the real PAT and model
 credential, so a security fix there matters here. Check anything security- or


### PR DESCRIPTION
The weekly `claude_version` bump rule lists the agent paths to skim the CHANGELOG for — first-run onboarding, `--model` alias resolution, headless `-p` result events, Stop-hook behavior. It omits the one dependency that can't be settled from the CHANGELOG at all: the `/code-review` waiver scan.

`code_review_notice` in `generator/src/tend/config.py` puts a bare `/code-review` token into every generated Claude prompt, specifically to trip the `Skill` tool's `disable-model-invocation` waiver. The regex that reads that token lives inside the `claude` binary, and `test_default_prompt_unlocks_code_review` pins only our side of the contract — it asserts the prompt still carries a token matching the regex we recorded. If the binary's scan changes, that test stays green, no run errors, and every review silently loses its second pass. That is exactly the failure class a version bump can introduce.

This adds `slash-command or Skill-tool handling` to the CHANGELOG skim list, and a short recipe that checks the two halves against the binary being pinned.

The gap is not hypothetical — it just fired. #918's body reached the right conclusion about the 2.1.223 `/code-review` entry ("no action needed") from the wrong evidence: it reasoned about which skill the review path invokes rather than about the token in the generated prompt. The checklist it followed didn't point at the real dependency, so nothing prompted a binary-side check. The reviewer caught it and verified separately.

<details><summary>Verification of the recipe, against 2.1.226</summary>

The download URL is the path the install actually takes. `claude.ai/install.sh` 302s to `downloads.claude.ai/claude-code-releases/bootstrap.sh`, which sets `DOWNLOAD_BASE_URL="https://downloads.claude.ai/claude-code-releases"` and fetches `$DOWNLOAD_BASE_URL/$version/$platform/claude`. The downloaded binary's sha256 matches that release's `manifest.json` entry for `linux-x64` (`4e9bec11...a55555`).

Both greps were run verbatim against the downloaded 2.1.226 binary:

```
$ grep -aoE '\(\?<!\\\\S\)/\$\{[^}]+\}\(\?=\$\|\\\\s\)' /tmp/claude-2.1.226
(?<!\\S)/${f2(e)}(?=$|\\s)

$ grep -aoE '.{90}"code-review".{40}' /tmp/claude-2.1.226
(VXu,{WORKFLOW_TOOL_NAME:()=>oR,CODE_REVIEW_WORKFLOW_NAME:()=>F_r});var oR="Workflow",F_r="code-review";var KXu="SearchPlugins",YXu="SearchSkil
o=E(()=>{Mt();CVs=require("crypto"),wBd=require("os");sU_=new Set(["verify","pr","commit","code-review","simplify","go"]),aU_=/[/\\]\.claude[/\
"artifact-capabilities",qzo="workshop",xGd="whiteboard",IGd="prototype",Vzo="dataviz",Wde="code-review",HGd="code-walkthrough",RGd="pr-explaine
```

The first grep's `f2(e)` is the tell that the scan builds its regex from a runtime argument rather than a constant, and the call site confirms `e` is the invoked skill's name:

```
function $8b(e,t){if(t.agentId!==void 0)return!1;let r=new RegExp(`(?<!\\S)/${f2(e)}(?=$|\\s)`);
...
let l=xIn(a,{commandName:o,userTypedThisTurn:$8b(o,t),...});if(l!==null){switch(l.reason){case"disable_model_invocation":{let{sanitizedName:c,skillNameHash:u}=RPe({rawName:o,canonicalName:a.name,
```

So the half that has to hold is the third hit — the bundled-skill name list, between `dataviz` and `code-walkthrough`. The first hit, `CODE_REVIEW_WORKFLOW_NAME`, names the built-in code-review workflow and is a separate constant; anchoring the check on it would report "still fine" through a skill-side rename. The identifiers (`f2`, `Wde`) are minified and will differ between releases, which is why the recipe prints context and asks the reader to identify the hit rather than matching a binding exactly.

</details>
