### PR TITLE
check: read a call out of the repo, and stop guarding one coming in

### DIFF
--- a/generator/src/tend/checks.py
+++ b/generator/src/tend/checks.py
@@ -702,14 +702,16 @@ class _WorkflowFacts:
     """What one workflow file says about the repo's credential surface."""
 
     path: str
-    steerable: frozenset[str]  # bot-steerable triggers it carries
-    call_only: bool  # `workflow_call` is the only thing that starts it
-    calls: frozenset[str]  # local reusable workflows this one invokes
-    environments: frozenset[str]  # environments its jobs deploy to
-    oidc_environments: frozenset[str]  # …of those, ones a job mints OIDC in
-    oidc_without_environment: frozenset[str]  # job ids minting OIDC ungated
-    filed_deployments: frozenset[str]  # job ids naming tend that file a record
-    unresolved: tuple[str, ...]
+    steerable: frozenset[str] = frozenset()  # bot-steerable triggers it carries
+    call_only: bool = False  # `workflow_call` is the only thing that starts it
+    calls: frozenset[str] = frozenset()  # local reusable workflows it invokes
+    external_calls: frozenset[str] = frozenset()  # job ids calling out of the repo
+    external_oidc: frozenset[str] = frozenset()  # …of those, ones granting OIDC
+    environments: frozenset[str] = frozenset()  # environments its jobs deploy to
+    oidc_environments: frozenset[str] = frozenset()  # …of those, ones minting OIDC
+    oidc_without_environment: frozenset[str] = frozenset()  # job ids minting ungated
+    filed_deployments: frozenset[str] = frozenset()  # job ids naming tend that file
+    unresolved: tuple[str, ...] = ()
 
 
 def _permissions_grant_oidc(permissions: object) -> bool:
@@ -726,9 +728,11 @@ def _called_workflow(uses: str, repo: str) -> str | None:
 
     Two spellings reach the same file: the relative form, and the
     `owner/repo/.github/workflows/x.yaml@ref` form a repo may use on its own
-    workflow to pin the ref it runs. Only a call landing in this repo is
-    followed — another repo's reusable workflow runs against that repo's
-    environments, not this one's.
+    workflow to pin the ref it runs. A call that leaves the repo returns None,
+    not because it deploys elsewhere — the callee's jobs deploy to *this*
+    repo's environments (see `_effective_triggers`) — but because its file
+    cannot be read from here, which `_credential_surface` reports as unread
+    rather than passes over.
     """
     relative = "./.github/workflows/"
     if uses.startswith(relative):
@@ -747,17 +751,12 @@ def _parse_workflow(path: str, text: str, repo: str) -> _WorkflowFacts:
     — a path tend cannot see is not a path tend can call gated.
     """
     unparsable = (f"{path} could not be parsed as a workflow",)
-    empty = frozenset[str]()
     try:
         data = YAML(typ="safe").load(io.StringIO(text))
     except (YAMLError, ValueError):
-        return _WorkflowFacts(
-            path, empty, False, empty, empty, empty, empty, empty, unparsable
-        )
+        return _WorkflowFacts(path, unresolved=unparsable)
     if not isinstance(data, dict):
-        return _WorkflowFacts(
-            path, empty, False, empty, empty, empty, empty, empty, unparsable
-        )
+        return _WorkflowFacts(path, unresolved=unparsable)
 
     # YAML 1.1 documents (`%YAML 1.1`) turn the `on:` key into the boolean
     # True; 1.2, which ruamel's safe loader defaults to, keeps it a string.
@@ -779,6 +778,8 @@ def _parse_workflow(path: str, text: str, repo: str) -> _WorkflowFacts:
     jobs = jobs if isinstance(jobs, dict) else {}
 
     calls: set[str] = set()
+    external_calls: set[str] = set()
+    external_oidc: set[str] = set()
     environments: set[str] = set()
     oidc_environments: set[str] = set()
     oidc_without_environment: set[str] = set()
@@ -788,17 +789,25 @@ def _parse_workflow(path: str, text: str, repo: str) -> _WorkflowFacts:
     for job_id, job in jobs.items():
         if not isinstance(job, dict):
             continue
+        permissions = job.get("permissions", workflow_permissions)
+        oidc = _permissions_grant_oidc(permissions)
+
         uses = job.get("uses")
         if uses is not None:
             # A job that calls another workflow declares no environment of its
-            # own — the called workflow's jobs do, and those are parsed there.
-            # Its `permissions:` only caps what the callee may request.
+            # own — the called workflow's jobs do. Those are parsed here when
+            # the call lands in this repo, and are unreadable when it doesn't,
+            # which is what `external_calls` records. Its `permissions:` only
+            # cap what the callee may request, so a callee mints OIDC on this
+            # repo's behalf exactly when the calling job grants it.
             called = _called_workflow(uses, repo) if isinstance(uses, str) else None
             if called is not None:
                 calls.add(called)
+            else:
+                external_calls.add(str(job_id))
+                if oidc:
+                    external_oidc.add(str(job_id))
             continue
-        permissions = job.get("permissions", workflow_permissions)
-        oidc = _permissions_grant_oidc(permissions)
 
         declared = job.get("environment")
         environment = declared
@@ -830,6 +839,8 @@ def _parse_workflow(path: str, text: str, repo: str) -> _WorkflowFacts:
         steerable=frozenset(steerable),
         call_only=triggers == {"workflow_call"},
         calls=frozenset(calls),
+        external_calls=frozenset(external_calls),
+        external_oidc=frozenset(external_oidc),
         environments=frozenset(environments),
         oidc_environments=frozenset(oidc_environments),
         oidc_without_environment=frozenset(oidc_without_environment),
@@ -846,14 +857,23 @@ def _effective_triggers(
     `workflow_call` on its own says only that a workflow is callable; what can
     start it is whatever starts its callers. Callers within the repo are
     followed to a fixpoint, and a workflow no such chain reaches is returned as
-    unreached — its callers may live in another repo, which this cannot
-    enumerate.
+    unreached — the only thing left that can start it is a caller in another
+    repo.
 
     A workflow carrying triggers of its own anchors the chain: `workflow_call`
     widens the way in rather than replacing it, so its own `on:` starts it here
     whatever else calls it. A callable workflow is then reached when one of its
     callers is, and unreached when every route to it runs through a workflow
     only an outside caller can start.
+
+    An unreached workflow spends nothing of this repo's, a point GitHub's
+    reusable-workflow docs leave unsaid: a run belongs to the repo that starts
+    it, down into any workflow it calls elsewhere. The secrets, the environment
+    a callee's `environment:` names, the deployment record and the OIDC `sub`
+    are the caller's throughout, and the caller's gate on that environment is
+    what holds the run. So the fact cuts both ways — a call arriving from
+    outside reaches nothing here, and one leaving for outside carries this
+    repo's environments with it.
     """
     resolved = {path: f.steerable for path, f in facts.items()}
     reached = {path: not f.call_only for path, f in facts.items()}
@@ -928,14 +948,34 @@ def _credential_surface(
     oidc_environments: set[str] = set()
     ungated_oidc: list[tuple[str, str]] = []
     for path, f in facts.items():
+        if path in unreached:
+            # Nothing here starts it, and the outside caller that does spends
+            # its own repo's credentials, not this one's — so its environments
+            # and its OIDC jobs are not this repo's surface to gate.
+            continue
         for env in f.environments:
             env_steerable.setdefault(env, set()).update(resolved[path])
         oidc_environments |= f.oidc_environments
         ungated_oidc.extend((path, job) for job in sorted(f.oidc_without_environment))
-        if path in unreached and f.environments:
+        # A call out of the repo runs against this repo's environments out of a
+        # file that cannot be read from here, so what it deploys to is unknown.
+        # That only matters where it could change a verdict: a steerable
+        # trigger defeats any ref policy the environment is gated by, and a
+        # granted `id-token: write` may be minted outside an environment
+        # altogether, which is `ungated_oidc`'s finding when it is visible.
+        if f.external_calls and resolved[path]:
+            triggers = ", ".join(f"`{t}`" for t in sorted(resolved[path]))
+            jobs = ", ".join(f"'{j}'" for j in sorted(f.external_calls))
             unresolved.append(
-                f"{path} is only reachable via `workflow_call` from outside this repo"
+                f"{path} runs on {triggers} and calls another repo's workflow "
+                f"({jobs}), whose jobs deploy to this repo's environments"
             )
+        unresolved.extend(
+            f"{path} job '{job}' grants `id-token: write` to another repo's "
+            "workflow, so whether the token is minted inside an environment is "
+            "not visible here"
+            for job in sorted(f.external_oidc)
+        )
 
     return _CredentialSurface(
         env_steerable={e: frozenset(t) for e, t in env_steerable.items()},

--- a/generator/src/tend/checks.py
+++ b/generator/src/tend/checks.py
@@ -939,9 +939,7 @@ def _credential_surface(
         if text is None:
             unresolved.append(f"{path} could not be read")
             continue
-        parsed = _parse_workflow(path, text, repo)
-        facts[path] = parsed
-        unresolved.extend(parsed.unresolved)
+        facts[path] = _parse_workflow(path, text, repo)
 
     resolved, unreached = _effective_triggers(facts)
     env_steerable: dict[str, set[str]] = {}
@@ -950,9 +948,12 @@ def _credential_surface(
     for path, f in facts.items():
         if path in unreached:
             # Nothing here starts it, and the outside caller that does spends
-            # its own repo's credentials, not this one's — so its environments
-            # and its OIDC jobs are not this repo's surface to gate.
+            # its own repo's credentials, not this one's — so neither what its
+            # jobs name nor what it leaves unreadable is this repo's surface to
+            # gate. A file that would not parse is never unreached: nothing
+            # read `workflow_call` off it, so its own unknown still reports.
             continue
+        unresolved.extend(f.unresolved)
         for env in f.environments:
             env_steerable.setdefault(env, set()).update(resolved[path])
         oidc_environments |= f.oidc_environments

--- a/generator/tests/test_checks.py
+++ b/generator/tests/test_checks.py
@@ -2094,9 +2094,10 @@ def test_credential_environments_absolute_self_call_inherits_caller_triggers() -
 def test_credential_environments_own_triggers_reach_a_callable_workflow() -> None:
     """`workflow_call` alongside triggers of its own widens the way in rather
     than replacing it: the workflow's own `on:` still starts it here, so an
-    uncallable-from-here verdict would skip a surface tend can read."""
+    uncallable-from-here verdict would walk past an ungated credential this
+    repo really can spend."""
     result = _credential_check(
-        {"pypi": (["PYPI_TOKEN"], _CUSTOM_POLICY, "branch main")},
+        {"pypi": ([], {"protection_rules": []}, "")},
         workflows={
             "tests.yaml": (
                 "on:\n"
@@ -2110,10 +2111,13 @@ def test_credential_environments_own_triggers_reach_a_callable_workflow() -> Non
                 "jobs:\n"
                 "  deploy:\n"
                 "    environment: pypi\n"
+                "    permissions:\n"
+                "      id-token: write\n"
             )
         },
     )
-    assert result.passed is True, result.message
+    assert result.passed is False, result.message
+    assert "pypi" in result.message
 
 
 def test_credential_environments_unreached_through_a_caller_spends_nothing() -> None:
@@ -2160,6 +2164,26 @@ def test_credential_environments_unreached_reusable_workflow_spends_nothing() ->
                 "    environment: pypi\n"
                 "    permissions:\n"
                 "      id-token: write\n"
+            )
+        },
+    )
+    assert result.passed is True, result.message
+
+
+def test_credential_environments_unreached_dynamic_environment_spends_nothing() -> None:
+    """What an unreachable workflow leaves unreadable is not this repo's to
+    gate either. A reusable deploy parameterised by its caller's input names no
+    environment tend can resolve, and reporting that would hold the check at
+    unverified for as long as the adopter keeps the workflow."""
+    result = _credential_check(
+        {"pypi": ([], {"protection_rules": []}, "")},
+        workflows={
+            "publish.yaml": (
+                "on:\n"
+                "  workflow_call:\n"
+                "jobs:\n"
+                "  publish:\n"
+                "    environment: ${{ inputs.environment }}\n"
             )
         },
     )

--- a/generator/tests/test_checks.py
+++ b/generator/tests/test_checks.py
@@ -2116,11 +2116,12 @@ def test_credential_environments_own_triggers_reach_a_callable_workflow() -> Non
     assert result.passed is True, result.message
 
 
-def test_credential_environments_unreached_through_a_caller_is_unverified() -> None:
-    """A caller that nothing here starts leaves its callee just as unreachable
-    — the chain has to anchor on a workflow with triggers of its own."""
+def test_credential_environments_unreached_through_a_caller_spends_nothing() -> None:
+    """The chain has to anchor on a workflow with triggers of its own: a caller
+    that nothing here starts leaves its callee unreachable too, and what an
+    unreachable job names is not this repo's to gate."""
     result = _credential_check(
-        {"pypi": (["PYPI_TOKEN"], _CUSTOM_POLICY, "branch main")},
+        {"pypi": ([], {"protection_rules": []}, "")},
         workflows={
             "wrapper.yaml": (
                 "on:\n"
@@ -2130,26 +2131,100 @@ def test_credential_environments_unreached_through_a_caller_is_unverified() -> N
                 "    uses: ./.github/workflows/publish.yaml\n"
             ),
             "publish.yaml": (
-                "on:\n  workflow_call:\njobs:\n  publish:\n    environment: pypi\n"
+                "on:\n"
+                "  workflow_call:\n"
+                "jobs:\n"
+                "  publish:\n"
+                "    environment: pypi\n"
+                "    permissions:\n"
+                "      id-token: write\n"
             ),
         },
     )
-    assert result.passed is None
-    assert "publish.yaml is only reachable" in result.message
+    assert result.passed is True, result.message
 
 
-def test_credential_environments_unreached_reusable_workflow_is_unverified() -> None:
-    """Its callers may live in another repo, which this cannot enumerate."""
+def test_credential_environments_unreached_reusable_workflow_spends_nothing() -> None:
+    """A run belongs to the repo that starts it: an outside caller's run reads
+    that repo's secrets, deploys to its environments, and mints OIDC for it. So
+    the ungated 'pypi' here is not a credential this repo can spend, and the
+    check must neither fail on it nor stop short of a verdict."""
+    result = _credential_check(
+        {"pypi": ([], {"protection_rules": []}, "")},
+        workflows={
+            "publish.yaml": (
+                "on:\n"
+                "  workflow_call:\n"
+                "jobs:\n"
+                "  publish:\n"
+                "    environment: pypi\n"
+                "    permissions:\n"
+                "      id-token: write\n"
+            )
+        },
+    )
+    assert result.passed is True, result.message
+
+
+def test_credential_environments_call_out_of_the_repo_is_unread() -> None:
+    """The same fact the other way: a workflow this repo calls elsewhere
+    deploys to *this* repo's environments, and its file cannot be read from
+    here — so which environment a steerable run reaches is unknown."""
     result = _credential_check(
         {"pypi": (["PYPI_TOKEN"], _CUSTOM_POLICY, "branch main")},
         workflows={
-            "publish.yaml": (
-                "on:\n  workflow_call:\njobs:\n  publish:\n    environment: pypi\n"
+            "dispatch.yaml": (
+                "on:\n"
+                "  repository_dispatch:\n"
+                "    types: [publish]\n"
+                "jobs:\n"
+                "  call:\n"
+                "    uses: other/repo/.github/workflows/publish.yaml@v1\n"
             )
         },
     )
     assert result.passed is None
-    assert "workflow_call" in result.message
+    assert "dispatch.yaml runs on `repository_dispatch`" in result.message
+    assert "'call'" in result.message
+
+
+def test_credential_environments_call_out_of_the_repo_granting_oidc_is_unread() -> None:
+    """A calling job's `permissions:` cap what the callee may request, so one
+    granting `id-token: write` mints on this repo's behalf — and whether the
+    callee does it inside an environment is not visible here."""
+    result = _credential_check(
+        {"pypi": (["PYPI_TOKEN"], _CUSTOM_POLICY, "branch main")},
+        workflows={
+            "release.yaml": (
+                "on: push\n"
+                "jobs:\n"
+                "  call:\n"
+                "    uses: other/repo/.github/workflows/publish.yaml@v1\n"
+                "    permissions:\n"
+                "      id-token: write\n"
+            )
+        },
+    )
+    assert result.passed is None
+    assert "release.yaml job 'call' grants `id-token: write`" in result.message
+
+
+def test_credential_environments_call_out_of_the_repo_changing_nothing() -> None:
+    """With no steerable trigger to defeat the ref policy and no OIDC granted,
+    the unread callee cannot change a verdict — and an unknown that changes no
+    verdict is a skip for nothing."""
+    result = _credential_check(
+        {"pypi": (["PYPI_TOKEN"], _CUSTOM_POLICY, "branch main")},
+        workflows={
+            "release.yaml": (
+                "on: push\n"
+                "jobs:\n"
+                "  call:\n"
+                "    uses: other/repo/.github/workflows/publish.yaml@v1\n"
+            )
+        },
+    )
+    assert result.passed is True, result.message
 
 
 def test_credential_environments_dynamic_environment_name_is_unverified() -> None:


### PR DESCRIPTION
A run belongs to the repo that starts it, down into any workflow it calls elsewhere: the secrets, the environment a callee's `environment:` names, the deployment record and the OIDC `sub` are the caller's throughout, and the caller's gate on that environment is what holds the run. `credential-environments` had it backwards in both directions, and each cost a verdict.

**A workflow only an outside caller can start was treated as this repo's surface.** It was reported unknown — or, where the environment held nothing but that job's OIDC claim, failed outright as an ungated credential the bot could reach. Nothing here starts such a workflow, and the outside caller that does spends its own repo's credentials, so what its jobs name — and what it leaves unreadable — now leaves the surface with it. That last part covers a reusable deploy parameterised by `environment: ${{ inputs.environment }}`, which named no environment tend could resolve and so held the check at unverified for as long as the adopter kept the workflow.

**A job calling another repo's workflow was passed over in silence.** The comment on that branch asserted the callee "runs against that repo's environments, not this one's"; it is the reverse. The callee deploys to *this* repo's environments, out of a file that cannot be read from here. That is now reported unread, but only where it could change a verdict — a steerable trigger, which defeats the ref policy an environment is gated by, or a granted `id-token: write`, which the callee may mint outside any environment. An unconditional unknown would have re-created the spurious skip the last fix removed.

<details>
<summary>Verified against the live API</summary>

Repo A calls repo B's reusable workflow, whose job declares `environment: probe-env`. B's `probe-env` held a secret and a deployment policy admitting only a branch that does not exist.

- B's environment secret was **absent**, even with `secrets: inherit`
- B's gate was never consulted — the run succeeded past a policy that admits nothing
- OIDC `sub` was `repo:A:environment:probe-env`; only `job_workflow_ref` named B
- the deployment record, and an auto-created `probe-env`, landed in A
- putting that same gate on **A**'s `probe-env` blocked the re-run: `Branch "…" is not allowed to deploy to probe-env due to environment protection rules`

GitHub's reusable-workflow docs leave this unsaid, which is why the old reading stood.

On the four live adopter repos the computed surface is identical before and after — this changes verdicts only for shapes none of them has — and `tend check` on this repo reports `PASS credential-environments` end to end. Six tests, five of them failing on the pre-change code. The reachability invariant's own test had stopped discriminating once the unreached branch went away, so it now uses an ungated environment and fails again under the `"workflow_call" in triggers` reading it guards.

</details>

> _This was written by Claude Code on behalf of max-sixty_
