### PR TITLE
skills(running-tend): skim the CHANGELOG for slash-command handling too

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -170,7 +170,7 @@ A stale `claude` binary resolves `--model opus`/`sonnet` to a superseded alias
 target, so drift silently downgrades the model. Skim the claude-code CHANGELOG
 between the two versions for anything touching the agent paths (first-run
 onboarding, `--model` alias resolution, headless `-p` result events, Stop-hook
-behavior) and note it in the PR.
+behavior, slash-command or Skill-tool handling) and note it in the PR.
 
 `mitmproxy_version` pins the process that holds the real PAT and model
 credential, so a security fix there matters here. Check anything security- or


### PR DESCRIPTION
The half of #926 that stands on its own, as [requested on close](https://github.com/max-sixty/tend/pull/926#issuecomment-5234093949): `slash-command or Skill-tool handling` joins the list of agent paths to skim the claude-code CHANGELOG for when bumping `claude_version`. No recipe — the waiver-scan check went with the mechanism it guarded.

The prompt shape a bump can move is not confined to model aliases and result events. `claude/action.yaml` passes tend's prompt to the binary as a leading slash command, so how the binary parses and dispatches that is a real dependency of every run, and a CHANGELOG entry touching it deserves a look on the way past.
