### PR TITLE
fix(running-in-ci): make the rerun poll cap terminal, and print conclusions

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -366,12 +366,22 @@ pending_jobs() {
   echo "$n"
 }
 for i in $(seq 1 9); do
-  [ "$(pending_jobs)" -eq 0 ] && break
+  if [ "$(pending_jobs)" -eq 0 ]; then
+    # `completed` is not `success`. Print each conclusion — a rerun that failed
+    # again is the case the follow-up turns on, and the loop above only ever
+    # asked whether the jobs stopped.
+    for id in $JOB_IDS; do
+      gh api "repos/$REPO/actions/jobs/$id" --jq '"\(.conclusion)\t\(.name)"'
+    done
+    exit 0
+  fi
   sleep 60
 done
+echo "Rerun jobs still running after 9 minutes"
+exit 1
 ```
 
-As with the CI Monitoring loop above, invoke this Bash call with `timeout: 600000` (10 min) — the default 2-min Bash timeout would kill the loop early, and the 9-iteration cap is sized to fit inside the harness's 10-min Bash maximum.
+As with the CI Monitoring loop above, invoke this Bash call with `timeout: 600000` (10 min) — the default 2-min Bash timeout would kill the loop early, and the 9-iteration cap is sized to fit inside the harness's 10-min Bash maximum. Exit terminally in both directions for the same reason that loop does: a bare `break` leaves "every job finished" and "the budget ran out with jobs still pending" looking identical in the transcript, and the next step reads the silence as a green rerun. On the cap, treat it as the whole poll budget — don't re-enter — and report the still-running jobs as unverified.
 
 ## Replying to Comments
 

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -365,6 +365,7 @@ pending_jobs() {
   done
   echo "$n"
 }
+[ -n "$JOB_IDS" ] || { echo "No rerun attempt surfaced — jobs were not re-queued"; exit 1; }
 for i in $(seq 1 9); do
   if [ "$(pending_jobs)" -eq 0 ]; then
     # `completed` is not `success`. Print each conclusion — a rerun that failed
@@ -381,7 +382,7 @@ echo "Rerun jobs still running after 9 minutes"
 exit 1
 ```
 
-As with the CI Monitoring loop above, invoke this Bash call with `timeout: 600000` (10 min) — the default 2-min Bash timeout would kill the loop early, and the 9-iteration cap is sized to fit inside the harness's 10-min Bash maximum. Exit terminally in both directions for the same reason that loop does: a bare `break` leaves "every job finished" and "the budget ran out with jobs still pending" looking identical in the transcript, and the next step reads the silence as a green rerun. On the cap, treat it as the whole poll budget — don't re-enter — and report the still-running jobs as unverified.
+As with the CI Monitoring loop above, invoke this Bash call with `timeout: 600000` (10 min) — the default 2-min Bash timeout would kill the loop early, and the 9-iteration cap is sized to fit inside the harness's 10-min Bash maximum. On the cap, treat it as the whole poll budget — don't re-enter — and report the still-running jobs as unverified.
 
 ## Replying to Comments
 


### PR DESCRIPTION
Surfaced by the nightly rolling survey of `plugins/tend-ci-runner/skills/running-in-ci/SKILL.md`.

The CI Monitoring loop two sections up is terminal in both directions — `exit 0` once the checks are terminal, `echo` + `exit 1` when the 9-iteration budget runs out. The `gh run rerun --failed` loop below it is not: it `break`s out on success and falls off the end on exhaustion, so those two outcomes produce identical output. An agent reading that transcript has nothing to distinguish "every reran job finished" from "the budget ran out with jobs still pending", and the natural reading of the silence is the first one.

The same loop also never printed a conclusion. `pending_jobs` only asks whether each job's `.status` reached `completed`, which is true of a job that failed again — the exact outcome a rerun exists to detect. So even the success path handed the next step no signal.

This makes the loop mirror the one above: print each job's `conclusion` and `exit 0` when the last one lands, `exit 1` with a message on the cap. The trailing paragraph now says why, and carries over the "the cap is the whole poll budget, don't re-enter" rule that item 4 of the CI Monitoring list already states.

No test — the change is skill prose plus the shell recipe embedded in it, and the repo has no harness that executes recipes out of skill markdown.
