### PR TITLE
fix(review-runs): anchor the census window on the predecessor run, not now-24h

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -38,9 +38,13 @@ Pass extra prefixes when running token reports or listing runs so these
 workflows are included:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" 24 "review-"
+"${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" "${HOURS:-24}" "review-"
 TARGET_REPO=max-sixty/tend "${CLAUDE_PLUGIN_ROOT}/scripts/list-recent-runs.sh" "tend-" "review-"
 ```
+
+Under `review-runs`, `$HOURS` is the lookback derived from its Step 1 anchor —
+passing a literal `24` there reopens the window gap that anchor closes. The
+default keeps an ad-hoc invocation working.
 
 ## Labels
 

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -132,7 +132,8 @@ List tend CI runs that completed since the previous `review-runs` run (nominally
 REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
 # Anchor on the predecessor's start: a `date -d '24 hours ago'` resolves when
 # the agent runs it, so the window opens after the predecessor started and
-# drops the band in between. Later steps read this same `$SINCE`.
+# drops the band in between. Steps 2 and 4 re-read the anchor from the file
+# written below; shell variables don't survive between Bash tool calls.
 #
 # Derive the workflow id from this run rather than assuming the file name;
 # exclude this run, because a re-run attempt of it can already read as
@@ -148,6 +149,7 @@ PREV_START=$(gh api "repos/$REPO/actions/workflows/$WF_ID/runs?status=success&pe
 SINCE=${PREV_START:-$(date -u -d '25 hours ago' +%Y-%m-%dT%H:%M:%SZ)}
 FLOOR=$(date -u -d '49 hours ago' +%Y-%m-%dT%H:%M:%SZ)
 if [[ "$SINCE" < "$FLOOR" ]]; then SINCE=$FLOOR; fi
+echo "$SINCE" > /tmp/review-runs-since
 # Add the repo's extra prefixes from its `running-tend` skill: any workflow
 # running the tend action is in scope, not just the generated `tend-*` ones.
 # Step 2 prices the same list.
@@ -204,7 +206,11 @@ Run the token report script to get per-run token counts:
 ```bash
 # Whole hours back to Step 1's anchor, rounded up so the whole band is priced.
 # A literal `24` here reopens the same gap Step 1 closed, and clips a wider band
-# than Step 1 did because `now` moved on during the session.
+# than Step 1 did because `now` moved on during the session. Re-read the anchor
+# from Step 1's file: `$SINCE` was set in a different Bash call and is empty
+# here, and `date -d ""` is today's midnight rather than an error, so the
+# arithmetic would quietly yield hours-since-midnight instead.
+SINCE=$(cat /tmp/review-runs-since)
 HOURS=$(( ( $(date -u +%s) - $(date -u -d "$SINCE" +%s) + 3599 ) / 3600 ))
 "${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" "$HOURS" > /tmp/token-report.json
 ```
@@ -231,7 +237,10 @@ For each analyzed run, compare what the bot did against what happened next. The 
 mention, notifications, weekly, and review-reviewers runs get the same treatment: find the bot's output and check whether it was accepted.
 
 ```bash
-# Example: check if a bot PR was merged or closed
+# Example: check if a bot PR was merged or closed. Re-read Step 1's anchor —
+# unset here, an empty string compares less than every non-null `closedAt` and
+# the check silently stops being windowed at all.
+SINCE=$(cat /tmp/review-runs-since)
 gh pr list --author "$BOT_LOGIN" --state all --json number,title,state,closedAt \
   --jq '.[] | select(.closedAt > "'$SINCE'")'
 ```

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -205,11 +205,8 @@ Run the token report script to get per-run token counts:
 
 ```bash
 # Whole hours back to Step 1's anchor, rounded up so the whole band is priced.
-# A literal `24` here reopens the same gap Step 1 closed, and clips a wider band
-# than Step 1 did because `now` moved on during the session. Re-read the anchor
-# from Step 1's file: `$SINCE` was set in a different Bash call and is empty
-# here, and `date -d ""` is today's midnight rather than an error, so the
-# arithmetic would quietly yield hours-since-midnight instead.
+# A literal `24` reopens the gap Step 1 closed. The `cat` isn't optional: an
+# unset `$SINCE` makes `date -d ""` today's midnight, not an error.
 SINCE=$(cat /tmp/review-runs-since)
 HOURS=$(( ( $(date -u +%s) - $(date -u -d "$SINCE" +%s) + 3599 ) / 3600 ))
 "${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" "$HOURS" > /tmp/token-report.json

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -130,13 +130,9 @@ List tend CI runs that completed since the previous `review-runs` run (nominally
 
 ```bash
 REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
-# Anchor the window on the predecessor's start, not on a duration back from
-# `now`. A `date -u -d '24 hours ago'` resolves when the *agent* runs it — the
-# run's start plus container boot and skill loading — so it opens strictly after
-# the predecessor started and drops every run in that band, which is exactly
-# the work the predecessor triggered. Anchoring makes consecutive windows tile,
-# and every later step reads the same `$SINCE` instead of recomputing a
-# duration that has drifted further by then.
+# Anchor on the predecessor's start: a `date -d '24 hours ago'` resolves when
+# the agent runs it, so the window opens after the predecessor started and
+# drops the band in between. Later steps read this same `$SINCE`.
 #
 # Derive the workflow id from this run rather than assuming the file name;
 # exclude this run, because a re-run attempt of it can already read as
@@ -163,15 +159,25 @@ if [[ "$SINCE" < "$FLOOR" ]]; then SINCE=$FLOOR; fi
 # applying it per page is harmless.
 PREFIXES=("tend-")
 PREFIX_RE="^($(IFS='|'; echo "${PREFIXES[*]}"))"
+# Census on *completion*, which is the axis that tiles. A run created before
+# `$SINCE` may still have been in progress at the predecessor's census, so
+# `status=completed` dropped it there — filtering on `created` here would drop
+# it again and nobody would ever see it, and those are the long-running runs
+# Step 3 goes on to hunt. So over-fetch by `created` and filter on
+# `updated_at`, as `list-recent-runs.sh` does. The floor is a run's whole
+# lifetime, not its job cap: `created_at` starts at queue time, and a
+# `cancel-in-progress: false` group can hold a run queued for many hours
+# before its 6h of execution even begins.
+FETCH_FROM=$(date -u -d "$SINCE - 24 hours" +%Y-%m-%dT%H:%M:%SZ)
 for workflow in $(gh api --paginate repos/$REPO/actions/workflows --jq ".workflows[] | select(.name | test(\"$PREFIX_RE\")) | .id"); do
-  gh api --paginate "repos/$REPO/actions/workflows/$workflow/runs?created=>=$SINCE&status=completed&per_page=100" \
-    --jq '.workflow_runs[] | {databaseId: .id, conclusion, createdAt: .created_at, name: .name}'
+  gh api --paginate "repos/$REPO/actions/workflows/$workflow/runs?created=>=$FETCH_FROM&status=completed&per_page=100" \
+    --jq ".workflow_runs[] | select(.updated_at >= \"$SINCE\") | {databaseId: .id, conclusion, createdAt: .created_at, updatedAt: .updated_at, name: .name}"
 done
 ```
 
 If no runs found, report "no runs to review" and exit.
 
-Report the run census as the count this returns. Cross-check any workflow whose count lands on a round page boundary (30, 100) against `.total_count` before trusting it — a count that equals the page size is the signature of a page that was never followed.
+Report the run census as the count this returns. `.total_count` counts the wider `FETCH_FROM` fetch, so it bounds the census from above rather than matching it — but a census that lands on a round page boundary (30, 100) is still the signature of a page that was never followed, so check that one against `.total_count` before trusting it.
 
 Then, for each run ID from above, pull its jobs and classify them:
 

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -126,11 +126,32 @@ Never replace the body — prior entries contain per-run evidence needed for gat
 
 ## Step 1: Find recent runs
 
-List tend CI runs that completed in the past 24 hours (the cron runs daily):
+List tend CI runs that completed since the previous `review-runs` run (nominally 24 hours — the cron runs daily):
 
 ```bash
 REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
-SINCE=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)
+# Anchor the window on the predecessor's start, not on a duration back from
+# `now`. A `date -u -d '24 hours ago'` resolves when the *agent* runs it — the
+# run's start plus container boot and skill loading — so it opens strictly after
+# the predecessor started and drops every run in that band, which is exactly
+# the work the predecessor triggered. Anchoring makes consecutive windows tile,
+# and every later step reads the same `$SINCE` instead of recomputing a
+# duration that has drifted further by then.
+#
+# Derive the workflow id from this run rather than assuming the file name;
+# exclude this run, because a re-run attempt of it can already read as
+# completed and anchoring on itself collapses the window to zero.
+# `status=success` reaches past a predecessor that died before its census, so
+# that band still gets covered. Clamp a stale or missing anchor (an outage, or
+# a fresh repo with no predecessor) so the window can recover one skipped day
+# without pulling in a week — Step 5 dedups whatever a widened window sees
+# twice.
+WF_ID=$(gh api "repos/$REPO/actions/runs/$GITHUB_RUN_ID" --jq '.workflow_id')
+PREV_START=$(gh api "repos/$REPO/actions/workflows/$WF_ID/runs?status=success&per_page=10" \
+  --jq "[.workflow_runs[] | select(.id != ${GITHUB_RUN_ID:-0}) | .created_at] | max // empty")
+SINCE=${PREV_START:-$(date -u -d '25 hours ago' +%Y-%m-%dT%H:%M:%SZ)}
+FLOOR=$(date -u -d '49 hours ago' +%Y-%m-%dT%H:%M:%SZ)
+if [[ "$SINCE" < "$FLOOR" ]]; then SINCE=$FLOOR; fi
 # Add the repo's extra prefixes from its `running-tend` skill: any workflow
 # running the tend action is in scope, not just the generated `tend-*` ones.
 # Step 2 prices the same list.
@@ -175,10 +196,14 @@ After retrieving the timeout cap from the workflow file, flag any job whose dura
 Run the token report script to get per-run token counts:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" 24 > /tmp/token-report.json
+# Whole hours back to Step 1's anchor, rounded up so the whole band is priced.
+# A literal `24` here reopens the same gap Step 1 closed, and clips a wider band
+# than Step 1 did because `now` moved on during the session.
+HOURS=$(( ( $(date -u +%s) - $(date -u -d "$SINCE" +%s) + 3599 ) / 3600 ))
+"${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" "$HOURS" > /tmp/token-report.json
 ```
 
-Pass the same extra prefixes Step 1 censuses, so the two steps agree on what the fleet is — the repo's `running-tend` skill is the source for both (e.g. `review-` for a `review-reviewers` workflow that uses the tend action but isn't named `tend-*`).
+Pass the same extra prefixes Step 1 censuses (after `$HOURS`, which the script reads as its first positional arg), so the two steps agree on what the fleet is — the repo's `running-tend` skill is the source for both (e.g. `review-` for a `review-reviewers` workflow that uses the tend action but isn't named `tend-*`).
 
 Include the totals and per-workflow breakdown in the summary (Step 7). Flag any runs with unusually high token usage for closer inspection in Step 3.
 


### PR DESCRIPTION
## Problem

`review-runs` Step 1 opened its window with `date -u -d '24 hours ago'`, which resolves when the *agent* runs the command — the run's start plus container boot and skill loading. The predecessor started at *its* own start time, earlier by whatever drift it saw, so the window opened strictly after the predecessor and dropped every run in the gap. The gap is never zero and never negative, so the census systematically under-counted rather than flaking. Step 2 clipped the same band independently, and by a wider margin, because `token-report.sh 24` measured 24 hours back from its own later invocation.

Reproduced on this repo, independently of the reporter's measurement on `max-sixty/cargo-affected`. Yesterday's `review-runs` run started `2026-08-09T08:01:45Z`; today's ([31369350870](https://github.com/max-sixty/tend/actions/runs/31369350870)) started `08:16:33Z`, so its window opened no earlier than that — a band of at least 14m48s, and wider by however long boot and skill loading took. Eight runs sat in it:

```
2026-08-09T08:03:08Z review-reviewers 31302588340
2026-08-09T08:12:32Z ci               31302963325
2026-08-09T08:12:32Z tend-review      31302963274
2026-08-09T08:13:08Z ci               31302989157
2026-08-09T08:13:08Z tend-review      31302989224
2026-08-09T08:14:21Z tend-mention     31303039387
2026-08-09T08:16:03Z tend-mention     31303111366
2026-08-09T08:16:11Z tend-mention     31303117289
```

Six of those are full agent sessions. The loss is also biased toward the runs that matter most to the audit: what happens in the minutes right after `review-runs` starts is largely the work that run triggers — its own PR getting reviewed, a mention firing on that review — and that is exactly the band the next run cannot see.

This is distinct from #886 and #888, which decide how much of the window is *visible*. A fully paginated census of a window that opens too late still misses these runs, and Step 2 — the fallback that recovered the truncated runs in #888 — has the same defect.

## Solution

Anchor `SINCE` on the predecessor's `created_at` so consecutive windows tile, and derive Step 2's lookback from the same anchor instead of a literal `24`.

Three details beyond the reported shape:

- **`status=success`, not `status=completed`.** The API's `completed` includes `failure` and `cancelled`, so anchoring on it would permanently strand the band of a predecessor that died before its census. Reaching for the last *successful* run covers that band on the next pass.
- **Clamp a stale or missing anchor at 49h.** A fresh repo has no predecessor, and after an outage a week-old anchor would pull in a week of runs. 49h lets the window absorb one skipped day without unbounded growth; Step 5 already dedups findings a widened window sees twice.
- **Exclude `$GITHUB_RUN_ID`.** A re-run attempt of the current run can surface as completed, and anchoring on itself collapses the window to zero. The workflow id is derived from the run rather than the file name.

## Testing

No test harness covers skill text, so both recipes were extracted verbatim from the edited file and executed here:

- Anchored form, simulating today's `review-runs` run: `SINCE=2026-08-09T08:01:45Z` — the predecessor's start, exit 0.
- Empty-predecessor branch: falls through to the `25 hours ago` default, exit 0.
- Stale anchor (`2026-08-01`): clamps to the 49h floor.
- `HOURS` derivation from that `SINCE`: `25`, exit 0.

The `if [[ ... ]]; then ... fi` form is deliberate over `[[ ... ]] && SINCE=$FLOOR`: the latter exits 1 when the test is false, which the agent's Bash tool reports as a failed block.

<details><summary>`review-reviewers` — already anchored, no change needed</summary>

The report flagged `review-reviewers` as possibly sharing the defect, unmeasured. It doesn't: it gets its window from [`list-recent-runs.sh`](https://github.com/max-sixty/tend/blob/fd23cd06b8850c8db6777a57f547931b86575f5c/plugins/tend-ci-runner/scripts/list-recent-runs.sh), which anchors the completion window to the most recent *intended* cron tick rather than to `now`, precisely so scheduler drift can't shift the window relative to actual start time. #845 extends that anchoring to every-N-hours crons.

</details>

## Review follow-ups

Two changes landed after review, both on this branch.

**The census is now on completion, not creation.** Anchoring alone made the *creation* windows tile, but Step 1's heading promised completed-since-the-predecessor and the query still filtered `created>=$SINCE`. A run created before the anchor and still in progress at the predecessor's census was dropped there by `status=completed` and dropped again here — censused by nobody, and that is precisely the long-running class Step 3 exists to hunt. Step 1 now over-fetches by `created` and filters on `updated_at`, the shape [`list-recent-runs.sh`](https://github.com/max-sixty/tend/blob/74328fc2898f386fd4569fcfdd392a88db92da80/plugins/tend-ci-runner/scripts/list-recent-runs.sh) already uses.

The over-fetch floor is 24h — a whole run lifetime, not the 6h hosted-runner job cap. `created_at` starts at queue time, and a `cancel-in-progress: false` group can hold a run queued for hours before execution begins; the longest completed run on this repo in the last three days spans 819 minutes wall-clock ([31281456692](https://github.com/max-sixty/tend/actions/runs/31281456692)), which a 6h floor still misses. Diffing the two floors against the live API in one pass, 24h is a strict superset that recovers exactly that run (242 -> 243). Also confirmed GitHub's `created=` filter honors time-of-day rather than rounding to the date, which the sub-day anchor depends on.

**Step 1's lead comment is trimmed** per CLAUDE.md's skill-authoring brevity rule; the argument lives here, not in a file loaded into every session.

**The anchor is now persisted to a file.** Step 1 set `$SINCE` in one Bash tool call and Steps 2 and 4 read it in others, where shell state is gone. Neither failed loudly: `date -d ""` resolves to today's midnight rather than erroring, so Step 2's `HOURS` silently became hours-since-midnight — 9 rather than 25 on this cron, pricing a *narrower* band than the literal `24` it replaced. Step 4's `closedAt > "$SINCE"` compared against the empty string, which sorts below every timestamp, so that cross-check admitted every closed bot PR ever (62 here against 10 for the correct anchor) and had never been windowed at all — that half predates this PR. Step 1 now writes the clamped anchor to `/tmp/review-runs-since` and both readers `cat` it back, verified across a real call boundary.

---

Closes #938 — automated triage


