### PR TITLE
fix(install-tend): trigger the skill on changes to an installed repo, not just new installs

### DIFF
--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -5,11 +5,12 @@ description: Sets up tend — an autonomous junior maintainer for a GitHub repo,
 
 # Install Tend
 
-Set up tend on the current repo. If the user hasn't supplied a bot name,
-get one via `AskUserQuestion` before step 1 using the candidate-generation
-pattern from step 6 (`<repo>-bot`, `<repo>-tend`, `tend-<repo>`, parallel
-availability check, present available ones). The user can pick "Other"
-to supply a custom name.
+Set up tend on the current repo, or change an installation it already has.
+When installing and the user hasn't supplied a bot name, get one via
+`AskUserQuestion` before step 1 using the candidate-generation pattern from
+step 6 (`<repo>-bot`, `<repo>-tend`, `tend-<repo>`, parallel availability
+check, present available ones). The user can pick "Other" to supply a custom
+name.
 
 When asking the user questions during these steps, use the `AskUserQuestion`
 tool — present concrete options when there are clear choices (e.g. bio
@@ -23,7 +24,14 @@ not have to ask "where do I do that?".
 
 ## Kickoff
 
-Before running step 1, choose the harness and lay out the plan:
+Read `.config/tend.yaml` first. Its presence says whether this is an install or
+a change to one, and where it exists it already names the harness.
+
+With a config in place, take `harness` from it, lay out only the steps the task
+touches, and start. The summary checklist at the end describes a finished
+install, so skip it.
+
+With no config yet, choose the harness and lay out the whole install:
 
 - Ask via `AskUserQuestion` which harness to use:
   - **Claude (Anthropic)** — uses a Claude Code OAuth token (recommended

--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: install-tend
-description: Sets up tend — an autonomous junior maintainer for a GitHub repo, powered by Claude or OpenAI Codex — that reviews PRs, triages issues, and fixes CI. Creates config, generates workflows, configures secrets and branch protection via API, creates the bot account, and provisions the harness auth token (Claude OAuth or OpenAI API key). Use when setting up tend on a new repo or when asked to install/configure tend.
+description: Sets up tend — an autonomous junior maintainer for a GitHub repo, powered by Claude or OpenAI Codex — that reviews PRs, triages issues, and fixes CI. Creates config, generates workflows, configures secrets and branch protection via API, creates the bot account, and provisions the harness auth token (Claude OAuth or OpenAI API key). Use when installing tend, when clearing a failing `tend check`, and when changing an installed repo's tend config, generated workflows, secrets, environments, branch protection, or bot access.
 ---
 
 # Install Tend

--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -25,10 +25,12 @@ not have to ask "where do I do that?".
 ## Kickoff
 
 Read `.config/tend.yaml` first. Its presence says whether this is an install or
-a change to one, and where it exists it already names the harness.
+a change to one, and where it exists it settles the harness: the `harness` key,
+or Claude when the key is absent, which is how a Claude install is normally
+written.
 
-With a config in place, take `harness` from it, lay out only the steps the task
-touches, and start. The summary checklist at the end describes a finished
+With a config in place, take the harness from it, lay out only the steps the
+task touches, and start. The summary checklist at the end describes a finished
 install, so skip it.
 
 With no config yet, choose the harness and lay out the whole install:


### PR DESCRIPTION
The description ended "Use when setting up tend on a new repo or when asked to install/configure tend." That reads as install-time only, so a session working on a repo where tend is already installed skips the skill — including for the case it covers best, clearing a failing `tend check`.

That happened on PRQL/prql. A session spent its whole length on `repo-secret-allowlist`, moving `TEND_BOT_TOKEN` out of repo-level storage and into the `tend` and `release` environments, and never loaded this skill. It fetched `docs/security-model.md` over `gh api` and reconstructed step 1's secret-migration procedure by hand instead, down to rediscovering that GitHub secrets are write-only so the migration needs a freshly minted token.

The new trigger clause names the entry points that reach an installed repo, with the failing check called out because that is how these tasks actually arrive.

Broadening the trigger then exposed the body, which was written as one linear first-install flow: Kickoff asked which harness to use and confirmed "Ready to start?" before step 1, and the opening asked for a bot name, all unconditionally. On an installed repo `.config/tend.yaml` answers the harness and the bot already exists. Kickoff now reads that file first and branches — take `harness` from it and plan only the steps the task touches, or, with no config, run the full install kickoff as before.

<details>
<summary>A/B measurement, 14 runs</summary>

Two scenarios in the affected repo — the dispatch prompt from that session verbatim, and the same `tend check` failure with no skill named — each arm running under its own `CLAUDE_CONFIG_DIR`. Criterion: did the session call `Skill(install-tend:install-tend)`.

| Description | Loaded it |
| --- | --- |
| Current ("setting up tend on a new repo") | 0/4 |
| Broadened, but not naming the check ("…and when changing an installed one: its config, workflows, secrets, environments…") | 1/4 |
| This PR | 4/4 |

Fisher's exact on 0/4 against 4/4 is p = 0.014. Naming `tend check` is what carries it; merely widening the scope was close to no change.

Guardrail: a scenario this skill should decline — "tend's nightly run failed last night, work out why" — declined it 2/2 under the new wording, and one of those runs loaded `install-tend:debug-tend-run` instead. So the broader trigger still discriminates.

The criterion measured loading only. The Kickoff change came from review of what a loaded session then does, and is not covered by these numbers.

</details>

> _This was written by Claude Code on behalf of max-sixty_
