### PR TITLE
fix(mention): keep both halves of the 👀 reaction in one job

### DIFF
--- a/generator/src/tend/templates/macros.yaml.j2
+++ b/generator/src/tend/templates/macros.yaml.j2
@@ -142,11 +142,20 @@
    unattended — and `unreact_eyes` takes it off at the end, under `always()`, so
    a failed or cancelled run doesn't strand it.
 
+   Both halves have to sit in the *same* job, which is what makes `always()`
+   mean anything: it governs step execution within a job that started, and a
+   job cancelled while still queued never allocates a runner, so no step of it
+   runs. Split across jobs, every route where the second never starts leaves
+   the eyes on with no session behind them.
+
    `target` is an API path under `repos/<owner>/<repo>/`: `issues/<number>` for
    an issue or PR (GitHub files PRs as issues for reactions), `issues/comments/`
    or `pulls/comments/<id>` for a comment. A repeat react returns the existing
    reaction rather than erroring, and the delete is filtered to the bot's own
-   reaction so a human's 👀 survives.
+   reaction so a human's 👀 survives. That lookup paginates: 👀 is also the
+   ordinary "watching this" reaction, so on a busy issue the bot's own can sit
+   past the first page, and finding nothing there keeps the reaction silently
+   (the step exits 0 either way).
 
    Either half failing warns rather than failing the job — an acknowledgment is
    not worth losing the run that does the work, and the unreact half runs on
@@ -171,7 +180,8 @@
 <<step_if(if_condition)>>
 {% endif %}
         run: |
-          REACTION_ID=$(gh api "repos/$REPO/$TARGET/reactions?content=eyes" \
+          REACTION_ID=$(gh api --paginate \
+            "repos/$REPO/$TARGET/reactions?content=eyes&per_page=100" \
             --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" | head -n1)
           if [ -n "$REACTION_ID" ]; then
             gh api -X DELETE "repos/$REPO/$TARGET/reactions/$REACTION_ID" --silent \

--- a/generator/src/tend/templates/mention.yaml.j2
+++ b/generator/src/tend/templates/mention.yaml.j2
@@ -161,12 +161,6 @@ jobs:
           PAYLOAD_PR: ${{ github.event.client_payload.pr }}
           PAYLOAD_ID: ${{ github.event.client_payload.id }}
 
-      # The dispatch arm covers a relayed inline comment, whose id the check
-      # step verified belongs to this PR; a review *submission* has no single
-      # comment to react to, so it gets no eyes — same as when the events
-      # arrived directly.
-<<react_eyes(reaction_target, if_condition="steps.check.outputs.should_run == 'true'\n&& " ~ summoned(cfg.bot_name, 'steps.check.outputs.reason'))>>
-
   handle:
     needs: verify
     if: needs.verify.outputs.should_run == 'true'
@@ -178,6 +172,19 @@ jobs:
     permissions:
 <<permissions()>>
     steps:
+      # Both halves of the reaction belong to this job, so the eyes can only
+      # go on once the job that takes them off has started. Put them in
+      # `verify` and `handle` respectively and the routine burst case strands
+      # them: a third mention on one thread evicts the second's pending
+      # `handle` — a job cancelled while queued allocates no runner and runs
+      # no steps, `always()` included — while its `verify` already reacted.
+      #
+      # The dispatch arm covers a relayed inline comment, whose id the check
+      # step verified belongs to this PR; a review *submission* has no single
+      # comment to react to, so it gets no eyes — same as when the events
+      # arrived directly. The job's own `if` already carries `should_run`.
+<<react_eyes(reaction_target, if_condition=summoned(cfg.bot_name, 'needs.verify.outputs.reason'))>>
+
 <<checkout(cfg)>>
 <<setup>>
       - name: Check out PR branch

--- a/generator/tests/_regtest_outputs/test_generate.test_extras_apply_path_regtest.out
+++ b/generator/tests/_regtest_outputs/test_generate.test_extras_apply_path_regtest.out
@@ -149,7 +149,8 @@ jobs:
       - name: Remove the eyes reaction
         if: always() && (steps.gate.outputs.should_run == 'true')
         run: |
-          REACTION_ID=$(gh api "repos/$REPO/$TARGET/reactions?content=eyes" \
+          REACTION_ID=$(gh api --paginate \
+            "repos/$REPO/$TARGET/reactions?content=eyes&per_page=100" \
             --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" | head -n1)
           if [ -n "$REACTION_ID" ]; then
             gh api -X DELETE "repos/$REPO/$TARGET/reactions/$REACTION_ID" --silent \

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-triage.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-triage.yaml].out
@@ -57,7 +57,8 @@ jobs:
       - name: Remove the eyes reaction
         if: always()
         run: |
-          REACTION_ID=$(gh api "repos/$REPO/$TARGET/reactions?content=eyes" \
+          REACTION_ID=$(gh api --paginate \
+            "repos/$REPO/$TARGET/reactions?content=eyes&per_page=100" \
             --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" | head -n1)
           if [ -n "$REACTION_ID" ]; then
             gh api -X DELETE "repos/$REPO/$TARGET/reactions/$REACTION_ID" --silent \

--- a/generator/tests/_regtest_outputs/test_generate.test_sandbox_levers_regtest.out
+++ b/generator/tests/_regtest_outputs/test_generate.test_sandbox_levers_regtest.out
@@ -341,26 +341,6 @@ jobs:
           PAYLOAD_PR: ${{ github.event.client_payload.pr }}
           PAYLOAD_ID: ${{ github.event.client_payload.id }}
 
-      # The dispatch arm covers a relayed inline comment, whose id the check
-      # step verified belongs to this PR; a review *submission* has no single
-      # comment to react to, so it gets no eyes ? same as when the events
-      # arrived directly.
-      - name: React with eyes
-        if: |
-          steps.check.outputs.should_run == 'true'
-          && ((github.event.comment && contains(github.event.comment.body, '@test-bot'))
-              || (github.event.client_payload.kind == 'pull_request_review_comment'
-                  && steps.check.outputs.reason == 'mention'))
-        run: |
-          gh api "repos/$REPO/$TARGET/reactions" -f content=eyes --silent \
-            || echo "::warning::could not add the eyes reaction"
-        env:
-          REPO: ${{ github.repository }}
-          TARGET: ${{ github.event_name == 'issue_comment'
-            && format('issues/comments/{0}', github.event.comment.id)
-            || format('pulls/comments/{0}', github.event.comment.id || github.event.client_payload.id) }}
-          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
-
   handle:
     needs: verify
     if: needs.verify.outputs.should_run == 'true'
@@ -377,6 +357,32 @@ jobs:
       actions: read
       issues: write
     steps:
+      # Both halves of the reaction belong to this job, so the eyes can only
+      # go on once the job that takes them off has started. Put them in
+      # `verify` and `handle` respectively and the routine burst case strands
+      # them: a third mention on one thread evicts the second's pending
+      # `handle` ? a job cancelled while queued allocates no runner and runs
+      # no steps, `always()` included ? while its `verify` already reacted.
+      #
+      # The dispatch arm covers a relayed inline comment, whose id the check
+      # step verified belongs to this PR; a review *submission* has no single
+      # comment to react to, so it gets no eyes ? same as when the events
+      # arrived directly. The job's own `if` already carries `should_run`.
+      - name: React with eyes
+        if: |
+          ((github.event.comment && contains(github.event.comment.body, '@test-bot'))
+              || (github.event.client_payload.kind == 'pull_request_review_comment'
+                  && needs.verify.outputs.reason == 'mention'))
+        run: |
+          gh api "repos/$REPO/$TARGET/reactions" -f content=eyes --silent \
+            || echo "::warning::could not add the eyes reaction"
+        env:
+          REPO: ${{ github.repository }}
+          TARGET: ${{ github.event_name == 'issue_comment'
+            && format('issues/comments/{0}', github.event.comment.id)
+            || format('pulls/comments/{0}', github.event.comment.id || github.event.client_payload.id) }}
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
+
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
@@ -457,7 +463,8 @@ jobs:
               || (github.event.client_payload.kind == 'pull_request_review_comment'
                   && needs.verify.outputs.reason == 'mention'))
         run: |
-          REACTION_ID=$(gh api "repos/$REPO/$TARGET/reactions?content=eyes" \
+          REACTION_ID=$(gh api --paginate \
+            "repos/$REPO/$TARGET/reactions?content=eyes&per_page=100" \
             --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" | head -n1)
           if [ -n "$REACTION_ID" ]; then
             gh api -X DELETE "repos/$REPO/$TARGET/reactions/$REACTION_ID" --silent \

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
@@ -341,26 +341,6 @@ jobs:
           PAYLOAD_PR: ${{ github.event.client_payload.pr }}
           PAYLOAD_ID: ${{ github.event.client_payload.id }}
 
-      # The dispatch arm covers a relayed inline comment, whose id the check
-      # step verified belongs to this PR; a review *submission* has no single
-      # comment to react to, so it gets no eyes ? same as when the events
-      # arrived directly.
-      - name: React with eyes
-        if: |
-          steps.check.outputs.should_run == 'true'
-          && ((github.event.comment && contains(github.event.comment.body, '@test-bot'))
-              || (github.event.client_payload.kind == 'pull_request_review_comment'
-                  && steps.check.outputs.reason == 'mention'))
-        run: |
-          gh api "repos/$REPO/$TARGET/reactions" -f content=eyes --silent \
-            || echo "::warning::could not add the eyes reaction"
-        env:
-          REPO: ${{ github.repository }}
-          TARGET: ${{ github.event_name == 'issue_comment'
-            && format('issues/comments/{0}', github.event.comment.id)
-            || format('pulls/comments/{0}', github.event.comment.id || github.event.client_payload.id) }}
-          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
-
   handle:
     needs: verify
     if: needs.verify.outputs.should_run == 'true'
@@ -377,6 +357,32 @@ jobs:
       actions: read
       issues: write
     steps:
+      # Both halves of the reaction belong to this job, so the eyes can only
+      # go on once the job that takes them off has started. Put them in
+      # `verify` and `handle` respectively and the routine burst case strands
+      # them: a third mention on one thread evicts the second's pending
+      # `handle` ? a job cancelled while queued allocates no runner and runs
+      # no steps, `always()` included ? while its `verify` already reacted.
+      #
+      # The dispatch arm covers a relayed inline comment, whose id the check
+      # step verified belongs to this PR; a review *submission* has no single
+      # comment to react to, so it gets no eyes ? same as when the events
+      # arrived directly. The job's own `if` already carries `should_run`.
+      - name: React with eyes
+        if: |
+          ((github.event.comment && contains(github.event.comment.body, '@test-bot'))
+              || (github.event.client_payload.kind == 'pull_request_review_comment'
+                  && needs.verify.outputs.reason == 'mention'))
+        run: |
+          gh api "repos/$REPO/$TARGET/reactions" -f content=eyes --silent \
+            || echo "::warning::could not add the eyes reaction"
+        env:
+          REPO: ${{ github.repository }}
+          TARGET: ${{ github.event_name == 'issue_comment'
+            && format('issues/comments/{0}', github.event.comment.id)
+            || format('pulls/comments/{0}', github.event.comment.id || github.event.client_payload.id) }}
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
+
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
@@ -447,7 +453,8 @@ jobs:
               || (github.event.client_payload.kind == 'pull_request_review_comment'
                   && needs.verify.outputs.reason == 'mention'))
         run: |
-          REACTION_ID=$(gh api "repos/$REPO/$TARGET/reactions?content=eyes" \
+          REACTION_ID=$(gh api --paginate \
+            "repos/$REPO/$TARGET/reactions?content=eyes&per_page=100" \
             --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" | head -n1)
           if [ -n "$REACTION_ID" ]; then
             gh api -X DELETE "repos/$REPO/$TARGET/reactions/$REACTION_ID" --silent \

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[review].out
@@ -147,7 +147,8 @@ jobs:
       - name: Remove the eyes reaction
         if: always() && (steps.gate.outputs.should_run == 'true')
         run: |
-          REACTION_ID=$(gh api "repos/$REPO/$TARGET/reactions?content=eyes" \
+          REACTION_ID=$(gh api --paginate \
+            "repos/$REPO/$TARGET/reactions?content=eyes&per_page=100" \
             --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" | head -n1)
           if [ -n "$REACTION_ID" ]; then
             gh api -X DELETE "repos/$REPO/$TARGET/reactions/$REACTION_ID" --silent \

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[triage].out
@@ -56,7 +56,8 @@ jobs:
       - name: Remove the eyes reaction
         if: always()
         run: |
-          REACTION_ID=$(gh api "repos/$REPO/$TARGET/reactions?content=eyes" \
+          REACTION_ID=$(gh api --paginate \
+            "repos/$REPO/$TARGET/reactions?content=eyes&per_page=100" \
             --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" | head -n1)
           if [ -n "$REACTION_ID" ]; then
             gh api -X DELETE "repos/$REPO/$TARGET/reactions/$REACTION_ID" --silent \

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
@@ -341,26 +341,6 @@ jobs:
           PAYLOAD_PR: ${{ github.event.client_payload.pr }}
           PAYLOAD_ID: ${{ github.event.client_payload.id }}
 
-      # The dispatch arm covers a relayed inline comment, whose id the check
-      # step verified belongs to this PR; a review *submission* has no single
-      # comment to react to, so it gets no eyes ? same as when the events
-      # arrived directly.
-      - name: React with eyes
-        if: |
-          steps.check.outputs.should_run == 'true'
-          && ((github.event.comment && contains(github.event.comment.body, '@test-bot'))
-              || (github.event.client_payload.kind == 'pull_request_review_comment'
-                  && steps.check.outputs.reason == 'mention'))
-        run: |
-          gh api "repos/$REPO/$TARGET/reactions" -f content=eyes --silent \
-            || echo "::warning::could not add the eyes reaction"
-        env:
-          REPO: ${{ github.repository }}
-          TARGET: ${{ github.event_name == 'issue_comment'
-            && format('issues/comments/{0}', github.event.comment.id)
-            || format('pulls/comments/{0}', github.event.comment.id || github.event.client_payload.id) }}
-          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
-
   handle:
     needs: verify
     if: needs.verify.outputs.should_run == 'true'
@@ -377,6 +357,32 @@ jobs:
       actions: read
       issues: write
     steps:
+      # Both halves of the reaction belong to this job, so the eyes can only
+      # go on once the job that takes them off has started. Put them in
+      # `verify` and `handle` respectively and the routine burst case strands
+      # them: a third mention on one thread evicts the second's pending
+      # `handle` ? a job cancelled while queued allocates no runner and runs
+      # no steps, `always()` included ? while its `verify` already reacted.
+      #
+      # The dispatch arm covers a relayed inline comment, whose id the check
+      # step verified belongs to this PR; a review *submission* has no single
+      # comment to react to, so it gets no eyes ? same as when the events
+      # arrived directly. The job's own `if` already carries `should_run`.
+      - name: React with eyes
+        if: |
+          ((github.event.comment && contains(github.event.comment.body, '@test-bot'))
+              || (github.event.client_payload.kind == 'pull_request_review_comment'
+                  && needs.verify.outputs.reason == 'mention'))
+        run: |
+          gh api "repos/$REPO/$TARGET/reactions" -f content=eyes --silent \
+            || echo "::warning::could not add the eyes reaction"
+        env:
+          REPO: ${{ github.repository }}
+          TARGET: ${{ github.event_name == 'issue_comment'
+            && format('issues/comments/{0}', github.event.comment.id)
+            || format('pulls/comments/{0}', github.event.comment.id || github.event.client_payload.id) }}
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
+
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
@@ -448,7 +454,8 @@ jobs:
               || (github.event.client_payload.kind == 'pull_request_review_comment'
                   && needs.verify.outputs.reason == 'mention'))
         run: |
-          REACTION_ID=$(gh api "repos/$REPO/$TARGET/reactions?content=eyes" \
+          REACTION_ID=$(gh api --paginate \
+            "repos/$REPO/$TARGET/reactions?content=eyes&per_page=100" \
             --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" | head -n1)
           if [ -n "$REACTION_ID" ]; then
             gh api -X DELETE "repos/$REPO/$TARGET/reactions/$REACTION_ID" --silent \

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review].out
@@ -148,7 +148,8 @@ jobs:
       - name: Remove the eyes reaction
         if: always() && (steps.gate.outputs.should_run == 'true')
         run: |
-          REACTION_ID=$(gh api "repos/$REPO/$TARGET/reactions?content=eyes" \
+          REACTION_ID=$(gh api --paginate \
+            "repos/$REPO/$TARGET/reactions?content=eyes&per_page=100" \
             --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" | head -n1)
           if [ -n "$REACTION_ID" ]; then
             gh api -X DELETE "repos/$REPO/$TARGET/reactions/$REACTION_ID" --silent \

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[triage].out
@@ -57,7 +57,8 @@ jobs:
       - name: Remove the eyes reaction
         if: always()
         run: |
-          REACTION_ID=$(gh api "repos/$REPO/$TARGET/reactions?content=eyes" \
+          REACTION_ID=$(gh api --paginate \
+            "repos/$REPO/$TARGET/reactions?content=eyes&per_page=100" \
             --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" | head -n1)
           if [ -n "$REACTION_ID" ]; then
             gh api -X DELETE "repos/$REPO/$TARGET/reactions/$REACTION_ID" --silent \

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_local_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_local_setup_regtest[mention].out
@@ -341,26 +341,6 @@ jobs:
           PAYLOAD_PR: ${{ github.event.client_payload.pr }}
           PAYLOAD_ID: ${{ github.event.client_payload.id }}
 
-      # The dispatch arm covers a relayed inline comment, whose id the check
-      # step verified belongs to this PR; a review *submission* has no single
-      # comment to react to, so it gets no eyes ? same as when the events
-      # arrived directly.
-      - name: React with eyes
-        if: |
-          steps.check.outputs.should_run == 'true'
-          && ((github.event.comment && contains(github.event.comment.body, '@test-bot'))
-              || (github.event.client_payload.kind == 'pull_request_review_comment'
-                  && steps.check.outputs.reason == 'mention'))
-        run: |
-          gh api "repos/$REPO/$TARGET/reactions" -f content=eyes --silent \
-            || echo "::warning::could not add the eyes reaction"
-        env:
-          REPO: ${{ github.repository }}
-          TARGET: ${{ github.event_name == 'issue_comment'
-            && format('issues/comments/{0}', github.event.comment.id)
-            || format('pulls/comments/{0}', github.event.comment.id || github.event.client_payload.id) }}
-          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
-
   handle:
     needs: verify
     if: needs.verify.outputs.should_run == 'true'
@@ -377,6 +357,32 @@ jobs:
       actions: read
       issues: write
     steps:
+      # Both halves of the reaction belong to this job, so the eyes can only
+      # go on once the job that takes them off has started. Put them in
+      # `verify` and `handle` respectively and the routine burst case strands
+      # them: a third mention on one thread evicts the second's pending
+      # `handle` ? a job cancelled while queued allocates no runner and runs
+      # no steps, `always()` included ? while its `verify` already reacted.
+      #
+      # The dispatch arm covers a relayed inline comment, whose id the check
+      # step verified belongs to this PR; a review *submission* has no single
+      # comment to react to, so it gets no eyes ? same as when the events
+      # arrived directly. The job's own `if` already carries `should_run`.
+      - name: React with eyes
+        if: |
+          ((github.event.comment && contains(github.event.comment.body, '@test-bot'))
+              || (github.event.client_payload.kind == 'pull_request_review_comment'
+                  && needs.verify.outputs.reason == 'mention'))
+        run: |
+          gh api "repos/$REPO/$TARGET/reactions" -f content=eyes --silent \
+            || echo "::warning::could not add the eyes reaction"
+        env:
+          REPO: ${{ github.repository }}
+          TARGET: ${{ github.event_name == 'issue_comment'
+            && format('issues/comments/{0}', github.event.comment.id)
+            || format('pulls/comments/{0}', github.event.comment.id || github.event.client_payload.id) }}
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
+
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
@@ -457,7 +463,8 @@ jobs:
               || (github.event.client_payload.kind == 'pull_request_review_comment'
                   && needs.verify.outputs.reason == 'mention'))
         run: |
-          REACTION_ID=$(gh api "repos/$REPO/$TARGET/reactions?content=eyes" \
+          REACTION_ID=$(gh api --paginate \
+            "repos/$REPO/$TARGET/reactions?content=eyes&per_page=100" \
             --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" | head -n1)
           if [ -n "$REACTION_ID" ]; then
             gh api -X DELETE "repos/$REPO/$TARGET/reactions/$REACTION_ID" --silent \

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_local_setup_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_local_setup_regtest[review].out
@@ -169,7 +169,8 @@ jobs:
       - name: Remove the eyes reaction
         if: always() && (steps.gate.outputs.should_run == 'true')
         run: |
-          REACTION_ID=$(gh api "repos/$REPO/$TARGET/reactions?content=eyes" \
+          REACTION_ID=$(gh api --paginate \
+            "repos/$REPO/$TARGET/reactions?content=eyes&per_page=100" \
             --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" | head -n1)
           if [ -n "$REACTION_ID" ]; then
             gh api -X DELETE "repos/$REPO/$TARGET/reactions/$REACTION_ID" --silent \

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
@@ -341,26 +341,6 @@ jobs:
           PAYLOAD_PR: ${{ github.event.client_payload.pr }}
           PAYLOAD_ID: ${{ github.event.client_payload.id }}
 
-      # The dispatch arm covers a relayed inline comment, whose id the check
-      # step verified belongs to this PR; a review *submission* has no single
-      # comment to react to, so it gets no eyes ? same as when the events
-      # arrived directly.
-      - name: React with eyes
-        if: |
-          steps.check.outputs.should_run == 'true'
-          && ((github.event.comment && contains(github.event.comment.body, '@test-bot'))
-              || (github.event.client_payload.kind == 'pull_request_review_comment'
-                  && steps.check.outputs.reason == 'mention'))
-        run: |
-          gh api "repos/$REPO/$TARGET/reactions" -f content=eyes --silent \
-            || echo "::warning::could not add the eyes reaction"
-        env:
-          REPO: ${{ github.repository }}
-          TARGET: ${{ github.event_name == 'issue_comment'
-            && format('issues/comments/{0}', github.event.comment.id)
-            || format('pulls/comments/{0}', github.event.comment.id || github.event.client_payload.id) }}
-          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
-
   handle:
     needs: verify
     if: needs.verify.outputs.should_run == 'true'
@@ -377,6 +357,32 @@ jobs:
       actions: read
       issues: write
     steps:
+      # Both halves of the reaction belong to this job, so the eyes can only
+      # go on once the job that takes them off has started. Put them in
+      # `verify` and `handle` respectively and the routine burst case strands
+      # them: a third mention on one thread evicts the second's pending
+      # `handle` ? a job cancelled while queued allocates no runner and runs
+      # no steps, `always()` included ? while its `verify` already reacted.
+      #
+      # The dispatch arm covers a relayed inline comment, whose id the check
+      # step verified belongs to this PR; a review *submission* has no single
+      # comment to react to, so it gets no eyes ? same as when the events
+      # arrived directly. The job's own `if` already carries `should_run`.
+      - name: React with eyes
+        if: |
+          ((github.event.comment && contains(github.event.comment.body, '@test-bot'))
+              || (github.event.client_payload.kind == 'pull_request_review_comment'
+                  && needs.verify.outputs.reason == 'mention'))
+        run: |
+          gh api "repos/$REPO/$TARGET/reactions" -f content=eyes --silent \
+            || echo "::warning::could not add the eyes reaction"
+        env:
+          REPO: ${{ github.repository }}
+          TARGET: ${{ github.event_name == 'issue_comment'
+            && format('issues/comments/{0}', github.event.comment.id)
+            || format('pulls/comments/{0}', github.event.comment.id || github.event.client_payload.id) }}
+          GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
+
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
@@ -450,7 +456,8 @@ jobs:
               || (github.event.client_payload.kind == 'pull_request_review_comment'
                   && needs.verify.outputs.reason == 'mention'))
         run: |
-          REACTION_ID=$(gh api "repos/$REPO/$TARGET/reactions?content=eyes" \
+          REACTION_ID=$(gh api --paginate \
+            "repos/$REPO/$TARGET/reactions?content=eyes&per_page=100" \
             --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" | head -n1)
           if [ -n "$REACTION_ID" ]; then
             gh api -X DELETE "repos/$REPO/$TARGET/reactions/$REACTION_ID" --silent \

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review].out
@@ -162,7 +162,8 @@ jobs:
       - name: Remove the eyes reaction
         if: always() && (steps.gate.outputs.should_run == 'true')
         run: |
-          REACTION_ID=$(gh api "repos/$REPO/$TARGET/reactions?content=eyes" \
+          REACTION_ID=$(gh api --paginate \
+            "repos/$REPO/$TARGET/reactions?content=eyes&per_page=100" \
             --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" | head -n1)
           if [ -n "$REACTION_ID" ]; then
             gh api -X DELETE "repos/$REPO/$TARGET/reactions/$REACTION_ID" --silent \

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[triage].out
@@ -59,7 +59,8 @@ jobs:
       - name: Remove the eyes reaction
         if: always()
         run: |
-          REACTION_ID=$(gh api "repos/$REPO/$TARGET/reactions?content=eyes" \
+          REACTION_ID=$(gh api --paginate \
+            "repos/$REPO/$TARGET/reactions?content=eyes&per_page=100" \
             --jq ".[] | select(.user.login == \"$BOT_NAME\") | .id" | head -n1)
           if [ -n "$REACTION_ID" ]; then
             gh api -X DELETE "repos/$REPO/$TARGET/reactions/$REACTION_ID" --silent \

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -744,29 +744,35 @@ def test_issue_and_pr_acknowledged_with_eyes(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
-    ("name", "react_job", "unreact_job"),
-    [
-        ("triage", "triage", "triage"),
-        ("review", "review", "review"),
-        ("mention", "verify", "handle"),
-    ],
+    ("name", "job"),
+    [("triage", "triage"), ("review", "review"), ("mention", "handle")],
 )
 def test_eyes_come_off_when_the_session_ends(
-    tmp_path: Path, name: str, react_job: str, unreact_job: str
+    tmp_path: Path, name: str, job: str
 ) -> None:
     """👀 means a session is working on this right now, so every workflow that
     puts it on takes it off again — under `always()`, so a failed or cancelled
     run doesn't strand it.
 
-    Both halves have to name the same reaction target. Mention splits them
-    across jobs, and a target that drifted between the two would leave the eyes
-    on every comment the bot ever answered."""
+    Both halves live in the *same* job, which is what makes `always()` mean
+    anything: a job cancelled while still queued never allocates a runner, so
+    none of its steps execute — `always()` governs execution within a job that
+    started. React in one job and unreact in another and every route where the
+    second job never starts leaves the eyes on with no session behind them.
+    `cancel-in-progress: false` doesn't close that: it holds a *running* job
+    while GitHub still evicts a *pending* one to make room for a newer run.
+
+    Both halves also have to name the same reaction target; one that drifted
+    would leave the eyes on every comment the bot ever answered."""
     cfg = Config.load(_minimal_config(tmp_path))
     workflows = {wf.filename: wf for wf in generate_all(cfg)}
     jobs = yaml.safe_load(workflows[f"tend-{name}.yaml"].content)["jobs"]
 
-    react = _eyes_steps(jobs[react_job]["steps"])[0]
-    unreact = _eyes_steps(jobs[unreact_job]["steps"])[-1]
+    reacting = {j for j, spec in jobs.items() if _eyes_steps(spec["steps"])}
+    assert reacting == {job}, f"{name}: the eyes are split across {reacting}"
+
+    eyes = _eyes_steps(jobs[job]["steps"])
+    react, unreact = eyes[0], eyes[-1]
     assert "-X DELETE" in unreact["run"], f"{name}: nothing removes the reaction"
     assert unreact["if"].startswith("always()"), (
         f"{name}: a failed session has to release the reaction too"
@@ -774,6 +780,11 @@ def test_eyes_come_off_when_the_session_ends(
     assert unreact["env"]["TARGET"] == react["env"]["TARGET"]
     # The bot's own reaction only — a human's 👀 on the same issue stays put.
     assert 'select(.user.login == \\"$BOT_NAME\\")' in unreact["run"]
+    # The bot's 👀 is one of many on a busy thread, and page 1 is 30 of them:
+    # unpaginated, the lookup misses its own reaction and silently keeps it.
+    assert "--paginate" in unreact["run"], (
+        f"{name}: the reaction lookup only reads the first page"
+    )
 
 
 def test_setup_raw_rejected_with_migration_hint(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

`tend-mention` put the 👀 on in `verify` and took it off in `handle`. `always()` on the remove step only governs step execution *within a job that started* — a job cancelled while still queued allocates no runner and runs no steps at all. `handle`'s `cancel-in-progress: false` holds a *running* job; GitHub still evicts a *pending* one when a newer run arrives ([workflow-syntax](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency)). So a burst of three mentions on one thread evicts run 2's pending `handle` after its `verify` already reacted, leaving a 👀 that claims a session is working with no session and nothing left to remove it. Eviction is the routine path; any route where `handle` never starts (a `verify` failure after the react, an environment-protection refusal) has the same shape. `review` and `triage` were never exposed — both halves are steps of one job there.

Separately, the remove step listed reactions with no `--paginate`, so it read only the first 30. On `review` and `triage` the target is the issue/PR itself, where 👀 is also the ordinary "watching this" reaction — past 30 of them the bot's own falls off page 1, `REACTION_ID` comes back empty, and the step exits 0 having silently kept the reaction.

Both bugs strand the same signal, so they're fixed together.

## Solution

Move `react_eyes` into `handle` as its first step, matching `review` and `triage`: the eyes can only go on once the job that removes them has started. Its `if:` drops the `should_run` conjunct (the job's own `if` already carries it) and reads `needs.verify.outputs.reason` instead of `steps.check.outputs.reason`.

Add `--paginate` (and `per_page=100`) to the reaction lookup in `unreact_eyes`; the existing `--jq` filter and `head -n1` already handle the rest.

Of the issue's three options this is #1. #3 (`queue: max`) would run every queued session instead of dropping the redundant ones — a cost change, not a fix.

## The trade this makes

What a user sees changes, and not only by a few seconds. On an idle thread the 👀 now lands after `verify` finishes rather than at the end of it — seconds, on a signal that already lags the comment by the length of `verify`. On a busy thread — the burst case this fix exists for — `handle` queues behind the in-flight session under `tend-mention-handle-<number>` with `cancel-in-progress: false`, so the second mention's 👀 waits out that whole session, and a third mention evicts the queued `handle` before it ever reacts, leaving the second comment with no acknowledgment at all. Before this change that comment got its 👀 immediately — stranded, which is the bug.

That's the intended trade: 👀 means "a session is working on this right now", and under the new placement it is never claimed falsely. Silence on a queued comment is recoverable — the handling prompt already tells the session to pick up other unaddressed comments on the thread — whereas a stranded 👀 is a standing false claim nothing clears.

## Testing

`test_eyes_come_off_when_the_session_ends` now asserts the invariant the bug violated — that exactly one job in each workflow carries eyes steps — plus `--paginate` on the lookup. Both assertions fail on the old templates (`mention: the eyes are split across {'handle', 'verify'}`; `triage/review: the reaction lookup only reads the first page`) and pass after. Regtest snapshots regenerated; full Python suite green (554 passed).

The generated `tend-*.yaml` in this repo are untouched — they track the released generator and update on the nightly regen.

---
Closes #989 — automated triage
