### PR TITLE
fix(mention): skip a third party's content-free approval

### DIFF
--- a/generator/src/tend/templates/mention.yaml.j2
+++ b/generator/src/tend/templates/mention.yaml.j2
@@ -289,6 +289,23 @@ jobs:
               echo "should_run=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
+
+            # Somebody else's content-free approval is terminal too. The gate
+            # above is author-keyed, so a human's bare APPROVED falls through to
+            # the PR-author short-circuit (on a bot-authored PR) or to
+            # BOT_REVIEWS (on one the bot has reviewed) and starts a session
+            # whose only possible outcome is a silent exit: an approval with no
+            # body and no inline comments asks for nothing, and the bot cannot
+            # merge on its own. Unlike the bot-authored gates this one requires
+            # `$INLINE` to be empty rather than reply-only — an approval whose
+            # nits live inline is a request to the PR's author, which on a
+            # bot-authored PR is a role the bot has to act in.
+            if [ "$REVIEW_STATE" = "approved" ] \
+               && [ -z "$COMMENT_BODY" ] \
+               && [ -z "$INLINE" ]; then
+              echo "should_run=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           fi
 
           # Non-mention: check bot engagement

--- a/generator/tests/_regtest_outputs/test_generate.test_sandbox_levers_regtest.out
+++ b/generator/tests/_regtest_outputs/test_generate.test_sandbox_levers_regtest.out
@@ -277,6 +277,23 @@ jobs:
               echo "should_run=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
+
+            # Somebody else's content-free approval is terminal too. The gate
+            # above is author-keyed, so a human's bare APPROVED falls through to
+            # the PR-author short-circuit (on a bot-authored PR) or to
+            # BOT_REVIEWS (on one the bot has reviewed) and starts a session
+            # whose only possible outcome is a silent exit: an approval with no
+            # body and no inline comments asks for nothing, and the bot cannot
+            # merge on its own. Unlike the bot-authored gates this one requires
+            # `$INLINE` to be empty rather than reply-only ? an approval whose
+            # nits live inline is a request to the PR's author, which on a
+            # bot-authored PR is a role the bot has to act in.
+            if [ "$REVIEW_STATE" = "approved" ] \
+               && [ -z "$COMMENT_BODY" ] \
+               && [ -z "$INLINE" ]; then
+              echo "should_run=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           fi
 
           # Non-mention: check bot engagement

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
@@ -277,6 +277,23 @@ jobs:
               echo "should_run=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
+
+            # Somebody else's content-free approval is terminal too. The gate
+            # above is author-keyed, so a human's bare APPROVED falls through to
+            # the PR-author short-circuit (on a bot-authored PR) or to
+            # BOT_REVIEWS (on one the bot has reviewed) and starts a session
+            # whose only possible outcome is a silent exit: an approval with no
+            # body and no inline comments asks for nothing, and the bot cannot
+            # merge on its own. Unlike the bot-authored gates this one requires
+            # `$INLINE` to be empty rather than reply-only ? an approval whose
+            # nits live inline is a request to the PR's author, which on a
+            # bot-authored PR is a role the bot has to act in.
+            if [ "$REVIEW_STATE" = "approved" ] \
+               && [ -z "$COMMENT_BODY" ] \
+               && [ -z "$INLINE" ]; then
+              echo "should_run=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           fi
 
           # Non-mention: check bot engagement

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
@@ -277,6 +277,23 @@ jobs:
               echo "should_run=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
+
+            # Somebody else's content-free approval is terminal too. The gate
+            # above is author-keyed, so a human's bare APPROVED falls through to
+            # the PR-author short-circuit (on a bot-authored PR) or to
+            # BOT_REVIEWS (on one the bot has reviewed) and starts a session
+            # whose only possible outcome is a silent exit: an approval with no
+            # body and no inline comments asks for nothing, and the bot cannot
+            # merge on its own. Unlike the bot-authored gates this one requires
+            # `$INLINE` to be empty rather than reply-only ? an approval whose
+            # nits live inline is a request to the PR's author, which on a
+            # bot-authored PR is a role the bot has to act in.
+            if [ "$REVIEW_STATE" = "approved" ] \
+               && [ -z "$COMMENT_BODY" ] \
+               && [ -z "$INLINE" ]; then
+              echo "should_run=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           fi
 
           # Non-mention: check bot engagement

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
@@ -277,6 +277,23 @@ jobs:
               echo "should_run=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
+
+            # Somebody else's content-free approval is terminal too. The gate
+            # above is author-keyed, so a human's bare APPROVED falls through to
+            # the PR-author short-circuit (on a bot-authored PR) or to
+            # BOT_REVIEWS (on one the bot has reviewed) and starts a session
+            # whose only possible outcome is a silent exit: an approval with no
+            # body and no inline comments asks for nothing, and the bot cannot
+            # merge on its own. Unlike the bot-authored gates this one requires
+            # `$INLINE` to be empty rather than reply-only ? an approval whose
+            # nits live inline is a request to the PR's author, which on a
+            # bot-authored PR is a role the bot has to act in.
+            if [ "$REVIEW_STATE" = "approved" ] \
+               && [ -z "$COMMENT_BODY" ] \
+               && [ -z "$INLINE" ]; then
+              echo "should_run=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           fi
 
           # Non-mention: check bot engagement

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -1200,6 +1200,16 @@ def test_mention_skips_third_party_bare_approval(tmp_path: Path) -> None:
         '&& [ -z "$INLINE" ]'
     ), "the third-party skip must key on state, empty body, and zero inline comments"
 
+    # `[ -z "$INLINE" ]` only means "zero inline comments" below the fetch that
+    # populates it, and that property is positional rather than textual, so the
+    # equality above does not pin it. Hoisting the gate above the fetch — the
+    # shape the bot-authored approval gate deliberately takes, one API call
+    # cheaper — leaves `$INLINE` unset, which reads as empty and silently skips
+    # exactly the approvals-with-inline-nits this gate must let through.
+    assert run.index("INLINE=$(") < run.index('[ -z "$INLINE" ]'), (
+        "the third-party skip must sit below the inline-comment fetch"
+    )
+
     # And it precedes the engagement heuristic that would otherwise count the
     # triggering review as prior participation.
     assert run.index('[ -z "$INLINE" ]') < run.index("BOT_REVIEWS=$(")

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -1160,6 +1160,51 @@ def test_mention_skips_bot_reply_container(tmp_path: Path) -> None:
     assert run.index(count) < run.index("BOT_REVIEWS=$(")
 
 
+def test_mention_skips_third_party_bare_approval(tmp_path: Path) -> None:
+    """A human's APPROVED review with no body and no inline comments is
+    terminal for the bot as well, and the two gates above are author-keyed, so
+    it falls through to the PR-author short-circuit (on a bot-authored PR) or
+    to BOT_REVIEWS (on one the bot has reviewed) and starts a session that can
+    only exit silently — the approval asks for nothing and the bot cannot
+    merge.
+
+    The narrowing is load-bearing in both directions:
+
+    - `approved` — a bare CHANGES_REQUESTED or COMMENTED review is not
+      terminal, and a human's synthetic reply container arrives as COMMENTED,
+      so widening the state would silence the bot on replies to its own review
+      threads (the same trap `test_mention_skips_bot_reply_container` pins from
+      the author side).
+    - `$INLINE` empty, not reply-only — an approval whose nits live inline is a
+      request addressed to the PR's author, a role the bot has to act in on its
+      own PRs.
+    """
+    cfg = Config.load(_minimal_config(tmp_path))
+    wf = generate_mention(cfg)
+    data = yaml.safe_load(wf.content)
+    check_step = next(
+        s for s in data["jobs"]["verify"]["steps"] if s.get("id") == "check"
+    )
+    run = check_step["run"]
+
+    # The two author-keyed gates both open on `$KIND` / `$REVIEW_AUTHOR`, so
+    # this opening belongs to the third-party gate alone. Compare the whole
+    # condition with whitespace normalized: an author clause added here, or the
+    # `$INLINE` clause dropped, fails the equality rather than sliding past an
+    # `in` check.
+    gate = run[run.index('if [ "$REVIEW_STATE" = "approved" ]') :]
+    condition = " ".join(gate.split("; then")[0].split())
+    assert condition == (
+        'if [ "$REVIEW_STATE" = "approved" ] \\ '
+        '&& [ -z "$COMMENT_BODY" ] \\ '
+        '&& [ -z "$INLINE" ]'
+    ), "the third-party skip must key on state, empty body, and zero inline comments"
+
+    # And it precedes the engagement heuristic that would otherwise count the
+    # triggering review as prior participation.
+    assert run.index('[ -z "$INLINE" ]') < run.index("BOT_REVIEWS=$(")
+
+
 # ---------------------------------------------------------------------------
 # Fork guard
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`tend-mention` starts a full billable session every time **someone other than the bot approves a PR with an empty review body and no inline comments**. The session reads the PR, finds nothing addressed to it, and exits silently. It can only ever no-op: a bare `APPROVED` asks for nothing, and the bot is barred from merging, so there is no role left for it to act in.

`verify` has two terminal-review gates and both key on `REVIEW_AUTHOR`: the empty-body `APPROVED` gate (#747) and the synthetic reply-container gate (#849/#866). A third party's approval matches neither, so it falls through to the `PR_AUTHOR == bot` short-circuit on a bot-authored PR — or to `BOT_REVIEWS`, which counts the triggering review itself — and `should_run=true` is unconditional. Structural: there is no decision point, so the same shape recurs every time a human approves one of the bot's PRs without typing anything.

Distinct from the three issues already open or closed on this path. #747 fixed the bot's *own* empty-body approval; #866 targets the synthetic empty-body `COMMENTED` container GitHub creates for an inline reply; #915/#916 target the bot's *own* content-bearing review on someone else's PR. All three are author-keyed by design; this is the residual their author-keying leaves behind, and it was named as such in the evidence log two days before this run.

## Evidence

Three occurrences on `PRQL/prql`, all traced to the review record rather than inferred from the run:

| When | PR | Approver | Review | Handle job |
|---|---|---|---|---|
| 2026-08-10 | [#6164](https://github.com/PRQL/prql/pull/6164) | `kgutwin` | `APPROVED`, empty body, no inline comments | [31395281267](https://github.com/PRQL/prql/actions/runs/31395281267) — 2 m 10 s, published nothing |
| 2026-08-12 08:18Z | [#6185](https://github.com/PRQL/prql/pull/6185) | `vanillajonathan` | `4914418538`, `APPROVED`, body length 0, `pulls/6185/comments` empty | [31577748274](https://github.com/PRQL/prql/actions/runs/31577748274) — 08:18:45Z→08:20:35Z (110 s), published nothing |
| 2026-08-12 13:27Z | [#6186](https://github.com/PRQL/prql/pull/6186) | `kgutwin` | `4916991960`, `APPROVED`, body length 0, zero inline comments | [31601473217](https://github.com/PRQL/prql/actions/runs/31601473217) — 13:27:22Z→13:28:51Z (89 s), published nothing |

The third one's session log says why it published nothing, in five tool calls: *"The trigger was a plain approval (`APPROVED`, empty body, no inline comments) from @kgutwin on PR #6186, which is already **MERGED**. No questions, no requested changes, no unaddressed comments anywhere on the thread. Per the review-response rules, a plain approval gets no reply, so I'm not posting anything."* The model reaches the right verdict every time; the cost is that it has to boot to reach it.

## Solution

A third clause on the same gate chain, inside the `pull_request_review` block and after the `@`-mention scan, so a mention buried in an inline comment still summons the bot:

```bash
if [ "$REVIEW_STATE" = "approved" ] \
   && [ -z "$COMMENT_BODY" ] \
   && [ -z "$INLINE" ]; then
  echo "should_run=false" >> "$GITHUB_OUTPUT"
  exit 0
fi
```

It costs no extra API call — `$INLINE` is already fetched a few lines above for the mention scan.

Two narrowings, both load-bearing:

- **`approved`, not any state.** A human's reply to one of the bot's review threads also arrives as an empty-body review container, but `COMMENTED`. Widening the state here would silence the bot on every human reply to its own threads — the same trap `test_mention_skips_bot_reply_container` pins from the author side, since `pull_request_review_comment` subscribes to `edited` only.
- **`$INLINE` empty, not reply-only.** An approval whose nits live in inline comments is a request addressed to the PR's author, and on a bot-authored PR that is a role the bot has to act in. Only a review with nothing in it anywhere is terminal.

The two author-keyed gates stay as they are: the bot's own empty-body `APPROVED` is skipped before the `$INLINE` fetch, which keeps that path one API call cheaper.

## Gate assessment

- **Evidence level: High** — a consistent pattern across three sessions on two PRs and two approvers, spanning two days. High needs 2–3; this is 3.
- **Structural, not stochastic.** The gate condition is author-keyed in the workflow YAML, so replaying any of these three scenarios ten times boots the agent ten times. The model's judgement is not involved and is not at fault.
- **Change type: targeted fix** — one clause on an existing chain, reusing data already fetched. Normal bar, met by Gate 1.
- Both gates passed.

Evidence log: https://gist.github.com/192514ea2c36586f9b7f842a482d62ab (`review-reviewers evidence: PRQL/prql 2026-08`), where this finding was recorded at one occurrence on 2026-08-10 and at two on 2026-08-12 before crossing here.

## Testing

`test_mention_skips_third_party_bare_approval` compares the whole gate condition with whitespace normalized, so an author clause added later — or the `$INLINE` clause dropped — fails on equality rather than sliding past an `in` check. It fails on `main` (`ValueError: substring not found`). The four `mention` regtest snapshots are updated. Full generator suite: 420 passed.
