### PR TITLE
test(notifications-check): cover the pre-check's sweep, cleanup and deferral

### DIFF
--- a/docs/tend.example.yaml
+++ b/docs/tend.example.yaml
@@ -109,13 +109,14 @@ bot_name: my-project-bot
 # `sandbox_setup:` below, which runs inside the Claude harness's sandbox. Under
 # codex there is no such lever; the agent installs what it needs itself.
 #
-# `tend-notifications` injects an `if:` guard on every step so setup is
-# skipped when the pre-check finds no work. A user-supplied `if:` is passed
-# through unchanged (with a generation-time warning) — your condition wins.
+# `tend-notifications` and `tend-review` decide up front whether the agent
+# needs to boot, and inject an `if:` guard on every setup step so a run that
+# found no work does no setup either. A user-supplied `if:` is passed through
+# unchanged (with a generation-time warning) — your condition wins.
 #
 # Each form below shows the config and the YAML it produces inside the
-# `steps:` block. The `if:` guard injected in `tend-notifications` is shown
-# on the first example; it's added the same way on every step.
+# `steps:` block. The guard is shown on the first example; it's added the same
+# way on every step.
 #
 # `uses`:
 #
@@ -125,6 +126,10 @@ bot_name: my-project-bot
 #     # renders as (in tend-notifications):
 #     #   - uses: astral-sh/setup-uv@v9.0.0
 #     #     if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'
+#     #
+#     # in tend-review:
+#     #   - uses: astral-sh/setup-uv@v9.0.0
+#     #     if: steps.gate.outputs.should_run == 'true'
 #     #
 #     # and in other workflows:
 #     #   - uses: astral-sh/setup-uv@v9.0.0

--- a/generator/src/tend/config.py
+++ b/generator/src/tend/config.py
@@ -125,8 +125,9 @@ class SetupStep:
 
     Exactly one of `uses` or `run`, plus any of `with`, `env`, `name`,
     `id`, `shell`, `working-directory`, `continue-on-error`,
-    `timeout-minutes`, `if`. The renderer injects the notifications
-    pre-check `if:` guard when absent. For multi-step setup, add multiple
+    `timeout-minutes`, `if`. In the workflows that pre-check whether the
+    agent needs to boot, the renderer injects that check as the step's `if:`
+    guard when the step declares none. For multi-step setup, add multiple
     entries to the `setup:` list — or reference a local composite action
     with `uses`.
     """

--- a/generator/tests/test_shared_steps.py
+++ b/generator/tests/test_shared_steps.py
@@ -292,9 +292,13 @@ esac
 # The script is written for the Ubuntu runners' GNU date; macOS ships BSD
 # date, which has no `-d`. Fixed values also make the day-scoping assertions
 # deterministic: "today" is 2026-01-02.
+# The relative offsets come first: every call also carries a format string, so
+# matching that branch first would collapse them all onto one timestamp.
 FAKE_DATE = r"""#!/usr/bin/env bash
 case "$*" in
+  *"30 minutes ago"*) echo "2026-01-02T11:30:00Z" ;;
   *"20 minutes ago"*) echo "2026-01-02T11:40:00Z" ;;
+  *"10 minutes ago"*) echo "2026-01-02T11:50:00Z" ;;
   *"yesterday"*) echo "2026-01-01" ;;
   *"6 days ago"*) echo "2025-12-27" ;;
   *"%Y-%m-%dT%H:%M:%SZ"*) echo "2026-01-02T12:00:00Z" ;;
@@ -302,8 +306,8 @@ case "$*" in
 esac
 """
 
-# The preflight jitters before its check-then-act; a real sleep would add up
-# to 30s per test.
+# The preflight jitters before its check-then-act, and the notifications
+# pre-check backs off between fetch attempts; real sleeps would add up.
 FAKE_SLEEP = "#!/usr/bin/env bash\nexit 0\n"
 
 TODAY = "2026-01-02"
@@ -1023,6 +1027,342 @@ def test_review_gate_fails_open_on_an_html_200(gate_env: dict[str, str]) -> None
 
     assert result.returncode == 0, result.stderr
     assert _should_run(gate_env) == "true"
+
+
+# ---------------------------------------------------------------------------
+# notifications-check.sh — the tend-notifications pre-check
+# ---------------------------------------------------------------------------
+
+NOTIFICATIONS_CHECK = (
+    REPO_ROOT / "generator" / "src" / "tend" / "templates" / "notifications-check.sh"
+)
+
+# `gh` stand-in for the notifications pre-check. Fixtures in, the script's own
+# `--jq` doing the filtering — the tend-workflow name regex and the PR
+# author/state read are the behaviour under test, so a pre-filtered fake would
+# assert nothing.
+FAKE_GH_NOTIFICATIONS = r"""#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_CALLS"
+
+jq_expr=""
+prev=""
+for arg in "$@"; do
+  [ "$prev" = "--jq" ] && jq_expr="$arg"
+  prev="$arg"
+done
+
+emit() {
+  if [ -n "$jq_expr" ]; then
+    printf '%s' "$1" | jq -r "$jq_expr"
+  else
+    printf '%s' "$1"
+  fi
+}
+
+case "$2" in
+  notifications)
+    # The script's diagnostic re-fetch on a failed attempt. The real one exits
+    # non-zero on an error status, which is what its `|| true` tolerates.
+    [ "$3" = "-i" ] && { echo "HTTP/2.0 502 Bad Gateway"; exit 1; }
+    # Fail the fetches in [FROM, UNTIL], so each consumer of the fetch can be
+    # failed on its own: FROM=1 fails every attempt, FROM=1 UNTIL=1 leaves the
+    # retry to succeed, and FROM=2 fails only the Layer-D recount.
+    if [ -n "${FAIL_NOTIFS_FROM:-}" ]; then
+      n=$(( $(cat "$FETCH_CALLS" 2>/dev/null || echo 0) + 1 ))
+      echo "$n" > "$FETCH_CALLS"
+      if [ "$n" -ge "$FAIL_NOTIFS_FROM" ] \
+        && { [ -z "${FAIL_NOTIFS_UNTIL:-}" ] || [ "$n" -le "$FAIL_NOTIFS_UNTIL" ]; }; then
+        exit 1
+      fi
+    fi
+    # A 200 carrying something other than JSON, verbatim.
+    if [ -n "${RAW_BODY:-}" ]; then cat "$RAW_BODY"; exit 0; fi
+    # A thread marked read leaves the unread listing, so a later fetch must not
+    # return it — which is what the Layer-D recount exists to observe.
+    jq -c --rawfile done "$READ_THREADS" \
+      '($done | split("\n")) as $d | [.[] | select(.id | IN($d[]) | not)]' \
+      "$NOTIFICATIONS_JSON"
+    ;;
+  notifications/threads/*)
+    echo "${2##*/}" >> "$READ_THREADS"
+    ;;
+  repos/*/actions/runs*) emit "$(cat "$RUNS_JSON")" ;;
+  repos/*/pulls/*)
+    # 404 for a PR the fixture doesn't carry, which the script's `|| continue`
+    # has to survive under `bash -e`.
+    pr=$(jq -c --argjson n "${2##*/}" \
+      'map(select(.number == $n)) | .[0] // empty' "$PULLS_JSON")
+    [ -n "$pr" ] || exit 1
+    emit "$pr"
+    ;;
+  *) exit 1 ;;
+esac
+"""
+
+# The fake `date` puts "now" at 12:00, so Layer D's 10-minute deferral window
+# opens at 11:50 and Layer B's shadowed-run lookback at 11:30.
+NOTIF_FRESH = "2026-01-02T11:55:00Z"
+NOTIF_SETTLED = "2026-01-02T11:45:00Z"
+
+
+def _notif(
+    tid: str, kind: str, number: int, updated_at: str, repo: str = "owner/repo"
+) -> dict:
+    """One unread notification as `GET /notifications` returns it.
+
+    *kind* is the subject's path segment: `pulls` or `issues`.
+    """
+    return {
+        "id": tid,
+        "updated_at": updated_at,
+        "repository": {"full_name": repo},
+        "subject": {
+            "url": f"https://api.github.com/repos/{repo}/{kind}/{number}",
+            "type": "PullRequest" if kind == "pulls" else "Issue",
+        },
+    }
+
+
+@pytest.fixture
+def notifications_env(tmp_path: Path) -> dict[str, str]:
+    """Fake gh/date/sleep on PATH, plus the workflow env the pre-check reads."""
+    bindir = _fake_bin(
+        tmp_path, gh=FAKE_GH_NOTIFICATIONS, date=FAKE_DATE, sleep=FAKE_SLEEP
+    )
+
+    # Both the fake gh and the script itself shell out to jq.
+    jq = shutil.which("jq")
+    assert jq, "jq is required for these tests"
+
+    notifications = tmp_path / "notifications.json"
+    notifications.write_text("[]")
+    runs = tmp_path / "runs.json"
+    runs.write_text(json.dumps({"workflow_runs": []}))
+    pulls = tmp_path / "pulls.json"
+    pulls.write_text("[]")
+    read_threads = tmp_path / "read-threads"
+    read_threads.write_text("")
+
+    return {
+        "PATH": f"{bindir}:{Path(jq).parent}:/usr/bin:/bin",
+        "GH_CALLS": str(tmp_path / "gh-calls.log"),
+        "FETCH_CALLS": str(tmp_path / "fetch-calls"),
+        "READ_THREADS": str(read_threads),
+        "GITHUB_OUTPUT": str(tmp_path / "output.txt"),
+        "GITHUB_REPOSITORY": "owner/repo",
+        "BOT_NAME": "tend-agent",
+        "NOTIFICATIONS_JSON": str(notifications),
+        "RUNS_JSON": str(runs),
+        "PULLS_JSON": str(pulls),
+    }
+
+
+def _run_check(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    # `bash -e` mirrors the shell GitHub Actions gives a `run:` block.
+    return subprocess.run(
+        ["bash", "-e", str(NOTIFICATIONS_CHECK)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _count(env: dict[str, str]) -> str:
+    lines = Path(env["GITHUB_OUTPUT"]).read_text().splitlines()
+    values = [line.split("=", 1)[1] for line in lines if line.startswith("count=")]
+    assert len(values) == 1, f"expected exactly one count, got: {lines}"
+    return values[0]
+
+
+def _marked_read(env: dict[str, str]) -> list[str]:
+    return Path(env["READ_THREADS"]).read_text().split()
+
+
+def _write_json(env: dict[str, str], key: str, value: object) -> None:
+    Path(env[key]).write_text(json.dumps(value))
+
+
+def test_notifications_check_reports_no_work_on_an_empty_inbox(
+    notifications_env: dict[str, str],
+) -> None:
+    result = _run_check(notifications_env)
+
+    assert result.returncode == 0, result.stderr
+    assert _count(notifications_env) == "0"
+    assert _marked_read(notifications_env) == []
+
+
+@pytest.mark.parametrize(
+    ("updated_at", "repo", "expected"),
+    [
+        # A dedicated workflow (review/mention/triage/ci-fix) is likely still
+        # mid-flight on this one, so processing it now would duplicate its work.
+        (NOTIF_FRESH, "owner/repo", "0"),
+        (NOTIF_SETTLED, "owner/repo", "1"),
+        # No dedicated workflow covers another repo, so there is nothing to wait
+        # for however fresh the notification is.
+        (NOTIF_FRESH, "other/repo", "1"),
+    ],
+)
+def test_notifications_check_defers_only_fresh_same_repo_work(
+    notifications_env: dict[str, str], updated_at: str, repo: str, expected: str
+) -> None:
+    _write_json(
+        notifications_env,
+        "NOTIFICATIONS_JSON",
+        [_notif("999", "issues", 7, updated_at, repo=repo)],
+    )
+
+    result = _run_check(notifications_env)
+
+    assert result.returncode == 0, result.stderr
+    assert _count(notifications_env) == expected
+
+
+def test_notifications_check_clears_what_a_recent_tend_run_covered(
+    notifications_env: dict[str, str],
+) -> None:
+    """A dedicated run that failed before its post-step leaves the notification
+    unread; clearing it here saves an agent turn rediscovering it. Matched on
+    the tend workflow names, so a run of the repo's own CI clears nothing.
+    """
+    _write_json(
+        notifications_env,
+        "NOTIFICATIONS_JSON",
+        [
+            _notif("11", "pulls", 7, NOTIF_SETTLED),
+            _notif("22", "pulls", 8, NOTIF_SETTLED),
+        ],
+    )
+    _write_json(
+        notifications_env,
+        "RUNS_JSON",
+        {
+            "workflow_runs": [
+                {"name": "tend-review", "pull_requests": [{"number": 7}]},
+                {"name": "ci", "pull_requests": [{"number": 8}]},
+            ]
+        },
+    )
+    # Open, and someone else's, so Layer C leaves both alone.
+    _write_json(
+        notifications_env,
+        "PULLS_JSON",
+        [
+            {"number": 7, "user": {"login": "human"}, "state": "open"},
+            {"number": 8, "user": {"login": "human"}, "state": "open"},
+        ],
+    )
+
+    result = _run_check(notifications_env)
+
+    assert result.returncode == 0, result.stderr
+    assert _marked_read(notifications_env) == ["11"]
+    assert _count(notifications_env) == "1"
+
+
+def test_notifications_check_clears_the_bots_own_closed_prs(
+    notifications_env: dict[str, str],
+) -> None:
+    """The bot auto-subscribes to its own PRs, so one that's closed is noise.
+    Someone else's closed PR, the bot's still-open PR, and a PR that can't be
+    read at all each stay unread and countable.
+    """
+    _write_json(
+        notifications_env,
+        "NOTIFICATIONS_JSON",
+        [_notif(str(n * 11), "pulls", n, NOTIF_SETTLED) for n in (1, 2, 3, 4)],
+    )
+    _write_json(
+        notifications_env,
+        "PULLS_JSON",
+        [
+            {"number": 1, "user": {"login": "tend-agent"}, "state": "closed"},
+            {"number": 2, "user": {"login": "human"}, "state": "closed"},
+            {"number": 3, "user": {"login": "tend-agent"}, "state": "open"},
+        ],
+    )
+
+    result = _run_check(notifications_env)
+
+    assert result.returncode == 0, result.stderr
+    assert _marked_read(notifications_env) == ["11"]
+    assert _count(notifications_env) == "3"
+
+
+def test_notifications_check_gives_up_cleanly_when_the_fetch_keeps_failing(
+    notifications_env: dict[str, str],
+) -> None:
+    """The step is `bash -e`, so an untolerated `gh` failure would fail the job
+    red. A cycle that can't enumerate just skips — the next one picks it up.
+    """
+    _write_json(
+        notifications_env,
+        "NOTIFICATIONS_JSON",
+        [_notif("999", "issues", 7, NOTIF_SETTLED)],
+    )
+    notifications_env["FAIL_NOTIFS_FROM"] = "1"
+
+    result = _run_check(notifications_env)
+
+    assert result.returncode == 0, result.stderr
+    assert _count(notifications_env) == "0"
+    assert _marked_read(notifications_env) == []
+
+
+def test_notifications_check_retries_a_transient_fetch_failure(
+    notifications_env: dict[str, str],
+) -> None:
+    """One failed attempt costs the cycle nothing: the retry enumerates."""
+    _write_json(
+        notifications_env,
+        "NOTIFICATIONS_JSON",
+        [_notif("999", "issues", 7, NOTIF_SETTLED)],
+    )
+    notifications_env["FAIL_NOTIFS_FROM"] = "1"
+    notifications_env["FAIL_NOTIFS_UNTIL"] = "1"
+
+    result = _run_check(notifications_env)
+
+    assert result.returncode == 0, result.stderr
+    assert _count(notifications_env) == "1"
+
+
+def test_notifications_check_tolerates_an_html_200(
+    notifications_env: dict[str, str], tmp_path: Path
+) -> None:
+    """A GitHub blip can answer 200 with an HTML error page: `gh` exits zero and
+    the body isn't JSON. Without the parse guard the run would carry on against
+    a non-JSON snapshot and fail the step.
+    """
+    body = tmp_path / "body.html"
+    body.write_text("<html>unicorn</html>")
+    notifications_env["RAW_BODY"] = str(body)
+
+    result = _run_check(notifications_env)
+
+    assert result.returncode == 0, result.stderr
+    assert _count(notifications_env) == "0"
+
+
+def test_notifications_check_counts_from_the_snapshot_when_the_recount_fails(
+    notifications_env: dict[str, str],
+) -> None:
+    """A failed recount over-counts by whatever Layers B/C cleared, spending one
+    agent run — the alternative, a zero count, would strand real work until the
+    next cycle.
+    """
+    _write_json(
+        notifications_env,
+        "NOTIFICATIONS_JSON",
+        [_notif("999", "issues", 7, NOTIF_SETTLED)],
+    )
+    notifications_env["FAIL_NOTIFS_FROM"] = "2"
+
+    result = _run_check(notifications_env)
+
+    assert result.returncode == 0, result.stderr
+    assert _count(notifications_env) == "1"
 
 
 REPORT_FAILURE = REPO_ROOT / "shared" / "steps" / "report-failure.sh"

--- a/generator/tests/test_shared_steps.py
+++ b/generator/tests/test_shared_steps.py
@@ -93,6 +93,18 @@ def _comments(env: dict[str, str]) -> str:
     return Path(env["COMMENT_BODIES"]).read_text()
 
 
+def _output(env: dict[str, str], key: str) -> str:
+    """The value a pre-check wrote to `$GITHUB_OUTPUT` under *key*.
+
+    Exactly one write: a second would leave the step's consumers reading
+    whichever line Actions kept, so two is a defect rather than a last-wins.
+    """
+    lines = Path(env["GITHUB_OUTPUT"]).read_text().splitlines()
+    values = [line.split("=", 1)[1] for line in lines if line.startswith(f"{key}=")]
+    assert len(values) == 1, f"expected exactly one {key}, got: {lines}"
+    return values[0]
+
+
 # The Run cell of a row generated under the fixtures' GITHUB_RUN_ID. What a
 # carried-over row is recognised by, on either record.
 RUN_LINK = "[workflow run](https://github.com/owner/repo/actions/runs/12345)"
@@ -938,13 +950,6 @@ def _run_gate(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
     )
 
 
-def _should_run(env: dict[str, str]) -> str:
-    lines = Path(env["GITHUB_OUTPUT"]).read_text().splitlines()
-    values = [line.split("=", 1)[1] for line in lines if line.startswith("should_run=")]
-    assert len(values) == 1, f"expected exactly one should_run, got: {lines}"
-    return values[0]
-
-
 def _stamp(env: dict[str, str], *statuses: dict[str, str]) -> None:
     Path(env["STATUS_JSON"]).write_text(json.dumps({"statuses": list(statuses)}))
 
@@ -956,7 +961,7 @@ def test_review_gate_skips_a_stamped_head(gate_env: dict[str, str]) -> None:
     result = _run_gate(gate_env)
 
     assert result.returncode == 0, result.stderr
-    assert _should_run(gate_env) == "false"
+    assert _output(gate_env, "should_run") == "false"
 
 
 def test_review_gate_runs_when_head_is_unstamped(gate_env: dict[str, str]) -> None:
@@ -973,7 +978,7 @@ def test_review_gate_runs_when_head_is_unstamped(gate_env: dict[str, str]) -> No
     result = _run_gate(gate_env)
 
     assert result.returncode == 0, result.stderr
-    assert _should_run(gate_env) == "true"
+    assert _output(gate_env, "should_run") == "true"
 
 
 def test_review_gate_only_gates_synchronize(gate_env: dict[str, str]) -> None:
@@ -985,7 +990,7 @@ def test_review_gate_only_gates_synchronize(gate_env: dict[str, str]) -> None:
     result = _run_gate(gate_env)
 
     assert result.returncode == 0, result.stderr
-    assert _should_run(gate_env) == "true"
+    assert _output(gate_env, "should_run") == "true"
     assert not Path(gate_env["GH_CALLS"]).exists(), "ungated event still hit the API"
 
 
@@ -998,7 +1003,7 @@ def test_review_gate_skips_closed_prs(gate_env: dict[str, str]) -> None:
     result = _run_gate(gate_env)
 
     assert result.returncode == 0, result.stderr
-    assert _should_run(gate_env) == "false"
+    assert _output(gate_env, "should_run") == "false"
 
 
 @pytest.mark.parametrize("failure", ["FAIL_PR", "FAIL_STATUS"])
@@ -1012,7 +1017,7 @@ def test_review_gate_fails_open_on_api_errors(
     result = _run_gate(gate_env)
 
     assert result.returncode == 0, result.stderr
-    assert _should_run(gate_env) == "true"
+    assert _output(gate_env, "should_run") == "true"
 
 
 def test_review_gate_fails_open_on_an_html_200(gate_env: dict[str, str]) -> None:
@@ -1026,7 +1031,7 @@ def test_review_gate_fails_open_on_an_html_200(gate_env: dict[str, str]) -> None
     result = _run_gate(gate_env)
 
     assert result.returncode == 0, result.stderr
-    assert _should_run(gate_env) == "true"
+    assert _output(gate_env, "should_run") == "true"
 
 
 # ---------------------------------------------------------------------------
@@ -1167,13 +1172,6 @@ def _run_check(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
     )
 
 
-def _count(env: dict[str, str]) -> str:
-    lines = Path(env["GITHUB_OUTPUT"]).read_text().splitlines()
-    values = [line.split("=", 1)[1] for line in lines if line.startswith("count=")]
-    assert len(values) == 1, f"expected exactly one count, got: {lines}"
-    return values[0]
-
-
 def _marked_read(env: dict[str, str]) -> list[str]:
     return Path(env["READ_THREADS"]).read_text().split()
 
@@ -1188,7 +1186,7 @@ def test_notifications_check_reports_no_work_on_an_empty_inbox(
     result = _run_check(notifications_env)
 
     assert result.returncode == 0, result.stderr
-    assert _count(notifications_env) == "0"
+    assert _output(notifications_env, "count") == "0"
     assert _marked_read(notifications_env) == []
 
 
@@ -1216,7 +1214,7 @@ def test_notifications_check_defers_only_fresh_same_repo_work(
     result = _run_check(notifications_env)
 
     assert result.returncode == 0, result.stderr
-    assert _count(notifications_env) == expected
+    assert _output(notifications_env, "count") == expected
 
 
 def test_notifications_check_clears_what_a_recent_tend_run_covered(
@@ -1258,7 +1256,7 @@ def test_notifications_check_clears_what_a_recent_tend_run_covered(
 
     assert result.returncode == 0, result.stderr
     assert _marked_read(notifications_env) == ["11"]
-    assert _count(notifications_env) == "1"
+    assert _output(notifications_env, "count") == "1"
 
 
 def test_notifications_check_clears_the_bots_own_closed_prs(
@@ -1287,7 +1285,7 @@ def test_notifications_check_clears_the_bots_own_closed_prs(
 
     assert result.returncode == 0, result.stderr
     assert _marked_read(notifications_env) == ["11"]
-    assert _count(notifications_env) == "3"
+    assert _output(notifications_env, "count") == "3"
 
 
 def test_notifications_check_gives_up_cleanly_when_the_fetch_keeps_failing(
@@ -1306,7 +1304,7 @@ def test_notifications_check_gives_up_cleanly_when_the_fetch_keeps_failing(
     result = _run_check(notifications_env)
 
     assert result.returncode == 0, result.stderr
-    assert _count(notifications_env) == "0"
+    assert _output(notifications_env, "count") == "0"
     assert _marked_read(notifications_env) == []
 
 
@@ -1325,7 +1323,7 @@ def test_notifications_check_retries_a_transient_fetch_failure(
     result = _run_check(notifications_env)
 
     assert result.returncode == 0, result.stderr
-    assert _count(notifications_env) == "1"
+    assert _output(notifications_env, "count") == "1"
 
 
 def test_notifications_check_tolerates_an_html_200(
@@ -1342,7 +1340,7 @@ def test_notifications_check_tolerates_an_html_200(
     result = _run_check(notifications_env)
 
     assert result.returncode == 0, result.stderr
-    assert _count(notifications_env) == "0"
+    assert _output(notifications_env, "count") == "0"
 
 
 def test_notifications_check_counts_from_the_snapshot_when_the_recount_fails(
@@ -1355,14 +1353,25 @@ def test_notifications_check_counts_from_the_snapshot_when_the_recount_fails(
     _write_json(
         notifications_env,
         "NOTIFICATIONS_JSON",
-        [_notif("999", "issues", 7, NOTIF_SETTLED)],
+        [
+            _notif("11", "pulls", 1, NOTIF_SETTLED),
+            _notif("999", "issues", 7, NOTIF_SETTLED),
+        ],
+    )
+    # Layer C clears this one, so a recount that ran would have returned 1 —
+    # which is what separates the fallback from a quietly successful recount.
+    _write_json(
+        notifications_env,
+        "PULLS_JSON",
+        [{"number": 1, "user": {"login": "tend-agent"}, "state": "closed"}],
     )
     notifications_env["FAIL_NOTIFS_FROM"] = "2"
 
     result = _run_check(notifications_env)
 
     assert result.returncode == 0, result.stderr
-    assert _count(notifications_env) == "1"
+    assert _marked_read(notifications_env) == ["11"]
+    assert _output(notifications_env, "count") == "2"
 
 
 REPORT_FAILURE = REPO_ROOT / "shared" / "steps" / "report-failure.sh"

--- a/plugins/install-tend/skills/install-tend/references/tend.example.yaml
+++ b/plugins/install-tend/skills/install-tend/references/tend.example.yaml
@@ -109,13 +109,14 @@ bot_name: my-project-bot
 # `sandbox_setup:` below, which runs inside the Claude harness's sandbox. Under
 # codex there is no such lever; the agent installs what it needs itself.
 #
-# `tend-notifications` injects an `if:` guard on every step so setup is
-# skipped when the pre-check finds no work. A user-supplied `if:` is passed
-# through unchanged (with a generation-time warning) — your condition wins.
+# `tend-notifications` and `tend-review` decide up front whether the agent
+# needs to boot, and inject an `if:` guard on every setup step so a run that
+# found no work does no setup either. A user-supplied `if:` is passed through
+# unchanged (with a generation-time warning) — your condition wins.
 #
 # Each form below shows the config and the YAML it produces inside the
-# `steps:` block. The `if:` guard injected in `tend-notifications` is shown
-# on the first example; it's added the same way on every step.
+# `steps:` block. The guard is shown on the first example; it's added the same
+# way on every step.
 #
 # `uses`:
 #
@@ -125,6 +126,10 @@ bot_name: my-project-bot
 #     # renders as (in tend-notifications):
 #     #   - uses: astral-sh/setup-uv@v9.0.0
 #     #     if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'
+#     #
+#     # in tend-review:
+#     #   - uses: astral-sh/setup-uv@v9.0.0
+#     #     if: steps.gate.outputs.should_run == 'true'
 #     #
 #     # and in other workflows:
 #     #   - uses: astral-sh/setup-uv@v9.0.0


### PR DESCRIPTION
`notifications-check.sh` became its own file so shellcheck could see it, which left its layers with no behaviour tests. This adds ten, one per belief: the shadowed-run sweep (matched on tend workflow names, so a run of the repo's own CI clears nothing), the bot's-own-closed-PR cleanup, the same-repo-only deferral window, and the four fetch paths — retry, give-up, HTML-carrying-a-200, and the Layer D recount falling back to the pre-mutation snapshot.

The fake `gh` drops threads it marked read from later listings, mirroring what the real unread listing does. Without that the recount returns the same snapshot every time and there is nothing to assert.

<details>
<summary>Mutation check — five breakages, each caught by the test that owns it</summary>

| Mutation | Test that failed |
|---|---|
| Layer C patches every PR notification | `clears_the_bots_own_closed_prs` (+ the Layer B count) |
| Layer B's name regex matches anything | `clears_what_a_recent_tend_run_covered` |
| Layer D drops the freshness cutoff | `defers_only_fresh_same_repo_work` |
| No JSON parse guard on the fetch | `tolerates_an_html_200` |
| Recount failure zeroes the count | `counts_from_the_snapshot_when_the_recount_fails` |

</details>

`_output(env, key)` replaces `_should_run` and `_count`, which were one reader keyed differently.

The shared fake `date` grew the two offsets this script asks for. Its relative-offset branches have to precede the format branch — every call also carries `+%Y-%m-%dT%H:%M:%SZ`, so matching that first would collapse both cutoffs onto one timestamp.

Also included: the example config and `SetupStep`'s docstring both still said only `tend-notifications` injects the setup `if:` guard. `tend-review` has done so since it grew its examined-HEAD gate.

> _This was written by Claude Code on behalf of max-sixty_

