### PR TITLE
skills(review-reviewers): map a relayed repository_dispatch run from its verify-job payload

### DIFF
--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -258,6 +258,12 @@ Use a cheap subagent (e.g. Haiku / gpt-mini) and a prompt like:
 >   `gh api repos/$ARGUMENTS/pulls/<pr>/reviews`
 > - `tend-notifications`: check for recent bot comments/issue-close events in the past hour
 > - `tend-mention`: map run to issue/PR from triggering comment, check for bot replies
+> - `tend-mention` on `repository_dispatch` (the relay path for review events): there is no triggering comment and `headBranch` is the default branch, so neither route above resolves it. Read the target off the `verify` job's log, where the step env block prints the relayed payload:
+>   ```bash
+>   JOB=$(gh api "repos/$ARGUMENTS/actions/runs/<run-id>/jobs" --jq '.jobs[] | select(.name == "verify") | .id')
+>   gh api "repos/$ARGUMENTS/actions/jobs/$JOB/logs" | grep -E 'PAYLOAD_(KIND|PR|ID):'
+>   ```
+>   `PAYLOAD_PR` is the issue/PR number and `PAYLOAD_KIND` is the relayed event (`pull_request_review`, `pull_request_review_comment`). If the `verify` job shows `React to mention: skipped`, the engagement gate declined and no agent booted — expected silence, not missing output.
 > - `tend-ci-fix`: map run → PR via `headBranch`, check for bot commits
 >
 > **Negative outcome signals** — report any sign the bot's output was rejected, corrected, or ignored. Common shapes (use judgment for signals not listed):

--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -263,7 +263,7 @@ Use a cheap subagent (e.g. Haiku / gpt-mini) and a prompt like:
 >   JOB=$(gh api "repos/$ARGUMENTS/actions/runs/<run-id>/jobs" --jq '.jobs[] | select(.name == "verify") | .id')
 >   gh api "repos/$ARGUMENTS/actions/jobs/$JOB/logs" | grep -E 'PAYLOAD_(KIND|PR|ID):'
 >   ```
->   `PAYLOAD_PR` is the issue/PR number and `PAYLOAD_KIND` is the relayed event (`pull_request_review`, `pull_request_review_comment`). If the `verify` job shows `React to mention: skipped`, the engagement gate declined and no agent booted — expected silence, not missing output.
+>   `PAYLOAD_PR` is the issue/PR number and `PAYLOAD_KIND` is the relayed event (`pull_request_review`, `pull_request_review_comment`). Read the gate's verdict off the `handle` job, which is gated on `should_run`: `handle` with conclusion `skipped` means the engagement gate declined and no agent booted — expected silence, not missing output. Do not read it off `React to mention`, which is skipped on every relayed `pull_request_review` regardless of the verdict (a review submission has no single comment to react to) and on a comment relay admitted for participation rather than a mention.
 > - `tend-ci-fix`: map run → PR via `headBranch`, check for bot commits
 >
 > **Negative outcome signals** — report any sign the bot's output was rejected, corrected, or ignored. Common shapes (use judgment for signals not listed):


### PR DESCRIPTION
Step 2's run→output mapping list tells the survey subagent to map a `tend-mention` run "from triggering comment". That works for the `issue_comment` path, but `tend-mention`'s relay re-posts review events as a `repository_dispatch`, and on that path there is no triggering comment at all: the run carries `head_branch: main`, `display_title: tend-mention-review`, and jobs named only `verify` / `relay` / `handle`. Neither of the two routes the list offers resolves it, so every window that contains one of these runs falls back to hand-derivation by the analysing agent.

Observed again this window on `max-sixty/worktrunk` run [31404694712](https://github.com/max-sixty/worktrunk/actions/runs/31404694712) — a `repository_dispatch` leg relaying the bot's own empty-body `APPROVED` review on [worktrunk#3798](https://github.com/max-sixty/worktrunk/pull/3798). The delegated survey reported it as "verify job: engagement check passed", conflating the step's `success` conclusion with the engagement *verdict*; the verdict was the opposite (`React to mention: skipped`, `handle: skipped` — the gate declined and no agent booted). Nothing shipped publicly from the misreport, because the mapping was re-derived by hand, which is the cost this bullet removes.

The fix is the verified route: the `verify` job's log prints the relayed payload in its step env block, so `PAYLOAD_PR` gives the number and `PAYLOAD_KIND` gives the relayed event directly. Confirmed against the run above — `PAYLOAD_KIND: pull_request_review`, `PAYLOAD_PR: 3798`, `PAYLOAD_ID: 4898462421`.

<details><summary>Gate assessment and evidence</summary>

Evidence log: https://gist.github.com/a88c03f4d0c3fb1791060ff3dd97d1c4

- **Gate 1 — Medium, occurrence 5 of a 5+ bar.** Recorded across prior windows in the gist as the "`repository_dispatch` mapping gap in Step 2" counter: reached 3, then 4, then held at 4 across five consecutive windows with no `repository_dispatch` run to count. This window supplies the fifth and the bar is met. **Structural** — the run's shape (no comment, default-branch `headBranch`) is fixed, so the recipe fails identically every time; it never depended on how the agent approached the task.
- **Gate 2 — targeted fix.** One bullet added to an existing list, with a recipe verified against a live run. No restructuring, no new section. Normal bar, which Gate 1 clears.
- **Not the same as [#869](https://github.com/max-sixty/tend/pull/869)**, which is open against Step 3 and covers confirming *attribution* from the posting run's log once a run ID is already in hand. This is the earlier problem — resolving which PR a dispatch run even belongs to — and it edits a different, non-overlapping part of the file.

Analysis run: https://github.com/max-sixty/tend/actions/runs/31407252869

</details>
