### PR TITLE
fix(checks): report only org secrets the repo can actually read

### DIFF
--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -101,7 +101,12 @@ where a credential can live:
   reopen the gate. Org-level secrets are swept into the same check
   best-effort: they cannot be environment-gated at all, and listing them
   needs `admin:org`, the one place the claim rests on the token the
-  maintainer ran `tend check` with.
+  maintainer ran `tend check` with. Only the org secrets this repo can
+  actually read count — one scoped away from it (`selected` without the
+  repo, `private` against a public repo, any of them against a private
+  repo in a GitHub Free org) reaches no workflow here, and naming it
+  would leave a failure no repo-side change can clear. A secret whose
+  reach cannot be determined is reported rather than dropped.
 - *The operational secrets actually live in the gated environment*
   (`environment`, `secrets`): the `tend` policy admits exactly the
   verified branches, and the bot PAT and harness auth are present there

--- a/generator/src/tend/checks.py
+++ b/generator/src/tend/checks.py
@@ -1415,7 +1415,9 @@ def _list_org_secrets(org: str, repo: str) -> tuple[set[str] | None, bool]:
     for name, visibility in listed:
         if visibility == "selected":
             shared = _org_secret_repos(org, name)
-            if shared is not None and repo not in shared:
+            if shared is not None and repo.casefold() not in {
+                r.casefold() for r in shared
+            }:
                 continue
         elif visibility == "private" and is_public:
             continue

--- a/generator/src/tend/checks.py
+++ b/generator/src/tend/checks.py
@@ -1321,7 +1321,7 @@ def check_secrets(repo: str, expected: list[str]) -> CheckResult:
         )
 
     org = repo.split("/")[0] if "/" in repo else None
-    org_secrets, org_forbidden = _list_org_secrets(org) if org else (None, False)
+    org_secrets, org_forbidden = _list_org_secrets(org, repo) if org else (None, False)
     found_at_org = [s for s in missing if org_secrets and s in org_secrets]
 
     msg = (
@@ -1344,18 +1344,83 @@ def check_secrets(repo: str, expected: list[str]) -> CheckResult:
     return CheckResult("secrets", False, msg)
 
 
-def _list_org_secrets(org: str) -> tuple[set[str] | None, bool]:
-    """List org-level secret names. Returns (secrets, permission_denied)."""
-    result = _gh("api", f"orgs/{org}/actions/secrets", "--jq", "[.secrets[].name]")
+def _repo_is_public(repo: str) -> bool | None:
+    """Whether `repo` is public. None when it cannot be determined."""
+    result = _gh("api", f"repos/{repo}", "--jq", ".private")
+    if result is None or result.returncode != 0:
+        return None
+    return {"true": False, "false": True}.get(result.stdout.strip())
+
+
+def _org_secret_repos(org: str, name: str) -> set[str] | None:
+    """Repos a `selected`-visibility org secret is shared with, or None if the
+    list cannot be read. Paginated: an org sharing a secret with more repos
+    than one page holds would otherwise look like it omits this one."""
+    result = _gh(
+        "api",
+        "--paginate",
+        f"orgs/{org}/actions/secrets/{name}/repositories",
+        "--jq",
+        ".repositories[].full_name",
+    )
+    if result is None or result.returncode != 0:
+        return None
+    return {line.strip() for line in result.stdout.splitlines() if line.strip()}
+
+
+def _org_plan_is_free(org: str) -> bool:
+    """Whether the org is on GitHub Free, which serves org secrets to public
+    repositories only. False whenever the plan can't be read — the caller
+    skips secrets on this, and skipping wrongly would blind the check."""
+    result = _gh("api", f"orgs/{org}", "--jq", '.plan.name // ""')
+    if result is None or result.returncode != 0:
+        return False
+    return result.stdout.strip() == "free"
+
+
+def _list_org_secrets(org: str, repo: str) -> tuple[set[str] | None, bool]:
+    """List the org-level secrets `repo` can actually read.
+
+    Returns (secrets, permission_denied). An org secret scoped away from this
+    repo is not part of its credential surface, and naming it produces a
+    failure no repo-side change can clear: the repo is already at the tightest
+    scoping GitHub offers, so the only lever left is a `secrets.allowed` entry
+    that would assert the opposite of the truth and mute the name permanently.
+
+    Filtering is fail-safe in one direction only — a secret whose reach cannot
+    be determined stays in the set. Under-reporting hides real exposure;
+    over-reporting is merely noise.
+    """
+    result = _gh(
+        "api",
+        f"orgs/{org}/actions/secrets",
+        "--jq",
+        "[.secrets[] | {name, visibility}]",
+    )
     if result is None:
         return None, False
     if result.returncode != 0:
         forbidden = "HTTP 403" in result.stderr
         return None, forbidden
     try:
-        return set(json.loads(result.stdout)), False
-    except (json.JSONDecodeError, TypeError):
+        listed = [(s["name"], s.get("visibility")) for s in json.loads(result.stdout)]
+    except (json.JSONDecodeError, TypeError, KeyError):
         return None, False
+
+    is_public = _repo_is_public(repo)
+    if is_public is False and _org_plan_is_free(org):
+        return set(), False
+
+    reachable = set()
+    for name, visibility in listed:
+        if visibility == "selected":
+            shared = _org_secret_repos(org, name)
+            if shared is not None and repo not in shared:
+                continue
+        elif visibility == "private" and is_public:
+            continue
+        reachable.add(name)
+    return reachable, False
 
 
 def check_repo_secret_allowlist(repo: str, allowed: set[str]) -> CheckResult:
@@ -1383,12 +1448,13 @@ def check_repo_secret_allowlist(repo: str, allowed: set[str]) -> CheckResult:
             "repo-secret-allowlist", None, "Could not parse secrets response"
         )
 
-    # Best-effort: include org-level secrets (also available to workflows).
+    # Best-effort: include the org-level secrets this repo can read (also
+    # available to its workflows). Ones scoped away from it are not.
     org = repo.split("/")[0] if "/" in repo else None
     org_secrets: set[str] = set()
     org_forbidden = False
     if org:
-        fetched, org_forbidden = _list_org_secrets(org)
+        fetched, org_forbidden = _list_org_secrets(org, repo)
         if fetched is not None:
             org_secrets = fetched
 

--- a/generator/tests/test_checks.py
+++ b/generator/tests/test_checks.py
@@ -144,12 +144,7 @@ def _org_secret_gh(
                 return _make_completed(returncode=repositories_rc, stderr="HTTP 404")
             return _make_completed("\n".join(shared.get(url.split("/")[-2], [])) + "\n")
         if url == "orgs/acme/actions/secrets":
-            jq = args[args.index("--jq") + 1] if "--jq" in args else ""
-            listed = (
-                [{"name": n, "visibility": v} for n, v in org_secrets]
-                if "visibility" in jq
-                else [n for n, _ in org_secrets]
-            )
+            listed = [{"name": n, "visibility": v} for n, v in org_secrets]
             return _make_completed(json.dumps(listed) + "\n")
         if url == "orgs/acme":
             return _make_completed(f"{plan}\n")
@@ -950,6 +945,22 @@ def test_repo_secret_allowlist_org_secret_shared_with_repo() -> None:
     assert result.passed is False
     assert "NPM_TOKEN" in result.message
     assert "org-level" in result.message
+
+
+def test_repo_secret_allowlist_org_secret_shared_case_insensitively() -> None:
+    """GitHub returns `full_name` in canonical casing while `repo` is whatever
+    was passed to `--repo`. A casing difference must not read as "not shared"
+    and drop the secret — that is the under-reporting direction."""
+    with patch(
+        "tend.checks._gh",
+        side_effect=_org_secret_gh(
+            org_secrets=[("NPM_TOKEN", "selected")],
+            shared={"NPM_TOKEN": ["Acme/Widget"]},
+        ),
+    ):
+        result = check_repo_secret_allowlist("acme/widget", {"TEND_BOT_TOKEN"})
+    assert result.passed is False
+    assert "NPM_TOKEN" in result.message
 
 
 def test_repo_secret_allowlist_org_secret_visibility_all() -> None:

--- a/generator/tests/test_checks.py
+++ b/generator/tests/test_checks.py
@@ -122,6 +122,44 @@ def _login_response(login: str | None) -> subprocess.CompletedProcess[str]:
     return _make_completed(f"{login}\n")
 
 
+def _org_secret_gh(
+    *,
+    org_secrets: list[tuple[str, str]],
+    shared: dict[str, list[str]] | None = None,
+    repo_private: bool = False,
+    plan: str = "team",
+    repositories_rc: int = 0,
+):
+    """A `_gh` stand-in serving the endpoints `_list_org_secrets` reads, for the
+    org `acme` and the repo `acme/widget`: the org secret listing as
+    (name, visibility) pairs, each `selected` secret's shared-repo list, the
+    org's plan, and the repo's own visibility. Repo-level secrets come back
+    empty so a test's subject is only what the org contributes."""
+    shared = shared or {}
+
+    def fake(*args, **kwargs) -> subprocess.CompletedProcess[str]:
+        url = next(a for a in args if a.startswith(("repos/", "orgs/")))
+        if url.endswith("/repositories"):
+            if repositories_rc != 0:
+                return _make_completed(returncode=repositories_rc, stderr="HTTP 404")
+            return _make_completed("\n".join(shared.get(url.split("/")[-2], [])) + "\n")
+        if url == "orgs/acme/actions/secrets":
+            jq = args[args.index("--jq") + 1] if "--jq" in args else ""
+            listed = (
+                [{"name": n, "visibility": v} for n, v in org_secrets]
+                if "visibility" in jq
+                else [n for n, _ in org_secrets]
+            )
+            return _make_completed(json.dumps(listed) + "\n")
+        if url == "orgs/acme":
+            return _make_completed(f"{plan}\n")
+        if url == "repos/acme/widget":
+            return _make_completed(f"{str(repo_private).lower()}\n")
+        return _make_completed("[]\n")
+
+    return fake
+
+
 def _role_actor(actor_id: int) -> dict[str, object]:
     """A `bypass_actors` entry granting a base repository role."""
     return {
@@ -720,14 +758,11 @@ def test_secrets_org_level_copy_fails() -> None:
     reads it — and every workflow keeps working, so the failure has to name
     the copy or the exposure stays invisible."""
 
-    def fake(*args, **kwargs) -> subprocess.CompletedProcess[str]:
-        url = next(a for a in args if a.startswith(("repos/", "orgs/")))
-        if url.startswith("orgs/"):
-            return _make_completed('["TEND_BOT_TOKEN"]\n')
-        return _make_completed("[]\n")
-
-    with patch("tend.checks._gh", side_effect=fake):
-        result = check_secrets("owner/repo", ["TEND_BOT_TOKEN"])
+    with patch(
+        "tend.checks._gh",
+        side_effect=_org_secret_gh(org_secrets=[("TEND_BOT_TOKEN", "all")]),
+    ):
+        result = check_secrets("acme/widget", ["TEND_BOT_TOKEN"])
     assert result.passed is False
     assert "org level" in result.message
 
@@ -883,6 +918,118 @@ def test_repo_secret_allowlist_empty_repo() -> None:
     ):
         result = check_repo_secret_allowlist("owner/repo", {"TEND_BOT_TOKEN"})
     assert result.passed is True
+
+
+def test_repo_secret_allowlist_org_secret_not_shared_with_repo() -> None:
+    """A `selected`-visibility org secret whose repository list omits this repo
+    is unreadable here, so it is not part of the repo's credential surface.
+    Reporting it produces a FAIL no repo-side change can clear — the repo is
+    already at the tightest scoping GitHub offers."""
+    with patch(
+        "tend.checks._gh",
+        side_effect=_org_secret_gh(
+            org_secrets=[("NPM_TOKEN", "selected")],
+            shared={"NPM_TOKEN": ["acme/other"]},
+        ),
+    ):
+        result = check_repo_secret_allowlist("acme/widget", {"TEND_BOT_TOKEN"})
+    assert result.passed is True, result.message
+    assert "NPM_TOKEN" not in result.message
+
+
+def test_repo_secret_allowlist_org_secret_shared_with_repo() -> None:
+    """The same secret, shared with this repo, is readable and still reported."""
+    with patch(
+        "tend.checks._gh",
+        side_effect=_org_secret_gh(
+            org_secrets=[("NPM_TOKEN", "selected")],
+            shared={"NPM_TOKEN": ["acme/other", "acme/widget"]},
+        ),
+    ):
+        result = check_repo_secret_allowlist("acme/widget", {"TEND_BOT_TOKEN"})
+    assert result.passed is False
+    assert "NPM_TOKEN" in result.message
+    assert "org-level" in result.message
+
+
+def test_repo_secret_allowlist_org_secret_visibility_all() -> None:
+    """`visibility: all` reaches every repo in the org, so it is reported."""
+    with patch(
+        "tend.checks._gh",
+        side_effect=_org_secret_gh(org_secrets=[("NPM_TOKEN", "all")]),
+    ):
+        result = check_repo_secret_allowlist("acme/widget", {"TEND_BOT_TOKEN"})
+    assert result.passed is False
+    assert "NPM_TOKEN" in result.message
+
+
+def test_repo_secret_allowlist_org_secret_private_visibility_public_repo() -> None:
+    """`visibility: private` reaches the org's private repos only."""
+    with patch(
+        "tend.checks._gh",
+        side_effect=_org_secret_gh(
+            org_secrets=[("NPM_TOKEN", "private")], repo_private=False
+        ),
+    ):
+        result = check_repo_secret_allowlist("acme/widget", {"TEND_BOT_TOKEN"})
+    assert result.passed is True, result.message
+    assert "NPM_TOKEN" not in result.message
+
+
+def test_repo_secret_allowlist_org_secret_private_visibility_private_repo() -> None:
+    """The same secret does reach a private repo in the org."""
+    with patch(
+        "tend.checks._gh",
+        side_effect=_org_secret_gh(
+            org_secrets=[("NPM_TOKEN", "private")], repo_private=True
+        ),
+    ):
+        result = check_repo_secret_allowlist("acme/widget", {"TEND_BOT_TOKEN"})
+    assert result.passed is False
+    assert "NPM_TOKEN" in result.message
+
+
+def test_repo_secret_allowlist_org_free_plan_private_repo() -> None:
+    """On GitHub Free, org secrets reach public repositories only — a private
+    repo in a free org reads none of them however they are scoped."""
+    with patch(
+        "tend.checks._gh",
+        side_effect=_org_secret_gh(
+            org_secrets=[("NPM_TOKEN", "all")], repo_private=True, plan="free"
+        ),
+    ):
+        result = check_repo_secret_allowlist("acme/widget", {"TEND_BOT_TOKEN"})
+    assert result.passed is True, result.message
+    assert "NPM_TOKEN" not in result.message
+
+
+def test_repo_secret_allowlist_org_secret_reach_unknown_is_reported() -> None:
+    """Filtering is fail-safe: when the shared-repo list can't be read, the
+    secret stays in the surface rather than being silently dropped."""
+    with patch(
+        "tend.checks._gh",
+        side_effect=_org_secret_gh(
+            org_secrets=[("NPM_TOKEN", "selected")], repositories_rc=1
+        ),
+    ):
+        result = check_repo_secret_allowlist("acme/widget", {"TEND_BOT_TOKEN"})
+    assert result.passed is False
+    assert "NPM_TOKEN" in result.message
+
+
+def test_secrets_org_level_copy_not_shared_with_repo() -> None:
+    """`check_secrets` reads the same surface: an org copy the repo cannot read
+    doesn't keep its workflows running, so it must not be named as if it did."""
+    with patch(
+        "tend.checks._gh",
+        side_effect=_org_secret_gh(
+            org_secrets=[("TEND_BOT_TOKEN", "selected")],
+            shared={"TEND_BOT_TOKEN": ["acme/other"]},
+        ),
+    ):
+        result = check_secrets("acme/widget", ["TEND_BOT_TOKEN"])
+    assert result.passed is False
+    assert "org level" not in result.message
 
 
 def test_repo_secret_allowlist_api_error() -> None:


### PR DESCRIPTION
## Problem

`repo-secret-allowlist` enumerated every org-level secret in the organization and flagged each one, without consulting whether that secret's visibility actually admits the repo being checked. On a repo where all ten org secrets are `visibility: selected` and none list it, the check reported all ten as "available to all workflows".

Nothing clears that. The repo is already at the tightest scoping GitHub offers — the secrets are not shared with it at all — so the only remaining lever is a `secrets.allowed` entry, whose documented meaning ("a deliberate acceptance that any workflow the repo runs can read that token") is false in that state, and which would mute those names permanently: if one *were* later shared with the repo, the sweep would stay silent about the one case it exists to catch.

It also penalized the grant it asks for. The check hints at `admin:org` to complete the sweep; granting it converted a pass into an unclearable FAIL, while the same ten secrets were equally unreachable before.

## Solution

`_list_org_secrets` now takes the repo and returns only the org secrets that repo can read. It reads each secret's `visibility` alongside its name and drops:

- `selected` whose `/orgs/{org}/actions/secrets/{name}/repositories` list omits the repo (paginated — an org sharing a secret past one page would otherwise look like it omits this one);
- `private` when the repo is public;
- all of them when the repo is private and the org is on GitHub Free, which serves org secrets to public repositories only.

The per-secret repositories endpoint needs `admin:org`, which the sweep already requires to enumerate org secrets at all, so no new scope is involved.

Filtering is deliberately one-directional: a secret whose reach can't be determined — the repositories list fails, the repo's visibility won't read, the plan field is absent — stays in the reported set. Under-reporting hides real exposure; over-reporting is only noise. `_org_plan_is_free` returns False on any read failure for the same reason.

`check_secrets` reads the same helper, so it gains the same correction: an org copy scoped away from the repo no longer gets named as the thing keeping its workflows running.

## Testing

`uv run pytest` — 563 pass. Seven new cases in `generator/tests/test_checks.py` drive `_list_org_secrets` end-to-end through a fake `gh` serving the real endpoint shapes, rather than mocking the helper out. Four reproduced the reported FAIL before the fix: a `selected` secret omitting the repo, `private` against a public repo, a free-org private repo, and `check_secrets` naming an unreachable org copy. The other three pin the directions that must keep failing — `selected` including the repo, `visibility: all`, and a repositories lookup that errors.

<details><summary>Not covered</summary>

Pagination of the org secret listing itself is untouched — `orgs/{org}/actions/secrets` still reads one page, so an org with more secrets than a page holds under-reports. That is pre-existing and independent of visibility; separate change if it matters.

The free-plan rule rests on `.plan.name`, which GitHub returns only to org owners. For a non-owner token the field is absent and the rule simply doesn't fire, leaving the pre-fix behavior for `visibility: all` on a free org. `selected` and `private` are unaffected — they're filtered from data any `admin:org` token can read.

</details>

---
Closes #993 — automated triage
