### PR TITLE
ci(worker): test on Node 22, matching the deploy job and Wrangler's floor

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -181,6 +181,11 @@ jobs:
       - uses: astral-sh/setup-uv@v9.0.0
       - run: uv run --no-project --with pytest pytest
 
+  # Node 22 to match worker-deploy.yaml, which had to move off 20 because
+  # Wrangler refuses to run there ("Wrangler requires at least Node.js
+  # v22.0.0"). That deploy job re-runs this job's typecheck and tests before
+  # shipping, so leaving the gate on a version the worker's own toolchain
+  # rejects makes the pre-merge signal weaker than the thing it gates.
   test-worker:
     runs-on: ubuntu-24.04
     defaults:
@@ -190,7 +195,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "22"
           cache: npm
           cache-dependency-path: worker/package-lock.json
       - run: npm ci

--- a/worker/package.json
+++ b/worker/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",


### PR DESCRIPTION
`ci.yaml`'s `test-worker` job pins Node 20, but the worker's own toolchain refuses to run there. Found during the nightly survey of `.github/workflows/ci.yaml`.

`worker-deploy.yaml` already had to move: [`da78f6e`](https://github.com/max-sixty/tend/commit/da78f6e92e011e43c29d3c7d023d29eaefeee463) ("ci(worker-deploy): bump Node to 22 for Wrangler", #429) bumped it after a real deploy failed with `Wrangler requires at least Node.js v22.0.0. You are using v20.20.2.` Both jobs were introduced on 20 together in #415; only the deploy one was fixed, so the two have been out of step since. Verified against the installed package rather than the commit message alone — `worker/node_modules/wrangler/package.json` at 4.90.0 declares `"engines": {"node": ">=22.0.0"}`.

That leaves the pre-merge gate weaker than the thing it gates: `worker-deploy.yaml` re-runs this job's `typecheck` and `test` on Node 22 immediately before `wrangler deploy`, so the authoritative run happens on a version CI never exercises.

Two changes:

- `ci.yaml`: `test-worker` moves to Node 22, matching the deploy job.
- `worker/package.json`: adds `"engines": {"node": ">=22.0.0"}`, so the floor lives with the package instead of being implied by two workflow files that already drifted apart once.

**On the `engines` field, stated plainly:** npm treats it as advisory unless `engine-strict=true` is set, so this warns (`EBADENGINE`) rather than fails. I did not add a `.npmrc` to harden it — that is new machinery for a constraint Wrangler already enforces itself at the point it matters. The value here is that the requirement is declared once, in the file that owns the dependency.

**No regression test.** The change is a CI runner version and a manifest field; the assertion that would cover it is the deploy job itself, which already runs this suite on 22. What I did verify locally on Node v22.23.1: `npm ci` clean, `tsc --noEmit` clean, and all 31 vitest tests passing, both before and after adding `engines`.

**Lockfile deliberately untouched.** `npm install --package-lock-only` would sync the new `engines` into the lock's root entry, but this npm also strips `libc` metadata from ~28 optional-dependency entries in the same pass — the resolution churn [`dev/test.sh`](https://github.com/max-sixty/tend/blob/c9e44e2266881538ce3ff6e55e497e790e067248/dev/test.sh#L50-L53) warns about. `npm ci` does not validate `engines` against the lock, and I re-ran it from a clean `node_modules` to confirm it is happy with the field present in `package.json` only.

Left alone as a separate concern: `test-codex-surface` in the same file still pins `actions/checkout@v6` and `actions/setup-node@v4` while every other job uses `@v7`. That is action-ref drift, which `running-tend` routes through the weekly bump rather than a sweep.
