### PR TITLE
fix(running-in-ci): re-read the branch before a terminal action on a PR

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -441,6 +441,19 @@ If the author resolved the issue, acknowledge it rather than post stale analysis
 
 **A new entry may be a directive, not a duplicate.** The re-fetch above guards against redundant posts, but a comment that arrived while you worked can also be a maintainer follow-up that *changes the work* — a second instruction, a correction, a narrowed scope. The window is widest after a long edit→commit→push sequence: minutes pass between the session-start read and the post, and that gap is exactly when a maintainer adds to the thread. So the re-fetch isn't only a dedup check — read what landed, and if it's a new directive, fold it into the same run rather than shipping a reply (or a commit) against the stale instruction. Treating the task as done is itself a kind of post: re-fetch before ending the turn, not only before commenting.
 
+### A terminal action collides with branch state, not comments
+
+The re-fetch above counts comments and reviews, because that is what a duplicate *post* collides with. Closing a PR, reverting it, or force-pushing over it collides with **commits** instead, and a sibling session's pushed, CI-green commit is invisible to all three checks a session typically runs first: a comments-and-reviews re-fetch, the `state == OPEN` check under **Re-check PR state before pushing a follow-up commit**, and a re-read of the review bodies that prompted the action. `--delete-branch` turns that blind spot destructive — the branch ref goes and the commit survives only through the PR ref.
+
+So before `gh pr close`, a revert, or a force-push, re-read the branch itself rather than the thread:
+
+```bash
+gh pr view <N> --json headRefOid,commits,comments,reviews \
+  --jq '{head: .headRefOid, commits: [.commits[].oid], comments: (.comments | length)}'
+```
+
+If the head moved past the SHA you last pushed, a sibling acted on this PR while you waited — read its commits before deciding. Usually it applied one of the remedies you were weighing, which changes what the close is *for*, not whether to close: a PR whose premise a review invalidated is still yours to withdraw, and the session holding the PR is the one that can. Say what the sibling landed and why the close stands anyway, so the thread reads as one decision instead of two contradictory ones, and drop `--delete-branch` so that work stays reachable.
+
 ### Dedup check for inline review comment replies
 
 A single PR review can fire both `pull_request_review` and `pull_request_review_comment` events, triggering separate workflow runs (serialized by the concurrency group, not truly concurrent). Before replying to an inline review comment, check whether the bot already replied:

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -451,7 +451,8 @@ So before `gh pr close`, a revert, or a force-push, re-read the branch itself ra
 
 ```bash
 gh pr view <N> --json headRefOid,commits,comments,reviews \
-  --jq '{head: .headRefOid, commits: [.commits[].oid], comments: (.comments | length)}'
+  --jq '{head: .headRefOid, commits: [.commits[].oid],
+         comments: (.comments | length), reviews: (.reviews | length)}'
 ```
 
 If the head moved past the SHA you last pushed, a sibling acted on this PR while you waited — read its commits before deciding. Usually it applied one of the remedies you were weighing, which changes what the close is *for*, not whether to close: a PR whose premise a review invalidated is still yours to withdraw, and the session holding the PR is the one that can. Say what the sibling landed and why the close stands anyway, so the thread reads as one decision instead of two contradictory ones, and drop `--delete-branch` so that work stays reachable.

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -88,6 +88,8 @@ Corollary: don't background anything whose output gates the deliverable. If a fu
 
 A pushed fix isn't done until its required checks are terminal — see **CI Monitoring**.
 
+Your closing summary is the session's only durable record of what happened, and it is read later as if it were current. Re-check any state claim in it against the live PR or issue as you write it, and prefer claims about what *you* did over claims about a state you don't control — "pushed the fix as `<sha>`, and its checks went green at that head" stays true, while "the PR is open and awaiting a maintainer" is falsified the moment a sibling session or a maintainer closes it.
+
 ## Filing Issues in This Repo
 
 An issue here is not a note to a maintainer — where `tend-triage` is enabled (the default), it fires on `issues` and does the work. Filing one for a fix you have already scoped hands your own analysis to a second agent run, which re-derives it from your issue body and opens the PR minutes later at full session cost, on a thread nobody needed.


### PR DESCRIPTION
## Problem

#943 reports a `tend-nightly` session closing (with `--delete-branch`) a PR it had opened, seconds after a `tend-mention` session had pushed the review's remedy to that same PR and polled its checks green. The branch ref is gone; the commit survives only through the PR ref.

The blind spot is structural, not bad luck. Every recheck a session runs before a terminal action looks at the *thread*: **Recheck Before Posting** counts comments and reviews, **Re-check PR state before pushing a follow-up commit** asserts `state == OPEN` (true here), and the closing session's own re-read was `gh pr view --json reviews`. A close collides with **commits and branch state**, which none of those queries return — so the sibling's pushed, CI-green work was invisible by construction, and the same query replays identically every time.

The second, separable half from the report: the mention session's closing summary — *"PR is open and awaiting a maintainer"* — was false 71 seconds after it was written, and it is the only durable record that session leaves.

## Solution

Two rules, one per commit, both in `running-in-ci`.

1. **A terminal action collides with branch state, not comments** — a new subsection under **Recheck Before Posting**, where the rule it extends already lives. Before `gh pr close`, a revert, or a force-push, re-read `headRefOid,commits` rather than the thread. If the head moved past the SHA the session last pushed, read the sibling's commits before deciding. Deliberately *not* a stand-down: withdrawing a PR whose premise a review invalidated is the PR-holder's call and it was the right call in #943 — what changes is that the close comment says what the sibling landed and why it stands anyway, and drops `--delete-branch` so that work stays reachable.
2. **Don't close on a state claim you can't hold** — one paragraph under **End the turn only when work is shipped**. Re-check state claims in the closing summary as they are written, and prefer reporting what the session did ("pushed the fix; its checks went green at that head") over a state it doesn't control.

## Relationship to #870

Complementary, and deliberately not the same rule. #870 makes a PR-holding session stand down from a review that lands mid-poll — applied to #943 that would have prevented the destructive close, but only by making nobody withdraw a PR that should have been withdrawn, since the mention session held author role and had no standing to conclude the PR shouldn't exist. This PR keeps the withdraw authority and puts the check on the terminal action itself, so it holds whether or not #870 lands. The two touch different sections of `running-in-ci` (this one is under **Recheck Before Posting** and **End the turn…**; #870 is under **Pushing to PR Branches** and **CI Monitoring**), so they don't conflict textually either.

## Testing

Skill prose — no test surface. Verified the file has no bang-backtick preprocessor poison, no trailing whitespace, and a trailing newline (the three local hooks that apply to it), and re-read both edits in place.

---

Closes #943 — automated triage
