### PR TITLE
fix(review-runs): size the combined evidence body, not the existing comment

### DIFF
--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -105,12 +105,14 @@ grep -qF "$GITHUB_RUN_ID" /tmp/findings.md || {
 }
 
 if [ -n "$EXISTING_COMMENT" ]; then
-  # Append to existing comment if it fits. GitHub rejects bodies over 65536
-  # characters — start a new comment when the existing one is too large.
+  # Append to the existing comment if the *combined* body fits. GitHub rejects
+  # bodies over 65536 characters and the PATCH has no fallback, so a 422 loses
+  # the leg's findings while the run still reports success. Size what you are
+  # about to POST: a fixed existing-size threshold assumes a maximum append,
+  # and appends have measured over 16 KB.
   gh api "repos/$REPO/issues/comments/$EXISTING_COMMENT" --jq '.body' > /tmp/existing.md
-  EXISTING_SIZE=$(wc -c < /tmp/existing.md)
-  if [ "$EXISTING_SIZE" -lt 50000 ]; then
-    cat /tmp/existing.md /tmp/findings.md > /tmp/combined.md
+  cat /tmp/existing.md /tmp/findings.md > /tmp/combined.md
+  if [ "$(wc -c < /tmp/combined.md)" -lt 60000 ]; then
     gh api "repos/$REPO/issues/comments/$EXISTING_COMMENT" -X PATCH -F body=@/tmp/combined.md
   else
     gh api "repos/$REPO/issues/$TRACKING_NUMBER/comments" -F body=@/tmp/findings.md

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -105,11 +105,11 @@ grep -qF "$GITHUB_RUN_ID" /tmp/findings.md || {
 }
 
 if [ -n "$EXISTING_COMMENT" ]; then
-  # Append to the existing comment if the *combined* body fits. GitHub rejects
-  # bodies over 65536 characters and the PATCH has no fallback, so a 422 loses
-  # the leg's findings while the run still reports success. Size what you are
-  # about to POST: a fixed existing-size threshold assumes a maximum append,
-  # and appends have measured over 16 KB.
+  # Append only if the *combined* body fits. GitHub rejects bodies over 65536
+  # characters and the PATCH has no fallback, so a 422 loses the leg's findings
+  # while the run still reports success — size what you are about to POST, not
+  # the existing comment. `wc -c` counts bytes, which is >= the character
+  # count, so 60000 is a conservative bound.
   gh api "repos/$REPO/issues/comments/$EXISTING_COMMENT" --jq '.body' > /tmp/existing.md
   cat /tmp/existing.md /tmp/findings.md > /tmp/combined.md
   if [ "$(wc -c < /tmp/combined.md)" -lt 60000 ]; then


### PR DESCRIPTION
`review-runs` appends each leg's findings to a single evidence comment on the monthly tracking issue, and guards the 65,536-character comment limit by checking the size of the comment **before** appending ([`review-runs/SKILL.md#L111-L112`](https://github.com/max-sixty/tend/blob/3222d4ce823b3ae10ebc2c76ee3825fd9eb6acbc/plugins/tend-ci-runner/skills/review-runs/SKILL.md#L111-L112) — `EXISTING_SIZE=$(wc -c < /tmp/existing.md)`, `-lt 50000`). That threshold implies a maximum append of 15,536 characters. Appends are larger than that.

Measured on `max-sixty/cargo-affected`'s tracking issue [#73](https://github.com/max-sixty/cargo-affected/issues/73), splitting both evidence comments on their `## Run` headings (character counts, not bytes):

| Comment | Appends | Largest | Final size |
|---|---|---|---|
| `5150650688` (Aug 1–7) | 4,570 / 3,980 / 7,985 / 8,661 / 8,202 / 9,215 / 14,559 | 14,559 | 57,172 |
| `5225265385` (Aug 8–11) | 11,481 / 12,938 / **16,947** / 14,467 | **16,947** | 55,833 |

The Aug 10 append (run [31369370104](https://github.com/max-sixty/cargo-affected/actions/runs/31369370104)) was 16,947 characters — 1,411 more than the headroom the guard leaves. Had it landed on a comment sized in `[48,590, 50,000)`, the guard would have taken the append branch and the PATCH would have exceeded 65,536. Appends have also grown steadily: ~4 KB on Aug 1, 12–17 KB since Aug 8. `max-sixty/tend`'s own tracking issue [#801](https://github.com/max-sixty/tend/issues/801) shows the same distribution (largest append 14,695).

The failure mode is invisible. `gh api ... -X PATCH` returns 422 on an over-length body, the recipe has no fallback branch, and the surrounding step is not `set -e` — so the leg's findings are dropped and the run still reports `success`. The next leg then reads a log missing its predecessor and counts occurrences against incomplete history.

The fix sizes the body it is about to POST rather than a proxy for it, which removes the assumption entirely: build `/tmp/combined.md` first, branch on its size, spill to a new comment when it wouldn't fit. `wc -c` counts bytes and bytes ≥ characters in UTF-8, so 60,000 is a conservative bound under the 65,536-character limit with room for the multi-byte overhead these bodies carry (~0.6%).

No behavior changes when the append fits, which is the common case; the spill branch it already had is simply reached on the correct condition.

<details><summary>Gate assessment</summary>

- **Evidence level**: structural, not stochastic — the guard's arithmetic is fixed, so whether it overflows depends only on sizes, and the premise (`append < 15,536`) is falsified by measurement rather than inferred from behavior. **Occurrences of a realized overflow: 0** — all 11 daily legs of August are present in the log on both repos, so no evidence has been lost yet. Occurrences of an append exceeding the guard's headroom: 1 of 11 on the target this month, with 5 more within 1 KB of it.
- **Gate 1**: this is below the table's bar read literally (a plausible problem seen once is Medium, needing 5+). Filing anyway because the finding is a provable defect in shipped recipe text rather than a judgment call about model behavior, and because the first realized occurrence costs a silently lost day of evidence. Close it as premature if you'd rather wait for the overflow.
- **Gate 2**: targeted fix — 7 lines changed in one recipe, strictly more accurate than the check it replaces, no new guidance or structure.
- Distinct from [#883](https://github.com/max-sixty/tend/issues/883) (append *target* selected with `| last`) and [#938](https://github.com/max-sixty/tend/issues/938) (window anchor), which touch the same recipe but not the size check.

Window analyzed: 2026-08-11T08:11:35Z → 09:11:35Z on `max-sixty/cargo-affected`, run [31476466100](https://github.com/max-sixty/tend/actions/runs/31476466100). Evidence log: https://gist.github.com/dca23a6e6a0d8cae2665944ba31676fb

</details>
