### PR TITLE
docs(nightly): the 100-commit cap can't hide a human commit here

### DIFF
--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -107,7 +107,9 @@ Skip the rest of this step only when every query landed and nothing printed.
 For each conflicted PR by one of these bots, first confirm the branch has no human commits — both triggers force-push and would discard local edits. The check compares each commit's author login against the bot's commit-author login (`dependabot[bot]` or `renovate[bot]`); note that the PR's `.author.login` is the App slug (`app/dependabot`, `app/renovate`) and does **not** match — use the literal commit-author login below.
 
 ```bash
-# COMMIT_LOGIN is "dependabot[bot]" or "renovate[bot]" depending on the bot
+# COMMIT_LOGIN is "dependabot[bot]" or "renovate[bot]" depending on the bot.
+# `--json commits` caps at this PR's first 100 commits; a bump branch carries
+# one or two, so the cap can't hide a human commit here.
 gh pr view <number> --json commits \
   | jq --arg bot "$COMMIT_LOGIN" \
        '[.commits[].authors[].login] | unique | map(select(. != $bot))'


### PR DESCRIPTION
`gh pr view --json commits` is `commits(first: 100)` — unpaginated and oldest-first. That cap is a real hazard where a PR accumulates history, which is why `bot-review-state.sh` carries a comment about it and resolves the head via `headRefOid` instead. Nightly's human-commit guard reads the same field, so the cap looks like the same bug there.

It isn't. The guard runs only on `dependabot[bot]` / `renovate[bot]` PRs, and a bump branch carries one or two commits — the list can't truncate, so no human commit can hide past position 100 and get discarded by the force-push the guard gates. This says so in place, so the next reader doesn't re-flag it.

> _This was written by Claude Code on behalf of max-sixty_
