### PR TITLE
fix(generator): don't double braces in a review prompt that never reaches format()

### DIFF
--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -185,14 +185,20 @@ def _escape_braces(prompt: str, placeholder: str) -> tuple[str, bool]:
     Returns (escaped_prompt, needs_format). In the escaped prompt, {placeholder}
     is replaced with {0} for use with GitHub Actions format(), and all other
     braces are doubled to prevent format() from interpreting them.
+
+    A prompt with no {placeholder} is returned untouched. Doubling is only
+    correct on the way into `format()`, which collapses each pair back to one
+    brace; without the placeholder the caller emits a bare string literal
+    instead, and GitHub Actions does not collapse braces there — the pairs
+    would reach the agent verbatim.
     """
     sentinel = "\x00PLACEHOLDER\x00"
     text = prompt.replace(f"{{{placeholder}}}", sentinel)
+    if sentinel not in text:
+        return prompt, False
     # Double all remaining braces so format() treats them as literals
     text = text.replace("{", "{{").replace("}", "}}")
-    has_placeholder = sentinel in text
-    text = text.replace(sentinel, "{0}")
-    return text, has_placeholder
+    return text.replace(sentinel, "{0}"), True
 
 
 def _effective_cfg(cfg: Config, wf: WorkflowConfig) -> Config:

--- a/generator/tests/test_config_edge_cases.py
+++ b/generator/tests/test_config_edge_cases.py
@@ -299,7 +299,13 @@ def test_prompt_with_zero_placeholder(tmp_path: Path) -> None:
 
 
 def test_prompt_with_numbered_placeholders(tmp_path: Path) -> None:
-    """Prompt with {1}, {2} — escaped to prevent format() runtime errors."""
+    """Prompt with {1}, {2} and no {pr_number} — emitted verbatim, not escaped.
+
+    Escaping guards `format()`, which collapses each doubled pair back to one
+    brace. With no {pr_number} there is nothing to interpolate, so the prompt
+    is emitted as a bare GHA string literal instead — nothing collapses the
+    pairs there, and doubling would ship `{{1}}` to the agent.
+    """
     path = _write_config(
         tmp_path,
         dedent("""\
@@ -312,9 +318,8 @@ def test_prompt_with_numbered_placeholders(tmp_path: Path) -> None:
     cfg = Config.load(path)
     workflows = {wf.filename: wf for wf in generate_all(cfg)}
     review = workflows["tend-review.yaml"]
-    # {1} and {2} are escaped to {{1}} and {{2}} — literals in GHA expressions
-    assert "{{1}}" in review.content
-    assert "{{2}}" in review.content
+    assert "format(" not in review.content
+    assert "'Fix issue {1} and {2}'" in review.content
 
 
 # ---------------------------------------------------------------------------

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -23,6 +23,7 @@ from tend.config import (
 from tend.workflows import (
     _deep_merge,
     GENERATORS,
+    GeneratedWorkflow,
     generate_all,
     generate_install_test,
     generate_mention,
@@ -393,6 +394,54 @@ def test_custom_prompt(tmp_path: Path) -> None:
     workflows = {wf.filename: wf for wf in generate_all(cfg)}
     triage = workflows["tend-triage.yaml"]
     assert "Custom triage:" in triage.content
+
+
+def _review_prompt(review: GeneratedWorkflow) -> str:
+    """The `prompt:` input the review job hands the harness action."""
+    steps = yaml.safe_load(review.content)["jobs"]["review"]["steps"]
+    step = next(
+        s for s in steps if s.get("uses", "").startswith("max-sixty/tend/claude@")
+    )
+    return step["with"]["prompt"]
+
+
+def test_review_prompt_without_placeholder_keeps_literal_braces(
+    tmp_path: Path,
+) -> None:
+    """A review prompt with braces but no `{pr_number}` reaches the agent verbatim.
+
+    The review prompt is the only one emitted inside a GHA expression. With the
+    placeholder it goes through `format()`, which needs every other brace
+    doubled; without it, it is a bare string literal that GHA never collapses,
+    so doubling there would ship `{{...}}` to the agent.
+    """
+    extra = dedent("""\
+        workflows:
+          review:
+            prompt: "Review this PR. Skip files matching {generated}."
+    """)
+    cfg = Config.load(_minimal_config(tmp_path, extra))
+    workflows = {wf.filename: wf for wf in generate_all(cfg)}
+    prompt = _review_prompt(workflows["tend-review.yaml"])
+    assert "{generated}" in prompt
+    assert "{{generated}}" not in prompt
+    assert "format(" not in prompt
+
+
+def test_review_prompt_with_placeholder_escapes_other_braces(tmp_path: Path) -> None:
+    """With `{pr_number}` present the prompt goes through `format()`, so the
+    placeholder becomes `{0}` and every other brace is doubled for it."""
+    extra = dedent("""\
+        workflows:
+          review:
+            prompt: "Review PR {pr_number}. Skip files matching {generated}."
+    """)
+    cfg = Config.load(_minimal_config(tmp_path, extra))
+    workflows = {wf.filename: wf for wf in generate_all(cfg)}
+    prompt = _review_prompt(workflows["tend-review.yaml"])
+    assert "format(" in prompt
+    assert "{0}" in prompt
+    assert "{{generated}}" in prompt
 
 
 def test_watched_workflows(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

`generate_review` is the only generator that emits the prompt inside a GitHub Actions expression, and it escapes braces for `format()` unconditionally — including on the path where `format()` is never used.

`_escape_braces` doubles every brace that isn't the `{pr_number}` placeholder. That is correct going into `format()`, which collapses each `{{` / `}}` pair back to a single brace. But `generate_review` only wraps the result in `format()` when the placeholder was actually found:

```python
format_body, needs_format = _escape_braces(raw_prompt, "pr_number")
escaped = format_body.replace("'", "''")
if needs_format:
    prompt_expr = f"format('{escaped}', github.event.pull_request.number)"
else:
    prompt_expr = f"'{escaped}'"     # <- doubled braces, nothing to collapse them
```

An adopter whose `workflows.review.prompt` contains braces but no `{pr_number}` gets the doubled pairs written straight into a bare string literal. Reproduced against `main` (`fd23cd0`) with `prompt: "Review this PR. Use the {code-review} skill."`:

```
${{ 'Review this PR. Use the {{code-review}} skill.' }}
```

Nothing downstream collapses that pair — `format()` is what does the collapsing and it isn't in the expression. So the agent receives `{{code-review}}` where the adopter wrote `{code-review}`, and the doubled `}}` also lands inside a `${{ … }}` expression, which is not a shape the generator should be emitting either way.

Only `review` is affected: every other workflow renders its prompt as a plain YAML block scalar (`block_prompt` in `macros.yaml.j2`, and the literal bodies in `ci-fix.yaml.j2` / `mention.yaml.j2`), so no brace escaping is involved.

## Solution

Return the prompt untouched when the placeholder isn't present. Escaping is a `format()` concern, so it now happens only on the branch that produces a `format()` call.

## Testing

Two tests in `test_generate.py` pin the two branches — braces preserved without the placeholder, braces doubled and `{pr_number}` → `{0}` with it. The first fails on `main`:

```
assert '{{generated}}' not in "${{ 'Review...rated}}.' }}"
  '{{generated}}' is contained here:
    ${{ 'Review this PR. Skip files matching {{generated}}.' }}
```

`test_prompt_with_numbered_placeholders` in `test_config_edge_cases.py` pinned the old output and had to change — worth a look, since it's a test asserting the defect rather than an incidental snapshot. Its rationale was "escaped to prevent `format()` runtime errors", but its fixture (`"Fix issue {1} and {2}"`) has no `{pr_number}`, so no `format()` call is generated and there is no runtime error to prevent. It now asserts the prompt is emitted verbatim. The sibling `test_prompt_with_zero_placeholder`, whose fixture does carry `{pr_number}`, is unchanged and still passes.

Full generator suite: 387 passed. `ruff check` / `ruff format --check` at the pinned `v0.14.11` are clean.

## Scope

No generated file in this repo changes — tend's own `.config/tend.yaml` sets no custom review prompt, and the default (`/tend-ci-runner:review {pr_number}`) carries the placeholder, so it takes the `format()` branch as before. The behavior change is visible only to an adopter with a brace-carrying custom review prompt, whose next regen will drop the spurious doubling.
