### PR TITLE
simplify: hand the Codex Cloud approvals to wt, at worktrunk 0.74.0

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -230,7 +230,7 @@ swamped run finishes nothing.
 | `uv_version` | `claude/action.yaml` | move it with `mitmproxy_version` |
 | `codex_version` | `codex/action.yaml` | `latest`; `alpha` only for a fix not yet released |
 | `uv_build` | `generator/pyproject.toml` | its range must contain the uv doing the build; a stale one only warns during `uv build`, so only this sweep catches it |
-| `WORKTRUNK_VERSION` | `.config/codex-cloud/environment.sh` | nothing in CI runs the script, and it dies under `set -euo pipefail` — confirm the release still ships `worktrunk-installer.sh`, and that `wt config show --format json` still has `.project.identifier` and `wt config approvals list --format=json` still has `.commands[].template` |
+| `WORKTRUNK_VERSION` | `.config/codex-cloud/environment.sh` | nothing in CI runs the script, and it dies under `set -euo pipefail` — confirm the release still ships `worktrunk-installer.sh` and that `wt config approvals add --yes` still records approvals without a TTY |
 
 A stale `claude` binary resolves `--model opus`/`sonnet` to a superseded alias
 target, so drift silently downgrades the model. Skim the claude-code CHANGELOG

--- a/.config/codex-cloud/README.md
+++ b/.config/codex-cloud/README.md
@@ -32,9 +32,9 @@ pre-commit --version. Require every command to pass and do not modify files.
 ## Keep it current
 
 `environment.sh` is the one setup command for both fresh and cached containers.
-It reads the command list out of Worktrunk, so a `.config/wt.toml` change needs
-no edit here. Reset the environment cache when a repository change makes the
+Worktrunk records the approvals itself, so a `.config/wt.toml` change needs no
+edit here. Reset the environment cache when a repository change makes the
 cached container incompatible.
 
-The script is Cloud-specific: it replaces the container's Worktrunk approvals
-file. Do not use it as local workstation setup.
+The script is Cloud-specific: it approves this repo's `wt` commands without
+review. Do not use it as local workstation setup.

--- a/.config/codex-cloud/environment.sh
+++ b/.config/codex-cloud/environment.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-WORKTRUNK_VERSION=0.73.0
+WORKTRUNK_VERSION=0.74.0
 if ! command -v wt >/dev/null 2>&1 ||
   [[ "$(wt --version)" != "wt v${WORKTRUNK_VERSION}" ]]; then
   curl --proto '=https' --tlsv1.2 -LsSf \
@@ -9,31 +9,10 @@ if ! command -v wt >/dev/null 2>&1 ||
     WORKTRUNK_UNMANAGED_INSTALL="$HOME/.local/bin" sh
 fi
 
-# Approve every command `.config/wt.toml` declares, read back out of Worktrunk
-# rather than copied here — a hand-kept list blocks every unattended session in
-# the container one `wt.toml` edit later, and re-reviewing buys nothing when the
-# container runs this script from that same branch. `wt config approvals add` is
-# the review flow and refuses a non-TTY even with `--yes`, so write the file
-# directly, reading everything before the redirect truncates it.
-WORKTRUNK_PROJECT=$(wt config show --format json | jq -r '.project.identifier | @json')
-WORKTRUNK_COMMANDS=$(wt config approvals list --format=json |
-  jq -r '.commands[] | "  \(.template | @json),"')
-WORKTRUNK_APPROVALS_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/worktrunk"
-install -d "$WORKTRUNK_APPROVALS_DIR"
-cat >"$WORKTRUNK_APPROVALS_DIR/approvals.toml" <<EOF
-[projects.$WORKTRUNK_PROJECT]
-approved-commands = [
-$WORKTRUNK_COMMANDS
-]
-EOF
-
-# Worktrunk parses what we just generated, so a release that changes the
-# approvals schema fails here rather than at the first hook of a Cloud session.
-if [[ "$(wt config approvals list --format=json | jq -r '.state')" != approved ]]; then
-  echo "Worktrunk approvals do not cover .config/wt.toml" >&2
-  wt config approvals list >&2
-  exit 1
-fi
+# Pre-approve the commands `.config/wt.toml` declares, so unattended `wt` runs
+# in the container don't block on the prompt. `--yes` is the CI path; review
+# buys nothing here, since the container runs this script from that same branch.
+wt config approvals add --yes
 
 uv sync --frozen
 npm ci --prefix site --prefer-offline --no-audit --no-fund


### PR DESCRIPTION
`.config/codex-cloud/environment.sh` hand-wrote the container's `approvals.toml`: read the project identifier out of `wt config show --format json`, render every command template through `jq`, write the file with a heredoc, then parse it back to confirm the schema still held. It was a reimplementation of `wt config approvals add`, and it existed for one reason — that command refused a non-TTY even when passed `--yes`, so there was no way to pre-approve a freshly cloned project unattended.

[worktrunk 0.74.0](https://github.com/max-sixty/worktrunk/releases/tag/v0.74.0) fixes that ([max-sixty/worktrunk#3819](https://github.com/max-sixty/worktrunk/pull/3819)), so the whole block is now `wt config approvals add --yes`. The schema re-parse goes with it: `add --yes` fails the command when it cannot save, rather than warning behind a `✓ saved` and exiting 0, which is exactly what that check was standing in for. The pin and the new line have to move together — `--yes` does nothing useful on 0.73.0.

Testing against the released binary corrected a README claim. `add --yes` merges into `approvals.toml` rather than truncating it, so an unrelated project's entry survives; the old `cat >` genuinely replaced the file. "It replaces the container's Worktrunk approvals file" now reads as what actually makes the script Cloud-only — it approves this repo's `wt` commands without review.

The `WORKTRUNK_VERSION` row in `running-tend` loses its instruction to check two `jq` paths the script no longer uses.

<details>
<summary>Verification</summary>

- v0.74.0 installed to a temp dir via the pinned `worktrunk-installer.sh`, and `wt --version` prints exactly `wt v0.74.0` — the string the script's install guard compares against
- `git merge-base --is-ancestor 92dfb686b v0.74.0` confirms the release carries the fix, rather than trusting the release notes
- with that binary, under a throwaway `XDG_CONFIG_HOME`: the approval line exits 0 from tend's root, records all 8 commands `.config/wt.toml` declares, and leaves `wt config approvals list --format=json` at `state: approved` with nothing stale
- seeding that file with an unrelated project's entry first leaves it intact — the basis for the README correction
- skimmed the rest of the 0.74.0 notes: the one breaking change (minijinja spelling JSON bools and null as `True`/`False`/`None` inside `{{ vars.… }}`) doesn't reach a `.config/wt.toml` that uses only `{{ branch | hash_port }}` and `{{ args }}`
- `pre-commit run --all-files` clean; `uv run pytest` 554 passed

</details>

> _This was written by Claude Code on behalf of max-sixty_
