### PR TITLE
fix(review): make the code-review second pass unconditional

### DIFF
--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -144,7 +144,7 @@ Scale depth to the change. A docs-only PR or a mechanical rename needs a skim fo
 
 Check the project's CLAUDE.md for language-specific review criteria and conventions. Load any project-specific review skill if available.
 
-Review the diff two ways at once: the manual checks below, plus a `/tend-ci-runner:code-review` pass over the PR's merged tree. That skill is a structured second pass — correctness and cleanup angles, then a verify pass — and it returns findings rather than posting anything. **Every review that reaches this step runs it**, trivial diffs included — the depth-scaling above sets how deep the pass goes, never whether it happens. Scale its depth to how core the change is:
+**Every review that reaches this step runs a `/tend-ci-runner:code-review` pass over the PR's merged tree** — trivial diffs included; the depth-scaling above sets how deep the pass goes, never whether it happens. It's a structured second pass — correctness and cleanup angles, then a verify pass — that returns findings rather than posting anything, and it runs alongside the manual checks below rather than replacing them. Scale its depth to how core the change is:
 
 - Peripheral or mechanical (docs, config, dependency bumps, test-only): tell it the change is peripheral, so it runs the short angle set in one pass.
 - The project's core logic: tell it the change is core, so it fans the angles out and sweeps for gaps.

--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -144,7 +144,7 @@ Scale depth to the change. A docs-only PR or a mechanical rename needs a skim fo
 
 Check the project's CLAUDE.md for language-specific review criteria and conventions. Load any project-specific review skill if available.
 
-Review the diff two ways at once: the manual checks below, plus a `/tend-ci-runner:code-review` pass over the PR's merged tree. That skill is a structured second pass — correctness and cleanup angles, then a verify pass — and it returns findings rather than posting anything. Scale its depth to how core the change is, the same way you scale the manual depth above:
+Review the diff two ways at once: the manual checks below, plus a `/tend-ci-runner:code-review` pass over the PR's merged tree. That skill is a structured second pass — correctness and cleanup angles, then a verify pass — and it returns findings rather than posting anything. **Every review that reaches this step runs it**, trivial diffs included — the depth-scaling above sets how deep the pass goes, never whether it happens. Scale its depth to how core the change is:
 
 - Peripheral or mechanical (docs, config, dependency bumps, test-only): tell it the change is peripheral, so it runs the short angle set in one pass.
 - The project's core logic: tell it the change is core, so it fans the angles out and sweeps for gaps.


### PR DESCRIPTION
Since [#819](https://github.com/max-sixty/tend/pull/819) made `/tend-ci-runner:code-review` reachable again, **every** `tend-review` session on `numbagg/numbagg` has still skipped the mandated second pass — 4 of 4 reviews that reached step 4, zero counter-examples. The reviews still get posted and still read as complete, so the missing pass is invisible from the outside; only the session logs show it.

The reachability bug ([#817](https://github.com/max-sixty/tend/issues/817)) is fixed — the skill is in the available-skills listing in every one of these sessions, and no session got a tool-use error. The agent simply never reaches for it, and in all four sessions never even mentions it in its reasoning.

## Why the text permits the skip

Step 4 opens with `Scale depth to the change… Don't over-analyze trivial changes.` Three lines later the second-pass mandate says `Scale its depth to how core the change is, **the same way you scale the manual depth above**`. That back-reference ties the pass to a scale whose bottom rung is explicitly "skim, not the full checklist" — so for a lockfile-only dependency bump, "scale it to nothing" is a defensible reading of the instruction as written. The pass is never stated to be unconditional.

This change says it is: the depth-scaling sets how deep the pass goes, never whether it happens. The peripheral bullet already names dependency bumps and gives them the short angle set in one pass, so the always-run reading is what the rest of the paragraph already assumes.

## Evidence

Run [31365030481](https://github.com/max-sixty/tend/actions/runs/31365030481). Full log: https://gist.github.com/19b5ab297bb7ac7e1e9a44d595ccde0f

`tend-ci-runner:code-review` first appears in a numbagg session's available-skills listing between 2026-08-06 and 2026-08-08 (absent in [31113573735](https://github.com/numbagg/numbagg/actions/runs/31113573735), present in [31246101561](https://github.com/numbagg/numbagg/actions/runs/31246101561)). Sessions before that are excluded — the skill was genuinely unreachable, and one of them ([31088428562](https://github.com/numbagg/numbagg/actions/runs/31088428562)) says so in as many words: *"I skipped the `/code-review` pass the workflow calls for. It isn't in this environment's available-skills list."* That agent checked, found it missing, and named the deviation — which is the behavior we want, and the reason the four sessions since are worth acting on.

| Review session | PR | Date | `code-review` reachable | Second pass run |
|---|---|---|---|---|
| [31246101561](https://github.com/numbagg/numbagg/actions/runs/31246101561) | #727 | 2026-08-08 | yes | no |
| [31258607744](https://github.com/numbagg/numbagg/actions/runs/31258607744) | #726 | 2026-08-08 | yes | no |
| [31360815248](https://github.com/numbagg/numbagg/actions/runs/31360815248) | #729 | 2026-08-10 | yes | no |
| [31361090036](https://github.com/numbagg/numbagg/actions/runs/31361090036) | #728 | 2026-08-10 | yes | no |

Each row is a session that read the diff (`gh pr diff`) and so reached step 4; none contains a `Skill` call for `tend-ci-runner:code-review`, and none mentions it in assistant reasoning.

## Gate assessment

- **Evidence level**: High — consistent across 4 sessions spanning 3 days and 4 distinct PRs, with zero counter-examples since the skill became reachable. Bar for High is 2–3.
- **Structural vs stochastic**: structural contributor in the skill text. The omission is a model behavior, but the text itself licenses it: the mandate delegates its own applicability to a scale that bottoms out at "skim". The same trivial-diff conditions read against the same paragraph produce the same skip, which is what 4/4 shows.
- **Change type**: targeted fix — one sentence, in place, no new section. Normal Gate 1 thresholds apply.
- **Passes both gates**: yes.

Honest limit: the evidence is from one adopter repo, and I can't prove wording alone fixes what is partly a salience problem. If a later cycle finds sessions still skipping the pass with this text in place, the next step is a harder mechanism (a distinct numbered step, or a step-5 pre-post check that the pass ran) rather than more wording.
