### PR TITLE
ci: build site/ on the PR, and derive the Cloud approvals from wt

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -230,8 +230,7 @@ swamped run finishes nothing.
 | `uv_version` | `claude/action.yaml` | move it with `mitmproxy_version` |
 | `codex_version` | `codex/action.yaml` | `latest`; `alpha` only for a fix not yet released |
 | `uv_build` | `generator/pyproject.toml` | its range must contain the uv doing the build; a stale one only warns during `uv build`, so only this sweep catches it |
-| `astro` | `site/package.json` | `publish-site.yaml` builds `site/` on push to main, not on the PR — run `npm --prefix site run build` before landing a bump |
-| `WORKTRUNK_VERSION` | `.config/codex-cloud/environment.sh` | nothing in CI runs the script, and it dies under `set -euo pipefail` — confirm the release still ships `worktrunk-installer.sh` and `wt config show --format json` still has `.project.identifier` |
+| `WORKTRUNK_VERSION` | `.config/codex-cloud/environment.sh` | nothing in CI runs the script, and it dies under `set -euo pipefail` — confirm the release still ships `worktrunk-installer.sh`, and that `wt config show --format json` still has `.project.identifier` and `wt config approvals list --format=json` still has `.commands[].template` |
 
 A stale `claude` binary resolves `--model opus`/`sonnet` to a superseded alias
 target, so drift silently downgrades the model. Skim the claude-code CHANGELOG

--- a/.config/codex-cloud/README.md
+++ b/.config/codex-cloud/README.md
@@ -1,7 +1,7 @@
 # Codex Cloud with Worktrunk
 
 Tend's Cloud setup lives in `environment.sh`. It installs the pinned Worktrunk
-release, approves Tend's reviewed `.config/wt.toml` commands, syncs all project
+release, approves every command `.config/wt.toml` declares, syncs all project
 dependencies, and installs `pre-commit` without installing Git hooks.
 
 ## Create the environment
@@ -32,10 +32,9 @@ pre-commit --version. Require every command to pass and do not modify files.
 ## Keep it current
 
 `environment.sh` is the one setup command for both fresh and cached containers.
-Keep its `approved-commands` list identical to the hooks and aliases in
-`.config/wt.toml`; Worktrunk blocks a changed or missing command in unattended
-sessions. Reset the environment cache when a repository change makes the cached
-container incompatible.
+It reads the command list out of Worktrunk, so a `.config/wt.toml` change needs
+no edit here. Reset the environment cache when a repository change makes the
+cached container incompatible.
 
 The script is Cloud-specific: it replaces the container's Worktrunk approvals
 file. Do not use it as local workstation setup.

--- a/.config/codex-cloud/environment.sh
+++ b/.config/codex-cloud/environment.sh
@@ -9,22 +9,26 @@ if ! command -v wt >/dev/null 2>&1 ||
     WORKTRUNK_UNMANAGED_INSTALL="$HOME/.local/bin" sh
 fi
 
+# Approve every command `.config/wt.toml` declares, read back out of Worktrunk
+# rather than copied here — a hand-kept list blocks every unattended session in
+# the container one `wt.toml` edit later, and re-reviewing buys nothing when the
+# container runs this script from that same branch. `wt config approvals add` is
+# the review flow and refuses a non-TTY even with `--yes`, so write the file
+# directly, reading everything before the redirect truncates it.
 WORKTRUNK_PROJECT=$(wt config show --format json | jq -r '.project.identifier | @json')
-install -d "$HOME/.config/worktrunk"
-cat >"$HOME/.config/worktrunk/approvals.toml" <<EOF
+WORKTRUNK_COMMANDS=$(wt config approvals list --format=json |
+  jq -r '.commands[] | "  \(.template | @json),"')
+WORKTRUNK_APPROVALS_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/worktrunk"
+install -d "$WORKTRUNK_APPROVALS_DIR"
+cat >"$WORKTRUNK_APPROVALS_DIR/approvals.toml" <<EOF
 [projects.$WORKTRUNK_PROJECT]
 approved-commands = [
-  "wt step copy-ignored",
-  "cd site && npm install --prefer-offline --no-audit --no-fund",
-  "cd site && npm run dev -- --port {{ branch | hash_port }}",
-  "lsof -ti :{{ branch | hash_port }} -sTCP:LISTEN | xargs kill 2>/dev/null || true",
-  "uv run pytest {{ args }}",
-  "npm --prefix worker ci --prefer-offline --no-audit --no-fund",
-  "npm --prefix worker test",
-  "npm --prefix worker run typecheck",
+$WORKTRUNK_COMMANDS
 ]
 EOF
 
+# Worktrunk parses what we just generated, so a release that changes the
+# approvals schema fails here rather than at the first hook of a Cloud session.
 if [[ "$(wt config approvals list --format=json | jq -r '.state')" != approved ]]; then
   echo "Worktrunk approvals do not cover .config/wt.toml" >&2
   wt config approvals list >&2

--- a/.github/workflows/publish-site.yaml
+++ b/.github/workflows/publish-site.yaml
@@ -6,6 +6,14 @@ on:
       - main
     paths:
       - 'site/**'
+      - '.github/workflows/publish-site.yaml'
+  # The same build on the PR, so a change that breaks it — an astro major, a
+  # bad lockfile — fails before merge rather than on the way to Pages. Only
+  # `build-site` runs there; publishing stays with push and dispatch.
+  pull_request:
+    paths:
+      - 'site/**'
+      - '.github/workflows/publish-site.yaml'
   workflow_dispatch:
 
 concurrency:
@@ -44,8 +52,8 @@ jobs:
     needs: build-site
     runs-on: ubuntu-24.04
 
-    # Don't attempt to publish if on a fork
-    if: ${{ github.repository_owner == 'max-sixty' }}
+    # A PR run is a build check, and a fork has no Pages to publish to.
+    if: ${{ github.event_name != 'pull_request' && github.repository_owner == 'max-sixty' }}
 
     permissions:
       pages: write


### PR DESCRIPTION
Two follow-ups from #981's sweep, each a pin whose bump nothing checked.

`publish-site.yaml` built `site/` only on push to main, so an astro bump merged green and broke on the way to Pages — which is why the weekly-bump table carried an `astro` row telling the agent to run `npm --prefix site run build` by hand first. The build job now runs on any PR touching `site/` or the workflow file, and `deploy-site` picks up `github.event_name != 'pull_request'`. Extending the workflow that already defines the build beat adding a `ci.yaml` job, which would have been a second copy of the same four steps. The `astro` row is gone with the manual step: it's an ordinary "move to latest and let CI decide" pin now.

`.config/codex-cloud/environment.sh` wrote the container's `approvals.toml` from a hand-copied duplicate of `.config/wt.toml`'s command list — correct today, and stranded by the next alias edit, at which point every unattended `wt` run in Codex Cloud fails the approvals gate. `wt config approvals list --format=json` already emits every command the project declares, so the script reads the list from there and drift stops being possible rather than being caught after the fact. `wt config approvals add` is the primitive that should do this whole job, but it refuses a non-TTY even with `--yes` (checked against the pinned 0.73.0 binary, not just a local build), so the file is still written directly. If worktrunk gains a working `add --yes`, the block collapses to one command.

What that gives up: the copied list doubled as a review anchor, since a new `wt.toml` command couldn't run in the container until someone edited this script too. It guards nothing here — the container runs `environment.sh` itself from the same branch, so a `wt.toml` a reviewer wouldn't trust arrives with a setup script they wouldn't either.

The script now writes to `${XDG_CONFIG_HOME:-$HOME/.config}/worktrunk` rather than a hardcoded `$HOME/.config`. That is where worktrunk documents it looks, and it is what makes the generation testable without touching a real approvals file.

<details>
<summary>Verification</summary>

- against worktrunk v0.73.0 installed to a temp dir, under a temp `XDG_CONFIG_HOME`: the generated `approvals.toml` matches the hand-kept file it replaces exactly, and `wt config approvals list` then reports `approved` with 0 stale
- appending a probe alias to `.config/wt.toml` puts it in the generated list and the state check still passes (reverted after)
- `wt config approvals add --yes` exits 1 on that same pinned binary, in both flag positions — the comment's claim is observed, not assumed
- `npm --prefix site run build` succeeds on this tree, so the new job lands green rather than red
- this PR edits `publish-site.yaml`, which is in the new path filter, so `build-site` runs on the PR itself
- `pre-commit run --all-files` clean; `uv run pytest` 554 passed

</details>

> _This was written by Claude Code on behalf of max-sixty_
