### PR TITLE
fix(skills): pass --limit on the dedup and survey gh list calls

### DIFF
--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -151,8 +151,8 @@ Read the project's CLAUDE.md before reviewing. Apply the review checklist below 
 ## Step 5: Check existing issues
 
 ```bash
-gh issue list --state open --json number,title
-gh pr list --state open --json number,title,headRefName
+gh issue list --state open --limit 200 --json number,title
+gh pr list --state open --limit 200 --json number,title,headRefName
 ```
 
 For each open issue, check whether recent commits or the current codebase state already resolve it. If resolved, comment with the evidence (commits, CI runs, or code state that resolves the issue). Close the issue with `gh issue close` when:
@@ -312,8 +312,8 @@ git worktree remove "/tmp/tend-update-workflows" --force
 Before acting on findings, check for duplicates and existing work:
 
 ```bash
-gh issue list --state open --json number,title
-gh pr list --state open --json number,title,headRefName
+gh issue list --state open --limit 200 --json number,title
+gh pr list --state open --limit 200 --json number,title,headRefName
 ```
 
 The default action is a PR, not an issue. If there's a plausible fix, make it — explain uncertainty in the PR description.

--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -394,8 +394,8 @@ Evaluate the subagent's diagnosis against the repo-specific guidance from Step 1
 Before creating issues or PRs, check exhaustively for existing ones:
 
 ```bash
-gh issue list --state open --label claude-behavior --json number,title,body
-gh issue list --state open --json number,title,body  # also check unlabeled issues
+gh issue list --state open --label claude-behavior --limit 200 --json number,title,body
+gh issue list --state open --limit 200 --json number,title,body  # also check unlabeled issues
 gh issue list --state closed --label claude-behavior --json number,title,closedAt --limit 30
 # --state all: a merged PR is the most common way a finding is already fixed
 gh pr list --state all --limit 40 --json number,title,state,mergedAt,headRefName,body

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -203,7 +203,7 @@ mention, notifications, weekly, and review-reviewers runs get the same treatment
 
 ```bash
 # Bot PR dispositions — merged or closed in the window
-gh pr list --author "$BOT_LOGIN" --state all --json number,title,state,closedAt \
+gh pr list --author "$BOT_LOGIN" --state all --limit 200 --json number,title,state,closedAt \
   --jq '.[] | select(.closedAt > "'$SINCE'")'
 ```
 

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -233,7 +233,7 @@ Write "no maintainer corrections" into the tracking issue only after that query 
 Before creating issues or PRs, check for existing ones:
 
 ```bash
-gh issue list --state open --json number,title,body
+gh issue list --state open --limit 200 --json number,title,body
 gh issue list --state closed --json number,title,closedAt --limit 30
 # --state all: a merged PR is the most common way a finding is already fixed
 gh pr list --state all --limit 40 --json number,title,state,mergedAt,headRefName,body

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -145,7 +145,7 @@ When asked to create a PR, use `gh pr create` directly.
 Before creating a branch or PR, check for existing work:
 
 ```bash
-gh pr list --state open --json number,title,headRefName --jq '.[] | "#\(.number) [\(.headRefName)]: \(.title)"'
+gh pr list --state open --limit 200 --json number,title,headRefName --jq '.[] | "#\(.number) [\(.headRefName)]: \(.title)"'
 git branch -r --list 'origin/fix/*'
 ```
 
@@ -587,6 +587,8 @@ If you can't find source evidence for a specific detail, say so ("I'm not sure o
 
 **`--jq` projections must include the ID when downstream URLs cite individual items.** Composing `actions/runs/<id>`, `#issuecomment-<id>`, or `pull/<n>` URLs from `gh run list` / `gh api .../comments` / `gh pr list` results requires the ID field in the projection (`databaseId` for runs, `id` for comments, `number` for PRs/issues). If the projection kept only timestamps, titles, or bodies, the bot composes the URL from what it has and fabricates the missing ID — the link 404s. Re-query with the ID field rather than guessing.
 
+**`gh` list commands cap at 30 by default — pass `--limit` whenever the result set is the answer.** `gh issue list`, `gh pr list`, and `gh run list` return 30 items unless told otherwise, and nothing in the output says it truncated. Two shapes go wrong: a dedup scan misses the existing issue or PR sitting past the cap and opens a duplicate, and a survey ("check every open issue") reports complete coverage of the 30 it happened to see. A count that reads exactly 30 across repeated measurements is the signature — that's the cap, not a stable value. Set an explicit `--limit` above the plausible ceiling on any query used to dedup, survey, or count.
+
 **"Likely" is a stop-sign.** A hedge in a user-facing claim — "likely works", "probably parses as", "should behave like", "I think" — means it rests on an unverified guess. Two options: verify and replace the hedge with the answer, or hedge explicitly ("I haven't tested this — would appreciate if you can confirm") and don't dress up the guess as analysis. The shape is the tell, not the exact words: posting an unverified guess as confident-sounding analysis is the hallucination that erodes trust the fastest.
 
 **Never ship literal placeholders in user-visible content.** Strings like `<PLACEHOLDER>`, `PR #PLACEHOLDER`, `<SHA>`, `TBD`, `XXX`, or `<TODO(fill)>` in an issue body, PR body, or comment are corruption: a deferred substitution that never ran. They survive into the rendered output and read as broken. When a multi-step ask references an artifact that doesn't yet exist ("file an issue that references the PR I'm about to file"), sequence the work so the referenced artifact exists before the referencing body is composed: create the PR → read its number → compose the issue with the number filled in → file the issue. If the cross-reference can't be resolved before posting (e.g. the artifact is out of scope or deferred), omit it or rephrase ("a follow-up PR will…") rather than emit a placeholder. Before any `gh issue create`, `gh pr create`, or `gh ... comment --body-file`, grep the body file for `PLACEHOLDER`, `<SHA>`, `<TODO`, `TBD`, `XXX` and refuse to post if any match. A session that times out mid-sequence leaves an unsubstituted placeholder permanently visible — pre-substitute, don't post-substitute.
@@ -739,7 +741,7 @@ When the correction identifies a gap or bug in a **bundled** skill — the same 
 2. **Check for an existing open PR against the same skill.** Dedup by the target file, not by title — title conventions vary per repo:
    ```bash
    BOT_LOGIN=$(gh api user --jq '.login')
-   gh pr list --state open --author "$BOT_LOGIN" --json number,title,headRefName,files \
+   gh pr list --state open --author "$BOT_LOGIN" --limit 200 --json number,title,headRefName,files \
      --jq '.[] | select([.files[].path] | index(".claude/skills/running-tend/SKILL.md"))'
    ```
    If one is open, add to it instead of opening a second.

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -170,7 +170,7 @@ A separate mention on a different issue/PR can trigger a concurrent run asking f
 
 ```bash
 BOT_LOGIN=$(gh api user --jq '.login')
-gh pr list --state all --author "$BOT_LOGIN" --limit 30 \
+gh pr list --state all --author "$BOT_LOGIN" --limit 200 \
   --json number,title,state,mergedAt,headRefName,createdAt
 ```
 
@@ -587,7 +587,7 @@ If you can't find source evidence for a specific detail, say so ("I'm not sure o
 
 **`--jq` projections must include the ID when downstream URLs cite individual items.** Composing `actions/runs/<id>`, `#issuecomment-<id>`, or `pull/<n>` URLs from `gh run list` / `gh api .../comments` / `gh pr list` results requires the ID field in the projection (`databaseId` for runs, `id` for comments, `number` for PRs/issues). If the projection kept only timestamps, titles, or bodies, the bot composes the URL from what it has and fabricates the missing ID — the link 404s. Re-query with the ID field rather than guessing.
 
-**`gh` list commands cap at 30 by default — pass `--limit` whenever the result set is the answer.** `gh issue list`, `gh pr list`, and `gh run list` return 30 items unless told otherwise, and nothing in the output says it truncated. Two shapes go wrong: a dedup scan misses the existing issue or PR sitting past the cap and opens a duplicate, and a survey ("check every open issue") reports complete coverage of the 30 it happened to see. A count that reads exactly 30 across repeated measurements is the signature — that's the cap, not a stable value. Set an explicit `--limit` above the plausible ceiling on any query used to dedup, survey, or count.
+**`gh` list commands truncate silently — pass `--limit` whenever the result set is the answer.** `gh issue list`, `gh pr list`, and `gh search` return 30 items unless told otherwise; `gh run list` returns 20. Nothing in the output says it truncated. Two shapes go wrong: a dedup scan misses the existing issue or PR sitting past the cap and opens a duplicate, and a survey ("check every open issue") reports complete coverage of the rows it happened to see. A count that reads exactly the default across repeated measurements is the signature — that's the cap, not a stable value. Set an explicit `--limit` above the plausible ceiling on any query used to dedup, survey, or count. Client-side filtering inside `--jq` is the worst variant: the filter hides the truncation, so a capped result reads as a legitimately short one.
 
 **"Likely" is a stop-sign.** A hedge in a user-facing claim — "likely works", "probably parses as", "should behave like", "I think" — means it rests on an unverified guess. Two options: verify and replace the hedge with the answer, or hedge explicitly ("I haven't tested this — would appreciate if you can confirm") and don't dress up the guess as analysis. The shape is the tell, not the exact words: posting an unverified guess as confident-sounding analysis is the hallucination that erodes trust the fastest.
 

--- a/plugins/tend-ci-runner/skills/weekly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/weekly/SKILL.md
@@ -14,7 +14,7 @@ Load `/tend-ci-runner:running-in-ci` first — it contains CI security rules, re
 ## Step 1: Find dependency PRs
 
 ```bash
-gh pr list --state open --json number,title,author,labels \
+gh pr list --state open --limit 200 --json number,title,author,labels \
   --jq '.[] | select(.author.login == "dependabot[bot]" or .author.login == "renovate[bot]" or (.labels | any(.name == "dependencies")))'
 ```
 


### PR DESCRIPTION
`gh issue list`, `gh pr list`, and `gh run list` return 30 items by default and give no signal that they truncated. Several bundled skills call them without `--limit` in exactly the two places where a silent cap does damage: the dedup scans that decide whether an artifact already exists, and the surveys that claim to have checked every open issue.

## How this surfaced

`review-reviewers`' evidence log for `PRQL/prql` has recorded "Open `tend-agent` PRs on tend: **30**, unchanged for a sixth consecutive window" and used that apparent stability as a standing justification for recording counters rather than opening artifacts. The value was never a count — it was the cap:

```
$ gh pr list --state open --author tend-agent --json number --jq 'length'
30
$ gh pr list --state open --author tend-agent --limit 200 --json number --jq 'length'
32
```

Six consecutive windows of published evidence reasoned from a truncated measurement, and nothing in the output flagged it. The signature is the giveaway in hindsight — a "stable" count sitting at exactly the default.

## Why it matters beyond the log

The same unbounded call shape sits in the dedup and survey steps themselves, where the consequence is a duplicate artifact or a survey that reports complete coverage of the 30 rows it happened to see:

- `review-reviewers` Step 4 and `review-runs` Step 5 — the open-issue dedup scans run before opening a PR or issue. Their neighbouring `--state closed` and `gh pr list` queries already carry explicit limits; the open-state ones were left unbounded on the assumption that "open" is small.
- `nightly` Step 5 ("check whether recent commits already resolve it", for each open issue) and Step 8 dedup.
- `running-in-ci` — the pre-PR existing-work check and the skill-overlay dedup.

tend's own open-issue count is 26 today, four below the cap, so the issue-side scans are about to start truncating silently on this repo.

## The change

Explicit `--limit 200` on the dedup and survey queries, plus a `Specific failure modes` entry in `running-in-ci` so the cap is recognisable next time it shows up as a suspiciously round number. No behavioural change beyond widening the queries.

## Gate assessment

- **Evidence level**: High. Structural — `gh` caps deterministically, so the same conditions truncate every time.
- **Occurrences**: 6 recorded. The evidence gist logged the capped `30` as a measured count across six consecutive windows and reasoned from its apparent stability; today's re-measurement with `--limit` returns 32. Gate 1 needs 2–3 for High.
- **Change type**: targeted fix (one flag per call site) plus one bullet appended to an existing failure-modes list. Gate 2's bar for a new paragraph is 3+ occurrences; met.
- **Not a duplicate**: nearest existing items are #839 (participation checks reduce inside `--jq` under `--paginate`), #888 (token-report caps at 100), and #838 (`list-recent-runs` fetch limit) — same family, different mechanisms. None covers the `gh` default.

Evidence: https://gist.github.com/192514ea2c36586f9b7f842a482d62ab
