### PR TITLE
feat: 👀 marks a session in flight, and comes off when it ends

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ file](docs/tend.example.yaml) and a repo-local `/running-tend` skill.
 | **notifications** | Every 15 minutes           | Polls GitHub notifications, responds to unhandled mentions, marks handled threads as read.                                                                  |
 | **review-runs**   | Daily                      | Reviews recent CI runs for behavioral problems and proposes skill/config improvements.                                                                      |
 
-The bot reacts 👀 when a job picks an event up. An opened issue or PR keeps
-the reaction; on a comment that mentions the bot, it comes off when the
-session ends.
+The bot reacts 👀 while a session is working: on an issue or PR when it opens,
+on a comment that mentions the bot. The reaction comes off when the session
+ends.
 
 Scheduled workflows also support manual dispatch for testing. GitHub runs
 `schedule` triggers on a best-effort basis and drops ticks under load, so

--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ file](docs/tend.example.yaml) and a repo-local `/running-tend` skill.
 | **notifications** | Every 15 minutes           | Polls GitHub notifications, responds to unhandled mentions, marks handled threads as read.                                                                  |
 | **review-runs**   | Daily                      | Reviews recent CI runs for behavioral problems and proposes skill/config improvements.                                                                      |
 
-The bot reacts 👀 while a session is working: on an issue or PR when it opens,
-on a comment that mentions the bot. The reaction comes off when the session
-ends.
+The bot reacts 👀 while a session is working: on an issue when it opens, on a
+PR whenever a review starts, and on a comment that mentions the bot. The
+reaction comes off when the session ends.
 
 Scheduled workflows also support manual dispatch for testing. GitHub runs
 `schedule` triggers on a best-effort basis and drops ticks under load, so

--- a/generator/src/tend/templates/macros.yaml.j2
+++ b/generator/src/tend/templates/macros.yaml.j2
@@ -126,27 +126,61 @@
 {% if cfg.repo_owner %}github.repository_owner == '<<cfg.repo_owner|replace("'", "''")>>' && {% endif %}
 {%- endmacro %}
 
-{# Acknowledge an inbound issue or PR the moment the job starts: the agent
-   takes minutes to reach its first comment, and until then an opened issue
-   looks unattended. GitHub files PRs as issues for reactions, so one endpoint
-   covers both, and a repeat call returns the existing reaction rather than
-   erroring.
+{# A step's `if:`, as a block scalar where the expression spans lines. #}
+{% macro step_if(condition) %}
+{% if '\n' in condition %}
+        if: |
+<<condition|trim|indent(10, first=True)>>
+{%- else %}
+        if: <<condition>>
+{%- endif %}
+{%- endmacro %}
 
-   The reaction stays for the life of the issue, recording that the bot saw the
-   event; mention's eyes track a session in flight on one comment and come off
-   when it ends. A failure warns rather than failing the job — an
-   acknowledgment is not worth losing the run that does the work. #}
-{% macro react_eyes(number_expr, if_condition='') %}
-      - name: Acknowledge with an eyes reaction
+{# 👀 means one thing wherever the bot uses it: a session is working on this
+   right now. `react_eyes` goes on at the top of the job — the agent takes
+   minutes to reach its first comment, and until then an opened issue looks
+   unattended — and `unreact_eyes` takes it off at the end, under `always()`, so
+   a failed or cancelled run doesn't strand it.
+
+   `target` is an API path under `repos/<owner>/<repo>/`: `issues/<number>` for
+   an issue or PR (GitHub files PRs as issues for reactions), `issues/comments/`
+   or `pulls/comments/<id>` for a comment. A repeat react returns the existing
+   reaction rather than erroring, and the delete is filtered to the bot's own
+   reaction so a human's 👀 survives.
+
+   Either half failing warns rather than failing the job — an acknowledgment is
+   not worth losing the run that does the work, and the unreact half runs on
+   jobs that have already failed. #}
+{% macro react_eyes(target, if_condition='') %}
+      - name: React with eyes
 {% if if_condition %}
-        if: <<if_condition>>
+<<step_if(if_condition)>>
 {% endif %}
         run: |
-          gh api "repos/$REPO/issues/$NUMBER/reactions" -f content=eyes --silent \
+          gh api "repos/$REPO/$TARGET/reactions" -f content=eyes --silent \
             || echo "::warning::could not add the eyes reaction"
         env:
           REPO: ${{ github.repository }}
-          NUMBER: <<number_expr>>
+          TARGET: <<target>>
+          GITHUB_TOKEN: ${{ secrets.<<bot_token_secret>> }}
+{%- endmacro %}
+
+{% macro unreact_eyes(cfg, target, if_condition='') %}
+      - name: Remove the eyes reaction
+{% if if_condition %}
+<<step_if(if_condition)>>
+{% endif %}
+        run: |
+          REACTION_ID=$(gh api "repos/$REPO/$TARGET/reactions?content=eyes" \
+            --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" | head -n1)
+          if [ -n "$REACTION_ID" ]; then
+            gh api -X DELETE "repos/$REPO/$TARGET/reactions/$REACTION_ID" --silent \
+              || echo "::warning::could not remove the eyes reaction"
+          fi
+        env:
+          REPO: ${{ github.repository }}
+          TARGET: <<target>>
+          BOT_NAME: <<cfg.bot_name>>
           GITHUB_TOKEN: ${{ secrets.<<bot_token_secret>> }}
 {%- endmacro %}
 

--- a/generator/src/tend/templates/mention.yaml.j2
+++ b/generator/src/tend/templates/mention.yaml.j2
@@ -1,3 +1,19 @@
+{#- The comment the eyes go on. `issue_comment` fires for issues and PRs alike
+    and its ids are issue comments; the other two arms are inline review
+    comments, which live under `pulls`. #}
+{%- set reaction_target -%}
+${{ github.event_name == 'issue_comment'
+            && format('issues/comments/{0}', github.event.comment.id)
+            || format('pulls/comments/{0}', github.event.comment.id || github.event.client_payload.id) }}
+{%- endset -%}
+{#- True where a comment summoned the bot by name. The dispatch arm covers a
+    relayed inline comment, whose id the check step verified belongs to this
+    PR; `reason` is read from whichever job the condition renders in. #}
+{%- macro summoned(bot_name, reason_expr) -%}
+((github.event.comment && contains(github.event.comment.body, '@<<bot_name>>'))
+    || (github.event.client_payload.kind == 'pull_request_review_comment'
+        && <<reason_expr>> == 'mention'))
+{%- endmacro -%}
 {%- set prompt_body %}prompt: >-
             ${{ steps.delay.outputs.seconds
             && format('This job started {0}s after the triggering event (over ~40s means it was queued). ',
@@ -149,19 +165,7 @@ jobs:
       # step verified belongs to this PR; a review *submission* has no single
       # comment to react to, so it gets no eyes — same as when the events
       # arrived directly.
-      - name: React to mention
-        if: |
-          steps.check.outputs.should_run == 'true'
-          && ((github.event.comment && contains(github.event.comment.body, '@<<cfg.bot_name>>'))
-              || (github.event.client_payload.kind == 'pull_request_review_comment'
-                  && steps.check.outputs.reason == 'mention'))
-        run: |
-          gh api "repos/$REPO/issues/comments/$COMMENT_ID/reactions" -f content=eyes 2>/dev/null || \
-          gh api "repos/$REPO/pulls/comments/$COMMENT_ID/reactions" -f content=eyes 2>/dev/null || true
-        env:
-          REPO: ${{ github.repository }}
-          COMMENT_ID: ${{ github.event.comment.id || github.event.client_payload.id }}
-          GITHUB_TOKEN: ${{ secrets.<<bot_token_secret>> }}
+<<react_eyes(reaction_target, if_condition="steps.check.outputs.should_run == 'true'\n&& " ~ summoned(cfg.bot_name, 'steps.check.outputs.reason'))>>
 
   handle:
     needs: verify
@@ -207,22 +211,4 @@ jobs:
 
 <<agent_step(cfg, prompt_body)>><<restore_local_actions(local_actions)>>
 
-      - name: Remove eyes reaction
-        if: |
-          always()
-          && ((github.event.comment && contains(github.event.comment.body, '@<<cfg.bot_name>>'))
-              || (github.event.client_payload.kind == 'pull_request_review_comment'
-                  && needs.verify.outputs.reason == 'mention'))
-        run: |
-          for KIND in issues pulls; do
-            REACTION_ID=$(gh api "repos/$REPO/$KIND/comments/$COMMENT_ID/reactions?content=eyes" \
-              --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" 2>/dev/null | head -n1)
-            if [ -n "$REACTION_ID" ]; then
-              gh api -X DELETE "repos/$REPO/$KIND/comments/$COMMENT_ID/reactions/$REACTION_ID" 2>/dev/null && break
-            fi
-          done
-        env:
-          REPO: ${{ github.repository }}
-          COMMENT_ID: ${{ github.event.comment.id || github.event.client_payload.id }}
-          BOT_NAME: <<cfg.bot_name>>
-          GITHUB_TOKEN: ${{ secrets.<<bot_token_secret>> }}
+<<unreact_eyes(cfg, reaction_target, if_condition="always()\n&& " ~ summoned(cfg.bot_name, 'needs.verify.outputs.reason'))>>

--- a/generator/src/tend/templates/review.yaml.j2
+++ b/generator/src/tend/templates/review.yaml.j2
@@ -34,9 +34,7 @@ jobs:
         run: |
 <<gate_script|indent(10, first=True)>>
 
-{# Arrival only: the other trigger types are pushes and state changes on a PR
-   the reaction is already on. #}
-<<react_eyes('${{ github.event.pull_request.number }}', if_condition=skip_condition ~ " && github.event.action == 'opened'")>>
+<<react_eyes('issues/${{ github.event.pull_request.number }}', if_condition=skip_condition)>>
 
 {% if has_setup %}
       # Two checkouts: `setup:` runs against the base tree, and the PR's own
@@ -66,3 +64,5 @@ jobs:
 <<checkout(cfg, ref='${{ steps.pr_ref.outputs.ref }}', if_condition=skip_condition, allow_unsafe_pr_checkout=True, clean=not has_setup)>>
 
 <<agent_step(cfg, prompt_body, if_condition=skip_condition)>><<restore_local_actions(local_actions, if_condition=skip_condition)>>
+
+<<unreact_eyes(cfg, 'issues/${{ github.event.pull_request.number }}', if_condition='always() && (' ~ skip_condition ~ ')')>>

--- a/generator/src/tend/templates/triage.yaml.j2
+++ b/generator/src/tend/templates/triage.yaml.j2
@@ -16,8 +16,10 @@ jobs:
     permissions:
 <<permissions()>>
     steps:
-<<react_eyes('${{ github.event.issue.number }}')>>
+<<react_eyes('issues/${{ github.event.issue.number }}')>>
 
 <<checkout(cfg, ref=cfg.default_branch)>>
 <<setup>>
 <<agent_step(cfg, block_prompt(prompt))>>
+
+<<unreact_eyes(cfg, 'issues/${{ github.event.issue.number }}', if_condition='always()')>>

--- a/generator/tests/_regtest_outputs/test_generate.test_extras_apply_path_regtest.out
+++ b/generator/tests/_regtest_outputs/test_generate.test_extras_apply_path_regtest.out
@@ -98,14 +98,14 @@ jobs:
 
           echo "should_run=true" >> "$GITHUB_OUTPUT"
 
-      - name: Acknowledge with an eyes reaction
-        if: steps.gate.outputs.should_run == 'true' && github.event.action == 'opened'
+      - name: React with eyes
+        if: steps.gate.outputs.should_run == 'true'
         run: |
-          gh api "repos/$REPO/issues/$NUMBER/reactions" -f content=eyes --silent \
+          gh api "repos/$REPO/$TARGET/reactions" -f content=eyes --silent \
             || echo "::warning::could not add the eyes reaction"
         env:
           REPO: ${{ github.repository }}
-          NUMBER: ${{ github.event.pull_request.number }}
+          TARGET: issues/${{ github.event.pull_request.number }}
           GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
 
       # GitHub only materializes refs/pull/N/merge for mergeable PRs ? on
@@ -145,6 +145,21 @@ jobs:
           model: opus
           prompt: >-
             ${{ format('/tend-ci-runner:review {0}', github.event.pull_request.number) }}
+
+      - name: Remove the eyes reaction
+        if: always() && (steps.gate.outputs.should_run == 'true')
+        run: |
+          REACTION_ID=$(gh api "repos/$REPO/$TARGET/reactions?content=eyes" \
+            --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" | head -n1)
+          if [ -n "$REACTION_ID" ]; then
+            gh api -X DELETE "repos/$REPO/$TARGET/reactions/$REACTION_ID" --silent \
+              || echo "::warning::could not remove the eyes reaction"
+          fi
+        env:
+          REPO: ${{ github.repository }}
+          TARGET: issues/${{ github.event.pull_request.number }}
+          BOT_NAME: test-bot
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
     timeout-minutes: 240
 env:
   FOO: bar

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-triage.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-triage.yaml].out
@@ -28,13 +28,13 @@ jobs:
       actions: read
       issues: write
     steps:
-      - name: Acknowledge with an eyes reaction
+      - name: React with eyes
         run: |
-          gh api "repos/$REPO/issues/$NUMBER/reactions" -f content=eyes --silent \
+          gh api "repos/$REPO/$TARGET/reactions" -f content=eyes --silent \
             || echo "::warning::could not add the eyes reaction"
         env:
           REPO: ${{ github.repository }}
-          NUMBER: ${{ github.event.issue.number }}
+          TARGET: issues/${{ github.event.issue.number }}
           GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: actions/checkout@v7
@@ -53,3 +53,18 @@ jobs:
           model: opus
           prompt: |
             /tend-ci-runner:triage ${{ github.event.issue.number }}
+
+      - name: Remove the eyes reaction
+        if: always()
+        run: |
+          REACTION_ID=$(gh api "repos/$REPO/$TARGET/reactions?content=eyes" \
+            --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" | head -n1)
+          if [ -n "$REACTION_ID" ]; then
+            gh api -X DELETE "repos/$REPO/$TARGET/reactions/$REACTION_ID" --silent \
+              || echo "::warning::could not remove the eyes reaction"
+          fi
+        env:
+          REPO: ${{ github.repository }}
+          TARGET: issues/${{ github.event.issue.number }}
+          BOT_NAME: test-bot
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}

--- a/generator/tests/_regtest_outputs/test_generate.test_sandbox_levers_regtest.out
+++ b/generator/tests/_regtest_outputs/test_generate.test_sandbox_levers_regtest.out
@@ -345,18 +345,20 @@ jobs:
       # step verified belongs to this PR; a review *submission* has no single
       # comment to react to, so it gets no eyes ? same as when the events
       # arrived directly.
-      - name: React to mention
+      - name: React with eyes
         if: |
           steps.check.outputs.should_run == 'true'
           && ((github.event.comment && contains(github.event.comment.body, '@test-bot'))
               || (github.event.client_payload.kind == 'pull_request_review_comment'
                   && steps.check.outputs.reason == 'mention'))
         run: |
-          gh api "repos/$REPO/issues/comments/$COMMENT_ID/reactions" -f content=eyes 2>/dev/null || \
-          gh api "repos/$REPO/pulls/comments/$COMMENT_ID/reactions" -f content=eyes 2>/dev/null || true
+          gh api "repos/$REPO/$TARGET/reactions" -f content=eyes --silent \
+            || echo "::warning::could not add the eyes reaction"
         env:
           REPO: ${{ github.repository }}
-          COMMENT_ID: ${{ github.event.comment.id || github.event.client_payload.id }}
+          TARGET: ${{ github.event_name == 'issue_comment'
+            && format('issues/comments/{0}', github.event.comment.id)
+            || format('pulls/comments/{0}', github.event.comment.id || github.event.client_payload.id) }}
           GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
 
   handle:
@@ -448,22 +450,23 @@ jobs:
               || format('A user commented on an issue/PR where you previously participated ({0}). Read the full context. Only respond if the comment is directed at you, asks a question you can help with, or requests changes you can make. If the conversation is between other participants, exit silently.', github.event.comment.html_url)
             }}
 
-      - name: Remove eyes reaction
+      - name: Remove the eyes reaction
         if: |
           always()
           && ((github.event.comment && contains(github.event.comment.body, '@test-bot'))
               || (github.event.client_payload.kind == 'pull_request_review_comment'
                   && needs.verify.outputs.reason == 'mention'))
         run: |
-          for KIND in issues pulls; do
-            REACTION_ID=$(gh api "repos/$REPO/$KIND/comments/$COMMENT_ID/reactions?content=eyes" \
-              --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" 2>/dev/null | head -n1)
-            if [ -n "$REACTION_ID" ]; then
-              gh api -X DELETE "repos/$REPO/$KIND/comments/$COMMENT_ID/reactions/$REACTION_ID" 2>/dev/null && break
-            fi
-          done
+          REACTION_ID=$(gh api "repos/$REPO/$TARGET/reactions?content=eyes" \
+            --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" | head -n1)
+          if [ -n "$REACTION_ID" ]; then
+            gh api -X DELETE "repos/$REPO/$TARGET/reactions/$REACTION_ID" --silent \
+              || echo "::warning::could not remove the eyes reaction"
+          fi
         env:
           REPO: ${{ github.repository }}
-          COMMENT_ID: ${{ github.event.comment.id || github.event.client_payload.id }}
+          TARGET: ${{ github.event_name == 'issue_comment'
+            && format('issues/comments/{0}', github.event.comment.id)
+            || format('pulls/comments/{0}', github.event.comment.id || github.event.client_payload.id) }}
           BOT_NAME: test-bot
           GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
@@ -345,18 +345,20 @@ jobs:
       # step verified belongs to this PR; a review *submission* has no single
       # comment to react to, so it gets no eyes ? same as when the events
       # arrived directly.
-      - name: React to mention
+      - name: React with eyes
         if: |
           steps.check.outputs.should_run == 'true'
           && ((github.event.comment && contains(github.event.comment.body, '@test-bot'))
               || (github.event.client_payload.kind == 'pull_request_review_comment'
                   && steps.check.outputs.reason == 'mention'))
         run: |
-          gh api "repos/$REPO/issues/comments/$COMMENT_ID/reactions" -f content=eyes 2>/dev/null || \
-          gh api "repos/$REPO/pulls/comments/$COMMENT_ID/reactions" -f content=eyes 2>/dev/null || true
+          gh api "repos/$REPO/$TARGET/reactions" -f content=eyes --silent \
+            || echo "::warning::could not add the eyes reaction"
         env:
           REPO: ${{ github.repository }}
-          COMMENT_ID: ${{ github.event.comment.id || github.event.client_payload.id }}
+          TARGET: ${{ github.event_name == 'issue_comment'
+            && format('issues/comments/{0}', github.event.comment.id)
+            || format('pulls/comments/{0}', github.event.comment.id || github.event.client_payload.id) }}
           GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
 
   handle:
@@ -438,22 +440,23 @@ jobs:
               || format('A user commented on an issue/PR where you previously participated ({0}). Read the full context. Only respond if the comment is directed at you, asks a question you can help with, or requests changes you can make. If the conversation is between other participants, exit silently.', github.event.comment.html_url)
             }}
 
-      - name: Remove eyes reaction
+      - name: Remove the eyes reaction
         if: |
           always()
           && ((github.event.comment && contains(github.event.comment.body, '@test-bot'))
               || (github.event.client_payload.kind == 'pull_request_review_comment'
                   && needs.verify.outputs.reason == 'mention'))
         run: |
-          for KIND in issues pulls; do
-            REACTION_ID=$(gh api "repos/$REPO/$KIND/comments/$COMMENT_ID/reactions?content=eyes" \
-              --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" 2>/dev/null | head -n1)
-            if [ -n "$REACTION_ID" ]; then
-              gh api -X DELETE "repos/$REPO/$KIND/comments/$COMMENT_ID/reactions/$REACTION_ID" 2>/dev/null && break
-            fi
-          done
+          REACTION_ID=$(gh api "repos/$REPO/$TARGET/reactions?content=eyes" \
+            --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" | head -n1)
+          if [ -n "$REACTION_ID" ]; then
+            gh api -X DELETE "repos/$REPO/$TARGET/reactions/$REACTION_ID" --silent \
+              || echo "::warning::could not remove the eyes reaction"
+          fi
         env:
           REPO: ${{ github.repository }}
-          COMMENT_ID: ${{ github.event.comment.id || github.event.client_payload.id }}
+          TARGET: ${{ github.event_name == 'issue_comment'
+            && format('issues/comments/{0}', github.event.comment.id)
+            || format('pulls/comments/{0}', github.event.comment.id || github.event.client_payload.id) }}
           BOT_NAME: test-bot
           GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[review].out
@@ -97,14 +97,14 @@ jobs:
 
           echo "should_run=true" >> "$GITHUB_OUTPUT"
 
-      - name: Acknowledge with an eyes reaction
-        if: steps.gate.outputs.should_run == 'true' && github.event.action == 'opened'
+      - name: React with eyes
+        if: steps.gate.outputs.should_run == 'true'
         run: |
-          gh api "repos/$REPO/issues/$NUMBER/reactions" -f content=eyes --silent \
+          gh api "repos/$REPO/$TARGET/reactions" -f content=eyes --silent \
             || echo "::warning::could not add the eyes reaction"
         env:
           REPO: ${{ github.repository }}
-          NUMBER: ${{ github.event.pull_request.number }}
+          TARGET: issues/${{ github.event.pull_request.number }}
           GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
 
       # GitHub only materializes refs/pull/N/merge for mergeable PRs ? on
@@ -143,3 +143,18 @@ jobs:
           model: gpt-5.5
           prompt: >-
             ${{ format('$review {0}', github.event.pull_request.number) }}
+
+      - name: Remove the eyes reaction
+        if: always() && (steps.gate.outputs.should_run == 'true')
+        run: |
+          REACTION_ID=$(gh api "repos/$REPO/$TARGET/reactions?content=eyes" \
+            --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" | head -n1)
+          if [ -n "$REACTION_ID" ]; then
+            gh api -X DELETE "repos/$REPO/$TARGET/reactions/$REACTION_ID" --silent \
+              || echo "::warning::could not remove the eyes reaction"
+          fi
+        env:
+          REPO: ${{ github.repository }}
+          TARGET: issues/${{ github.event.pull_request.number }}
+          BOT_NAME: test-bot
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[triage].out
@@ -28,13 +28,13 @@ jobs:
       actions: read
       issues: write
     steps:
-      - name: Acknowledge with an eyes reaction
+      - name: React with eyes
         run: |
-          gh api "repos/$REPO/issues/$NUMBER/reactions" -f content=eyes --silent \
+          gh api "repos/$REPO/$TARGET/reactions" -f content=eyes --silent \
             || echo "::warning::could not add the eyes reaction"
         env:
           REPO: ${{ github.repository }}
-          NUMBER: ${{ github.event.issue.number }}
+          TARGET: issues/${{ github.event.issue.number }}
           GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: actions/checkout@v7
@@ -52,3 +52,18 @@ jobs:
           model: gpt-5.5
           prompt: |
             $triage ${{ github.event.issue.number }}
+
+      - name: Remove the eyes reaction
+        if: always()
+        run: |
+          REACTION_ID=$(gh api "repos/$REPO/$TARGET/reactions?content=eyes" \
+            --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" | head -n1)
+          if [ -n "$REACTION_ID" ]; then
+            gh api -X DELETE "repos/$REPO/$TARGET/reactions/$REACTION_ID" --silent \
+              || echo "::warning::could not remove the eyes reaction"
+          fi
+        env:
+          REPO: ${{ github.repository }}
+          TARGET: issues/${{ github.event.issue.number }}
+          BOT_NAME: test-bot
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
@@ -345,18 +345,20 @@ jobs:
       # step verified belongs to this PR; a review *submission* has no single
       # comment to react to, so it gets no eyes ? same as when the events
       # arrived directly.
-      - name: React to mention
+      - name: React with eyes
         if: |
           steps.check.outputs.should_run == 'true'
           && ((github.event.comment && contains(github.event.comment.body, '@test-bot'))
               || (github.event.client_payload.kind == 'pull_request_review_comment'
                   && steps.check.outputs.reason == 'mention'))
         run: |
-          gh api "repos/$REPO/issues/comments/$COMMENT_ID/reactions" -f content=eyes 2>/dev/null || \
-          gh api "repos/$REPO/pulls/comments/$COMMENT_ID/reactions" -f content=eyes 2>/dev/null || true
+          gh api "repos/$REPO/$TARGET/reactions" -f content=eyes --silent \
+            || echo "::warning::could not add the eyes reaction"
         env:
           REPO: ${{ github.repository }}
-          COMMENT_ID: ${{ github.event.comment.id || github.event.client_payload.id }}
+          TARGET: ${{ github.event_name == 'issue_comment'
+            && format('issues/comments/{0}', github.event.comment.id)
+            || format('pulls/comments/{0}', github.event.comment.id || github.event.client_payload.id) }}
           GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
 
   handle:
@@ -439,22 +441,23 @@ jobs:
               || format('A user commented on an issue/PR where you previously participated ({0}). Read the full context. Only respond if the comment is directed at you, asks a question you can help with, or requests changes you can make. If the conversation is between other participants, exit silently.', github.event.comment.html_url)
             }}
 
-      - name: Remove eyes reaction
+      - name: Remove the eyes reaction
         if: |
           always()
           && ((github.event.comment && contains(github.event.comment.body, '@test-bot'))
               || (github.event.client_payload.kind == 'pull_request_review_comment'
                   && needs.verify.outputs.reason == 'mention'))
         run: |
-          for KIND in issues pulls; do
-            REACTION_ID=$(gh api "repos/$REPO/$KIND/comments/$COMMENT_ID/reactions?content=eyes" \
-              --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" 2>/dev/null | head -n1)
-            if [ -n "$REACTION_ID" ]; then
-              gh api -X DELETE "repos/$REPO/$KIND/comments/$COMMENT_ID/reactions/$REACTION_ID" 2>/dev/null && break
-            fi
-          done
+          REACTION_ID=$(gh api "repos/$REPO/$TARGET/reactions?content=eyes" \
+            --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" | head -n1)
+          if [ -n "$REACTION_ID" ]; then
+            gh api -X DELETE "repos/$REPO/$TARGET/reactions/$REACTION_ID" --silent \
+              || echo "::warning::could not remove the eyes reaction"
+          fi
         env:
           REPO: ${{ github.repository }}
-          COMMENT_ID: ${{ github.event.comment.id || github.event.client_payload.id }}
+          TARGET: ${{ github.event_name == 'issue_comment'
+            && format('issues/comments/{0}', github.event.comment.id)
+            || format('pulls/comments/{0}', github.event.comment.id || github.event.client_payload.id) }}
           BOT_NAME: test-bot
           GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review].out
@@ -97,14 +97,14 @@ jobs:
 
           echo "should_run=true" >> "$GITHUB_OUTPUT"
 
-      - name: Acknowledge with an eyes reaction
-        if: steps.gate.outputs.should_run == 'true' && github.event.action == 'opened'
+      - name: React with eyes
+        if: steps.gate.outputs.should_run == 'true'
         run: |
-          gh api "repos/$REPO/issues/$NUMBER/reactions" -f content=eyes --silent \
+          gh api "repos/$REPO/$TARGET/reactions" -f content=eyes --silent \
             || echo "::warning::could not add the eyes reaction"
         env:
           REPO: ${{ github.repository }}
-          NUMBER: ${{ github.event.pull_request.number }}
+          TARGET: issues/${{ github.event.pull_request.number }}
           GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
 
       # GitHub only materializes refs/pull/N/merge for mergeable PRs ? on
@@ -144,3 +144,18 @@ jobs:
           model: opus
           prompt: >-
             ${{ format('/tend-ci-runner:review {0}', github.event.pull_request.number) }}
+
+      - name: Remove the eyes reaction
+        if: always() && (steps.gate.outputs.should_run == 'true')
+        run: |
+          REACTION_ID=$(gh api "repos/$REPO/$TARGET/reactions?content=eyes" \
+            --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" | head -n1)
+          if [ -n "$REACTION_ID" ]; then
+            gh api -X DELETE "repos/$REPO/$TARGET/reactions/$REACTION_ID" --silent \
+              || echo "::warning::could not remove the eyes reaction"
+          fi
+        env:
+          REPO: ${{ github.repository }}
+          TARGET: issues/${{ github.event.pull_request.number }}
+          BOT_NAME: test-bot
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[triage].out
@@ -28,13 +28,13 @@ jobs:
       actions: read
       issues: write
     steps:
-      - name: Acknowledge with an eyes reaction
+      - name: React with eyes
         run: |
-          gh api "repos/$REPO/issues/$NUMBER/reactions" -f content=eyes --silent \
+          gh api "repos/$REPO/$TARGET/reactions" -f content=eyes --silent \
             || echo "::warning::could not add the eyes reaction"
         env:
           REPO: ${{ github.repository }}
-          NUMBER: ${{ github.event.issue.number }}
+          TARGET: issues/${{ github.event.issue.number }}
           GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: actions/checkout@v7
@@ -53,3 +53,18 @@ jobs:
           model: opus
           prompt: |
             /tend-ci-runner:triage ${{ github.event.issue.number }}
+
+      - name: Remove the eyes reaction
+        if: always()
+        run: |
+          REACTION_ID=$(gh api "repos/$REPO/$TARGET/reactions?content=eyes" \
+            --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" | head -n1)
+          if [ -n "$REACTION_ID" ]; then
+            gh api -X DELETE "repos/$REPO/$TARGET/reactions/$REACTION_ID" --silent \
+              || echo "::warning::could not remove the eyes reaction"
+          fi
+        env:
+          REPO: ${{ github.repository }}
+          TARGET: issues/${{ github.event.issue.number }}
+          BOT_NAME: test-bot
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_local_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_local_setup_regtest[mention].out
@@ -345,18 +345,20 @@ jobs:
       # step verified belongs to this PR; a review *submission* has no single
       # comment to react to, so it gets no eyes ? same as when the events
       # arrived directly.
-      - name: React to mention
+      - name: React with eyes
         if: |
           steps.check.outputs.should_run == 'true'
           && ((github.event.comment && contains(github.event.comment.body, '@test-bot'))
               || (github.event.client_payload.kind == 'pull_request_review_comment'
                   && steps.check.outputs.reason == 'mention'))
         run: |
-          gh api "repos/$REPO/issues/comments/$COMMENT_ID/reactions" -f content=eyes 2>/dev/null || \
-          gh api "repos/$REPO/pulls/comments/$COMMENT_ID/reactions" -f content=eyes 2>/dev/null || true
+          gh api "repos/$REPO/$TARGET/reactions" -f content=eyes --silent \
+            || echo "::warning::could not add the eyes reaction"
         env:
           REPO: ${{ github.repository }}
-          COMMENT_ID: ${{ github.event.comment.id || github.event.client_payload.id }}
+          TARGET: ${{ github.event_name == 'issue_comment'
+            && format('issues/comments/{0}', github.event.comment.id)
+            || format('pulls/comments/{0}', github.event.comment.id || github.event.client_payload.id) }}
           GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
 
   handle:
@@ -448,22 +450,23 @@ jobs:
           git checkout "$GITHUB_SHA" -- "$dir" ||
             echo "::warning::could not restore $dir from $GITHUB_SHA; POST cleanup of the local action may fail"
 
-      - name: Remove eyes reaction
+      - name: Remove the eyes reaction
         if: |
           always()
           && ((github.event.comment && contains(github.event.comment.body, '@test-bot'))
               || (github.event.client_payload.kind == 'pull_request_review_comment'
                   && needs.verify.outputs.reason == 'mention'))
         run: |
-          for KIND in issues pulls; do
-            REACTION_ID=$(gh api "repos/$REPO/$KIND/comments/$COMMENT_ID/reactions?content=eyes" \
-              --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" 2>/dev/null | head -n1)
-            if [ -n "$REACTION_ID" ]; then
-              gh api -X DELETE "repos/$REPO/$KIND/comments/$COMMENT_ID/reactions/$REACTION_ID" 2>/dev/null && break
-            fi
-          done
+          REACTION_ID=$(gh api "repos/$REPO/$TARGET/reactions?content=eyes" \
+            --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" | head -n1)
+          if [ -n "$REACTION_ID" ]; then
+            gh api -X DELETE "repos/$REPO/$TARGET/reactions/$REACTION_ID" --silent \
+              || echo "::warning::could not remove the eyes reaction"
+          fi
         env:
           REPO: ${{ github.repository }}
-          COMMENT_ID: ${{ github.event.comment.id || github.event.client_payload.id }}
+          TARGET: ${{ github.event_name == 'issue_comment'
+            && format('issues/comments/{0}', github.event.comment.id)
+            || format('pulls/comments/{0}', github.event.comment.id || github.event.client_payload.id) }}
           BOT_NAME: test-bot
           GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_local_setup_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_local_setup_regtest[review].out
@@ -97,14 +97,14 @@ jobs:
 
           echo "should_run=true" >> "$GITHUB_OUTPUT"
 
-      - name: Acknowledge with an eyes reaction
-        if: steps.gate.outputs.should_run == 'true' && github.event.action == 'opened'
+      - name: React with eyes
+        if: steps.gate.outputs.should_run == 'true'
         run: |
-          gh api "repos/$REPO/issues/$NUMBER/reactions" -f content=eyes --silent \
+          gh api "repos/$REPO/$TARGET/reactions" -f content=eyes --silent \
             || echo "::warning::could not add the eyes reaction"
         env:
           REPO: ${{ github.repository }}
-          NUMBER: ${{ github.event.pull_request.number }}
+          TARGET: issues/${{ github.event.pull_request.number }}
           GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
 
       # Two checkouts: `setup:` runs against the base tree, and the PR's own
@@ -165,3 +165,18 @@ jobs:
           dir=.github/actions/tend-setup
           git checkout "$GITHUB_SHA" -- "$dir" ||
             echo "::warning::could not restore $dir from $GITHUB_SHA; POST cleanup of the local action may fail"
+
+      - name: Remove the eyes reaction
+        if: always() && (steps.gate.outputs.should_run == 'true')
+        run: |
+          REACTION_ID=$(gh api "repos/$REPO/$TARGET/reactions?content=eyes" \
+            --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" | head -n1)
+          if [ -n "$REACTION_ID" ]; then
+            gh api -X DELETE "repos/$REPO/$TARGET/reactions/$REACTION_ID" --silent \
+              || echo "::warning::could not remove the eyes reaction"
+          fi
+        env:
+          REPO: ${{ github.repository }}
+          TARGET: issues/${{ github.event.pull_request.number }}
+          BOT_NAME: test-bot
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
@@ -345,18 +345,20 @@ jobs:
       # step verified belongs to this PR; a review *submission* has no single
       # comment to react to, so it gets no eyes ? same as when the events
       # arrived directly.
-      - name: React to mention
+      - name: React with eyes
         if: |
           steps.check.outputs.should_run == 'true'
           && ((github.event.comment && contains(github.event.comment.body, '@test-bot'))
               || (github.event.client_payload.kind == 'pull_request_review_comment'
                   && steps.check.outputs.reason == 'mention'))
         run: |
-          gh api "repos/$REPO/issues/comments/$COMMENT_ID/reactions" -f content=eyes 2>/dev/null || \
-          gh api "repos/$REPO/pulls/comments/$COMMENT_ID/reactions" -f content=eyes 2>/dev/null || true
+          gh api "repos/$REPO/$TARGET/reactions" -f content=eyes --silent \
+            || echo "::warning::could not add the eyes reaction"
         env:
           REPO: ${{ github.repository }}
-          COMMENT_ID: ${{ github.event.comment.id || github.event.client_payload.id }}
+          TARGET: ${{ github.event_name == 'issue_comment'
+            && format('issues/comments/{0}', github.event.comment.id)
+            || format('pulls/comments/{0}', github.event.comment.id || github.event.client_payload.id) }}
           GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
 
   handle:
@@ -441,22 +443,23 @@ jobs:
               || format('A user commented on an issue/PR where you previously participated ({0}). Read the full context. Only respond if the comment is directed at you, asks a question you can help with, or requests changes you can make. If the conversation is between other participants, exit silently.', github.event.comment.html_url)
             }}
 
-      - name: Remove eyes reaction
+      - name: Remove the eyes reaction
         if: |
           always()
           && ((github.event.comment && contains(github.event.comment.body, '@test-bot'))
               || (github.event.client_payload.kind == 'pull_request_review_comment'
                   && needs.verify.outputs.reason == 'mention'))
         run: |
-          for KIND in issues pulls; do
-            REACTION_ID=$(gh api "repos/$REPO/$KIND/comments/$COMMENT_ID/reactions?content=eyes" \
-              --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" 2>/dev/null | head -n1)
-            if [ -n "$REACTION_ID" ]; then
-              gh api -X DELETE "repos/$REPO/$KIND/comments/$COMMENT_ID/reactions/$REACTION_ID" 2>/dev/null && break
-            fi
-          done
+          REACTION_ID=$(gh api "repos/$REPO/$TARGET/reactions?content=eyes" \
+            --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" | head -n1)
+          if [ -n "$REACTION_ID" ]; then
+            gh api -X DELETE "repos/$REPO/$TARGET/reactions/$REACTION_ID" --silent \
+              || echo "::warning::could not remove the eyes reaction"
+          fi
         env:
           REPO: ${{ github.repository }}
-          COMMENT_ID: ${{ github.event.comment.id || github.event.client_payload.id }}
+          TARGET: ${{ github.event_name == 'issue_comment'
+            && format('issues/comments/{0}', github.event.comment.id)
+            || format('pulls/comments/{0}', github.event.comment.id || github.event.client_payload.id) }}
           BOT_NAME: test-bot
           GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review].out
@@ -97,14 +97,14 @@ jobs:
 
           echo "should_run=true" >> "$GITHUB_OUTPUT"
 
-      - name: Acknowledge with an eyes reaction
-        if: steps.gate.outputs.should_run == 'true' && github.event.action == 'opened'
+      - name: React with eyes
+        if: steps.gate.outputs.should_run == 'true'
         run: |
-          gh api "repos/$REPO/issues/$NUMBER/reactions" -f content=eyes --silent \
+          gh api "repos/$REPO/$TARGET/reactions" -f content=eyes --silent \
             || echo "::warning::could not add the eyes reaction"
         env:
           REPO: ${{ github.repository }}
-          NUMBER: ${{ github.event.pull_request.number }}
+          TARGET: issues/${{ github.event.pull_request.number }}
           GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
 
       # Two checkouts: `setup:` runs against the base tree, and the PR's own
@@ -158,3 +158,18 @@ jobs:
           model: opus
           prompt: >-
             ${{ format('/tend-ci-runner:review {0}', github.event.pull_request.number) }}
+
+      - name: Remove the eyes reaction
+        if: always() && (steps.gate.outputs.should_run == 'true')
+        run: |
+          REACTION_ID=$(gh api "repos/$REPO/$TARGET/reactions?content=eyes" \
+            --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" | head -n1)
+          if [ -n "$REACTION_ID" ]; then
+            gh api -X DELETE "repos/$REPO/$TARGET/reactions/$REACTION_ID" --silent \
+              || echo "::warning::could not remove the eyes reaction"
+          fi
+        env:
+          REPO: ${{ github.repository }}
+          TARGET: issues/${{ github.event.pull_request.number }}
+          BOT_NAME: test-bot
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[triage].out
@@ -28,13 +28,13 @@ jobs:
       actions: read
       issues: write
     steps:
-      - name: Acknowledge with an eyes reaction
+      - name: React with eyes
         run: |
-          gh api "repos/$REPO/issues/$NUMBER/reactions" -f content=eyes --silent \
+          gh api "repos/$REPO/$TARGET/reactions" -f content=eyes --silent \
             || echo "::warning::could not add the eyes reaction"
         env:
           REPO: ${{ github.repository }}
-          NUMBER: ${{ github.event.issue.number }}
+          TARGET: issues/${{ github.event.issue.number }}
           GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
 
       - uses: actions/checkout@v7
@@ -55,3 +55,18 @@ jobs:
           model: opus
           prompt: |
             /tend-ci-runner:triage ${{ github.event.issue.number }}
+
+      - name: Remove the eyes reaction
+        if: always()
+        run: |
+          REACTION_ID=$(gh api "repos/$REPO/$TARGET/reactions?content=eyes" \
+            --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" | head -n1)
+          if [ -n "$REACTION_ID" ]; then
+            gh api -X DELETE "repos/$REPO/$TARGET/reactions/$REACTION_ID" --silent \
+              || echo "::warning::could not remove the eyes reaction"
+          fi
+        env:
+          REPO: ${{ github.repository }}
+          TARGET: issues/${{ github.event.issue.number }}
+          BOT_NAME: test-bot
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -90,6 +90,11 @@ def test_setup_steps_rendered(tmp_path: Path) -> None:
         )
 
 
+def _eyes_steps(steps: list[dict[str, object]]) -> list[dict[str, object]]:
+    """The steps that put the eyes reaction on and take it off, in order."""
+    return [s for s in steps if "content=eyes" in str(s.get("run", ""))]
+
+
 def _restore_step_index(steps: list[dict[str, object]]) -> int | None:
     """Index of the step that puts the loaded tree's local setup actions back."""
     for i, step in enumerate(steps):
@@ -703,21 +708,20 @@ def test_review_queues_pushes_behind_a_gate(tmp_path: Path) -> None:
     assert "tend-review/$PR" in steps[0]["run"]
     gate = "steps.gate.outputs.should_run == 'true'"
     for step in steps[1:]:
-        # A step may narrow further (the eyes reaction fires only on `opened`),
-        # but the gate's verdict stays a required conjunct.
+        # A step may narrow further (the eyes reaction fires only on `opened`)
+        # or widen to `always()` (the reaction comes off a failed run too), but
+        # the gate's verdict stays a conjunct of whatever it builds.
         condition = step.get("if", "")
-        assert condition == gate or condition.startswith(f"{gate} && "), (
-            f"ungated step after the gate: {step}"
-        )
+        assert gate in condition, f"ungated step after the gate: {step}"
 
 
-def test_opened_issue_and_pr_acknowledged_with_eyes(tmp_path: Path) -> None:
-    """A newly opened issue or PR carries an eyes reaction before the agent
+def test_issue_and_pr_acknowledged_with_eyes(tmp_path: Path) -> None:
+    """An issue or PR the bot takes up carries an eyes reaction before the agent
     boots: the session takes minutes to reach its first comment, and until then
     the author has nothing telling them the bot picked the event up.
 
-    Review narrows to `opened` — a synchronize or reopen lands on a PR already
-    carrying the reaction.
+    So the reaction goes on wherever a session starts, not only on the first
+    one — a push mid-review that boots its own session earns its own eyes.
     """
     cfg = Config.load(_minimal_config(tmp_path))
     workflows = {wf.filename: wf for wf in generate_all(cfg)}
@@ -725,18 +729,48 @@ def test_opened_issue_and_pr_acknowledged_with_eyes(tmp_path: Path) -> None:
     triage = yaml.safe_load(workflows["tend-triage.yaml"].content)
     first = triage["jobs"]["triage"]["steps"][0]
     assert "content=eyes" in first["run"]
-    assert first["env"]["NUMBER"] == "${{ github.event.issue.number }}"
+    assert first["env"]["TARGET"] == "issues/${{ github.event.issue.number }}"
     # Every issues:opened event the job-level `if` admits is the bot's to take.
     assert "if" not in first
 
     review = yaml.safe_load(workflows["tend-review.yaml"].content)
-    react = next(
-        step
-        for step in review["jobs"]["review"]["steps"]
-        if "content=eyes" in str(step.get("run", ""))
+    react = _eyes_steps(review["jobs"]["review"]["steps"])[0]
+    assert react["env"]["TARGET"] == "issues/${{ github.event.pull_request.number }}"
+    # Nothing beyond the gate: a run that boots an agent says so.
+    assert react["if"] == "steps.gate.outputs.should_run == 'true'"
+
+
+@pytest.mark.parametrize(
+    ("name", "react_job", "unreact_job"),
+    [
+        ("triage", "triage", "triage"),
+        ("review", "review", "review"),
+        ("mention", "verify", "handle"),
+    ],
+)
+def test_eyes_come_off_when_the_session_ends(
+    tmp_path: Path, name: str, react_job: str, unreact_job: str
+) -> None:
+    """👀 means a session is working on this right now, so every workflow that
+    puts it on takes it off again — under `always()`, so a failed or cancelled
+    run doesn't strand it.
+
+    Both halves have to name the same reaction target. Mention splits them
+    across jobs, and a target that drifted between the two would leave the eyes
+    on every comment the bot ever answered."""
+    cfg = Config.load(_minimal_config(tmp_path))
+    workflows = {wf.filename: wf for wf in generate_all(cfg)}
+    jobs = yaml.safe_load(workflows[f"tend-{name}.yaml"].content)["jobs"]
+
+    react = _eyes_steps(jobs[react_job]["steps"])[0]
+    unreact = _eyes_steps(jobs[unreact_job]["steps"])[-1]
+    assert "-X DELETE" in unreact["run"], f"{name}: nothing removes the reaction"
+    assert unreact["if"].startswith("always()"), (
+        f"{name}: a failed session has to release the reaction too"
     )
-    assert react["env"]["NUMBER"] == "${{ github.event.pull_request.number }}"
-    assert "github.event.action == 'opened'" in react["if"]
+    assert unreact["env"]["TARGET"] == react["env"]["TARGET"]
+    # The bot's own reaction only — a human's 👀 on the same issue stays put.
+    assert 'select(.user.login == \\"$BOT_NAME\\")' in unreact["run"]
 
 
 def test_setup_raw_rejected_with_migration_hint(tmp_path: Path) -> None:

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -708,11 +708,14 @@ def test_review_queues_pushes_behind_a_gate(tmp_path: Path) -> None:
     assert "tend-review/$PR" in steps[0]["run"]
     gate = "steps.gate.outputs.should_run == 'true'"
     for step in steps[1:]:
-        # A step may narrow further (the eyes reaction fires only on `opened`)
-        # or widen to `always()` (the reaction comes off a failed run too), but
-        # the gate's verdict stays a conjunct of whatever it builds.
+        # A step may narrow further, or widen to `always()` (the reaction comes
+        # off a failed run too), but the gate's verdict stays a conjunct of
+        # whatever it builds. Matched by shape rather than by substring, which
+        # a step disjoining its way past the gate would also satisfy.
         condition = step.get("if", "")
-        assert gate in condition, f"ungated step after the gate: {step}"
+        assert condition in (gate, f"always() && ({gate})") or condition.startswith(
+            f"{gate} && "
+        ), f"ungated step after the gate: {step}"
 
 
 def test_issue_and_pr_acknowledged_with_eyes(tmp_path: Path) -> None:


### PR DESCRIPTION
👀 meant two different things. On a comment that mentions the bot it tracked a session in flight and came off when the session ended; on an opened issue or PR it went on and stayed forever. Both now mean the same thing — a session is working on this right now — and the reaction is released at the end of the run under `always()`, so a failed or cancelled session doesn't strand it.

Review's reaction no longer narrows to `opened`. That narrowing made sense while the reaction was permanent (a push lands on a PR that already carries it), but once the eyes come off, a push mid-review boots a session with no reaction at all. Every run that clears the gate takes them.

The three workflows now share one `react_eyes`/`unreact_eyes` pair, parameterized by the reaction target — `issues/<n>` for an issue or PR, `issues/comments/<id>` or `pulls/comments/<id>` for a comment. Mention's try-issues-then-pulls fallback goes with it: `github.event_name` says which endpoint the comment lives under, so the target is computed rather than probed. That also closes a latent mis-target, since the probe would have accepted an unrelated issue comment that happened to share an id with the review comment.

<details>
<summary>Verification</summary>

Both API calls were run against `tend-agent/tend-integration` with the bot's own token: the POST, the filtered `?content=eyes` lookup, and the DELETE all returned as expected, and the probe reaction was removed afterwards. `actionlint` (which runs shellcheck over the `run:` blocks) is clean on freshly generated workflows for every trigger — the committed `tend-*.yaml` in this repo still track the released generator and don't carry these steps yet.

</details>

> _This was written by Claude Code on behalf of max-sixty_
