### PR TITLE
fix(review-reviewers): map a review-runs append, which lands as a comment edit

### DIFF
--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -288,9 +288,9 @@ Use a cheap subagent (e.g. Haiku / gpt-mini) and a prompt like:
 > - `tend-review-runs`: its findings ship as a **PATCH to the month's tracking comment**, so the body carries an old `created_at` and a fresh `updated_at` — invisible to both the sweep above and the corruption scan below, which filter on `created_at`. Find it by the mismatch, then scan the appended tail:
 >   ```bash
 >   gh api "repos/$ARGUMENTS/issues/comments?since=$WINDOW_START&per_page=100" \
->     --jq ".[] | select(.user.login == \"$BOT_LOGIN\" and .created_at < \"$WINDOW_START\") | {id, created_at, updated_at}"
+>     --jq ".[] | select(.user.login == \"$BOT_LOGIN\" and .created_at < \"$WINDOW_START\" and .updated_at <= \"$WINDOW_END\") | {id, created_at, updated_at}"
 >   ```
->   Past ~65 KB the run opens a fresh comment instead, so the same workflow's output is sometimes an edit and sometimes a create — a window with no such row is not evidence the run stayed silent.
+>   Past ~60 KB the run opens a fresh comment instead, so the same workflow's output is sometimes an edit and sometimes a create — a window with no such row is not evidence the run stayed silent.
 >
 > **Negative outcome signals** — report any sign the bot's output was rejected, corrected, or ignored. Common shapes (use judgment for signals not listed):
 > - Human reviewer posted CHANGES_REQUESTED after bot approved

--- a/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-reviewers/SKILL.md
@@ -253,7 +253,7 @@ Use a cheap subagent (e.g. Haiku / gpt-mini) and a prompt like:
 > done | jq -s add
 > ```
 >
-> Filter the comment calls on `created_at` at both ends. `since` is an `updated_at` floor with no ceiling, so unfiltered it also returns comments written days earlier and merely edited in the window, plus everything posted between the window end and now — this skill starts 20–40 min after its tick, so on a busy repo that is most windows. Those are rows the per-run walk was right not to reach, and a check that contradicts a correct walk every run stops being believed. Leave `CANDIDATES` unbounded above: `updated:` matches the PR's own `updated_at`, so a range drops any PR that got bot output inside the window and was touched after it, and over-inclusion in a candidate list costs nothing. `--limit 100` is load-bearing — `gh pr list` defaults to 30 and truncates silently.
+> Filter the comment calls on `created_at` at both ends. `since` is an `updated_at` floor with no ceiling, so unfiltered it also returns comments written days earlier and merely edited in the window, plus everything posted between the window end and now — this skill starts 20–40 min after its tick, so on a busy repo that is most windows. Those are rows the per-run walk was right not to reach, and a check that contradicts a correct walk every run stops being believed. One shape it drops is genuine in-window output — a `tend-review-runs` append lands as a PATCH to a comment created earlier in the month — so four zeros do not settle a window that contained such a run; map it per the bullet below rather than widening the sweep. Leave `CANDIDATES` unbounded above: `updated:` matches the PR's own `updated_at`, so a range drops any PR that got bot output inside the window and was touched after it, and over-inclusion in a candidate list costs nothing. `--limit 100` is load-bearing — `gh pr list` defaults to 30 and truncates silently.
 >
 > The comment endpoints cover conversation and inline-review comments only; neither returns review submissions, and an empty-body `APPROVE` is `tend-review`'s most common output. Without the fourth count an approvals-only window reports `0, 0` and satisfies the gate below with two zeros carrying no signal. Report all four numbers at the top of your summary. If the sweep found in-window rows your per-run walk did not reach, the walk is wrong — re-map from the PR numbers the sweep found rather than reporting those runs as silent.
 >
@@ -285,6 +285,12 @@ Use a cheap subagent (e.g. Haiku / gpt-mini) and a prompt like:
 >   ```
 >   `PAYLOAD_PR` is the issue/PR number and `PAYLOAD_KIND` is the relayed event (`pull_request_review`, `pull_request_review_comment`). Read the gate's verdict off the `handle` job, which is gated on `should_run`: `handle` with conclusion `skipped` means the engagement gate declined and no agent booted — expected silence, not missing output. Do not read it off `React to mention`, which is skipped on every relayed `pull_request_review` regardless of the verdict (a review submission has no single comment to react to) and on a comment relay admitted for participation rather than a mention.
 > - `tend-ci-fix`: map run → PR via `headBranch`, check for bot commits
+> - `tend-review-runs`: its findings ship as a **PATCH to the month's tracking comment**, so the body carries an old `created_at` and a fresh `updated_at` — invisible to both the sweep above and the corruption scan below, which filter on `created_at`. Find it by the mismatch, then scan the appended tail:
+>   ```bash
+>   gh api "repos/$ARGUMENTS/issues/comments?since=$WINDOW_START&per_page=100" \
+>     --jq ".[] | select(.user.login == \"$BOT_LOGIN\" and .created_at < \"$WINDOW_START\") | {id, created_at, updated_at}"
+>   ```
+>   Past ~65 KB the run opens a fresh comment instead, so the same workflow's output is sometimes an edit and sometimes a create — a window with no such row is not evidence the run stayed silent.
 >
 > **Negative outcome signals** — report any sign the bot's output was rejected, corrected, or ignored. Common shapes (use judgment for signals not listed):
 > - Human reviewer posted CHANGES_REQUESTED after bot approved


### PR DESCRIPTION
`review-reviewers` decides whether a window was silent from four repo-wide counts, all of which filter bot comments on `created_at` inside the window. `tend-review-runs` posts its findings by PATCHing the month's tracking comment, so its body carries a `created_at` from earlier in the month and only its `updated_at` moves. The sweep therefore reports zero for a window that carried a full agent session's public output, the corruption scan's `created_at` filter skips that body too, and the "How to map runs to outputs" list has no `tend-review-runs` entry — so neither the backstop nor the per-run walk reaches it.

## What was observed

Window `[2026-08-13T08:12:00Z, 09:14:00Z]` on `max-sixty/cargo-affected` contained [`tend-review-runs` 31681045176](https://github.com/max-sixty/cargo-affected/actions/runs/31681045176) — a 15-minute agent session whose sole output was a ~5 KB append to evidence comment [`5264211453`](https://github.com/max-sixty/cargo-affected/issues/73#issuecomment-5264211453) at 08:26:51Z. That comment's `created_at` is `2026-08-12T08:21:36Z`; its `updated_at` is in-window. Attribution is from the run's own session log, which contains the write verbatim:

```
gh api "repos/$REPO/issues/comments/$EXISTING_COMMENT" -X PATCH -F body=@/tmp/combined.md --jq '.id, .html_url'
```

Running the sweep block as written returned `0, 0, (no candidate PRs), 0`. An unfiltered `issues/comments?since=…` returns exactly one row — that edit. Nothing in the skill directs a run to make that second call, so the four zeros read as a quiet hour.

The same `gh api` block shows the shape alternates: under 65,000 bytes the run PATCHes, over it posts a fresh comment. So the output is visible to the sweep on the rollover window and invisible on every other one, which is worse than uniformly invisible — the absence of a row looks like evidence of silence.

## Fix

One bullet in the mapping list keyed on the `created_at` / `updated_at` mismatch, plus a clause on the sweep rationale so four zeros aren't read as settling a window that contained such a run. The sweep itself is left alone: widening it to `updated_at` would re-admit every days-old comment merely edited in the window, which is the noise that filter exists to drop.

## Gate assessment

- **Evidence level**: High, structural — the filter excludes the shape arithmetically, `review-runs` runs daily on every adopter, and the mapping list has no entry to fall back on. Not a model lapse; replaying the window produces the same four zeros every time.
- **Occurrences**: 3 of the condition in the current evidence log — this run, plus two prior legs where the analysis reached the append only by going outside the recipe (one scanned it after finding it by hand, one saw the row and dismissed it in a parenthetical as "the bot's own evidence-comment edit"). Realized all-clear misses: 0, because each leg happened to look further. Meets the 2–3 bar for High.
- **Change type**: targeted fix — one mapping bullet and one clause, no new section, no change to the sweep commands.
- **Both gates**: pass.

Evidence log: https://gist.github.com/dca23a6e6a0d8cae2665944ba31676fb
