### PR TITLE
docs: record the claude_version marker decision in CLAUDE.md

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -186,8 +186,8 @@ shape — headless sessions losing a long-lived `CLAUDE_CODE_OAUTH_TOKEN` to a
 stored short-lived one, the startup connectivity check hanging behind an HTTPS
 proxy. `stable` would not even keep un-promoted code out of the job:
 `install.sh` always fetches the `latest` build as its bootstrap installer before
-handing off to the pinned target. Pin an exact version either way — the marker
-only picks the number.
+handing off to the pinned target — only the agent session runs the pinned
+version. Pin an exact version either way — the marker only picks the number.
 
 `mitmproxy_version` pins the process that holds the real PAT and model
 credential, so a security fix there matters here. Check anything security- or

--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -157,7 +157,7 @@ both.
 
 | Pin | File | Rule |
 |---|---|---|
-| `claude_version` | `claude/action.yaml` | track latest |
+| `claude_version` | `claude/action.yaml` | track npm's `latest` dist-tag, not `stable` — see below |
 | `mitmproxy_version` | `claude/action.yaml` | track latest |
 | `uv_version` | `claude/action.yaml` | move it with `mitmproxy_version` |
 | `codex_version` | `codex/action.yaml` | track latest; the surface job confirms the bump |
@@ -178,6 +178,16 @@ target, so drift silently downgrades the model. Skim the claude-code CHANGELOG
 between the two versions for anything touching the agent paths (first-run
 onboarding, `--model` alias resolution, headless `-p` result events, Stop-hook
 behavior, slash-command or Skill-tool handling) and note it in the PR.
+
+`latest` over `stable` is a decision, not a default. Both markers exist on npm
+and in the release bucket, several releases apart (2026-08-12: `stable` 2.1.222,
+`latest` 2.1.229), and the fixes in that window have repeatedly been tend's own
+shape — headless sessions losing a long-lived `CLAUDE_CODE_OAUTH_TOKEN` to a
+stored short-lived one, the startup connectivity check hanging behind an HTTPS
+proxy. `stable` would not even keep un-promoted code out of the job:
+`install.sh` always fetches the `latest` build as its bootstrap installer before
+handing off to the pinned target. Pin an exact version either way — the marker
+only picks the number.
 
 `mitmproxy_version` pins the process that holds the real PAT and model
 credential, so a security fix there matters here. Check anything security- or

--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -157,7 +157,7 @@ both.
 
 | Pin | File | Rule |
 |---|---|---|
-| `claude_version` | `claude/action.yaml` | track npm's `latest` dist-tag, not `stable` — see below |
+| `claude_version` | `claude/action.yaml` | track npm's `latest` dist-tag |
 | `mitmproxy_version` | `claude/action.yaml` | track latest |
 | `uv_version` | `claude/action.yaml` | move it with `mitmproxy_version` |
 | `codex_version` | `codex/action.yaml` | track latest; the surface job confirms the bump |
@@ -178,16 +178,6 @@ target, so drift silently downgrades the model. Skim the claude-code CHANGELOG
 between the two versions for anything touching the agent paths (first-run
 onboarding, `--model` alias resolution, headless `-p` result events, Stop-hook
 behavior, slash-command or Skill-tool handling) and note it in the PR.
-
-`latest` over `stable` is a decision, not a default. Both markers exist on npm
-and in the release bucket, several releases apart (2026-08-12: `stable` 2.1.222,
-`latest` 2.1.229), and the fixes in that window have repeatedly been tend's own
-shape — headless sessions losing a long-lived `CLAUDE_CODE_OAUTH_TOKEN` to a
-stored short-lived one, the startup connectivity check hanging behind an HTTPS
-proxy. `stable` would not even keep un-promoted code out of the job:
-`install.sh` always fetches the `latest` build as its bootstrap installer before
-handing off to the pinned target — only the agent session runs the pinned
-version. Pin an exact version either way — the marker only picks the number.
 
 `mitmproxy_version` pins the process that holds the real PAT and model
 credential, so a security fix there matters here. Check anything security- or

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,12 @@ Between a generator commit and the next release the committed workflows lag
 the in-tree generator; that is expected, and the gap closes at the next
 release (which tags `X.Y.Z` before regenerating, so the pin always resolves).
 
+`claude_version` in `claude/action.yaml` is an exact version taken from npm's
+`latest` dist-tag, not `stable`. `stable` lags several releases, and pinning it
+wouldn't keep un-promoted code out of the job anyway: `install.sh` always
+downloads the `latest` build as its bootstrap installer, and only the agent
+session runs the pin.
+
 ## Generator vs adopter ownership
 
 | Aspect | Owner | Lives in |


### PR DESCRIPTION
#927 asked whether `claude_version` should track npm's `latest` dist-tag, given it runs several releases ahead of `stable`. Answered in [#927](https://github.com/max-sixty/tend/issues/927#issuecomment-5273490373): yes, stay on `latest`.

So this records the decision where repo rationale lives — five lines in `CLAUDE.md` under "Key details" — and leaves the weekly-bump skill with a one-line rule (`track npm's `latest` dist-tag`). Nothing about the pin itself changes: it stays an exact version, and the weekly recipe is untouched.

The one non-obvious fact, and the reason `stable` isn't the safer-looking choice it appears to be: `install.sh` validates the target against `stable|latest|X.Y.Z` and then unconditionally downloads the `latest` build as its bootstrap installer before handing off (`"$binary_path" install ${TARGET:+"$TARGET"}`). Only the agent session runs the pinned version, so a `stable` pin would not keep un-promoted code out of the job.

Closes #927.
