### PR TITLE
fix(generator): skip the monthly tracking issues in triage and mention

### DIFF
--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -103,8 +103,14 @@ _JINJA.globals["openai_key_secret"] = OPENAI_KEY_SECRET
 # each row the rate-limit preflight appends is a comment, which would fire
 # tend-mention, whose handle job trips the same limit and appends another.
 # A global rather than a literal per template, so the next such label is added
-# in one place.
-BOOKKEEPING_LABELS = ("tend-outage", "tend-rate-limit")
+# in one place. The monthly `*-tracking` issues are the same shape: the bot
+# opens one, so `issues: opened` fires a triage session on its own ledger.
+BOOKKEEPING_LABELS = (
+    "tend-outage",
+    "tend-rate-limit",
+    "review-runs-tracking",
+    "review-reviewers-tracking",
+)
 _JINJA.globals["bookkeeping_labels"] = BOOKKEEPING_LABELS
 
 

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-triage.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-triage.yaml].out
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   triage:
-    if: github.repository_owner == 'test-owner' && contains(github.event.issue.labels.*.name, 'tend-outage') == false && contains(github.event.issue.labels.*.name, 'tend-rate-limit') == false
+    if: github.repository_owner == 'test-owner' && contains(github.event.issue.labels.*.name, 'tend-outage') == false && contains(github.event.issue.labels.*.name, 'tend-rate-limit') == false && contains(github.event.issue.labels.*.name, 'review-runs-tracking') == false && contains(github.event.issue.labels.*.name, 'review-reviewers-tracking') == false
     runs-on: ubuntu-24.04
     environment:
       name: tend

--- a/generator/tests/_regtest_outputs/test_generate.test_sandbox_levers_regtest.out
+++ b/generator/tests/_regtest_outputs/test_generate.test_sandbox_levers_regtest.out
@@ -103,7 +103,7 @@ jobs:
       (github.event_name == 'issues' &&
         contains(github.event.issue.body, '@test-bot')) ||
       (github.event_name == 'issue_comment' &&
-        contains(github.event.issue.labels.*.name, 'tend-outage') == false && contains(github.event.issue.labels.*.name, 'tend-rate-limit') == false)
+        contains(github.event.issue.labels.*.name, 'tend-outage') == false && contains(github.event.issue.labels.*.name, 'tend-rate-limit') == false && contains(github.event.issue.labels.*.name, 'review-runs-tracking') == false && contains(github.event.issue.labels.*.name, 'review-reviewers-tracking') == false)
     runs-on: ubuntu-24.04
     environment:
       name: tend

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
@@ -103,7 +103,7 @@ jobs:
       (github.event_name == 'issues' &&
         contains(github.event.issue.body, '@test-bot')) ||
       (github.event_name == 'issue_comment' &&
-        contains(github.event.issue.labels.*.name, 'tend-outage') == false && contains(github.event.issue.labels.*.name, 'tend-rate-limit') == false)
+        contains(github.event.issue.labels.*.name, 'tend-outage') == false && contains(github.event.issue.labels.*.name, 'tend-rate-limit') == false && contains(github.event.issue.labels.*.name, 'review-runs-tracking') == false && contains(github.event.issue.labels.*.name, 'review-reviewers-tracking') == false)
     runs-on: ubuntu-24.04
     environment:
       name: tend

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[triage].out
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   triage:
-    if: contains(github.event.issue.labels.*.name, 'tend-outage') == false && contains(github.event.issue.labels.*.name, 'tend-rate-limit') == false
+    if: contains(github.event.issue.labels.*.name, 'tend-outage') == false && contains(github.event.issue.labels.*.name, 'tend-rate-limit') == false && contains(github.event.issue.labels.*.name, 'review-runs-tracking') == false && contains(github.event.issue.labels.*.name, 'review-reviewers-tracking') == false
     runs-on: ubuntu-24.04
     environment:
       name: tend

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
@@ -103,7 +103,7 @@ jobs:
       (github.event_name == 'issues' &&
         contains(github.event.issue.body, '@test-bot')) ||
       (github.event_name == 'issue_comment' &&
-        contains(github.event.issue.labels.*.name, 'tend-outage') == false && contains(github.event.issue.labels.*.name, 'tend-rate-limit') == false)
+        contains(github.event.issue.labels.*.name, 'tend-outage') == false && contains(github.event.issue.labels.*.name, 'tend-rate-limit') == false && contains(github.event.issue.labels.*.name, 'review-runs-tracking') == false && contains(github.event.issue.labels.*.name, 'review-reviewers-tracking') == false)
     runs-on: ubuntu-24.04
     environment:
       name: tend

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[triage].out
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   triage:
-    if: contains(github.event.issue.labels.*.name, 'tend-outage') == false && contains(github.event.issue.labels.*.name, 'tend-rate-limit') == false
+    if: contains(github.event.issue.labels.*.name, 'tend-outage') == false && contains(github.event.issue.labels.*.name, 'tend-rate-limit') == false && contains(github.event.issue.labels.*.name, 'review-runs-tracking') == false && contains(github.event.issue.labels.*.name, 'review-reviewers-tracking') == false
     runs-on: ubuntu-24.04
     environment:
       name: tend

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_local_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_local_setup_regtest[mention].out
@@ -103,7 +103,7 @@ jobs:
       (github.event_name == 'issues' &&
         contains(github.event.issue.body, '@test-bot')) ||
       (github.event_name == 'issue_comment' &&
-        contains(github.event.issue.labels.*.name, 'tend-outage') == false && contains(github.event.issue.labels.*.name, 'tend-rate-limit') == false)
+        contains(github.event.issue.labels.*.name, 'tend-outage') == false && contains(github.event.issue.labels.*.name, 'tend-rate-limit') == false && contains(github.event.issue.labels.*.name, 'review-runs-tracking') == false && contains(github.event.issue.labels.*.name, 'review-reviewers-tracking') == false)
     runs-on: ubuntu-24.04
     environment:
       name: tend

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
@@ -103,7 +103,7 @@ jobs:
       (github.event_name == 'issues' &&
         contains(github.event.issue.body, '@test-bot')) ||
       (github.event_name == 'issue_comment' &&
-        contains(github.event.issue.labels.*.name, 'tend-outage') == false && contains(github.event.issue.labels.*.name, 'tend-rate-limit') == false)
+        contains(github.event.issue.labels.*.name, 'tend-outage') == false && contains(github.event.issue.labels.*.name, 'tend-rate-limit') == false && contains(github.event.issue.labels.*.name, 'review-runs-tracking') == false && contains(github.event.issue.labels.*.name, 'review-reviewers-tracking') == false)
     runs-on: ubuntu-24.04
     environment:
       name: tend

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[triage].out
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   triage:
-    if: contains(github.event.issue.labels.*.name, 'tend-outage') == false && contains(github.event.issue.labels.*.name, 'tend-rate-limit') == false
+    if: contains(github.event.issue.labels.*.name, 'tend-outage') == false && contains(github.event.issue.labels.*.name, 'tend-rate-limit') == false && contains(github.event.issue.labels.*.name, 'review-runs-tracking') == false && contains(github.event.issue.labels.*.name, 'review-reviewers-tracking') == false
     runs-on: ubuntu-24.04
     environment:
       name: tend

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -1590,6 +1590,27 @@ def test_job_extras_replace_if_for_skip_review_label(tmp_path: Path) -> None:
     assert "steps" in data["jobs"]["review"]
 
 
+def test_bookkeeping_labels_cover_the_monthly_trackers(tmp_path: Path) -> None:
+    """`tend-triage` and `tend-mention` skip every label tend puts on its own
+    bookkeeping issues — the outage and rate-limit trackers, and the monthly
+    tracking issues the `review-runs` / `review-reviewers` skills open. Without
+    the tracker labels, opening one boots a full triage session on the bot's own
+    record-keeping, every month, in every adopter."""
+    cfg = Config.load(_minimal_config(tmp_path))
+    workflows = {wf.filename: wf.content for wf in generate_all(cfg)}
+    triage_if = yaml.safe_load(workflows["tend-triage.yaml"])["jobs"]["triage"]["if"]
+    mention = workflows["tend-mention.yaml"]
+    for label in (
+        "tend-outage",
+        "tend-rate-limit",
+        "review-runs-tracking",
+        "review-reviewers-tracking",
+    ):
+        guard = f"contains(github.event.issue.labels.*.name, '{label}') == false"
+        assert guard in triage_if, f"tend-triage does not skip `{label}`"
+        assert guard in mention, f"tend-mention does not skip `{label}`"
+
+
 def test_null_drops_top_level_key(tmp_path: Path) -> None:
     """YAML-native `null` in workflow_extra removes the targeted key under
     RFC 7396 Merge Patch semantics. The motivating case: keep nightly's


### PR DESCRIPTION
## Problem

`BOOKKEEPING_LABELS` held `tend-outage` and `tend-rate-limit`, but not the monthly tracking issues the bundled `review-runs` and `review-reviewers` skills open. Those trackers are also bot-authored ledgers with nothing to triage — the body of each says "Do not close manually" — so `issues: opened` on one booted a full `tend-triage` session that could only no-op. #967 is the current instance: a scheduled `review-reviewers` run opened the August tracker and `tend-triage` fired on it.

This isn't a one-off. This repo has 19 open-or-closed issues carrying `review-runs-tracking` / `review-reviewers-tracking`, each of which fired a triage session at creation, and `review-runs-tracking` comes from a bundled skill on a generated workflow — so every adopter running `tend-review-runs` pays the same monthly boot. The evidence that these labels belong on the list is already in the tree: the website Worker independently enumerates them as bookkeeping ([`worker/src/index.ts`](https://github.com/max-sixty/tend/blob/9388505/worker/src/index.ts#L147-L153)) to keep them out of the `issues` activity count, while the generator's copy had drifted behind.

## Solution

Add both tracking labels to `BOOKKEEPING_LABELS`. The comment on that tuple already anticipated this ("the next such label is added in one place"): it feeds the `not_bookkeeping()` macro, so `tend-triage`'s job `if:` and `tend-mention`'s `should_run` both pick the labels up with no template change.

Not added: `nightly-cleanup`, which the Worker also lists — nothing in the tree creates that label and this repo has no such label, so it would be dead config on the generator side.

## Consequence for `tend-mention`

One list, two gates: `not_bookkeeping()` sits on [`mention.yaml.j2`](https://github.com/max-sixty/tend/blob/9388505f77c44f3454456d8bfd329c8033de185d/generator/src/tend/templates/mention.yaml.j2#L120)'s `issue_comment` branch as well as [`triage.yaml.j2`](https://github.com/max-sixty/tend/blob/9388505f77c44f3454456d8bfd329c8033de185d/generator/src/tend/templates/triage.yaml.j2#L13)'s job, so this also stops an `@bot` comment on a tracking issue from booting an immediate reply — a behavior change reaching every adopter, and a maintainer's call rather than an obvious win.

It differs from the two labels already on the list. Their rationale is the comment→run→comment loop the action's own auto-comments create, which trackers don't have, and trackers are threads maintainers are meant to read and follow up on — `review-reviewers` posts gist links there so they're discoverable. What it degrades to is latency, not silence: `tend-notifications` picks the mention up as a stale unanswered item on its next tick. The alternative is splitting the tuple into triage-only and mention-only sets, which buys back the immediate reply at the cost of the single list the tuple's comment is built around; I'd take the latency, but say so here rather than land it unflagged.

## Testing

`test_bookkeeping_labels_cover_the_monthly_trackers` asserts the rendered `tend-triage` `if:` and `tend-mention` body carry a guard for each of the four labels. It fails on `main` (`tend-triage does not skip 'review-runs-tracking'`) and passes here. The nine regtest outputs that pin the rendered `if:` are reset; full generator suite is 459 passed.

Tend's own `tend-*.yaml` still carry the two-label `if:` until the next release regenerates them from a published tag, per the pinning rule in `CLAUDE.md`.

## Scope

Refs #967 — deliberately not `Closes`, since that tracker is a live ledger `review-reviewers` appends gist links to and recreates when closed.

