### PR TITLE
docs(running-in-ci): scope PR-description claims to the merge base

### DIFF
--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -64,6 +64,8 @@ git fetch --no-tags --quiet origin "$BASE_SHA" 2>/dev/null || true
 git log --no-merges --numstat --format='%h %s' "$LAST_REVIEW_SHA..$HEAD_SHA" --not "$BASE_SHA"
 ```
 
+The incremental scopes the *review*, not anything this run writes about the PR as a whole: if you also edit the PR description, scope its claims to the merge base per **Keeping PR Titles and Descriptions Current** in `/tend-ci-runner:running-in-ci`.
+
 If the incremental changes are trivial, skip the full review — go directly to step 7 to resolve any bot threads addressed by the new changes. After resolving threads: if the most recent bot review was a COMMENT that flagged issues, and those issues are now addressed, submit an APPROVE with an empty body so the PR isn't left in limbo. Otherwise do not submit a new review — the existing one stands. Do NOT proceed to steps 2–6; finish at step 9. Rough heuristic: changes under ~20 added+deleted lines that don't introduce new functions, types, or control flow are typically trivial.
 
 **Commit and PR authorship do not affect review behavior.** Apply the same trivial-vs-substantive heuristic regardless of who pushed the new commits. When `tend-notifications` or `tend-ci-fix` pushes a fix to a human-authored PR, reviewing (and re-approving) the updated state is expected — the reviewer role is independent of commit authorship.

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -403,6 +403,14 @@ gh api repos/{owner}/{repo}/pulls/{number} -X PATCH \
   -f title="new title" -F body=@/tmp/updated-body.md
 ```
 
+**A description describes the whole PR, not the increment this run reviewed.** Scope every behavior claim in it to the PR's merge base — not `LAST_REVIEW_SHA`, and not whatever range this run happened to diff:
+
+```bash
+git merge-base "origin/$(gh pr view <number> --json baseRefName --jq '.baseRefName')" HEAD
+```
+
+On a long-lived branch those are different commits — nightly's rolling `tend/update-workflows` PR accumulates a release per run, so its head is several releases past its merge base — and a claim that is true of the last increment can be false of the PR. If you can only verify the increment, name the base the claim is against instead of writing it as a claim about the PR. Nothing downstream catches a wrong description: it never turns a check red, and each later run re-anchors one increment further out.
+
 ## Atomic PRs
 
 Split unrelated changes into separate PRs — one concern per PR. If one change could be reverted without affecting the other, they belong in separate PRs.

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -406,7 +406,7 @@ gh api repos/{owner}/{repo}/pulls/{number} -X PATCH \
 **A description describes the whole PR, not the increment this run reviewed.** Scope every behavior claim in it to the PR's merge base — not `LAST_REVIEW_SHA`, and not whatever range this run happened to diff:
 
 ```bash
-git merge-base "origin/$(gh pr view <number> --json baseRefName --jq '.baseRefName')" HEAD
+gh pr diff <number>   # merge-base→head, whatever this session has checked out
 ```
 
 On a long-lived branch those are different commits — nightly's rolling `tend/update-workflows` PR accumulates a release per run, so its head is several releases past its merge base — and a claim that is true of the last increment can be false of the PR. If you can only verify the increment, name the base the claim is against instead of writing it as a claim about the PR. Nothing downstream catches a wrong description: it never turns a check red, and each later run re-anchors one increment further out.


### PR DESCRIPTION
## Problem

A review run reads its diff from `LAST_REVIEW_SHA` but edits a whole-PR artifact when it updates the description, and **Keeping PR Titles and Descriptions Current** never said which base a description claim is scoped to. So the increment's conclusion goes into the description as if it described the PR. On a long-lived branch — nightly's rolling `tend/update-workflows` PR, which accumulates a release per run — the two bases are several releases apart, and nothing catches the mismatch afterwards: a wrong description never turns a check red, and each later run re-anchors on a still-newer `LAST_REVIEW_SHA`. #991 traces three successive runs rewriting the same bullet from three different bases.

## Solution

State the scope rule where the description edit happens, in `running-in-ci`: a description describes the whole PR, so scope behavior claims to the merge base, and when only the increment can be verified, name that base rather than writing an unscoped claim. `review/SKILL.md` gets a one-line pointer beside the incremental setup — the point where the wrong base enters context — rather than a second copy of the rule.

## Testing

No test: the failure is prose the agent reads, not code. `uvx pre-commit run --files <the two SKILL.md>` passes (typos, trailing whitespace, the plugin-skill bang-backtick and reference-sync hooks).

---
Closes #991 — automated triage
