### PR TITLE
docs(worker): README bookkeeping-label list was missing tend-rate-limit

### DIFF
--- a/worker/README.md
+++ b/worker/README.md
@@ -92,7 +92,7 @@ parent issue/PR — that is what the bot created.
 | bucket | Search query | "the bot …" |
 | --- | --- | --- |
 | `prs` | `author:<bot> is:pr` | opened these PRs (any state) |
-| `issues` | `author:<bot> is:issue` minus four bookkeeping labels (`tend-outage`, `review-runs-tracking`, `review-reviewers-tracking`, `nightly-cleanup`) | opened these issues, filed against the repo — tend's own outage and tracking issues are excluded |
+| `issues` | `author:<bot> is:issue` minus five bookkeeping labels (`tend-outage`, `tend-rate-limit`, `review-runs-tracking`, `review-reviewers-tracking`, `nightly-cleanup`) | opened these issues, filed against the repo — tend's own outage and tracking issues are excluded |
 | `reviews` | `reviewed-by:<bot>` | reviewed these PRs (approve / request-changes / review comment) — by volume, tend's main action |
 | `comments` | `commenter:<bot> -author:<bot> -reviewed-by:<bot>` | commented on these PRs/issues — excludes its own threads and items already in `reviews` |
 


### PR DESCRIPTION
The `/activity` table in [`worker/README.md`](https://github.com/max-sixty/tend/blob/main/worker/README.md) describes the `issues` bucket as dropping "four bookkeeping labels" and names four. The filter it documents is built from `BOOKKEEPING_LABELS` in [`worker/src/index.ts`](https://github.com/max-sixty/tend/blob/fffe32f44000696aa576a689eb3516aeb4e04552/worker/src/index.ts#L147-L153), which holds five — `tend-rate-limit` was missing from the prose. Doc-only; the filter itself is unchanged.

Noticed while reviewing #968, which touches the generator's separate copy of the same list.
