### PR TITLE
fix(generator): don't migrate the config under `init --dry-run`

### DIFF
--- a/generator/src/tend/cli.py
+++ b/generator/src/tend/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+import tempfile
 from pathlib import Path
 
 import click
@@ -18,7 +19,7 @@ from tend.checks import (
     run_all_checks,
 )
 from tend.config import Config
-from tend.migrate import migrate_toml_to_yaml
+from tend.migrate import migrate_toml_to_yaml, render_toml_as_yaml
 from tend.workflows import generate_all
 
 
@@ -83,14 +84,35 @@ def init(config_path: Path | None, dry_run: bool, with_install_test: bool) -> No
     # adopters bumping past the TOML→YAML cutover; the migration verifies
     # the parsed structures match before swapping, so the no-op case (no
     # .toml on disk) is the steady state.
+    #
+    # Under --dry-run the migration is rendered and verified but not applied:
+    # the flag's contract is that the command writes nothing, and the one run
+    # an adopter makes to preview the upgrade is exactly the run that would
+    # otherwise perform it — silently, and irreversibly for an uncommitted
+    # config, since the migration deletes the TOML.
+    preview_yaml: str | None = None
     if config_path is None:
         default_yaml = Path(".config/tend.yaml")
         default_toml = Path(".config/tend.toml")
         if not default_yaml.exists() and default_toml.exists():
-            migrate_toml_to_yaml(default_toml, default_yaml)
-            click.echo(f"Migrated {default_toml} → {default_yaml}")
+            if dry_run:
+                preview_yaml = render_toml_as_yaml(default_toml, default_yaml)
+                click.echo(f"  would migrate {default_toml} → {default_yaml}")
+            else:
+                migrate_toml_to_yaml(default_toml, default_yaml)
+                click.echo(f"Migrated {default_toml} → {default_yaml}")
 
-    cfg = Config.load(config_path)
+    if preview_yaml is None:
+        cfg = Config.load(config_path)
+    else:
+        # `Config.load` reads a path, and the real one must stay unwritten —
+        # so the preview loads from a throwaway copy. Same bytes the migration
+        # would have committed, so the workflows printed below are the ones a
+        # real `init` would produce.
+        with tempfile.TemporaryDirectory() as tmp:
+            preview_path = Path(tmp) / "tend.yaml"
+            preview_path.write_text(preview_yaml)
+            cfg = Config.load(preview_path)
     cfg.default_branch = _detect_default_branch_local()
     cfg.repo_owner = detect_canonical_owner() or ""
     if not cfg.repo_owner:

--- a/generator/src/tend/migrate.py
+++ b/generator/src/tend/migrate.py
@@ -22,8 +22,13 @@ import click
 from ruamel.yaml import YAML
 
 
-def migrate_toml_to_yaml(toml_path: Path, yaml_path: Path) -> None:
-    """Read `toml_path`, write equivalent YAML at `yaml_path`, delete the TOML.
+def render_toml_as_yaml(toml_path: Path, yaml_path: Path) -> str:
+    """Return `toml_path` rendered as verified-equivalent YAML text.
+
+    Touches neither file — `yaml_path` is read only to refuse a migration that
+    would overwrite it. This is the whole migration bar the two writes, so
+    `tend init --dry-run` runs it to preview the upgrade on a config it must
+    leave exactly as it found it.
 
     Raises `click.ClickException` if `yaml_path` already exists or the
     round-trip verification fails.
@@ -60,5 +65,15 @@ def migrate_toml_to_yaml(toml_path: Path, yaml_path: Path) -> None:
             f"YAML: {yaml_data!r}"
         )
 
+    return yaml_text
+
+
+def migrate_toml_to_yaml(toml_path: Path, yaml_path: Path) -> None:
+    """Read `toml_path`, write equivalent YAML at `yaml_path`, delete the TOML.
+
+    Raises `click.ClickException` if `yaml_path` already exists or the
+    round-trip verification fails.
+    """
+    yaml_text = render_toml_as_yaml(toml_path, yaml_path)
     yaml_path.write_text(yaml_text)
     toml_path.unlink()

--- a/generator/tests/test_migrate.py
+++ b/generator/tests/test_migrate.py
@@ -155,6 +155,41 @@ def test_init_auto_migrates_legacy_toml(
     assert (wf_dir / "tend-review.yaml").exists()
 
 
+def test_init_dry_run_previews_the_migration_without_performing_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`init --dry-run` writes nothing — including the migration.
+
+    The preview run is the one an adopter makes to see what the upgrade would
+    do, so performing the migration there converts the config behind their
+    back and deletes the TOML they were still deciding about.
+    """
+    _write_toml(
+        tmp_path,
+        dedent("""\
+        bot_name = "test-bot"
+        [workflows.ci-fix]
+        watched_workflows = ["ci"]
+    """),
+    )
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(main, ["init", "--dry-run"])
+    assert result.exit_code == 0, result.output
+
+    # Neither config file moved.
+    assert (tmp_path / ".config" / "tend.toml").exists()
+    assert not (tmp_path / ".config" / "tend.yaml").exists()
+    # …and no workflows were written either.
+    assert not (tmp_path / ".github" / "workflows").exists()
+
+    # The preview still reports the migration and renders the workflows the
+    # migrated config would produce — otherwise it previews nothing useful.
+    assert "would migrate" in result.output
+    assert "tend-review.yaml" in result.output
+    assert "test-bot" in result.output
+
+
 def test_init_does_not_touch_yaml_when_both_exist(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
`tend init --dry-run` performs the legacy TOML→YAML config migration, despite the flag documenting itself as "Print generated files without writing" (and CLAUDE.md as "preview without writing"). The migration runs before the flag is ever consulted, so the preview run writes `.config/tend.yaml` and **deletes** `.config/tend.toml`.

The bad part is which run this is. `--dry-run` exists so an adopter can see what an upgrade would do before committing to it, and on a legacy-TOML repo that is exactly the run that silently converts the config out from under them. For an uncommitted `.config/tend.toml` the deletion is unrecoverable.

## Fix

Split the write half of the migration off from the render half. `render_toml_as_yaml()` does everything the migration does — parse, dump, verify the round-trip matches — and returns the YAML text without touching either file; `migrate_toml_to_yaml()` is now that call plus the two writes, so the applied path is unchanged.

Under `--dry-run` the CLI renders instead of migrating, reports `would migrate .config/tend.toml → .config/tend.yaml`, and loads the config from a throwaway copy of the rendered bytes. The preview stays useful: the workflows it prints are the ones the migrated config would produce, and the round-trip verification still runs, so a config that would fail to migrate still fails loudly under `--dry-run`.

The existing-`.config/tend.yaml` guard moves into the renderer, so `--dry-run` refuses the same overwrite the real migration refuses, rather than previewing a migration that would abort.

## Testing

`test_init_dry_run_previews_the_migration_without_performing_it` asserts both config files are untouched, no workflows are written, and the preview still names the migration and renders the workflows. It fails on the pre-fix code with `assert (tmp_path / ".config" / "tend.toml").exists()` — the TOML is already gone by the time the assertion runs.

Full generator suite: 390 passed. `ruff check` / `ruff format --check` clean at the repo's pinned `v0.14.11`.
