### PR TITLE
docs(running-tend): sweep every pin, not a hand-kept table

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -182,8 +182,6 @@ uvx pre-commit autoupdate
 
 # npm: `Wanted` ≠ `Current` is lockfile drift (`npm update`); `Latest` ≠
 # `Wanted` needs the range in package.json moved. Exits 1 when a row prints.
-# `publish-site.yaml` builds site/ only on push to main, so run
-# `npm --prefix site run build` yourself before landing an astro bump.
 npm --prefix worker outdated
 npm --prefix site outdated
 
@@ -206,9 +204,10 @@ Out of scope entirely: runner images (`ubuntu-24.04`), `node-version`, and
 `requires-python` are platform choices carrying their own rationale, so they
 move when a reason arrives rather than on a cadence.
 
-Default rule: move to latest and let CI decide. Split PRs by who runs the
-result, and take what fits in one session rather than clearing a backlog at
-once — an unswept pin waits a week, a swamped run finishes nothing.
+Default rule: move to latest and let CI decide — the table below names the pins
+where CI can't. Split PRs by who runs the result, and take what fits in one
+session rather than clearing a backlog at once — an unswept pin waits a week, a
+swamped run finishes nothing.
 
 - **Ships to adopters** — `claude/action.yaml` and `codex/action.yaml` run in
   every adopter's job from the next release; `generator/src/tend/templates/`
@@ -231,6 +230,8 @@ once — an unswept pin waits a week, a swamped run finishes nothing.
 | `uv_version` | `claude/action.yaml` | move it with `mitmproxy_version` |
 | `codex_version` | `codex/action.yaml` | `latest`; `alpha` only for a fix not yet released |
 | `uv_build` | `generator/pyproject.toml` | its range must contain the uv doing the build; a stale one only warns during `uv build`, so only this sweep catches it |
+| `astro` | `site/package.json` | `publish-site.yaml` builds `site/` on push to main, not on the PR — run `npm --prefix site run build` before landing a bump |
+| `WORKTRUNK_VERSION` | `.config/codex-cloud/environment.sh` | nothing in CI runs the script, and it dies under `set -euo pipefail` — confirm the release still ships `worktrunk-installer.sh` and `wt config show --format json` still has `.project.identifier` |
 
 A stale `claude` binary resolves `--model opus`/`sonnet` to a superseded alias
 target, so drift silently downgrades the model. Skim the claude-code CHANGELOG

--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -161,32 +161,76 @@ the whole list.
 
 ## Weekly: bump pinned versions
 
-Title each PR `chore: bump <name> to <version>`; the uv-plus-mitmproxy PR names
-both.
+Every dependency pin in the repo is in scope — no bot watches this repo, so a
+pin outside the sweep drifts until it breaks. Each command below enumerates its
+own ecosystem, so a pin added later shows up without anyone remembering to list
+it here.
 
-### Tool versions
+```bash
+# Composite-action inputs
+yq -r '.inputs | to_entries[] | select(.key | test("_version$"))
+  | "\(filename) \(.key) = \(.value.default)"' */action.yaml
+
+# Python: `==` and upper bounds freeze a version. Floors (`click>=8.0`) state
+# compatibility instead and stay put — raising one only narrows adopter support.
+git grep -nE '(==|~=|<=?)[0-9]' -- '*pyproject.toml'
+uv lock --upgrade --dry-run
+
+# pre-commit hook revs — the updater rewrites them, `git diff` is the report.
+# Through uvx: the weekly job installs uv and nothing else.
+uvx pre-commit autoupdate
+
+# npm: `Wanted` ≠ `Current` is lockfile drift (`npm update`); `Latest` ≠
+# `Wanted` needs the range in package.json moved. Exits 1 when a row prints.
+# `publish-site.yaml` builds site/ only on push to main, so run
+# `npm --prefix site run build` yourself before landing an astro bump.
+npm --prefix worker outdated
+npm --prefix site outdated
+
+# Versions pinned in a shell script (worktrunk, in the Codex Cloud setup)
+git grep -nE '^[A-Za-z_]*VERSION=' -- '*.sh'
+```
+
+What upstream currently publishes:
+
+```bash
+npm view @anthropic-ai/claude-code dist-tags.latest
+npm view @openai/codex dist-tags.latest
+curl -fsS https://pypi.org/pypi/mitmproxy/json | jq -r .info.version
+curl -fsS https://pypi.org/pypi/uv/json | jq -r .info.version
+gh api repos/max-sixty/worktrunk/releases/latest --jq '.tag_name | ltrimstr("v")'
+```
+
+GHA `uses:` refs sweep separately, under a rule of their own — see below.
+Out of scope entirely: runner images (`ubuntu-24.04`), `node-version`, and
+`requires-python` are platform choices carrying their own rationale, so they
+move when a reason arrives rather than on a cadence.
+
+Default rule: move to latest and let CI decide. Split PRs by who runs the
+result, and take what fits in one session rather than clearing a backlog at
+once — an unswept pin waits a week, a swamped run finishes nothing.
+
+- **Ships to adopters** — `claude/action.yaml` and `codex/action.yaml` run in
+  every adopter's job from the next release; `generator/src/tend/templates/`
+  and `workflows.py` render into their workflow files. One PR each, titled
+  `chore: bump <name> to <version>` (the uv-plus-mitmproxy PR names both), its
+  body naming what changed.
+- **Ours alone** — everything else: pre-commit revs, the workspace dev pins,
+  the `uv_build` backend, npm devDependencies, `WORKTRUNK_VERSION`, the
+  hand-maintained `.github/workflows/` files and `.config/tend.yaml`. One PR
+  for the lot.
+- **A major** — an npm `Latest` ≠ `Wanted`, or a new mitmproxy/uv major — gets
+  its own PR from either bucket, its body reporting the migration notes.
+
+### Pins with rules of their own
 
 | Pin | File | Rule |
 |---|---|---|
-| `claude_version` | `claude/action.yaml` | track npm's `latest` dist-tag |
-| `mitmproxy_version` | `claude/action.yaml` | track latest; move the root `pyproject.toml` dev pin with it and `uv lock` |
+| `claude_version` | `claude/action.yaml` | npm's `latest` dist-tag, not `stable` |
+| `mitmproxy_version` | `claude/action.yaml` | move the root `pyproject.toml` `==` pin with it and `uv lock` |
 | `uv_version` | `claude/action.yaml` | move it with `mitmproxy_version` |
-| `codex_version` | `codex/action.yaml` | track latest; the surface job confirms the bump |
-| `WORKTRUNK_VERSION` | `.config/codex-cloud/environment.sh` | track latest GitHub release |
-
-```bash
-yq '.inputs.claude_version.default' claude/action.yaml
-npm view @anthropic-ai/claude-code dist-tags.latest
-
-yq '.inputs.mitmproxy_version.default' claude/action.yaml
-curl -fsS https://pypi.org/pypi/mitmproxy/json | jq -r .info.version
-
-yq '.inputs.codex_version.default' codex/action.yaml
-npm view @openai/codex dist-tags.latest
-
-sed -n 's/^WORKTRUNK_VERSION=//p' .config/codex-cloud/environment.sh
-gh api repos/max-sixty/worktrunk/releases/latest --jq '.tag_name | ltrimstr("v")'
-```
+| `codex_version` | `codex/action.yaml` | `latest`; `alpha` only for a fix not yet released |
+| `uv_build` | `generator/pyproject.toml` | its range must contain the uv doing the build; a stale one only warns during `uv build`, so only this sweep catches it |
 
 A stale `claude` binary resolves `--model opus`/`sonnet` to a superseded alias
 target, so drift silently downgrades the model. Skim the claude-code CHANGELOG
@@ -199,15 +243,14 @@ credential, so a security fix there matters here. Check anything security- or
 addon-related in its CHANGELOG against the `mitmdump` flags in
 `proxy/setup-sandbox.sh`, and report the comparison in the PR. `uv_version`
 only launches that mitmproxy and CI smokes the two together, so it needs no
-release stream of its own; move both in one PR, at whatever uv is latest then
-(`curl -fsS https://pypi.org/pypi/uv/json | jq -r .info.version`).
+release stream of its own; move both in one PR.
 
-Bump `codex_version` to `latest`; drop to `alpha` only for a fix not yet
-released. CI's `test-codex-surface` job installs whatever is pinned and asserts
-the CLI surface the action depends on, so a bump that breaks it fails on its own
-PR. No `OPENAI_API_KEY` reaches this repo's runs, so a live agent session stays
-unverified — skim the codex CHANGELOG across the bump for model availability,
-sandbox behavior, and `--output-last-message`, and note what you find in the PR.
+For `codex_version`, CI's `test-codex-surface` job installs whatever is pinned
+and asserts the CLI surface the action depends on, so a bump that breaks it
+fails on its own PR. No `OPENAI_API_KEY` reaches this repo's runs, so a live
+agent session stays unverified — skim the codex CHANGELOG across the bump for
+model availability, sandbox behavior, and `--output-last-message`, and note what
+you find in the PR.
 
 ### `uses:` refs
 
@@ -224,14 +267,9 @@ git grep -hoE 'uses: [^ ./][^ @]*@[^ ]+' -- ':!generator/tests' ':!*.md' \
 
 An action listed twice is pinned at two majors: refs move when someone needs a
 behavior from one of them, never in a sweep. `git grep` each drifted action for
-its call sites, then split the PRs by who runs the result.
-
-- **Ships to adopters** — `generator/src/tend/templates/` and `workflows.py`
-  render into adopters' workflow files; `claude/action.yaml` and
-  `codex/action.yaml` run in every adopter's job from the next release. One PR
-  per action, its body naming what changed across the majors it crosses.
-- **Ours alone** — the hand-maintained `.github/workflows/` files and
-  `.config/tend.yaml`. One PR for the lot.
+its call sites, then split the PRs by the buckets above — a ref that ships to
+adopters gets its own, its body naming what changed across the majors it
+crosses.
 
 The generated `tend-*.yaml` show up in that grep too; their refs come from the
 templates and from `.config/tend.yaml`'s `setup:`, which is where they move.


### PR DESCRIPTION
The weekly bump section was a table of four action inputs, so every other pin in the repo drifted unswept — a pin entered scope only when someone remembered to add a row for it, and `WORKTRUNK_VERSION` arrived exactly that way in #978. What the closed table was hiding, measured on this tree: ruff `v0.14.11` → `v0.16.3`, uv-pre-commit `0.7.12` → `0.12.4`, typos `v1.42.0` → `v1.49.0`, vitest 2 → 4, typescript 5 → 7, wrangler 4.90 → 4.123, astro 5 → 7, plus the `uv_build` range that has excluded the local uv since 0.12.

Each ecosystem now enumerates its own pins, so the next one added shows up without an edit to this file:

```bash
yq -r '.inputs | to_entries[] | select(.key | test("_version$")) | ...' */action.yaml
git grep -nE '(==|~=|<=?)[0-9]' -- '*pyproject.toml'   # freeze-pins; floors like click>=8.0 stay
uv lock --upgrade --dry-run
uvx pre-commit autoupdate
npm --prefix worker outdated; npm --prefix site outdated
git grep -nE '^[A-Za-z_]*VERSION=' -- '*.sh'
```

The table survives only for pins whose rule isn't "move to latest and let CI decide" — `claude_version` tracking `latest` over `stable`, mitmproxy dragging the workspace `==` pin with it — and, after the review, for every pin CI can't verify at all: `uv_build`'s stale range only *warns* during `uv build`, `publish-site.yaml` builds `site/` on push to main rather than on the PR, and nothing anywhere runs `.config/codex-cloud/environment.sh`, which dies under `set -euo pipefail` in a maintainer's Codex Cloud setup rather than in a job. Those three were carved out in three different places in the first push; they're one table now, so the default rule means what it says. The PR-splitting rule that used to sit under `uses:` refs (ships-to-adopters / ours-alone) now governs all pins, with majors getting their own PR from either bucket.

`WORKTRUNK_VERSION` is the test of whether the frame works: #978's row and `sed` lookup are gone, and the shell-script sweep finds the pin on its own. It keeps a row, but for what CI can't check rather than for existing.

Runner images, `node-version` and `requires-python` are named as out of scope rather than silently omitted — platform choices carrying their own rationale, moved when a reason arrives.

<details>
<summary>Verification</summary>

Every command run against this tree before it went in:

- the `yq` sweep prints all four action inputs with their file
- the Python grep returns exactly the two freeze-pins (`mitmproxy==`, `uv_build`'s cap) and no floors or `requires-python`
- `uvx pre-commit autoupdate` works with only uv installed (the weekly job's whole toolchain) — run against a scratch copy of the config, which is where the three rev numbers above come from
- `npm outdated` exits 1 with rows, which is why the comment says so
- the shell-script grep returns `WORKTRUNK_VERSION` and nothing else
- `uv build --package tend` warns on the stale `uv_build` range and still succeeds, so the "only this sweep catches it" claim is the observed behavior
- `pre-commit run --all-files` passes

</details>

> _This was written by Claude Code on behalf of max-sixty_
