### PR TITLE
chore: move the uv_build range onto the 0.12 line

### DIFF
--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["uv_build>=0.11.14,<0.12"]
+requires = ["uv_build>=0.12,<0.13"]
 build-backend = "uv_build"
 
 [project]

--- a/generator/tests/test_repo_pins.py
+++ b/generator/tests/test_repo_pins.py
@@ -1,0 +1,49 @@
+"""Cross-file pin invariants that no single suite owns.
+
+`test_pinned_mitmproxy_matches_the_action` (proxy/) is the sibling of this
+idea: a version named in two places drifts silently unless something asserts
+the pair.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+from packaging.version import Version
+from ruamel.yaml import YAML
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_uv_build_range_admits_the_pinned_uv() -> None:
+    # uv only *warns* when `build-system.requires` doesn't contain the uv
+    # running the build, so a stale range survives every release and every
+    # `uv sync` without failing anything. `uv_version` in claude/action.yaml is
+    # the repo's statement of which uv is current — the weekly sweep moves it to
+    # the latest release — so tying the range to it makes that sweep carry the
+    # backend along instead of leaving it for someone to notice in the noise.
+    # Both operands are in-repo, so this can only go red on a bump, never on
+    # the day astral publishes something.
+    requires = tomllib.loads((REPO_ROOT / "generator" / "pyproject.toml").read_text())[
+        "build-system"
+    ]["requires"]
+    backends = [
+        Requirement(r)
+        for r in requires
+        if canonicalize_name(Requirement(r).name) == "uv-build"
+    ]
+    assert len(backends) == 1, f"expected one uv_build requirement, got: {requires}"
+
+    action = YAML(typ="safe", pure=True).load(
+        (REPO_ROOT / "claude" / "action.yaml").read_text()
+    )
+    uv_version = action["inputs"]["uv_version"]["default"]
+
+    assert Version(uv_version) in backends[0].specifier, (
+        f"build-system.requires pins `{backends[0]}`, which does not contain the "
+        f"uv this repo pins ({uv_version}); `uv build` warns and the wheel is "
+        "built by a backend a release older than the uv building it"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,4 +34,7 @@ dev = [
   # That same test reads claude/action.yaml. `tend` happens to pull ruamel in,
   # but the proxy suite doesn't depend on the generator, so declare it here.
   "ruamel.yaml>=0.18",
+  # test_repo_pins.py reads a version specifier out of a pyproject and asks
+  # whether a version satisfies it. Only ever arrives transitively otherwise.
+  "packaging>=25",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -969,6 +969,7 @@ source = { virtual = "." }
 [package.dev-dependencies]
 dev = [
     { name = "mitmproxy" },
+    { name = "packaging" },
     { name = "pytest" },
     { name = "pytest-regtest" },
     { name = "ruamel-yaml" },
@@ -980,6 +981,7 @@ dev = [
 [package.metadata.requires-dev]
 dev = [
     { name = "mitmproxy", specifier = "==12.2.3" },
+    { name = "packaging", specifier = ">=25" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-regtest", specifier = ">=2.1.1" },
     { name = "ruamel-yaml", specifier = ">=0.18" },


### PR DESCRIPTION
## Problem

`generator/pyproject.toml` declares `build-system.requires = ["uv_build>=0.11.14,<0.12"]`, unchanged since the backend was switched in #546. uv is now on 0.12.x, so every build prints:

```
warning: `build_system.requires = ["uv-build>=0.11.14,<0.12"]` does not contain the current uv version 0.12.5
```

It's a warning, not an error, so nothing has ever failed on it — the 0.1.17 wheel built fine. But it fires on `uv build --package tend` in `pypi-release.yaml` and on every `uv sync` that builds the workspace member, which is every fresh dev environment and every CI job, and it means the released wheel is produced by a backend a minor behind the uv driving it.

The `running-tend` skill's pin table already names this exact case — "its range must contain the uv doing the build; a stale one only warns during `uv build`, so only this sweep catches it" — and the sweep is weekly, so it stayed stale for the whole 0.12 line.

## Fix

Move the range to `>=0.12,<0.13`. The floor is the minor rather than a specific patch so the whole 0.12 line is admitted — the release job takes whatever `setup-uv@v9` installs (0.12.5 today) and a developer may be on an earlier 0.12.x.

## Regression test

`generator/tests/test_repo_pins.py` asserts the range contains the `uv_version` pinned in `claude/action.yaml`. That input is what the weekly sweep moves to the latest uv, so coupling the two makes the sweep carry the build backend along instead of leaving it to be noticed in build noise. Both operands are in-repo, so the test can only go red on a deliberate bump — never on the day astral publishes a release. It's the same shape as `test_pinned_mitmproxy_matches_the_action`, which guards the other version this repo names twice.

Verified it fails on the old pin and passes on the new one:

<details><summary>Before and after</summary>

```
$ uv build --package tend                       # before
warning: `build_system.requires = ["uv-build>=0.11.14,<0.12"]` does not contain the current uv version 0.12.5

$ uv build --package tend                       # after
Successfully built dist/tend-0.1.17.tar.gz      # no warning

$ uv run pytest generator/tests/test_repo_pins.py   # with the old range restored
FAILED test_uv_build_range_admits_the_pinned_uv - AssertionError: build-system.requires
pins `uv_build<0.12,>=0.11.14`, which does not contain the uv this repo pins (0.12.1)
```

`packaging` is added to the root dev group: the test asks whether a version satisfies a specifier, and `packaging` only arrived transitively before — the same reason `ruamel.yaml` is declared there.

Full suite: 555 passed. `pre-commit` clean on the changed files.

</details>
