### PR TITLE
simplify: one tested review-anchor resolver, skill depth into references

### DIFF
--- a/generator/tests/test_bot_review_state.py
+++ b/generator/tests/test_bot_review_state.py
@@ -229,9 +229,7 @@ def test_the_newest_rewrite_is_the_one_that_counts(env: dict[str, str]) -> None:
 def test_an_approval_that_predates_the_rewrite_is_stale(env: dict[str, str]) -> None:
     """A rebased dependency PR carries an approval it never earned; the skip
     paths comment that it isn't mergeable while the PR reads as bot-approved."""
-    _write(
-        env, "REVIEWS_JSON", [_review(3, "2026-01-01T00:00:00Z", state="APPROVED")]
-    )
+    _write(env, "REVIEWS_JSON", [_review(3, "2026-01-01T00:00:00Z", state="APPROVED")])
     _rewrite_at(env, "2026-01-02T00:00:00Z")
 
     state = _state(env)
@@ -259,6 +257,15 @@ def test_a_later_approval_supersedes_the_stale_one(env: dict[str, str]) -> None:
 
     assert state["stale_approval_id"] == ""
     assert state["fresh_approval_sha"] == HEAD
+
+
+def test_a_dismissed_approval_is_not_re_dismissed(env: dict[str, str]) -> None:
+    """Dismissing sets the state to DISMISSED, which stops matching — `weekly`
+    relies on that to keep a later run from dismissing the same review again."""
+    _write(env, "REVIEWS_JSON", [_review(3, "2026-01-01T00:00:00Z", state="DISMISSED")])
+    _rewrite_at(env, "2026-01-02T00:00:00Z")
+
+    assert _state(env)["stale_approval_id"] == ""
 
 
 def test_an_approval_on_an_older_commit_is_not_an_approval_of_this_one(

--- a/generator/tests/test_bot_review_state.py
+++ b/generator/tests/test_bot_review_state.py
@@ -1,0 +1,347 @@
+"""Tests for bot-review-state.sh — which of the bot's reviews anchors the head.
+
+Every field here decides an outward action: whether the bot re-reviews a
+commit, whether it approves one it never read, whether it edits an existing
+review or duplicates it, and whether a stale approval gets dismissed. The
+logic used to be copy-pasted across five skill call sites, where the copies
+had already drifted; these pin the single implementation they collapsed into.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from tests import BASH, GH_PREAMBLE, fake_bin, tool_path
+
+BOT_REVIEW_STATE = (
+    Path(__file__).resolve().parents[2]
+    / "plugins"
+    / "tend-ci-runner"
+    / "scripts"
+    / "bot-review-state.sh"
+)
+
+BOT = "tend-bot"
+HEAD = "head000"
+OLD = "old0000"
+
+FAKE_GH = (
+    GH_PREAMBLE
+    + r"""
+case "$*" in
+  "api user"*)          emit '{"login":"'"$BOT_LOGIN"'"}' ;;
+  "pr view "*)          emit "$(cat "$COMMITS_JSON")" ;;
+  *"/pulls/"*"/comments"*) emit "$(cat "$INLINE_JSON")" ;;
+  *"/issues/"*"/timeline"*) emit "$(cat "$TIMELINE_JSON")" ;;
+  *"/pulls/"*"/reviews"*)   emit "$(cat "$REVIEWS_JSON")" ;;
+  *) exit 1 ;;
+esac
+"""
+)
+
+
+@pytest.fixture
+def env(tmp_path: Path) -> dict[str, str]:
+    """Fake `gh` plus fixtures for a PR at HEAD with no reviews and no rewrite."""
+    bindir = fake_bin(tmp_path, gh=FAKE_GH)
+    files = {
+        "COMMITS_JSON": {"commits": [{"oid": OLD}, {"oid": HEAD}]},
+        "INLINE_JSON": [],
+        "TIMELINE_JSON": [],
+        "REVIEWS_JSON": [],
+    }
+    paths = {}
+    for key, value in files.items():
+        path = tmp_path / f"{key.lower()}.json"
+        path.write_text(json.dumps(value))
+        paths[key] = str(path)
+    return {
+        "PATH": tool_path(bindir),
+        "GH_CALLS": str(tmp_path / "gh-calls.log"),
+        "GITHUB_REPOSITORY": "owner/repo",
+        "BOT_LOGIN": BOT,
+        **paths,
+    }
+
+
+def _state(env: dict[str, str]) -> dict:
+    result = subprocess.run(
+        [BASH, str(BOT_REVIEW_STATE), "7"], env=env, capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def _write(env: dict[str, str], key: str, value: object) -> None:
+    Path(env[key]).write_text(json.dumps(value))
+
+
+def _review(
+    rid: int,
+    at: str,
+    *,
+    author: str = BOT,
+    body: str = "",
+    state: str = "COMMENTED",
+    sha: str = HEAD,
+) -> dict:
+    return {
+        "id": rid,
+        "user": {"login": author},
+        "body": body,
+        "state": state,
+        "commit_id": sha,
+        "submitted_at": at,
+    }
+
+
+def _rewrite_at(env: dict[str, str], *times: str) -> None:
+    _write(
+        env,
+        "TIMELINE_JSON",
+        [{"event": "head_ref_force_pushed", "created_at": t} for t in times],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Substantive vs. synthetic reply containers
+# ---------------------------------------------------------------------------
+
+
+def test_a_clean_pr_reports_nothing_anchored(env: dict[str, str]) -> None:
+    state = _state(env)
+
+    assert state["head_sha"] == HEAD
+    assert state["last_substantive"] is None
+    assert state["at_head"] is None
+    assert state["orphan_id"] is None
+    assert state["fresh_approval_sha"] == ""
+    assert state["stale_approval_id"] == ""
+    assert state["force_pushed_since"] is False
+
+
+def test_a_reply_container_does_not_read_as_a_review(env: dict[str, str]) -> None:
+    """Replying to a review thread makes GitHub wrap the reply in a zero-body
+    COMMENTED review anchored at the then-current head. Counted, it would tell
+    the next run this commit was already reviewed and discard a real review."""
+    _write(env, "REVIEWS_JSON", [_review(1, "2026-01-01T00:00:00Z")])
+
+    state = _state(env)
+
+    assert state["last_substantive"] is None
+    assert state["at_head"] is None
+
+
+@pytest.mark.parametrize(
+    ("kind", "review"),
+    [
+        ("a body", _review(1, "2026-01-01T00:00:00Z", body="findings")),
+        ("an approval", _review(1, "2026-01-01T00:00:00Z", state="APPROVED")),
+    ],
+)
+def test_a_review_with_content_anchors(
+    env: dict[str, str], kind: str, review: dict
+) -> None:
+    """An empty-body approval still anchors — it is a verdict on this commit."""
+    _write(env, "REVIEWS_JSON", [review])
+
+    assert _state(env)["at_head"]["id"] == 1, kind
+
+
+def test_a_review_owning_a_fresh_inline_comment_anchors(env: dict[str, str]) -> None:
+    """An empty-body review carrying real inline findings is indistinguishable
+    from a reply container by body alone; the top-level inline comment is what
+    separates them."""
+    _write(env, "REVIEWS_JSON", [_review(9, "2026-01-01T00:00:00Z")])
+    _write(env, "INLINE_JSON", [{"in_reply_to_id": None, "pull_request_review_id": 9}])
+
+    assert _state(env)["at_head"]["id"] == 9
+
+
+def test_a_reply_only_inline_comment_does_not_promote_its_container(
+    env: dict[str, str],
+) -> None:
+    _write(env, "REVIEWS_JSON", [_review(9, "2026-01-01T00:00:00Z")])
+    _write(env, "INLINE_JSON", [{"in_reply_to_id": 4, "pull_request_review_id": 9}])
+
+    assert _state(env)["at_head"] is None
+
+
+def test_another_authors_review_is_not_ours(env: dict[str, str]) -> None:
+    _write(
+        env,
+        "REVIEWS_JSON",
+        [_review(1, "2026-01-01T00:00:00Z", author="human", state="APPROVED")],
+    )
+
+    state = _state(env)
+
+    assert state["at_head"] is None
+    assert state["fresh_approval_sha"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Force-push re-anchoring
+# ---------------------------------------------------------------------------
+
+
+def test_a_rewrite_after_the_review_invalidates_its_anchor(env: dict[str, str]) -> None:
+    """GitHub re-points an earlier review's commit_id at the new head, so the
+    anchor reads as current for code that was rewritten away. Without the flag
+    the run exits silently and a stale APPROVE stands as the verdict."""
+    _write(env, "REVIEWS_JSON", [_review(1, "2026-01-01T00:00:00Z", body="findings")])
+    _rewrite_at(env, "2026-01-02T00:00:00Z")
+
+    state = _state(env)
+
+    assert state["force_pushed_since"] is True
+    assert state["at_head"] is None, "a rewritten-away review must not gate a re-review"
+    assert state["last_substantive"]["id"] == 1
+
+
+def test_a_rewrite_before_the_review_leaves_it_standing(env: dict[str, str]) -> None:
+    _write(env, "REVIEWS_JSON", [_review(1, "2026-01-03T00:00:00Z", body="findings")])
+    _rewrite_at(env, "2026-01-02T00:00:00Z")
+
+    state = _state(env)
+
+    assert state["force_pushed_since"] is False
+    assert state["at_head"]["id"] == 1
+
+
+def test_the_newest_rewrite_is_the_one_that_counts(env: dict[str, str]) -> None:
+    """Timeline order is not guaranteed, and an older rewrite would let a
+    review submitted between the two read as still anchored."""
+    _write(env, "REVIEWS_JSON", [_review(1, "2026-01-03T00:00:00Z", body="findings")])
+    _rewrite_at(env, "2026-01-04T00:00:00Z", "2026-01-01T00:00:00Z")
+
+    assert _state(env)["force_pushed_since"] is True
+
+
+# ---------------------------------------------------------------------------
+# Approvals: fresh vs. stale
+# ---------------------------------------------------------------------------
+
+
+def test_an_approval_that_predates_the_rewrite_is_stale(env: dict[str, str]) -> None:
+    """A rebased dependency PR carries an approval it never earned; the skip
+    paths comment that it isn't mergeable while the PR reads as bot-approved."""
+    _write(
+        env, "REVIEWS_JSON", [_review(3, "2026-01-01T00:00:00Z", state="APPROVED")]
+    )
+    _rewrite_at(env, "2026-01-02T00:00:00Z")
+
+    state = _state(env)
+
+    assert state["stale_approval_id"] == 3
+    assert state["fresh_approval_sha"] == "", "a rewritten-away approval is not earned"
+
+
+def test_a_later_approval_supersedes_the_stale_one(env: dict[str, str]) -> None:
+    """Newest-then-test, never test-then-newest: the question is whether the
+    approval now setting the PR's state is stale. Filtering first would name
+    the pre-rewrite id and leave the live approval standing while dismissing a
+    review that no longer decides anything."""
+    _write(
+        env,
+        "REVIEWS_JSON",
+        [
+            _review(3, "2026-01-01T00:00:00Z", state="APPROVED", sha=OLD),
+            _review(4, "2026-01-03T00:00:00Z", state="APPROVED"),
+        ],
+    )
+    _rewrite_at(env, "2026-01-02T00:00:00Z")
+
+    state = _state(env)
+
+    assert state["stale_approval_id"] == ""
+    assert state["fresh_approval_sha"] == HEAD
+
+
+def test_an_approval_on_an_older_commit_is_not_an_approval_of_this_one(
+    env: dict[str, str],
+) -> None:
+    _write(
+        env,
+        "REVIEWS_JSON",
+        [_review(3, "2026-01-01T00:00:00Z", state="APPROVED", sha=OLD)],
+    )
+
+    state = _state(env)
+
+    assert state["fresh_approval_sha"] == OLD
+    assert state["at_head"] is None
+
+
+# ---------------------------------------------------------------------------
+# Orphan bodies from a partially-failed review POST
+# ---------------------------------------------------------------------------
+
+
+def test_a_body_bearing_review_on_the_head_is_the_orphan_to_edit(
+    env: dict[str, str],
+) -> None:
+    """A review POST whose inline comments are rejected still persists the
+    body. Retrying blind duplicates it."""
+    _write(env, "REVIEWS_JSON", [_review(5, "2026-01-01T00:00:00Z", body="findings")])
+
+    assert _state(env)["orphan_id"] == 5
+
+
+def test_a_reply_container_is_never_mistaken_for_an_orphan(
+    env: dict[str, str],
+) -> None:
+    """The body-length test is what separates them, and getting it wrong means
+    the recovery PUT overwrites an unrelated reply."""
+    _write(env, "REVIEWS_JSON", [_review(5, "2026-01-01T00:00:00Z")])
+
+    assert _state(env)["orphan_id"] is None
+
+
+def test_a_pre_rewrite_body_is_never_mistaken_for_an_orphan(
+    env: dict[str, str],
+) -> None:
+    """It reports commit_id == head and passes the body test, so without the
+    rewrite filter the PUT destroys a published review — overwriting its text
+    with this run's findings, over inline comments on code that is gone."""
+    _write(env, "REVIEWS_JSON", [_review(5, "2026-01-01T00:00:00Z", body="published")])
+    _rewrite_at(env, "2026-01-02T00:00:00Z")
+
+    assert _state(env)["orphan_id"] is None
+
+
+def test_the_newest_orphan_wins(env: dict[str, str]) -> None:
+    _write(
+        env,
+        "REVIEWS_JSON",
+        [
+            _review(5, "2026-01-01T00:00:00Z", body="first"),
+            _review(6, "2026-01-02T00:00:00Z", body="second"),
+        ],
+    )
+
+    assert _state(env)["orphan_id"] == 6
+
+
+# ---------------------------------------------------------------------------
+# Shape of the call
+# ---------------------------------------------------------------------------
+
+
+def test_the_head_is_the_last_commit_not_the_first(env: dict[str, str]) -> None:
+    assert _state(env)["head_sha"] == HEAD
+
+
+def test_the_repo_is_named_explicitly_on_every_call(env: dict[str, str]) -> None:
+    """The script runs from whatever cwd a skill happens to be in — a bare
+    `gh pr view` would resolve the wrong repo, or none."""
+    _state(env)
+
+    calls = Path(env["GH_CALLS"]).read_text().splitlines()
+    lookups = [c for c in calls if c.startswith("pr view") or "repos/" in c]
+    assert lookups
+    for call in lookups:
+        assert "owner/repo" in call, call

--- a/generator/tests/test_bot_review_state.py
+++ b/generator/tests/test_bot_review_state.py
@@ -33,7 +33,7 @@ FAKE_GH = (
     + r"""
 case "$*" in
   "api user"*)          emit '{"login":"'"$BOT_LOGIN"'"}' ;;
-  "pr view "*)          emit "$(cat "$COMMITS_JSON")" ;;
+  "pr view "*)          emit "$(cat "$PR_HEAD_JSON")" ;;
   *"/pulls/"*"/comments"*) emit "$(cat "$INLINE_JSON")" ;;
   *"/issues/"*"/timeline"*) emit "$(cat "$TIMELINE_JSON")" ;;
   *"/pulls/"*"/reviews"*)   emit "$(cat "$REVIEWS_JSON")" ;;
@@ -48,7 +48,13 @@ def env(tmp_path: Path) -> dict[str, str]:
     """Fake `gh` plus fixtures for a PR at HEAD with no reviews and no rewrite."""
     bindir = fake_bin(tmp_path, gh=FAKE_GH)
     files = {
-        "COMMITS_JSON": {"commits": [{"oid": OLD}, {"oid": HEAD}]},
+        # `commits` is deliberately wrong-last: `gh pr view --json commits`
+        # is `commits(first: 100)`, oldest-first, so past the cap `.commits[-1]`
+        # is commit #100. A reader that goes back to it reads OLD here.
+        "PR_HEAD_JSON": {
+            "headRefOid": HEAD,
+            "commits": [{"oid": HEAD}, {"oid": OLD}],
+        },
         "INLINE_JSON": [],
         "TIMELINE_JSON": [],
         "REVIEWS_JSON": [],
@@ -338,8 +344,16 @@ def test_the_newest_orphan_wins(env: dict[str, str]) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_the_head_is_the_last_commit_not_the_first(env: dict[str, str]) -> None:
+def test_the_head_comes_from_head_ref_oid(env: dict[str, str]) -> None:
+    """`--json commits` caps at 100 and returns oldest-first, so on a long PR
+    `.commits[-1]` is commit #100. Every head-keyed field then matches nothing
+    and goes quiet: the pre-post guard stops firing and a re-run posts a second
+    review, the 422 recovery duplicates instead of editing the orphan, and
+    `weekly`'s redundant-approval guard lets approvals pile up on one commit."""
     assert _state(env)["head_sha"] == HEAD
+
+    calls = Path(env["GH_CALLS"]).read_text()
+    assert "--json headRefOid" in calls, calls
 
 
 def test_the_repo_is_named_explicitly_on_every_call(env: dict[str, str]) -> None:

--- a/plugins/tend-ci-runner/scripts/bot-review-state.sh
+++ b/plugins/tend-ci-runner/scripts/bot-review-state.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Resolves which of the bot's reviews actually anchors the PR's current head,
+# and emits the answer as one JSON object.
+#
+# Usage: bot-review-state.sh <pr-number>
+#
+# Two GitHub behaviours make `.commit_id` alone unreadable, and every caller
+# that reads a review anchor has to account for both:
+#
+#   Reply containers. Replying to a review thread (POST
+#   /pulls/{n}/comments/{id}/replies) makes GitHub wrap the reply in a synthetic
+#   zero-body COMMENTED review anchored at the then-current head. The newest
+#   review record therefore routinely points at a commit nothing reviewed. A
+#   review counts as *substantive* when it has a body, owns a top-level
+#   (non-reply) inline comment, or is an APPROVED — containers are always
+#   zero-body COMMENTED, while an empty-body approval and an empty-body review
+#   carrying real inline findings both still anchor.
+#
+#   Force-push re-anchoring. A rewrite does not just move the head: GitHub
+#   re-points earlier reviews' `.commit_id` at the NEW head. So a review of code
+#   that no longer exists reports the current head, and `.commit_id` alone
+#   cannot tell an ordinary push from a rewrite. Anything submitted before the
+#   newest `head_ref_force_pushed` is discounted.
+#
+# Output (one object, all fields always present; absent values are null or ""):
+#   head_sha            the PR's current head
+#   last_force_push_at  newest head_ref_force_pushed timestamp, "" if none
+#   last_substantive    {id, sha, state, at} — newest substantive bot review at
+#                       any anchor, null if none. `sha` is unreliable when
+#                       force_pushed_since is true; that is what the flag is for.
+#   force_pushed_since  true when a rewrite postdates last_substantive — the
+#                       commit the bot read was rewritten away, so its anchor
+#                       now names the current head and every incremental keyed
+#                       on it under-reports
+#   at_head             {id, state, at} — newest substantive bot review anchored
+#                       at head and submitted after the newest rewrite, else
+#                       null. Non-null means this head is genuinely reviewed.
+#   orphan_id           id of the newest body-bearing bot review anchored at
+#                       head post-rewrite, else null. A partially-failed review
+#                       POST persists the body and drops the inline comments;
+#                       this is the record to edit rather than duplicate.
+#   fresh_approval_sha  commit_id of the newest post-rewrite bot APPROVED, ""
+#                       if none — an approval that was genuinely earned
+#   stale_approval_id   id of the newest bot APPROVED when that newest approval
+#                       predates the rewrite, "" otherwise. Newest-then-test,
+#                       never test-then-newest: the question is whether the
+#                       approval now setting the PR's state is stale, so
+#                       filtering first would name a superseded one and leave
+#                       the live approval standing.
+#
+# env: GITHUB_REPOSITORY (optional; falls back to the checkout's remote)
+
+set -euo pipefail
+
+PR="$1"
+REPO="${GITHUB_REPOSITORY:-$(gh repo view --json nameWithOwner --jq '.nameWithOwner')}"
+BOT=$(gh api user --jq '.login')
+
+HEAD_SHA=$(gh pr view "$PR" --repo "$REPO" --json commits --jq '.commits[-1].oid')
+
+# Review ids owning at least one top-level inline comment. `gh api --paginate`
+# applies `--jq` per page, so reduce with a second jq over the merged stream
+# rather than inside the filter.
+SUBSTANTIVE=$(gh api --paginate "repos/$REPO/pulls/$PR/comments" \
+  --jq '.[] | select(.in_reply_to_id == null) | .pull_request_review_id' | jq -s 'unique')
+
+LAST_FORCE_PUSH_AT=$(gh api --paginate "repos/$REPO/issues/$PR/timeline" \
+  | jq -rs 'add | [.[] | select(.event == "head_ref_force_pushed") | .created_at] | max // ""')
+
+gh api --paginate "repos/$REPO/pulls/$PR/reviews" \
+  | jq -s --argjson sub "$SUBSTANTIVE" --arg bot "$BOT" --arg head "$HEAD_SHA" \
+      --arg fp "$LAST_FORCE_PUSH_AT" '
+    add
+    | [.[] | select(.user.login == $bot)] as $mine
+    | ($mine | map(select((.body | length) > 0 or (.id | IN($sub[])) or .state == "APPROVED"))) as $subs
+    | ($subs | last) as $lastsub
+    | ($mine | map(select(.state == "APPROVED")) | last) as $lastapp
+    | ($fp == "") as $norewrite
+    | {
+        head_sha: $head,
+        last_force_push_at: $fp,
+        last_substantive: (if $lastsub == null then null else
+          {id: $lastsub.id, sha: $lastsub.commit_id, state: $lastsub.state, at: $lastsub.submitted_at}
+        end),
+        force_pushed_since:
+          ($lastsub != null and $fp != "" and $fp > $lastsub.submitted_at),
+        at_head: ($subs
+          | map(select(.commit_id == $head and ($norewrite or .submitted_at > $fp)))
+          | last
+          | if . == null then null else {id, state, at: .submitted_at} end),
+        orphan_id: ($subs
+          | map(select(.commit_id == $head and (.body | length) > 0
+                       and ($norewrite or .submitted_at > $fp)))
+          | last | .id),
+        fresh_approval_sha: (($mine
+          | map(select(.state == "APPROVED" and ($norewrite or .submitted_at > $fp)))
+          | last | .commit_id) // ""),
+        stale_approval_id: (
+          if $lastapp != null and $fp != "" and $lastapp.submitted_at < $fp
+          then $lastapp.id else "" end),
+      }'

--- a/plugins/tend-ci-runner/scripts/bot-review-state.sh
+++ b/plugins/tend-ci-runner/scripts/bot-review-state.sh
@@ -56,7 +56,11 @@ PR="$1"
 REPO="${GITHUB_REPOSITORY:-$(gh repo view --json nameWithOwner --jq '.nameWithOwner')}"
 BOT=$(gh api user --jq '.login')
 
-HEAD_SHA=$(gh pr view "$PR" --repo "$REPO" --json commits --jq '.commits[-1].oid')
+# `--json commits` is `commits(first: 100)`, unpaginated and oldest-first, so
+# past 100 commits `.commits[-1]` is commit #100 rather than the head — and
+# every head-keyed field below then silently matches nothing. `headRefOid` is
+# the head by definition.
+HEAD_SHA=$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq '.headRefOid')
 
 # Review ids owning at least one top-level inline comment. `gh api --paginate`
 # applies `--jq` per page, so reduce with a second jq over the merged stream

--- a/plugins/tend-ci-runner/skills/notifications/SKILL.md
+++ b/plugins/tend-ci-runner/skills/notifications/SKILL.md
@@ -40,7 +40,7 @@ If step 1 returned at least one notification, load `/tend-ci-runner:running-in-c
 Before acting on ANY notification:
 
 1. **Identify the source.** Extract the issue/PR number from the notification's `subject.url` (it's an API URL like `https://api.github.com/repos/OWNER/REPO/issues/123`).
-2. **Check scope.** Notifications from this repository (`$GITHUB_REPOSITORY`) can be processed normally. For cross-repo notifications, read and understand the context but apply extra caution before acting — only respond if the bot was directly mentioned and the request is straightforward. PRs, pushes, and comments on existing threads in other repos are off-limits; filing fresh issues follows **Filing Issues in Other Repos** in `running-in-ci`. Mark as read after reviewing:
+2. **Check scope.** Notifications from this repository (`$GITHUB_REPOSITORY`) can be processed normally. For cross-repo notifications, read and understand the context but apply extra caution before acting — only respond if the bot was directly mentioned and the request is straightforward. PRs, pushes, and comments on existing threads in other repos are off-limits; filing fresh issues follows **Other Repos** in `running-in-ci`. Mark as read after reviewing:
    ```bash
    gh api notifications/threads/{id} -X PATCH
    ```

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -329,7 +329,7 @@ Improvements target **repo-local** files by default:
 - **`.config/tend.yaml`** — adjust workflow configuration if the problem is structural (e.g., wrong cron schedule, missing setup step).
 - **`CLAUDE.md`** — add project-specific guidance if the problem is about code conventions or patterns the bot keeps getting wrong.
 
-**Bundled-skill defects.** If the root cause is a gap or bug in a bundled skill (`plugins/tend-ci-runner/skills/...` in `max-sixty/tend`) — the same pattern would fire in every consumer — file the fix against tend per **Filing Issues in Other Repos** in `running-in-ci`. Signal: the fix reads as generic guidance that would apply to any consumer.
+**Bundled-skill defects.** If the root cause is a gap or bug in a bundled skill (`plugins/tend-ci-runner/skills/...` in `max-sixty/tend`) — the same pattern would fire in every consumer — file the fix against tend per **Other Repos** in `running-in-ci`. Signal: the fix reads as generic guidance that would apply to any consumer.
 
 **Prefer PRs over issues.** A PR with a clear description is immediately actionable.
 

--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -25,50 +25,20 @@ Load `/tend-ci-runner:running-in-ci` first — it contains CI security rules, po
 Before reading the diff, run cheap checks to avoid redundant work. Shell state doesn't persist between tool calls — re-derive `REPO` in each bash invocation or combine commands.
 
 ```bash
-REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
-BOT_LOGIN=$(gh api user --jq '.login')
 HEAD_SHA=$(gh pr view <number> --json commits --jq '.commits[-1].oid')
 PR_AUTHOR=$(gh pr view <number> --json author --jq '.author.login')
 IS_DRAFT=$(gh pr view <number> --json isDraft --jq '.isDraft')
 EVENT_ACTION=$(jq -r '.action // ""' < "${GITHUB_EVENT_PATH:-/dev/null}" 2>/dev/null)
 
-# Find the bot's most recent *real* review. Replying to a review thread
-# (`POST /pulls/{n}/comments/{id}/replies`) makes GitHub wrap the reply in a
-# synthetic zero-body COMMENTED review anchored at the then-current HEAD, so the
-# newest review record routinely points at a commit nothing reviewed. Count a
-# record only when it has a body, owns a top-level (non-reply) inline comment, or
-# is an APPROVED review — reply containers are always zero-body COMMENTED, while
-# an empty-body approval and an empty-body review carrying real inline findings
-# both still anchor.
-SUBSTANTIVE=$(gh api --paginate "repos/$REPO/pulls/<number>/comments" \
-  --jq '.[] | select(.in_reply_to_id == null) | .pull_request_review_id' | jq -s 'unique')
-
-# IMPORTANT: REST reviews carry `.commit_id`, NOT the `.commit.oid` that
-# `gh pr view --json reviews` returns — don't confuse the two. `gh api --jq`
-# accepts no `--arg`/`--argjson`, so pipe to `jq` rather than using `--jq`.
-LAST_REVIEW=$(gh api --paginate "repos/$REPO/pulls/<number>/reviews" \
-  | jq -s --argjson sub "$SUBSTANTIVE" --arg bot "$BOT_LOGIN" \
-    'add | [.[] | select(.user.login == $bot)
-                | select((.body | length) > 0 or (.id | IN($sub[])) or .state == "APPROVED")]
-         | last // {}')
-LAST_REVIEW_SHA=$(jq -r '.commit_id // empty' <<<"$LAST_REVIEW")
-
-# A force-push does not just move HEAD — GitHub re-points the prior review's
-# `.commit_id` at the NEW head, so `LAST_REVIEW_SHA == HEAD_SHA` reads true for
-# code nothing ever reviewed and the run exits silently, leaving a stale APPROVE
-# standing as the active verdict. (An ordinary push leaves the old anchor
-# intact; only a rewrite re-points it, so `.commit_id` alone can't tell the two
-# apart.) Probe the timeline for a rewrite newer than that review.
-LAST_REVIEW_AT=$(jq -r '.submitted_at // empty' <<<"$LAST_REVIEW")
-FORCE_PUSHED=0
-if [ -n "$LAST_REVIEW_AT" ]; then
-  FORCE_PUSHED=$(gh api --paginate "repos/$REPO/issues/<number>/timeline" \
-    | jq -s --arg at "$LAST_REVIEW_AT" \
-      'add | [.[] | select(.event == "head_ref_force_pushed" and .created_at > $at)] | length')
-fi
+# Which of the bot's reviews actually anchors this head — reply containers and
+# force-push re-anchoring both discounted. See the script header for why
+# `.commit_id` alone can't be read directly.
+STATE=$(${CLAUDE_PLUGIN_ROOT}/scripts/bot-review-state.sh <number>)
+LAST_REVIEW_SHA=$(jq -r '.last_substantive.sha // empty' <<<"$STATE")
+FORCE_PUSHED=$(jq -r '.force_pushed_since' <<<"$STATE")
 ```
 
-If `FORCE_PUSHED` is non-zero, the commit the bot reviewed was rewritten away: ignore `LAST_REVIEW_SHA` entirely and review `HEAD_SHA` in full. The incremental below can't run either — `LAST_REVIEW_SHA` now names the current head rather than anything the bot read, so `LAST_REVIEW_SHA..HEAD_SHA` is empty and every trivial-skip heuristic keyed on it under-reports. If that prior review was an `APPROVED` and the re-review lands on findings rather than an approval, dismiss it too — it is re-anchored onto the rewritten head, so posting a COMMENT alone leaves the PR reading as bot-approved. `jq -r '.state, .id' <<<"$LAST_REVIEW"` gives the state and the `$REVIEW_ID` for step 6's `reviews/$REVIEW_ID/dismissals` call.
+If `FORCE_PUSHED` is `true`, the commit the bot reviewed was rewritten away: ignore `LAST_REVIEW_SHA` entirely and review `HEAD_SHA` in full. The incremental below can't run either — `LAST_REVIEW_SHA` now names the current head rather than anything the bot read, so `LAST_REVIEW_SHA..HEAD_SHA` is empty and every trivial-skip heuristic keyed on it under-reports. If that prior review was an `APPROVED` and the re-review lands on findings rather than an approval, dismiss it too — it is re-anchored onto the rewritten head, so posting a COMMENT alone leaves the PR reading as bot-approved. `jq -r '.last_substantive.state, .last_substantive.id' <<<"$STATE"` gives the state and the `$REVIEW_ID` for step 6's `reviews/$REVIEW_ID/dismissals` call.
 
 Otherwise, if `LAST_REVIEW_SHA == HEAD_SHA`, this commit has already been reviewed — finish at step 9 without posting. Two exceptions: an unanswered conversation question directed at the bot (check below), or `EVENT_ACTION == "ready_for_review"` (the PR just transitioned out of draft, so any prior review was a draft-mode review and the author is now asking for a full one — proceed).
 
@@ -241,36 +211,19 @@ gh api "repos/$REPO/issues/<number>/reactions" -f content="+1"
 Before posting, verify HEAD hasn't moved, the PR is still open, and no review was already posted for this commit:
 
 ```bash
-REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
-BOT_LOGIN=$(gh api user --jq '.login')
 read -r CURRENT_HEAD PR_STATE < <(gh pr view <number> --json commits,state \
   --jq '"\(.commits[-1].oid) \(.state)"')
 [ "$CURRENT_HEAD" != "$HEAD_SHA" ] && echo "HEAD moved — fold in per step 9, then re-run these mechanics against $CURRENT_HEAD" && exit 0
 [ "$PR_STATE" != "OPEN" ] && echo "PR is $PR_STATE — skipping" && exit 0
 
-# Same substantive-review filter as step 1, and for the same reason: a synthetic
-# reply container is anchored at whatever HEAD was when the reply posted, so one
-# left on the current HEAD would read as "already reviewed" and discard this run's
-# review at the last step, after all the work. Shell state doesn't carry between
-# tool calls, so re-derive $SUBSTANTIVE here.
-#
-# The force-push re-anchoring from step 1 lands on this guard too, and harder: a
-# review submitted against the rewritten-away commit now reports
-# `.commit_id == $HEAD_SHA`, so it reads as "already reviewed" and discards the
-# very re-review step 1's `FORCE_PUSHED` probe just unblocked. Drop reviews older
-# than the newest rewrite; anything submitted after it really did anchor here.
-# NOTE: REST API uses .commit_id (not .commit.oid from gh pr view --json)
-SUBSTANTIVE=$(gh api --paginate "repos/$REPO/pulls/<number>/comments" \
-  --jq '.[] | select(.in_reply_to_id == null) | .pull_request_review_id' | jq -s 'unique')
-LAST_FORCE_PUSH_AT=$(gh api --paginate "repos/$REPO/issues/<number>/timeline" \
-  | jq -rs 'add | [.[] | select(.event == "head_ref_force_pushed") | .created_at] | max // ""')
-ALREADY_POSTED=$(gh api --paginate "repos/$REPO/pulls/<number>/reviews" \
-  | jq -rs --argjson sub "$SUBSTANTIVE" --arg bot "$BOT_LOGIN" --arg head "$HEAD_SHA" \
-    --arg fp "$LAST_FORCE_PUSH_AT" \
-    'add | [.[] | select(.user.login == $bot and .commit_id == $head)
-                | select($fp == "" or .submitted_at > $fp)
-                | select((.body | length) > 0 or (.id | IN($sub[])) or .state == "APPROVED")]
-         | last | .submitted_at // empty')
+# `at_head` is non-null only for a review that genuinely anchors this commit: a
+# synthetic reply container left on the current HEAD would otherwise read as
+# "already reviewed" and discard this run's review at the last step, after all
+# the work — and so would a review of the commit a rewrite replaced, which
+# reports `.commit_id == $HEAD_SHA` and would discard the very re-review step
+# 1's `FORCE_PUSHED` probe just unblocked.
+ALREADY_POSTED=$(${CLAUDE_PLUGIN_ROOT}/scripts/bot-review-state.sh <number> \
+  | jq -r '.at_head.at // empty')
 [ -n "$ALREADY_POSTED" ] && echo "Already reviewed — finish at step 9" && exit 0
 ```
 
@@ -378,26 +331,14 @@ GitHub returns `422 Unprocessable Entity` with "Line could not be resolved" when
 **Check which case you are in before deciding how to recover** — query for an orphan review on the current HEAD first, then branch on the result.
 
 ```bash
-# The body-length test is what distinguishes an orphan from a synthetic reply
-# container sitting on the same HEAD: case (a) persists the body, a container
-# never has one. Without it, the PUT below would overwrite an unrelated reply.
-# `gh api --paginate` applies `--jq` to each page separately, so a `| last`
-# inside `--jq` returns one id *per page* — pipe to `jq -rs 'add | …'` to reduce
-# over the merged array instead.
-#
-# The force-push filter from the pre-post guard is required here too, and the
-# consequence of omitting it is worse than a skipped run: a body-bearing review
-# from before a rewrite reports `.commit_id == $HEAD_SHA`, passes the body-length
-# test, and the PUT below overwrites that older review's text with this run's
-# findings — destroying a published review and leaving the new body over the old
-# review's inline comments on code that no longer exists.
-LAST_FORCE_PUSH_AT=$(gh api --paginate "repos/$REPO/issues/<number>/timeline" \
-  | jq -rs 'add | [.[] | select(.event == "head_ref_force_pushed") | .created_at] | max // ""')
-ORPHAN_ID=$(gh api --paginate "repos/$REPO/pulls/<number>/reviews" \
-  | jq -rs --arg bot "$BOT_LOGIN" --arg head "$HEAD_SHA" --arg fp "$LAST_FORCE_PUSH_AT" \
-    'add | [.[] | select(.user.login == $bot and .commit_id == $head and (.body | length) > 0)
-                | select($fp == "" or .submitted_at > $fp)]
-         | last | .id // empty')
+# `orphan_id` is the body-bearing bot review anchored here, and only that: a
+# synthetic reply container on the same HEAD has no body, so the PUT below
+# can't overwrite an unrelated reply, and a body-bearing review from before a
+# rewrite is excluded too — it reports `.commit_id == $HEAD_SHA`, so without
+# that filter the PUT destroys a published review, leaving this run's findings
+# over the old review's inline comments on code that no longer exists.
+ORPHAN_ID=$(${CLAUDE_PLUGIN_ROOT}/scripts/bot-review-state.sh <number> \
+  | jq -r '.orphan_id // empty')
 ```
 
 Then, in either case, **move the failed inline comments into the review body** as fenced code blocks with file paths, and:

--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -25,7 +25,7 @@ Load `/tend-ci-runner:running-in-ci` first — it contains CI security rules, po
 Before reading the diff, run cheap checks to avoid redundant work. Shell state doesn't persist between tool calls — re-derive `REPO` in each bash invocation or combine commands.
 
 ```bash
-HEAD_SHA=$(gh pr view <number> --json commits --jq '.commits[-1].oid')
+HEAD_SHA=$(gh pr view <number> --json headRefOid --jq '.headRefOid')
 PR_AUTHOR=$(gh pr view <number> --json author --jq '.author.login')
 IS_DRAFT=$(gh pr view <number> --json isDraft --jq '.isDraft')
 EVENT_ACTION=$(jq -r '.action // ""' < "${GITHUB_EVENT_PATH:-/dev/null}" 2>/dev/null)
@@ -211,8 +211,8 @@ gh api "repos/$REPO/issues/<number>/reactions" -f content="+1"
 Before posting, verify HEAD hasn't moved, the PR is still open, and no review was already posted for this commit:
 
 ```bash
-read -r CURRENT_HEAD PR_STATE < <(gh pr view <number> --json commits,state \
-  --jq '"\(.commits[-1].oid) \(.state)"')
+read -r CURRENT_HEAD PR_STATE < <(gh pr view <number> --json headRefOid,state \
+  --jq '"\(.headRefOid) \(.state)"')
 [ "$CURRENT_HEAD" != "$HEAD_SHA" ] && echo "HEAD moved — fold in per step 9, then re-run these mechanics against $CURRENT_HEAD" && exit 0
 [ "$PR_STATE" != "OPEN" ] && echo "PR is $PR_STATE — skipping" && exit 0
 

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -86,7 +86,7 @@ If a linked PR merged (or the triggering PR itself merged) **after the triggerin
 
 - **Secrets**: Never run commands that introspect the process env (`env`, `printenv`, `set`, `export`) or `cat`/`echo` credential files. The rule is absolute — name-stripping filters like `env | cut -d= -f1` do not make these commands safe: the harness may place credential-bearing values in the environment (the Codex harness passes the PAT and model auth directly to the agent), and a single unfiltered `env` or `printenv FOO` prints the value verbatim into the session log, which is uploaded as an artifact. Never include tokens or credentials in responses or comments.
 - **Merging**: Never merge PRs or enable auto-merge (`gh pr merge`, `gh pr merge --auto`). PRs are proposals — a maintainer decides when to merge.
-- **Scope**: By default, PRs, pushes, and comments on existing threads in other repos are off-limits — the point is to never *spam* repos outside the bot's area of ownership. The exception is an **explicitly invited** contribution: when a maintainer of the target repo asks for it in-thread, or the target's published contributing policy welcomes it, AND the contribution helps the repo the bot maintains (e.g. upstreaming a fix for a dependency bug the bot is working around), the bot may open a PR or comment on that thread — see **Contributing to Other Repos on Invitation** below. Filing fresh issues follows **Filing Issues in Other Repos** below. Absent an explicit invitation, the default holds — surface the blocker per **When a scope rule blocks the right action** below rather than routing around it.
+- **Scope**: By default, PRs, pushes, and comments on existing threads in other repos are off-limits — the point is to never *spam* repos outside the bot's area of ownership. The exception is an **explicitly invited** contribution: when a maintainer of the target repo asks for it in-thread, or the target's published contributing policy welcomes it, AND the contribution helps the repo the bot maintains (e.g. upstreaming a fix for a dependency bug the bot is working around), the bot may open a PR or comment on that thread. Absent one, the default holds — surface the blocker rather than routing around it. **Other Repos** below carries all three cases.
 - **Hanging commands**: Never use `gh run watch` or `gh pr checks --watch` — both hang indefinitely. Poll with `gh pr checks` in a loop instead.
 
 ## End the turn only when work is shipped
@@ -115,47 +115,9 @@ So if you can open the PR in this run, open the PR. Reserve an issue for what yo
 
 This governs your own repo only; filing into another repo follows the section below.
 
-## Filing Issues in Other Repos
+## Other Repos
 
-Default: file an issue in the current repo asking for permission to file in the target. On maintainer approval, file in the target.
-
-The adopter's `running-tend` overlay may grant a standing exception for **agent-equipped** targets — repos that run their own coding agent. Signals:
-
-- `.github/workflows/tend-*.yaml` present (the target uses tend).
-- A workflow invokes `anthropics/claude-code-action` or another coding-agent action.
-- Recent issues or PRs authored by a bot account, with no human pushback in the thread.
-
-Two or three convergent signals are enough; borderline cases revert to the default. Without an explicit opt-in in `running-tend`, the default also applies.
-
-When asking permission (the default path), close with a short offer so the user can record a preference for future asks. The offer should let them pick either outcome: have the bot file without asking next time, or keep approving each one but stop seeing the offer. Phrase it to fit the thread.
-
-Either reply gets codified in the consumer repo's `running-tend` overlay per **Learning from Feedback** below — opt-in adds the target (or "all agent-equipped targets") to the exceptions list; suppress adds a one-line rule telling the bot to skip the offer for future asks.
-
-Whether filed direct or post-approval, the issue body includes:
-
-- Problem statement: what fires, where, under what conditions.
-- Evidence: run links; cost/duration if relevant.
-- Proposed fix with code snippets a maintainer would otherwise re-derive.
-
-### Contributing to Other Repos on Invitation
-
-The Scope default bars *unsolicited* PRs/comments in other repos. It does not bar an *invited* one. When BOTH hold, the bot may open a PR or comment on an existing thread in the target repo:
-
-- **Explicit invitation** — a maintainer of the target repo asked for the contribution in-thread (e.g. "do you want to open the PR?"), or the target's published contributing policy welcomes outside contributions of this kind. Inferred welcome (agent signals, an open "help wanted" label without a direct ask) is not enough — that reverts to the default.
-- **Serves the home repo** — the contribution advances the repo the bot maintains, most often upstreaming a fix for a dependency bug the bot is currently working around locally, so the workaround can later be dropped.
-
-Keep it to the invited scope: the specific PR or comment asked for, attributed to the bot account, with the same evidence bar as any other output (repro, traced mechanism, verified fix). Don't expand into unrelated upstream work. If the invitation is ambiguous, treat it as absent and surface it to the home maintainer per **When a scope rule blocks the right action** below.
-
-### When a scope rule blocks the right action
-
-When a **Scope** restriction is the only thing between you and the correct move (e.g. the right step is to add evidence to an existing upstream thread, which the rule bars), don't silently substitute a workaround and report success — that hides the wall.
-
-Surface the blocker on the triggering thread and offer the maintainer both:
-
-1. **Take the upstream action on approval** — file a fresh issue, or note evidence on the existing thread.
-2. **Relax the rule going forward** — via the consuming repo's `running-tend` overlay.
-
-Record their choice per **Learning from Feedback** below.
+Default: don't act in another repo unsolicited. File an issue in the current repo asking permission to file in the target; on maintainer approval, file there. `references/other-repos.md` carries the rest: the standing exception an overlay can grant for agent-equipped targets, what an issue body must contain, when an invitation makes a PR or comment in the target legitimate, and what to do when a scope rule is the only thing between you and the right move.
 
 ## PR Creation
 
@@ -483,188 +445,11 @@ CI runs are not interactive — every claim must be grounded in evidence. The th
 
 Read logs, code, and API data before drawing conclusions. Show evidence: cite log lines, file paths, commit SHAs. Trace causation — if two things co-occur, find the mechanism rather than saying "this may be related." Never claim a failure is "pre-existing" without checking main branch CI history. Distinguish what you verified from what you inferred.
 
-### User-facing comments require source evidence
-
-Public comments — on issues, PRs, or in review threads — are permanent and visible. A hallucinated detail (wrong syntax, invented API, nonexistent flag) misleads users and erodes trust. **It is always better to take longer and produce a correct response than to respond quickly with fabricated details.**
-
-Before posting any specific claim — a configuration snippet, command syntax, variable name, or API behavior — find the **source text** that confirms it. Source text means documentation, help output, test expectations, or the code that implements the public interface. Internal implementation code (struct fields, variable names in Rust/Python/etc.) shows what exists internally but not how it's exposed to users — read the docs or user-facing layer too.
-
-<example>
-<bad reason="Read Rust code showing a 'target' variable and invented $WT_TARGET">
-
-Bad: Saw `extra_vars.push(("target", target_branch))` in Rust source → posted a hook example using `$WT_TARGET` (an environment variable that doesn't exist — hooks use `{{ target }}` Jinja templates).
-
-</bad>
-<good reason="Verified syntax against user-facing documentation before posting">
-
-Good: Saw `("target", target_branch)` in Rust source → read `docs/hook.md` → confirmed hooks use `{{ target }}` syntax → posted correct example.
-
-</good>
-</example>
-
-For **behavioral claims** — "X happens when you run Y", "command Z works in scenario W" — reading code is not sufficient. Code has conditional branches, early returns, and error paths that are easy to miss when tracing mentally. Before asserting what a command does in a specific scenario, either find a test that exercises that exact scenario or run the command yourself. If neither is feasible, hedge: "Based on code reading, I believe X, but I haven't verified this end-to-end."
-
-<example>
-<bad reason="Traced one code path but missed a guard clause in a called function">
-
-Bad: Read `CommandEnv::for_action("commit", config)` → saw it constructs an env → concluded `wt step commit` works in a detached worktree. Missed that `for_action()` calls `require_current_branch()`, which errors on detached HEAD.
-
-</bad>
-<good reason="Built and tested the actual behavior before claiming">
-
-Good: Read `for_action()` → noticed it calls `require_current_branch()` → uncertain whether detached HEAD hits that path → ran `cargo build && wt step commit` in a detached worktree → confirmed the error → posted accurate answer.
-
-</good>
-</example>
-
-When a project has user-facing documentation (a docs site, `--help` pages, a wiki), link to it. A link to the relevant docs page is more useful than a paraphrased explanation — and finding the link forces verifying the claim.
-
-If you can't find source evidence for a specific detail, say so ("I'm not sure of the exact syntax") rather than guessing. An honest gap is fixable; a confident hallucination gets copy-pasted.
-
-### Specific failure modes
-
-**Links must be fetched, not guessed.** Before pasting any URL in a comment, run `curl -sI <url> | head -1` and confirm `200`. Docs-site slugs are particularly treacherous — `escaping.html` and `quoting.html` and `quote-strings.html` are all plausible nushell page names; only one (or none) actually exists. The canonical source for that project's docs sidebar will tell you which.
-
-**`--jq` projections must include the ID when downstream URLs cite individual items.** Composing `actions/runs/<id>`, `#issuecomment-<id>`, or `pull/<n>` URLs from `gh run list` / `gh api .../comments` / `gh pr list` results requires the ID field in the projection (`databaseId` for runs, `id` for comments, `number` for PRs/issues). If the projection kept only timestamps, titles, or bodies, the bot composes the URL from what it has and fabricates the missing ID — the link 404s. Re-query with the ID field rather than guessing.
-
-**`gh` list commands truncate silently — pass `--limit` whenever the result set is the answer.** `gh issue list`, `gh pr list`, and `gh search` return 30 items unless told otherwise; `gh run list` returns 20. Nothing in the output says it truncated. Two shapes go wrong: a dedup scan misses the existing issue or PR sitting past the cap and opens a duplicate, and a survey ("check every open issue") reports complete coverage of the rows it happened to see. A count that reads exactly the default across repeated measurements is the signature — that's the cap, not a stable value. Set an explicit `--limit` above the plausible ceiling on any query used to dedup, survey, or count. Client-side filtering inside `--jq` is the worst variant: the filter hides the truncation, so a capped result reads as a legitimately short one.
-
-**"Likely" is a stop-sign.** A hedge in a user-facing claim — "likely works", "probably parses as", "should behave like", "I think" — means it rests on an unverified guess. Two options: verify and replace the hedge with the answer, or hedge explicitly ("I haven't tested this — would appreciate if you can confirm") and don't dress up the guess as analysis. The shape is the tell, not the exact words: posting an unverified guess as confident-sounding analysis is the hallucination that erodes trust the fastest.
-
-**Never ship literal placeholders in user-visible content.** Strings like `<PLACEHOLDER>`, `PR #PLACEHOLDER`, `<SHA>`, `TBD`, `XXX`, or `<TODO(fill)>` in an issue body, PR body, or comment are corruption: a deferred substitution that never ran. They survive into the rendered output and read as broken. When a multi-step ask references an artifact that doesn't yet exist ("file an issue that references the PR I'm about to file"), sequence the work so the referenced artifact exists before the referencing body is composed: create the PR → read its number → compose the issue with the number filled in → file the issue. If the cross-reference can't be resolved before posting (e.g. the artifact is out of scope or deferred), omit it or rephrase ("a follow-up PR will…") rather than emit a placeholder. Before any `gh issue create`, `gh pr create`, or `gh ... comment --body-file`, grep the body file for `PLACEHOLDER`, `<SHA>`, `<TODO`, `TBD`, `XXX` and refuse to post if any match. A session that times out mid-sequence leaves an unsubstituted placeholder permanently visible — pre-substitute, don't post-substitute.
-
-### Distinguish transient incidents from durable bugs
-
-Intermittent or inconsistent behavior — the same query returning different results within seconds, an API silently returning empty when records demonstrably exist, a CLI flag working sometimes — points more strongly at an active upstream incident than at a CLI or skill bug. Reproducing the flake confirms the symptom but not the cause; the cause is often a current incident on the upstream service, in which case the right disposition is to wait for resolution rather than commit a code workaround that outlives the incident. Before designing a workaround, check upstream status. For GitHub-side symptoms:
-
-```bash
-# Fetch first, parse second. The endpoint sits behind an edge that sometimes
-# answers a CI runner with an HTML challenge page instead of JSON; piping that
-# straight into jq gives a parse error on stderr and an empty stdout, which
-# reads exactly like "no open incidents". `-f` catches a challenge served as a
-# non-200 and the `jq -e` probe catches one served as 200; capturing the body
-# means the status is curl's or jq's, not a pipeline's (a bare
-# `curl … | jq … || …` exits 0 on the challenge page).
-if ! INCIDENTS=$(curl -fsS 'https://www.githubstatus.com/api/v2/incidents/unresolved.json') \
-   || ! echo "$INCIDENTS" | jq -e . >/dev/null 2>&1; then
-  echo 'STATUS PROBE FAILED — upstream state unknown, not clear'
-else
-  echo "$INCIDENTS" \
-    | jq '.incidents[] | {created_at, name, impact, components: [.components[].name]}'
-fi
-```
-
-**A failed probe is `unknown`, never `clear`.** Empty output from a successful query means no open incident; a probe that errored means you didn't check. Both resolve the same way — record the symptom in the evidence log and skip the workaround PR — so an unreachable status endpoint is not a reason to file one.
-
-If the response is non-empty and the components/timing match the symptom (e.g. Issues / Pull Requests / Actions during a search-degradation incident), record the symptom in the run's evidence log and exit without a PR. Sibling matrix legs that hit different surface symptoms of the same incident otherwise each open their own near-duplicate workaround PR — title and file dedup don't catch them because each leg picks a different command to mitigate.
-
-<example>
-<bad reason="Reproduced an API flake during an active incident, opened code workarounds without checking upstream status">
-
-Bad: `gh issue list` returns `[]` intermittently for queries whose matching issues clearly exist. Bot opens a PR adding a retry loop. A sibling matrix leg sees the same shape on `gh run list` and opens its own workaround PR swapping to client-side filtering. Both are workarounds for an active upstream search-degradation incident; both get closed once the incident link surfaces.
-
-</bad>
-<good reason="Checked status.github.com first, treated the symptom as transient">
-
-Good: Same flake → `curl /api/v2/incidents/unresolved.json` returns an active "GitHub search is degraded" incident touching Issues + Pull Requests → record the symptom in the evidence log, skip the PR, let the incident resolve.
-
-</good>
-</example>
-
-### Verifying external-tool behavior
-
-When a claim turns on how an external CLI, API, or system behaves, verify by running the code.
-
-Two paths, in order of preference:
-
-1. **Run the tool.** If it's installable in this environment, install it and invoke the specific command or flag in question. Link the output in your reply.
-2. **Read the source.** Tend can clone any public repo. `gh repo clone <owner>/<repo>` then grep for the flag or behavior. Source doesn't lag itself, and a flag that isn't defined in the parser doesn't exist.
-
-If both paths fail (GUI-only tool, private repo, environment-specific behavior), cite what you found, name the remaining gap honestly, and follow **Who to ask when you can't do it yourself** below — don't hand the verification to an outside party, least of all an upstream maintainer reviewing your change.
-
-<example>
-<bad reason="Trusted upstream docs for a fast-moving external CLI and shipped a broken recipe">
-
-Bad: Review asked whether `cmux list-workspaces` had structured output. Read a mintlify page describing `--json` → rewrote the recipe to `cmux list-workspaces --json | jq ...` → committed. The installed cmux had no `--json` flag; every reader hit a broken recipe.
-
-</bad>
-<good reason="Cloned the upstream source and verified the flag before shipping">
-
-Good: Same question. Cloned cmux's source repo → grepped the CLI parser for `list-workspaces` → saw no `--json` flag defined → replied with the source link and proposed an alternative that matched the actual CLI surface.
-
-</good>
-</example>
-
-**Path 1 runs against the live repo.** Verifying a skill's own recipe is the common case, and those recipes write: `gh issue close`, `gh pr comment`, `git push`. Never extract a block programmatically to run it — not by position (`awk` on the Nth fence, `sed` on a line range), and not by anchor either: both hand you a block you haven't read, and the ordinal additionally moves with every edit to the file, so what runs isn't even the block you meant to test. Read the file, then run the commands directly. Run the read half and stop before the pipe into the write:
-
-```bash
-gh issue list --state open --author '@me' --search '"..." in:title' --json number --jq '.[].number'
-# ...and read that, rather than piping it into `xargs gh issue close`.
-```
-
-If the write is the part in question, point it at a scratch object you own. A wrong write is only partly recoverable: reopening an issue leaves the close in its timeline, and a deleted comment has already fired its `issue_comment` event, so any workflow it triggered ran and is still in the run list.
-
-### Who to ask when you can't do it yourself
-
-Some checks need hardware or an environment CI doesn't have (Windows, a GPU, a physical terminal). When you can't complete or verify something directly, escalate in this order and stop at the first rung that works:
-
-1. **Do it yourself.** Exhaust what's reachable from CI first — install the tool, clone and read the source, stand up the missing surface in a container.
-2. **Make it doable yourself.** Add the capability to *your own* repo so no future run needs a favor — e.g. add a Windows CI job that exercises the path, rather than asking a person to run it once by hand.
-3. **Ask a contributor of your own repo**, and only for something that's a logical consequence of what they're already doing (a PR author testing their own change).
-4. **Escalate to your own repo's maintainer** that you're blocked and need help.
-
-Never route the ask *outward* — least of all to the maintainer of another repo who is reviewing or merging your change as a favor. Closing an upstream PR with "if you can confirm on a real Windows terminal I'd appreciate it" hands them work; state the gap honestly ("verified by source inspection, not on hardware") and take rung 2 back home instead.
-
-### Rewriting is authoring
-
-Cross-posting, summarizing, or paraphrasing is not copying — any new content you add requires the same source verification as a fresh comment. If you expand with a config section header, code block, or usage example, verify each addition against the source.
-
-<example>
-<bad reason="Composed new TOML section header without verifying it">
-
-Bad: Cross-posted a hook snippet, added an alias example with `[step]` as the section header (inferred from the `wt step` command name). The actual config section is `[aliases]`.
-
-</bad>
-<good reason="Verified new content against docs before posting">
-
-Good: Cross-posted a hook snippet, added an alias example → checked `dev/*.example.toml` to confirm the section is `[aliases]` → posted with correct syntax.
-
-</good>
-</example>
+`references/grounded-analysis.md` carries the depth: what counts as source evidence for a user-facing claim, how to verify an external tool's behavior and run a skill's own recipes safely, the hallucination shapes that recur (guessed links, silently truncated `gh` lists, unsubstituted placeholders), how to tell an upstream incident from a durable bug before writing a workaround, and who to ask when a check needs hardware CI doesn't have.
 
 ## Learning from Feedback
 
-When a maintainer corrects the bot's behavior during a run — points out a repo convention, a repeated mistake, or a preference the bot should have known — propose a follow-up PR against the consuming repo's `.claude/skills/running-tend/SKILL.md`. This turns one-off corrections into durable guidance for future runs in *this* repo. The PR targets the consuming repo, not tend; bundled tend defaults change through separate PRs against the tend repo.
-
-### When to propose
-
-Open a repo-overlay PR only when feedback is **generalizable** — applies to future runs, not just the current task — AND at least one of these bars is met:
-
-- **Recurrence**: the same correction has been observed at least twice, or there is direct evidence the failure mode is recurring. "Saw it once, wrote a rule" is below the bar.
-- **Invisible failure mode**: the bad behavior would not surface as a future CI failure (e.g. cancelled/timed-out runs whose actual work succeeded), so without codification it would not be caught next time.
-- **Maintainer-explicit codification request**: a maintainer has explicitly asked for the rule to be codified after a single occurrence.
-
-This mirrors the bar tend uses for bundled-skill changes — those go through human review on the tend repo before merge, which acts as an implicit recurrence/impact filter. Per-repo overlays don't get the same scrutiny, so the bar belongs here.
-
-Signals that point toward a generalizable rule:
-
-- Correction names a pattern (*"stop adding inline suggestions for formatting — the linter handles that"*), not a task detail (*"rename this variable"*)
-- Feedback references a repo convention (*"we use conventional commits"*, *"PRs go to the `develop` branch, not `main`"*)
-
-Do **not** propose when:
-
-- The feedback is task-specific (a one-off rewording, a particular variable name)
-- The lesson is already covered by a bundled tend skill — those update through PRs against the tend repo, not per-repo overlays
-- Confidence that the feedback generalizes is low — ask for clarification instead
-- The feedback comes from a non-maintainer — check `author_association` and skip the skill PR. Non-maintainers can raise preferences, but only a maintainer authorizes codifying them. If the pattern is worth capturing, note it in a reply and let a maintainer confirm.
-
-### Bundled-skill defects
-
-When the correction identifies a gap or bug in a **bundled** skill — the same root cause would fire in every tend consumer — the fix belongs in tend, not in this overlay. Signals: the fix reads as generic guidance that would apply to any consumer; the behavior being corrected comes from bundled skill text. File against tend per **Filing Issues in Other Repos** above.
-
-### How to propose
-
-Follow `references/skill-pr-workflow.md` in this skill's directory. It carries the whole recipe: dedup by target file against the bot's open PRs, drafting rules (state the rule, not the incident), the workaround for the read-only `.claude/skills/` mount, and the branch/PR mechanics. Open the PR and exit — don't merge, don't wait, don't ping for review.
+When a maintainer corrects the bot's behavior during a run — a repo convention, a repeated mistake, a preference the bot should have known — propose a follow-up PR against the consuming repo's `.claude/skills/running-tend/SKILL.md`, turning a one-off correction into durable guidance for future runs in *this* repo. Follow `references/skill-pr-workflow.md`: it carries the bar the feedback has to clear, when the fix belongs in tend instead, and the branch/PR mechanics. Open the PR and exit — don't merge, don't wait, don't ping for review.
 
 ## Tone
 

--- a/plugins/tend-ci-runner/skills/running-in-ci/references/grounded-analysis.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/references/grounded-analysis.md
@@ -1,0 +1,216 @@
+# Grounded analysis
+
+Depth behind `running-in-ci`'s **Grounded Analysis** section: how to establish
+that a claim is true before a permanent public comment carries it.
+
+- [Source evidence for user-facing claims](#source-evidence-for-user-facing-claims)
+- [Verifying external-tool behavior](#verifying-external-tool-behavior)
+- [Recurring hallucination shapes](#recurring-hallucination-shapes)
+- [Transient incidents vs. durable bugs](#transient-incidents-vs-durable-bugs)
+- [Who to ask when you can't do it yourself](#who-to-ask-when-you-cant-do-it-yourself)
+
+## Source evidence for user-facing claims
+
+Before posting any specific claim — a configuration snippet, command syntax,
+variable name, or API behavior — find the **source text** that confirms it:
+documentation, help output, test expectations, or the code implementing the
+public interface. Internal implementation code shows what exists internally,
+not how it's exposed; read the docs or user-facing layer too.
+
+<example>
+<bad reason="Read Rust code showing a 'target' variable and invented $WT_TARGET">
+
+Bad: Saw `extra_vars.push(("target", target_branch))` in Rust source → posted a hook example using `$WT_TARGET` (an environment variable that doesn't exist — hooks use `{{ target }}` Jinja templates).
+
+</bad>
+<good reason="Verified syntax against user-facing documentation before posting">
+
+Good: Saw `("target", target_branch)` in Rust source → read `docs/hook.md` → confirmed hooks use `{{ target }}` syntax → posted correct example.
+
+</good>
+</example>
+
+For **behavioral claims** — "X happens when you run Y" — reading code is not
+enough. Conditional branches, early returns, and error paths are easy to miss
+when tracing mentally. Find a test that exercises that exact scenario, or run
+the command. If neither is feasible, hedge explicitly: "Based on code reading,
+I believe X, but I haven't verified this end-to-end."
+
+<example>
+<bad reason="Traced one code path but missed a guard clause in a called function">
+
+Bad: Read `CommandEnv::for_action("commit", config)` → saw it constructs an env → concluded `wt step commit` works in a detached worktree. Missed that `for_action()` calls `require_current_branch()`, which errors on detached HEAD.
+
+</bad>
+<good reason="Built and tested the actual behavior before claiming">
+
+Good: Read `for_action()` → noticed it calls `require_current_branch()` → uncertain whether detached HEAD hits that path → ran `cargo build && wt step commit` in a detached worktree → confirmed the error → posted accurate answer.
+
+</good>
+</example>
+
+Link to user-facing documentation where a project has it — finding the link
+forces verifying the claim. Where no source evidence turns up, say so ("I'm not
+sure of the exact syntax"). An honest gap is fixable; a confident hallucination
+gets copy-pasted.
+
+**Rewriting is authoring.** Cross-posting, summarizing, or paraphrasing carries
+the same bar for anything *added*: a config section header inferred from a
+command name (`[step]` from `wt step`, where the real section is `[aliases]`)
+is a fresh claim, not a copy.
+
+## Verifying external-tool behavior
+
+When a claim turns on how an external CLI, API, or system behaves, verify by
+running the code. Two paths, in order:
+
+1. **Run the tool.** If it's installable here, install it and invoke the
+   specific command or flag. Link the output in your reply.
+2. **Read the source.** Tend can clone any public repo. `gh repo clone
+   <owner>/<repo>`, then grep for the flag or behavior. Source doesn't lag
+   itself, and a flag the parser doesn't define doesn't exist.
+
+If both fail (GUI-only tool, private repo, environment-specific behavior), cite
+what you found and name the gap — then see **Who to ask** below.
+
+<example>
+<bad reason="Trusted upstream docs for a fast-moving external CLI and shipped a broken recipe">
+
+Bad: Review asked whether `cmux list-workspaces` had structured output. Read a mintlify page describing `--json` → rewrote the recipe to `cmux list-workspaces --json | jq ...` → committed. The installed cmux had no `--json` flag; every reader hit a broken recipe.
+
+</bad>
+<good reason="Cloned the upstream source and verified the flag before shipping">
+
+Good: Same question. Cloned cmux's source repo → grepped the CLI parser for `list-workspaces` → saw no `--json` flag defined → replied with the source link and proposed an alternative that matched the actual CLI surface.
+
+</good>
+</example>
+
+**Path 1 runs against the live repo.** Verifying a skill's own recipe is the
+common case, and those recipes write: `gh issue close`, `gh pr comment`, `git
+push`. Never extract a block programmatically to run it — not by position
+(`awk` on the Nth fence, `sed` on a line range) and not by anchor: both hand
+you a block you haven't read, and the ordinal moves with every edit, so what
+runs isn't even the block you meant to test. Read the file, then run the
+commands directly. Run the read half and stop before the pipe into the write:
+
+```bash
+gh issue list --state open --author '@me' --search '"..." in:title' --json number --jq '.[].number'
+# ...and read that, rather than piping it into `xargs gh issue close`.
+```
+
+If the write is the part in question, point it at a scratch object you own. A
+wrong write is only partly recoverable: reopening an issue leaves the close in
+its timeline, and a deleted comment has already fired its `issue_comment`
+event, so any workflow it triggered ran and is still in the run list.
+
+## Recurring hallucination shapes
+
+**Links must be fetched, not guessed.** Before pasting any URL, run `curl -sI
+<url> | head -1` and confirm `200`. Docs-site slugs are treacherous —
+`escaping.html`, `quoting.html`, and `quote-strings.html` are all plausible;
+only one (or none) exists.
+
+**`--jq` projections must keep the ID when downstream URLs cite individual
+items.** Composing `actions/runs/<id>`, `#issuecomment-<id>`, or `pull/<n>`
+needs the ID in the projection (`databaseId` for runs, `id` for comments,
+`number` for PRs/issues). A projection that kept only timestamps or titles
+leaves the bot fabricating the missing ID, and the link 404s. Re-query instead.
+
+**`gh` list commands truncate silently — pass `--limit` whenever the result set
+is the answer.** `gh issue list`, `gh pr list`, and `gh search` return 30 items
+by default; `gh run list` returns 20, and nothing in the output says it
+truncated. A dedup scan then misses the existing issue past the cap and opens a
+duplicate; a survey reports complete coverage of the rows it happened to see. A
+count that reads exactly the default across repeated measurements is the
+signature. Client-side filtering inside `--jq` is the worst variant: the filter
+hides the truncation, so a capped result reads as a legitimately short one.
+
+**"Likely" is a stop-sign.** A hedge in a user-facing claim — "likely works",
+"probably parses as", "I think" — means it rests on an unverified guess. Verify
+and replace the hedge with the answer, or hedge explicitly ("I haven't tested
+this — would appreciate if you can confirm"). The shape is the tell, not the
+exact words: an unverified guess dressed as confident analysis erodes trust
+fastest.
+
+**Never ship literal placeholders.** `<PLACEHOLDER>`, `PR #PLACEHOLDER`,
+`<SHA>`, `TBD`, `XXX`, `<TODO(fill)>` in an issue body, PR body, or comment are
+corruption — a deferred substitution that never ran, rendered permanently.
+Sequence the work so a referenced artifact exists before the referencing body
+is composed: create the PR → read its number → compose the issue with the
+number filled in → file it. Where the cross-reference can't be resolved before
+posting, omit it or rephrase ("a follow-up PR will…"). Before any `gh issue
+create`, `gh pr create`, or `gh ... comment --body-file`, grep the body for
+those strings and refuse to post on a match. A session that times out
+mid-sequence leaves an unsubstituted placeholder visible forever —
+pre-substitute, don't post-substitute.
+
+## Transient incidents vs. durable bugs
+
+Intermittent or inconsistent behavior — the same query returning different
+results within seconds, an API returning empty when records demonstrably exist,
+a CLI flag working sometimes — points at an active upstream incident more
+strongly than at a CLI or skill bug. Reproducing the flake confirms the symptom,
+not the cause, and a code workaround committed during an incident outlives it.
+Check upstream status before designing one. For GitHub-side symptoms:
+
+```bash
+# Fetch first, parse second. The endpoint sits behind an edge that sometimes
+# answers a CI runner with an HTML challenge page instead of JSON; piping that
+# straight into jq gives a parse error on stderr and an empty stdout, which
+# reads exactly like "no open incidents". `-f` catches a challenge served as a
+# non-200 and the `jq -e` probe catches one served as 200; capturing the body
+# means the status is curl's or jq's, not a pipeline's (a bare
+# `curl … | jq … || …` exits 0 on the challenge page).
+if ! INCIDENTS=$(curl -fsS 'https://www.githubstatus.com/api/v2/incidents/unresolved.json') \
+   || ! echo "$INCIDENTS" | jq -e . >/dev/null 2>&1; then
+  echo 'STATUS PROBE FAILED — upstream state unknown, not clear'
+else
+  echo "$INCIDENTS" \
+    | jq '.incidents[] | {created_at, name, impact, components: [.components[].name]}'
+fi
+```
+
+**A failed probe is `unknown`, never `clear`.** Empty output from a successful
+query means no open incident; a probe that errored means you didn't check. Both
+resolve the same way — record the symptom in the evidence log and skip the
+workaround PR — so an unreachable status endpoint is not a reason to file one.
+
+If the response is non-empty and the components and timing match the symptom,
+record it in the run's evidence log and exit without a PR. Sibling matrix legs
+hitting different surface symptoms of one incident otherwise each open their own
+near-duplicate workaround PR — title and file dedup don't catch them, because
+each leg picks a different command to mitigate.
+
+<example>
+<bad reason="Reproduced an API flake during an active incident, opened code workarounds without checking upstream status">
+
+Bad: `gh issue list` returns `[]` intermittently for queries whose matching issues clearly exist. Bot opens a PR adding a retry loop. A sibling matrix leg sees the same shape on `gh run list` and opens its own workaround PR swapping to client-side filtering. Both are workarounds for an active upstream search-degradation incident; both get closed once the incident link surfaces.
+
+</bad>
+<good reason="Checked status.github.com first, treated the symptom as transient">
+
+Good: Same flake → `curl /api/v2/incidents/unresolved.json` returns an active "GitHub search is degraded" incident touching Issues + Pull Requests → record the symptom in the evidence log, skip the PR, let the incident resolve.
+
+</good>
+</example>
+
+## Who to ask when you can't do it yourself
+
+Some checks need hardware or an environment CI doesn't have (Windows, a GPU, a
+physical terminal). Escalate in this order and stop at the first rung that works:
+
+1. **Do it yourself.** Exhaust what's reachable from CI — install the tool,
+   clone and read the source, stand up the missing surface in a container.
+2. **Make it doable yourself.** Add the capability to *your own* repo so no
+   future run needs a favor — a Windows CI job that exercises the path, rather
+   than asking a person to run it once by hand.
+3. **Ask a contributor of your own repo**, and only for something that follows
+   from what they're already doing (a PR author testing their own change).
+4. **Escalate to your own repo's maintainer** that you're blocked.
+
+Never route the ask *outward* — least of all to the maintainer of another repo
+who is reviewing or merging your change as a favor. Closing an upstream PR with
+"if you can confirm on a real Windows terminal I'd appreciate it" hands them
+work; state the gap honestly ("verified by source inspection, not on hardware")
+and take rung 2 back home instead.

--- a/plugins/tend-ci-runner/skills/running-in-ci/references/other-repos.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/references/other-repos.md
@@ -1,0 +1,49 @@
+# Acting in other repos
+
+Depth behind `running-in-ci`'s **Other Repos** section.
+
+- [Filing issues](#filing-issues)
+- [Contributing on invitation](#contributing-on-invitation)
+- [When a scope rule blocks the right action](#when-a-scope-rule-blocks-the-right-action)
+
+## Filing issues
+
+Default: file an issue in the current repo asking for permission to file in the target. On maintainer approval, file in the target.
+
+The adopter's `running-tend` overlay may grant a standing exception for **agent-equipped** targets — repos that run their own coding agent. Signals:
+
+- `.github/workflows/tend-*.yaml` present (the target uses tend).
+- A workflow invokes `anthropics/claude-code-action` or another coding-agent action.
+- Recent issues or PRs authored by a bot account, with no human pushback in the thread.
+
+Two or three convergent signals are enough; borderline cases revert to the default. Without an explicit opt-in in `running-tend`, the default also applies.
+
+When asking permission (the default path), close with a short offer so the user can record a preference for future asks. The offer should let them pick either outcome: have the bot file without asking next time, or keep approving each one but stop seeing the offer. Phrase it to fit the thread.
+
+Either reply gets codified in the consumer repo's `running-tend` overlay per `skill-pr-workflow.md` — opt-in adds the target (or "all agent-equipped targets") to the exceptions list; suppress adds a one-line rule telling the bot to skip the offer for future asks.
+
+Whether filed direct or post-approval, the issue body includes:
+
+- Problem statement: what fires, where, under what conditions.
+- Evidence: run links; cost/duration if relevant.
+- Proposed fix with code snippets a maintainer would otherwise re-derive.
+
+## Contributing on invitation
+
+SKILL.md's **Restrictions → Scope** bars *unsolicited* PRs/comments in other repos. It does not bar an *invited* one. When BOTH hold, the bot may open a PR or comment on an existing thread in the target repo:
+
+- **Explicit invitation** — a maintainer of the target repo asked for the contribution in-thread (e.g. "do you want to open the PR?"), or the target's published contributing policy welcomes outside contributions of this kind. Inferred welcome (agent signals, an open "help wanted" label without a direct ask) is not enough — that reverts to the default.
+- **Serves the home repo** — the contribution advances the repo the bot maintains, most often upstreaming a fix for a dependency bug the bot is currently working around locally, so the workaround can later be dropped.
+
+Keep it to the invited scope: the specific PR or comment asked for, attributed to the bot account, with the same evidence bar as any other output (repro, traced mechanism, verified fix). Don't expand into unrelated upstream work. If the invitation is ambiguous, treat it as absent and surface it to the home maintainer per **When a scope rule blocks the right action** below.
+
+## When a scope rule blocks the right action
+
+When that Scope restriction is the only thing between you and the correct move (e.g. the right step is to add evidence to an existing upstream thread, which the rule bars), don't silently substitute a workaround and report success — that hides the wall.
+
+Surface the blocker on the triggering thread and offer the maintainer both:
+
+1. **Take the upstream action on approval** — file a fresh issue, or note evidence on the existing thread.
+2. **Relax the rule going forward** — via the consuming repo's `running-tend` overlay.
+
+Record their choice per `skill-pr-workflow.md`.

--- a/plugins/tend-ci-runner/skills/running-in-ci/references/skill-pr-workflow.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/references/skill-pr-workflow.md
@@ -1,7 +1,43 @@
 # Opening a skill PR from CI
 
-The mechanics for proposing a change to a repo's `.claude/skills/` from a CI
-session — when to propose is **Learning from Feedback** in SKILL.md.
+Turning a maintainer's correction into durable guidance: whether it clears the
+bar, and the mechanics of proposing it against the consuming repo's
+`.claude/skills/running-tend/SKILL.md`.
+
+## Whether to propose
+
+The feedback must be **generalizable** — it applies to future runs, not just
+this task — and clear at least one bar:
+
+- **Recurrence**: the same correction seen at least twice, or direct evidence
+  the failure mode recurs. "Saw it once, wrote a rule" is below the bar.
+- **Invisible failure mode**: the bad behavior wouldn't surface as a future CI
+  failure (a cancelled or timed-out run whose work actually succeeded), so
+  nothing would catch it next time.
+- **Maintainer asked** for the rule to be codified, even after one occurrence.
+
+Bundled tend defaults go through human review on the tend repo, which acts as
+an implicit recurrence filter; per-repo overlays don't, so the bar lives here.
+
+Signals pointing at a generalizable rule: the correction names a pattern
+("stop adding inline suggestions for formatting — the linter handles that")
+rather than a task detail, or references a repo convention ("we use
+conventional commits", "PRs go to `develop`").
+
+Don't propose when the feedback is task-specific, when a bundled tend skill
+already covers the lesson (that changes through a PR against tend — see
+**Filing issues** in `other-repos.md`), when confidence that it
+generalizes is low (ask instead), or when it comes from a non-maintainer —
+check `author_association`. Non-maintainers can raise preferences, but only a
+maintainer authorizes codifying them; note the pattern in a reply and let one
+confirm.
+
+When the correction identifies a gap in a **bundled** skill — the same root
+cause would fire in every tend consumer — the fix belongs in tend rather than
+the overlay. Signals: the fix reads as generic guidance any consumer would
+want, and the corrected behavior comes from bundled skill text.
+
+## Mechanics
 
 1. **Complete the current task first.** The skill update is always a separate
    PR.

--- a/plugins/tend-ci-runner/skills/weekly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/weekly/SKILL.md
@@ -27,25 +27,15 @@ If no dependency PRs are open, note "0 dependency PRs to process" and continue t
 3. If the update is safe (patch/minor with green CI), check whether the bot has already approved this commit before approving — a dependabot PR open across multiple weekly runs (or already approved by `tend-review` on creation) would otherwise accumulate redundant approvals on the same `commit_id`:
    ```bash
    HEAD_SHA=$(gh pr view <number> --json commits --jq '.commits[-1].oid')
-   BOT_LOGIN=$(gh api user --jq '.login')
-   REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
 
-   # A force-push re-points an existing review's commit anchor at the NEW head,
-   # so an approval of the pre-rebase code reports the current `$HEAD_SHA` and
-   # this guard skips a commit the bot never read — leaving the rebased PR
-   # carrying an approval it never earned. Dependency PRs are the population
-   # tend rewrites on purpose (`nightly` posts `@dependabot recreate` and ticks
-   # renovate's rebase-check), so ignore approvals older than the newest
-   # rewrite. REST reviews carry `.commit_id`/`.submitted_at`, NOT the
-   # `.commit.oid` that `gh pr view --json reviews` returns; `gh api --jq`
-   # accepts no `--arg`, so pipe to `jq`.
-   LAST_FORCE_PUSH_AT=$(gh api --paginate "repos/$REPO/issues/<number>/timeline" \
-     | jq -rs 'add | [.[] | select(.event == "head_ref_force_pushed") | .created_at] | max // ""')
-   LAST_APPROVAL_SHA=$(gh api --paginate "repos/$REPO/pulls/<number>/reviews" \
-     | jq -rs --arg bot "$BOT_LOGIN" --arg fp "$LAST_FORCE_PUSH_AT" \
-       'add | [.[] | select(.user.login == $bot and .state == "APPROVED")
-                   | select($fp == "" or .submitted_at > $fp)]
-            | last | .commit_id // empty')
+   # `fresh_approval_sha` counts only approvals the bot actually earned: a
+   # force-push re-points an earlier approval's anchor at the NEW head, so a
+   # raw `.commit_id` read would skip a commit nothing reviewed and leave the
+   # rebased PR carrying an approval it never earned. Dependency PRs are the
+   # population tend rewrites on purpose (`nightly` posts `@dependabot
+   # recreate` and ticks renovate's rebase-check), so this matters here most.
+   LAST_APPROVAL_SHA=$(${CLAUDE_PLUGIN_ROOT}/scripts/bot-review-state.sh <number> \
+     | jq -r '.fresh_approval_sha')
 
    if [ -n "$LAST_APPROVAL_SHA" ] && [ "$LAST_APPROVAL_SHA" = "$HEAD_SHA" ]; then
      echo "Already approved on this commit; skipping."
@@ -62,23 +52,13 @@ If no dependency PRs are open, note "0 dependency PRs to process" and continue t
 5. If a major version bump, comment noting it needs manual review and skip
 6. On either skip path (4 or 5), dismiss an approval that predates the newest rewrite before you leave. Both paths are reachable *because* a rebase changed something, and neither passes through item 3's guard — so the pre-rewrite approval stays the bot's latest review, re-anchored onto the current head, and the PR still reads as bot-approved while you comment that it isn't mergeable:
    ```bash
-   BOT_LOGIN=$(gh api user --jq '.login')
    REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
-   LAST_FORCE_PUSH_AT=$(gh api --paginate "repos/$REPO/issues/<number>/timeline" \
-     | jq -rs 'add | [.[] | select(.event == "head_ref_force_pushed") | .created_at] | max // ""')
-   # `last` BEFORE the staleness test, not after: the question is whether the
-   # newest approval is stale, not whether some stale approval exists. Filtering
-   # first would return the pre-rewrite id even when a later approval already
-   # superseded it — dismissing a review that no longer sets the PR's state
-   # while the one that does stands untouched. Item 3 keeps the opposite order
-   # and is still correct: `submitted_at` is monotonic here, so its `> $fp` keeps
-   # a suffix (last-of-suffix == last-of-list) while this `< $fp` keeps a prefix.
-   STALE_APPROVAL_ID=$(gh api --paginate "repos/$REPO/pulls/<number>/reviews" \
-     | jq -rs --arg bot "$BOT_LOGIN" --arg fp "$LAST_FORCE_PUSH_AT" \
-       'add | [.[] | select(.user.login == $bot and .state == "APPROVED")]
-            | last
-            | select(. != null and $fp != "" and .submitted_at < $fp)
-            | .id')
+   # `stale_approval_id` is set only when the approval currently deciding the
+   # PR's state is the pre-rewrite one — never merely when some stale approval
+   # exists, which would dismiss a review a later approval already superseded
+   # and leave the live one untouched.
+   STALE_APPROVAL_ID=$(${CLAUDE_PLUGIN_ROOT}/scripts/bot-review-state.sh <number> \
+     | jq -r '.stale_approval_id')
 
    if [ -n "$STALE_APPROVAL_ID" ]; then
      # PUT, not POST — the dismiss endpoint requires it. Keep the message to what

--- a/plugins/tend-ci-runner/skills/weekly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/weekly/SKILL.md
@@ -26,7 +26,7 @@ If no dependency PRs are open, note "0 dependency PRs to process" and continue t
 2. If CI is passing, review the diff for breaking changes (major version bumps, API changes, deprecation warnings)
 3. If the update is safe (patch/minor with green CI), check whether the bot has already approved this commit before approving — a dependabot PR open across multiple weekly runs (or already approved by `tend-review` on creation) would otherwise accumulate redundant approvals on the same `commit_id`:
    ```bash
-   HEAD_SHA=$(gh pr view <number> --json commits --jq '.commits[-1].oid')
+   HEAD_SHA=$(gh pr view <number> --json headRefOid --jq '.headRefOid')
 
    # `fresh_approval_sha` counts only approvals the bot actually earned: a
    # force-push re-points an earlier approval's anchor at the NEW head, so a


### PR DESCRIPTION
Two rounds of cutting, both aimed at the same shape: logic that mattered enough to be right, living in prose that nothing checked.

## One resolver for "which review anchors this head"

A review's `.commit_id` can't be read on its own. Replying to a review thread makes GitHub wrap the reply in a synthetic zero-body review anchored at the then-current head, so the newest record routinely points at a commit nothing reviewed. And a force-push doesn't just move the head — it re-points earlier reviews' `.commit_id` at the new one, so a review of code that no longer exists reports the current head.

Every caller that reads an anchor has to discount both, and five did: three sites in `review` (step 1's anchor resolution, step 5's pre-post guard, step 6's orphan probe) and two in `weekly` (the redundant-approval guard and the stale-approval dismissal). All five were untested shell, each carrying its own paragraph of rationale — and they had already drifted, to the point that `weekly` documents its filter ordering as *deliberately* different from `review`'s.

`plugins/tend-ci-runner/scripts/bot-review-state.sh` answers the question once and emits it as JSON — the newest substantive review and whether a rewrite postdates it, whether anything genuinely anchors the current head, the orphan body a partially-failed review POST left behind, and the fresh and stale approvals. Each call site now reads one field.

The consequences of getting any of this wrong are outward, which is what earns the mechanism its place: a reply container counted as a review discards a real one after the work is done; a missing rewrite filter leaves a rebased PR carrying an approval it never earned, or makes the recovery `PUT` overwrite a published review with this run's findings.

## A head-resolution bug the extraction surfaced

Centralizing the anchor logic made a pre-existing bug visible, so it's fixed here too. `gh pr view --json commits` issues `commits(first: 100)` — unpaginated, oldest-first — so past 100 commits `.commits[-1]` is commit #100 rather than the head. Every head-keyed field then matches nothing and goes quiet rather than wrong-loud: the pre-post guard stops firing, so a fold-in re-run posts a second review on a commit it already reviewed; the 422 recovery finds no orphan and duplicates instead of editing it; `review`'s moved-head check inverts, so a push that *did* move the head reads as "HEAD hasn't moved" and the review posts against a stale commit; and `weekly`'s redundant-approval guard never matches, collecting an approval per weekly run on one commit.

Four sites now read `headRefOid`, which is the head by definition and can't truncate. The test fixture serves a deliberately wrong-last `commits` list alongside it, so reverting fails nine tests rather than passing on a short PR.

## Skill depth into `references/`

`running-in-ci` was 677 lines against the 500-line cap `authoring-skills` sets, and that skill's own remedy is splitting into `references/`, which costs nothing until read. Grounded-analysis depth, the other-repos rules, and the bar for proposing a skill PR move there; SKILL.md keeps each rule and a pointer. Every bundled skill is now under the cap.

| skill | before | after |
|---|---|---|
| `running-in-ci` | 677 | 462 |
| `review` | 533 | 474 |
| `weekly` | 98 | 78 |

## Testing

20 tests in `generator/tests/test_bot_review_state.py` run the script against a fake `gh`: reply containers vs. real reviews, rewrite timing on both sides of a review, fresh vs. stale approvals, a dismissed one that must not be re-dismissed, orphan bodies, and the repo being named on every call. Five mutations confirm they bite — counting reply containers as substantive, counting a DISMISSED review as an approval, dropping the rewrite filter from `at_head` or from `orphan_id`, and the ordering flip below each fail 1–2 tests.

The ordering subtlety is the one `weekly` had split two ways, and the single implementation settles it: take the newest approval, *then* test whether it predates the rewrite. Filtering first names a pre-rewrite approval that a later one already superseded — dismissing a review that no longer decides anything while the one that does stands untouched.

<details><summary>What this trades away</summary>

The brief was to accept modest reductions in feature precision. Only one materialized: "rewriting is authoring" is now a sentence inside `grounded-analysis.md` rather than a section with a worked example. Everything else here is behaviour-preserving — the duplication turned out to be a better trade than cutting precision.

Reading the anchor state is now up to three script calls in a review run rather than the same work inlined three times, each fetching one endpoint more than the site strictly needs. That's compute, not correctness, and the repo's own rule puts it a distant third.

</details>

> _This was written by Claude Code on behalf of max-sixty_


