### PR TITLE
docs(security-model): point adopter config at the overlay tend actually pins

### DIFF
--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -16,8 +16,9 @@ Each adopting repo should document its specific configuration (admin accounts,
 token names, protected environments) in its own
 `.claude/skills/running-tend/SKILL.md`, the adopter-owned overlay the rest of
 the docs name. Not `.github/CLAUDE.md`: fork-PR instruction pinning covers root
-`CLAUDE.md`, every `AGENTS.md`, and `.claude/` (`shared/steps/pin-instruction-files.sh`),
-so notes parked outside those paths are read from the fork's own tree.
+`CLAUDE.md` and `.claude/` under both harnesses (`shared/steps/restore-sensitive-config.sh`
+for Claude, `shared/steps/pin-instruction-files.sh` for Codex, which also pins every
+`AGENTS.md`), so notes parked outside those paths are read from the fork's own tree.
 
 ## Threats
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -13,7 +13,11 @@ tokens less valuable when leaked, limit what a hijacked session can do, and
 make unsophisticated attacks fail outright.
 
 Each adopting repo should document its specific configuration (admin accounts,
-token names, protected environments) in its own `.github/CLAUDE.md`.
+token names, protected environments) in its own
+`.claude/skills/running-tend/SKILL.md`, the adopter-owned overlay the rest of
+the docs name. Not `.github/CLAUDE.md`: fork-PR instruction pinning covers root
+`CLAUDE.md`, every `AGENTS.md`, and `.claude/` (`shared/steps/pin-instruction-files.sh`),
+so notes parked outside those paths are read from the fork's own tree.
 
 ## Threats
 


### PR DESCRIPTION
`docs/security-model.md` opened by telling adopters to document their tend configuration — admin accounts, token names, protected environments — in `.github/CLAUDE.md`. That path appears nowhere else in the repo, and it is not one that fork-PR instruction pinning covers: [`shared/steps/pin-instruction-files.sh`](https://github.com/max-sixty/tend/blob/b78372c/shared/steps/pin-instruction-files.sh) restores root `CLAUDE.md`, every `AGENTS.md`, and `.claude/`, and `restore-sensitive-config.sh`'s list is root-scoped the same way. An adopter who followed the line would park their security-configuration notes where a fork PR can rewrite them and have Claude Code read the fork's copy when it touches anything under `.github/` — the opposite of what the surrounding document claims.

The fix points the sentence at `.claude/skills/running-tend/SKILL.md`, which is the adopter-owned location the rest of the docs already name (`README.md`, the `install-tend` skill and its final checklist), and which the pinning step does cover.

No regression test: the change is one sentence of prose, and a test asserting the doc doesn't contain a particular string is machinery that restates the diff rather than guarding behavior. `pre-commit run --files docs/security-model.md` passes.

<details><summary>Where the path was and wasn't referenced</summary>

```
$ rg -n '\.github/CLAUDE\.md' .
./docs/security-model.md:16

$ rg -n 'running-tend/SKILL\.md' README.md plugins/install-tend/skills/install-tend/SKILL.md
README.md:215
plugins/install-tend/skills/install-tend/SKILL.md:445
plugins/install-tend/skills/install-tend/SKILL.md:875
```

`SENSITIVE` in [`restore-sensitive-config.sh#L27`](https://github.com/max-sixty/tend/blob/b78372c/shared/steps/restore-sensitive-config.sh#L27) is `.claude .mcp.json .claude.json .gitmodules .ripgreprc CLAUDE.md CLAUDE.local.md .husky` — no `.github/` entry.

</details>
