### PR TITLE
fix(review-runs): line-anchor the evidence-log selector

### DIFF
--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -92,9 +92,14 @@ REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
 BOT_LOGIN=$(gh api user --jq '.login')
 # Match the evidence log by its `## Run <id>` heading, not by "newest bot
 # comment" — other skills (nightly) post their own comments on this issue, and
-# the newest one is often not the log.
+# the newest one is often not the log. Anchor with `(^|\n)`, not `^`: jq's `^`
+# matches the start of the *string*, so a log comment that opens with a blank
+# line or a `---` separator — the ordinary shape of the comment the create-new
+# branch below posts — never matches, and the selector silently falls back to a
+# superseded log comment. jq's `m` flag doesn't help; there it means "`.`
+# matches newline", not multi-line anchors.
 EXISTING_COMMENT=$(gh api "repos/$REPO/issues/$TRACKING_NUMBER/comments" \
-  --jq "[.[] | select(.user.login == \"$BOT_LOGIN\" and (.body | test(\"^## Run [0-9]\")))] | last | .id // empty")
+  --jq "[.[] | select(.user.login == \"$BOT_LOGIN\" and (.body | test(\"(^|\n)## Run [0-9]\")))] | last | .id // empty")
 
 # Verify the run heading references this run's $GITHUB_RUN_ID literally —
 # fabricated round numbers produce dead Workflow links, see @review-gates.md.


### PR DESCRIPTION
`review-runs` picks its evidence-log append target with `test("^## Run [0-9]")` ([`review-runs/SKILL.md#L96-L97`](https://github.com/max-sixty/tend/blob/c9e44e2266881538ce3ff6e55e497e790e067248/plugins/tend-ci-runner/skills/review-runs/SKILL.md#L96-L97)). jq's `^` anchors to the start of the **string**, not the start of a line, so the predicate only matches a log comment whose body begins at offset 0 with the heading. The rollover comment that the create-new branch three lines below posts routinely does not: the appended entry carries its own leading blank line or `---` separator, so the body opens with `\n## Run …` or `\n\n---\n\n## Run …`.

When that happens the selector skips the live log and resolves to an older one — in practice the comment that was rolled over precisely because it had grown near GitHub's 65536-byte body limit. From there the run either appends its entry into a superseded comment out of chronological order, or (once `existing + findings ≥ 60000`) takes the rollover branch again and posts a fresh comment, repeating every run. Both are wrong outward actions on a public issue, and both return 200, so nothing surfaces the fault: the only symptom is that a later run's "read historical evidence" step gets a fragmented, out-of-order log and evaluates its gates on it.

The fix anchors the heading to a line start with `(^|\n)`. One character class; no new state, no new step.

## Evidence

The shape is the ordinary output of the recipe's own rollover branch, not an edge case. Measured live against `max-sixty/cargo-affected`'s two `review-runs` trackers, projecting each bot comment's opening bytes and both predicates:

```
tracker #62                                        ^## Run [0-9]   (^|\n)## Run [0-9]
  4852429465  "## Run 28505825777 — 202"  50513B       true              true
  4933725185  "\n## Run 29081041973 — 20" 49882B       false             true
  5020367025  "\n\n---\n\n## Run 2972877" 53815B       false             true
  5115269072  "\n\n---\n\n## Run 3043648" 14314B       false             true    <- the live log
```

Three of the four log comments are invisible to the current predicate, and the one it does match is the 50 KB comment that was superseded first. On `cargo-affected`'s current tracker `#73` all three log comments happen to open at offset 0, so the predicate resolves correctly there today.

It does not resolve correctly on **this** repo's own trackers, which have the same rollover shape:

```
tracker #801 (2026-08, live)                       ^## Run [0-9]   (^|\n)## Run [0-9]
  5150655987  "## Run 30691978877 (revie" 51624B       true              true
  5225291682  "\n\n## Run 31247464586 (re" 49817B      false             true    <- the live log

tracker #752 (2026-07)
  4852508712  "## Run 28505815799 (revie" 51431B       true              true
  4967003130  "\n\n## Run 29318247045 (re" 51451B      false             true
  5089350899  "\n\n## Run 30251718970 (re" 18327B      false             true    <- that month's live log
```

On `#801` the predicate skips the live log and resolves to the 51,624-byte comment — 8,376 bytes under the recipe's own 60,000-byte append bound, so the next run either appends out of chronological order or forks a third comment.

The fault has not fired yet, and the append history shows why: `5150655987` carries runs `30691978877`…`31160618137` (last updated 2026-08-07) and `5225291682` carries `31247464586`…`31577212332` (last updated 2026-08-12), in order and without interleaving. Every one of those runs predates the predicate — they executed the bare `| last` path. `0.1.15` was tagged and this repo's workflows were pinned to it in #958 at 2026-08-12 21:38 UTC, after that day's `review-runs` run (`31577212332`, 08:11 UTC). The next daily cron here is the first execution of the mis-anchored predicate anywhere, and `#801` is already in the shape that mis-resolves.

Replayed against a fixture of the four `cargo-affected` shapes plus a `tend-nightly` comment and a non-bot comment, using the recipe's exact `--jq` string:

```
OLD selector picks:  1        # the oldest, superseded, near-limit log
NEW selector picks:  3        # the live log
NEW selector, full matched set: [1, 2, 3]   # nightly and non-bot comments correctly excluded
```

jq's `m` flag is not an alternative — in jq it means "`.` matches newline", not multi-line anchors:

```
$ jq -n '"\n## Run 123" | test("^## Run [0-9]")'        # false
$ jq -n '"\n## Run 123" | test("^## Run [0-9]"; "m")'   # false
$ jq -n '"\n## Run 123" | test("(^|\n)## Run [0-9]")'   # true
```

(jq-1.7, the version on the runner.)

## Relation to prior work

The predicate arrived in #875 as the fix for #883, replacing a bare `| last` that any other bot comment on the tracker could hijack. That change is right and this doesn't undo it — it only corrects the anchor. A [comment on #883](https://github.com/max-sixty/tend/issues/883#issuecomment-5214580659) reasoned that the rollover branch was covered because "`/tmp/findings.md` always opens with `## Run <RUN_ID>`"; the bodies above are the counterexample. #883 stays open on its remaining half (the gist migration), which this doesn't touch.

## Gate assessment

- **Gate 1 — confidence**: High. Structural: jq's `^` has no decision point, and the selector depends on a property (`findings.md` starting at offset 0) that the recipe never establishes anywhere. Occurrences: 6 log comments across three trackers that the predicate fails to match, measured live and independently of the observation that raised it — including this repo's own live tracker `#801`. It has not fired yet only because every run so far executed `0.1.14`'s bare `| last`; the `0.1.15` pin bump lands the mis-anchored predicate in service on the next cron.
- **Gate 2 — magnitude**: targeted fix to a specific incorrect instruction, at the normal threshold. One line changed plus the comment explaining why `^` isn't enough, so a later session doesn't simplify it back.
- **Gate 3 — cost**: wrong outward action. Each occurrence posts to the wrong comment on a public issue or adds another comment to the tracker the recipe exists to avoid spamming, and permanently forks the evidence log the gates are evaluated against. The fix is a character class, well below what that class justifies.

Observed on `max-sixty/cargo-affected` during [review-reviewers run 31676935131](https://github.com/max-sixty/tend/actions/runs/31676935131). Accumulated evidence: https://gist.github.com/dca23a6e6a0d8cae2665944ba31676fb
