### PR TITLE
docs(running-in-ci): fork PR reviews reach no successor session

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -252,7 +252,7 @@ If you cannot verify, say "I haven't confirmed whether these failures are pre-ex
 
 Poll your checks to terminal, do the follow-up you were gated on, and exit; name the outstanding review in your summary. This covers a review that arrives *while* you work — a session dispatched to answer a specific review owns that review and actions it normally.
 
-**On a fork PR the premise fails — nothing succeeds you.** `tend-mention`'s relay job is gated on `head.repo.full_name == github.repository`, so a review on a fork PR dispatches nothing, and the notifications poll named as that filter's fallback can't see it either: GitHub doesn't notify an actor of their own activity, so the bot's own review is invisible there by construction. Findings left for a successor session strand until a human happens to comment. So when the review is on a fork PR: if you pushed the commits under a maintainer directive you are the de-facto author — action your own review's findings before ending. Otherwise say in your closing comment that they are unaddressed and unowned, so the thread shows someone has to pick them up.
+**On a fork PR the premise fails — nothing succeeds you.** `tend-mention`'s relay job is gated on `head.repo.full_name == github.repository`, so a review on a fork PR dispatches nothing, and the notifications poll named as that filter's fallback can't see it either: GitHub doesn't notify an actor of their own activity, so the bot's own review is invisible there by construction. Findings left for a successor session strand until a human happens to comment. So if you pushed the commits under a maintainer directive you are the de-facto author — action your own review's findings before ending. If you pushed them without one, name them in your closing comment as unaddressed and unowned, so the thread shows someone has to pick them up. A review on commits the contributor pushed already reached them — leave it.
 
 ### Rerunning failed jobs
 
@@ -328,7 +328,7 @@ gh pr view <number> --json comments,reviews \
   --jq '{comments: (.comments | length), reviews: (.reviews | length)}'
 ```
 
-Keep `reviews` in the PR projection rather than narrowing to `comments` — a review submitted while you worked is a directive, not a duplicate, and it is the entry a dedup-shaped check is most likely to drop. On a fork PR it is also the one nothing else will pick up (see **A review that lands while you poll is not yours to action**).
+Keep `reviews` in the PR projection rather than narrowing to `comments` — it is the entry a dedup-shaped check is most likely to drop, and on a fork PR it is the one nothing else will pick up (see **A review that lands while you poll is not yours to action**).
 
 If any prior entry — from a human or another tend workflow — already addresses a point the response would make, omit that point. The dedup applies equally to comment bodies, review bodies, and inline replies. If the response is now entirely redundant, don't post it.
 

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -252,6 +252,8 @@ If you cannot verify, say "I haven't confirmed whether these failures are pre-ex
 
 Poll your checks to terminal, do the follow-up you were gated on, and exit; name the outstanding review in your summary. This covers a review that arrives *while* you work — a session dispatched to answer a specific review owns that review and actions it normally.
 
+**On a fork PR the premise fails — nothing succeeds you.** `tend-mention`'s relay job is gated on `head.repo.full_name == github.repository`, so a review on a fork PR dispatches nothing, and the notifications poll named as that filter's fallback can't see it either: GitHub doesn't notify an actor of their own activity, so the bot's own review is invisible there by construction. Findings left for a successor session strand until a human happens to comment. So when the review is on a fork PR: if you pushed the commits under a maintainer directive you are the de-facto author — action your own review's findings before ending. Otherwise say in your closing comment that they are unaddressed and unowned, so the thread shows someone has to pick them up.
+
 ### Rerunning failed jobs
 
 To rerun a run's failed jobs and wait for the outcome, use the bundled script — it reruns, finds the new attempt's jobs (the parent run's `.status` and the commit rollup stay pending on unrelated siblings, so neither is a usable signal), and polls them to terminal:
@@ -325,6 +327,8 @@ gh issue view <number> --json comments --jq '.comments | length'
 gh pr view <number> --json comments,reviews \
   --jq '{comments: (.comments | length), reviews: (.reviews | length)}'
 ```
+
+Keep `reviews` in the PR projection rather than narrowing to `comments` — a review submitted while you worked is a directive, not a duplicate, and it is the entry a dedup-shaped check is most likely to drop. On a fork PR it is also the one nothing else will pick up (see **A review that lands while you poll is not yours to action**).
 
 If any prior entry — from a human or another tend workflow — already addresses a point the response would make, omit that point. The dedup applies equally to comment bodies, review bodies, and inline replies. If the response is now entirely redundant, don't post it.
 


### PR DESCRIPTION
## Problem

Two sections of `running-in-ci` rest on a premise that fails on fork PRs. "A review that lands while you poll is not yours to action" justifies leaving a review alone with "`tend-mention` is dispatched on `pull_request_review` for every PR the bot authored" — but the relay job is gated on `github.event.pull_request.head.repo.full_name == github.repository` ([`mention.yaml.j2:92-95`](https://github.com/max-sixty/tend/blob/8a18d6c/generator/src/tend/templates/mention.yaml.j2#L92-L95)), so a review on a fork PR dispatches nothing. The fallback that gate's comment names — the notifications poll — can't see it either, since GitHub doesn't notify an actor of their own activity. And **Recheck Before Posting** specifies `--json comments,reviews` without saying why `reviews` has to stay, so sessions narrow it to `comments` and never see their own review land.

Reported in #984 with two occurrences on one fork PR in a 24h window: bot review findings sat unaddressed for 3h53m and 3h29m, recovered only because unrelated human comments woke later sessions.

## Solution

Two paragraphs of skill text, no workflow change — the fork filter is a security boundary, and widening it is moot anyway while a fork run's token is refused the dispatch POST (per the same comment block).

- In "A review that lands while you poll is not yours to action": state that the premise fails on a fork PR and nothing succeeds you, so a session that pushed the commits under a maintainer directive actions its own review's findings, and otherwise names them as unowned in its closing comment.
- In **Recheck Before Posting**: say why `reviews` stays in the projection — a review that landed while you worked is a directive, not a duplicate, and on a fork PR it's the entry nothing else picks up.

## Testing

`uv run pytest` passes (554 tests). No test covers skill prose, so there is no reproduction test to add here; the behavioral claims were verified against the relay gate in the mention template rather than reproduced.

---
Closes #984 — automated triage
