### PR TITLE
docs: drop the pinned version from the port's preamble

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -280,11 +280,16 @@ The same gap covers `tend-outage`; #816 tracks it from that side, and the
 ## Decide whether the built-in `/code-review` replaces the vendored port
 
 `plugins/tend-ci-runner/skills/code-review/` is a copy of Claude Code's
-built-in `/code-review`, read out of the 2.1.220 binary `claude/action.yaml`
-pins. The two share their method almost verbatim — the same ten angles, the
-same three-verdict verify with "PLAUSIBLE by default", the same sweep — so the
-copy buys nothing on method and costs the usual: it drifts silently, and
-nothing re-checks it against the binary.
+built-in `/code-review`, taken from a 2.1.220 binary. The two share their
+method almost verbatim — the same ten angles, the same three-verdict verify
+with "PLAUSIBLE by default", the same sweep — so the copy buys nothing on
+method and costs the usual: it drifts silently, and nothing re-checks it
+against the binary.
+
+That drift is no longer hypothetical. `claude/action.yaml` now pins 2.1.226,
+which restructured the built-in without touching those texts, so the copy is
+already a version behind the binary CI runs — and the thing that changed is
+exactly what decides this question.
 
 Reaching the built-in is possible. It carries `disable-model-invocation`,
 which the `Skill` tool waives for a turn whose own user message names the

--- a/plugins/tend-ci-runner/skills/code-review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/code-review/SKILL.md
@@ -8,7 +8,7 @@ metadata:
 
 # Code review
 
-A structured pass over a diff that returns ranked findings. Ported from Claude Code's built-in `/code-review`, read out of the 2.1.220 binary `claude/action.yaml` pins. The Codex harness has no built-in equivalent, and on Claude the built-in carries `disable-model-invocation`, which no tend prompt lifts. This copy is tend-owned: reachable from the model on either harness.
+A structured pass over a diff that returns ranked findings. Ported from Claude Code's built-in `/code-review`. The Codex harness has no built-in equivalent, and on Claude the built-in carries `disable-model-invocation`, which no tend prompt lifts. This copy is tend-owned: reachable from the model on either harness.
 
 **Return findings; don't act on them.** No review, comment, commit, or artifact from this skill — the caller folds the findings into its own single review.
 


### PR DESCRIPTION
`claude/action.yaml` moved to 2.1.226 while #904 was in flight, so the sentence naming 2.1.220 as the version it pins was already false when it landed. The skill's preamble no longer names a version at all — it had no reason to, and a version sitting in a file nothing re-checks is a claim waiting to rot.

`TODO.md` keeps the provenance, where the drift is the point rather than an aside: the port was taken from 2.1.220, CI now runs 2.1.226, and what changed between them is exactly what decides whether the port should survive. That entry already listed a version bump as a revisit trigger; this records that the trigger has fired.

> _This was written by Claude Code on behalf of max-sixty_
