### PR TITLE
docs(site): don't tell readers to start a dev server wt already started

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -12,7 +12,7 @@ second server on a different port instead of reusing the one listening.
 
 ```sh
 wt list statusline --format json | jq -r '.[].url'   # the URL to open
-ls .git/wt/logs/                                     # dev-server output
+wt config state logs                                 # dev-server output
 ```
 
 Outside a `wt` worktree — a plain clone, or CI — start it by hand and open

--- a/site/README.md
+++ b/site/README.md
@@ -5,15 +5,28 @@ deployed to GitHub Pages via `.github/workflows/publish-site.yaml`.
 
 ## Run locally
 
+In a `wt` worktree the dev server is already running: a post-start hook in
+[`.config/wt.toml`](../.config/wt.toml) installs deps and starts Astro on a
+port derived from the branch name. Don't run `npm run dev` — it starts a
+second server on a different port instead of reusing the one listening.
+
+```sh
+wt list statusline --format json | jq -r '.[].url'   # the URL to open
+ls .git/wt/logs/                                     # dev-server output
+```
+
+Outside a `wt` worktree — a plain clone, or CI — start it by hand and open
+<http://localhost:4321/>:
+
 ```sh
 cd site
 npm install
 npm run dev
 ```
 
-Then open <http://localhost:4321/>. The live-data elements (currently-tending
-indicator, stats strip, activity feed) fetch the Worker at `api.tend-src.com`;
-set `PUBLIC_WORKER_URL` in `.env.local` to point elsewhere (see `.env.example`).
+Either way, the live-data elements (currently-tending indicator, stats strip,
+activity feed) fetch the Worker at `api.tend-src.com`; set `PUBLIC_WORKER_URL`
+in `.env.local` to point elsewhere (see `.env.example`).
 
 ## Build
 


### PR DESCRIPTION
Surfaced by the nightly rolling survey of `site/README.md`.

The README's "Run locally" section tells the reader to `cd site && npm install && npm run dev` and open port 4321. The root `CLAUDE.md` says the opposite: *"The site's dev server starts automatically per worktree via a `wt` post-start hook (`.config/wt.toml`) on a deterministic port derived from the branch name. […] Don't run `npm run dev`; it duplicates the running server on a different port."*

Both are in the tree, and the README is the file someone lands on first when they open `site/`. `.config/wt.toml` confirms `CLAUDE.md` is the accurate one — the `[[post-start]]` hooks run `npm install --prefer-offline` and then `npm run dev -- --port {{ branch | hash_port }}`, and a `[[pre-remove]]` hook kills whatever is listening on that port when the worktree goes away. Following the README in a `wt` worktree gets you a second Astro process on 4321 that the pre-remove hook won't clean up, showing the same site the already-running server was serving.

This rewrites the section to lead with the `wt` case (URL via `wt list statusline`, logs in `.git/wt/logs/`, both as `CLAUDE.md` documents them), keeps the manual `npm run dev` path for a plain clone or CI where no hook has run, and moves the `PUBLIC_WORKER_URL` note below both so it applies to either.

No test — documentation only.
