### PR TITLE
fix(scripts): page the check rollup instead of refusing past 100 contexts

### DIFF
--- a/generator/tests/test_poll_scripts.py
+++ b/generator/tests/test_poll_scripts.py
@@ -25,20 +25,31 @@ RERUN_FAILED_JOBS = SCRIPTS / "rerun-failed-jobs.sh"
 
 HEAD_SHA = "aaaa111122223333aaaa111122223333aaaa1111"
 
-# GraphQL responses are served in sequence: call N reads $ROLLUP_DIR/N.json,
-# falling back to final.json once the sequence runs out. The run endpoint
-# serves `run_attempt` values consumed line-by-line from $ATTEMPTS (the last
-# line repeats), so a rerun's attempt bump is scriptable. `pr view` and the
-# jobs endpoints run the script's `--jq` through real jq.
+# First-page GraphQL responses are served in sequence: poll N reads
+# $ROLLUP_DIR/N.json, falling back to final.json once the sequence runs out.
+# A call carrying a cursor is a *later page* of the poll in flight and is
+# served from $ROLLUP_DIR/page-<cursor>.json instead — so a page reachable
+# only through the cursor is genuinely unreachable without it. The run
+# endpoint serves `run_attempt` values consumed line-by-line from $ATTEMPTS
+# (the last line repeats), so a rerun's attempt bump is scriptable. `pr view`
+# and the jobs endpoints run the script's `--jq` through real jq.
 FAKE_GH = (
     GH_PREAMBLE
     + r"""case "$1 $2" in
   "api graphql")
-    n=$(( $(cat "$GRAPHQL_CALLS" 2>/dev/null || echo 0) + 1 ))
-    echo "$n" > "$GRAPHQL_CALLS"
-    f="$ROLLUP_DIR/$n.json"
-    [ -f "$f" ] || f="$ROLLUP_DIR/final.json"
-    cat "$f"
+    cursor=""
+    for arg in "$@"; do
+      case "$arg" in cursor=*) cursor="${arg#cursor=}" ;; esac
+    done
+    if [ -n "$cursor" ] && [ "$cursor" != "null" ]; then
+      cat "$ROLLUP_DIR/page-$cursor.json"
+    else
+      n=$(( $(cat "$GRAPHQL_CALLS" 2>/dev/null || echo 0) + 1 ))
+      echo "$n" > "$GRAPHQL_CALLS"
+      f="$ROLLUP_DIR/$n.json"
+      [ -f "$f" ] || f="$ROLLUP_DIR/final.json"
+      cat "$f"
+    fi
     ;;
   "pr view")
     emit "$(cat "$HEAD_JSON")"
@@ -100,7 +111,7 @@ def _status_ctx(context: str, state: str) -> dict:
     }
 
 
-def _resp(*nodes: dict, total: int | None = None) -> str:
+def _resp(*nodes: dict, has_next: bool = False, end_cursor: str | None = None) -> str:
     return json.dumps(
         {
             "data": {
@@ -108,7 +119,10 @@ def _resp(*nodes: dict, total: int | None = None) -> str:
                     "object": {
                         "statusCheckRollup": {
                             "contexts": {
-                                "totalCount": len(nodes) if total is None else total,
+                                "pageInfo": {
+                                    "hasNextPage": has_next,
+                                    "endCursor": end_cursor,
+                                },
                                 "nodes": list(nodes),
                             }
                         }
@@ -156,6 +170,11 @@ def _serve(env: dict[str, str], *responses: str) -> None:
     for i, resp in enumerate(responses, start=1):
         (Path(env["ROLLUP_DIR"]) / f"{i}.json").write_text(resp)
     (Path(env["ROLLUP_DIR"]) / "final.json").write_text(responses[-1])
+
+
+def _serve_page(env: dict[str, str], cursor: str, response: str) -> None:
+    """Serve *response* to any call that asks for the page after *cursor*."""
+    (Path(env["ROLLUP_DIR"]) / f"page-{cursor}.json").write_text(response)
 
 
 def _poll(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
@@ -316,15 +335,30 @@ def test_null_rollup_never_reads_green(env: dict[str, str]) -> None:
     assert "UNVERIFIED, not green" in result.stdout
 
 
-def test_more_contexts_than_one_page_never_reads_green(env: dict[str, str]) -> None:
-    """The query reads one 100-node page; past that, a dropped node could be
-    the failing check, so an all-green page must not read as a verdict."""
-    _serve(env, _resp(_check_run("tests"), total=150))
+def test_paginates_past_the_first_page(env: dict[str, str]) -> None:
+    """A full matrix registers more than the query's 100-node page — routine
+    on a dependency bump, which opens every path filter. The failing check can
+    sit on any page, so an all-green first page must never stand in for the
+    whole rollup."""
+    _serve(env, _resp(_check_run("tests"), has_next=True, end_cursor="Y3Vyc29yOjE"))
+    _serve_page(env, "Y3Vyc29yOjE", _resp(_check_run("lint", conclusion="FAILURE")))
+
+    result = _poll(env)
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "lint https://github.com/o/r/actions/runs/100/job/1" in result.stdout
+
+
+def test_truncated_pagination_never_reads_green(env: dict[str, str]) -> None:
+    """`hasNextPage` with no cursor to follow leaves the rollup incomplete —
+    refetching page one would loop forever, and trusting it could hide a
+    failure on a page never read."""
+    _serve(env, _resp(_check_run("tests"), has_next=True, end_cursor=None))
 
     result = _poll(env)
 
     assert result.returncode == 2
-    assert "more than 100 check contexts" in result.stdout
+    assert "UNVERIFIED, not green" in result.stdout
 
 
 def test_cap_report_survives_a_late_api_blip(env: dict[str, str]) -> None:

--- a/generator/tests/test_poll_scripts.py
+++ b/generator/tests/test_poll_scripts.py
@@ -338,15 +338,25 @@ def test_null_rollup_never_reads_green(env: dict[str, str]) -> None:
 def test_paginates_past_the_first_page(env: dict[str, str]) -> None:
     """A full matrix registers more than the query's 100-node page — routine
     on a dependency bump, which opens every path filter. The failing check can
-    sit on any page, so an all-green first page must never stand in for the
-    whole rollup."""
-    _serve(env, _resp(_check_run("tests"), has_next=True, end_cursor="Y3Vyc29yOjE"))
+    sit on any page, so every page has to survive the walk: a red on the first
+    is dropped by an accumulator that lets the last page win, and a red on the
+    last is invisible to a query that never follows the cursor."""
+    _serve(
+        env,
+        _resp(
+            _check_run("tests"),
+            _check_run("build", conclusion="FAILURE", run_id=101),
+            has_next=True,
+            end_cursor="Y3Vyc29yOjE",
+        ),
+    )
     _serve_page(env, "Y3Vyc29yOjE", _resp(_check_run("lint", conclusion="FAILURE")))
 
     result = _poll(env)
 
     assert result.returncode == 1, result.stdout + result.stderr
     assert "lint https://github.com/o/r/actions/runs/100/job/1" in result.stdout
+    assert "build https://github.com/o/r/actions/runs/101/job/1" in result.stdout
 
 
 def test_truncated_pagination_never_reads_green(env: dict[str, str]) -> None:

--- a/plugins/tend-ci-runner/scripts/poll-pr-checks.sh
+++ b/plugins/tend-ci-runner/scripts/poll-pr-checks.sh
@@ -36,8 +36,8 @@
 #      OID; an ephemeral merge-ref commit, which carries none; a commit with
 #      zero checks and zero statuses (a push every workflow's paths filter
 #      excludes — the rollup is null then too, so "nothing to gate on" is
-#      indistinguishable from "nothing answered"); or more contexts than the
-#      query's one 100-node page, where a dropped node could hide a failure
+#      indistinguishable from "nothing answered"); or a page walk that could
+#      not be finished, where an unread node could hide a failure
 #   3  poll cap hit with checks still pending — UNVERIFIED, not green
 
 set -euo pipefail
@@ -47,75 +47,92 @@ SHA="$2"
 OWNER="${GITHUB_REPOSITORY%/*}"
 NAME="${GITHUB_REPOSITORY#*/}"
 
-# One call returns check runs *and* legacy status contexts. `pending` counts
-# every non-terminal shape; `failed` counts every terminal-and-red conclusion
-# — STARTUP_FAILURE and ACTION_REQUIRED are terminal CheckConclusionStates
-# that land in neither bucket if forgotten, so a job that never started would
-# read as green. CANCELLED stays excluded: a cancelled sibling is not a
-# verdict on this commit. Empty output means no usable rollup — an errors
-# envelope, an unresolvable OID, and a null rollup all land there, and none
-# of them may read as settled green.
+# One query returns check runs *and* legacy status contexts, a page at a
+# time. The pages are walked to exhaustion rather than sampled: a full matrix
+# passes 100 contexts routinely — a dependency bump touching a lockfile opens
+# every path filter at once — and the failing check can sit on any page.
+# `pending` counts every non-terminal shape; `failed` counts every
+# terminal-and-red conclusion — STARTUP_FAILURE and ACTION_REQUIRED are
+# terminal CheckConclusionStates that land in neither bucket if forgotten, so
+# a job that never started would read as green. CANCELLED stays excluded: a
+# cancelled sibling is not a verdict on this commit. Empty output means no
+# usable rollup — an errors envelope, an unresolvable OID, a null rollup, and
+# a pagination that could not be finished all land there, and none of them may
+# read as settled green.
 rollup() {
-  local resp
-  resp=$(gh api graphql \
-    -f owner="$OWNER" -f name="$NAME" -f oid="$SHA" \
-    -f query='
-      query($owner: String!, $name: String!, $oid: GitObjectID!) {
-        repository(owner: $owner, name: $name) {
-          object(oid: $oid) {
-            ... on Commit {
-              statusCheckRollup {
-                contexts(first: 100) {
-                  totalCount
-                  nodes {
-                    __typename
-                    ... on CheckRun {
-                      name status conclusion startedAt detailsUrl
-                      checkSuite { workflowRun { workflow { name } } }
+  local resp page nodes cursor
+  local -a cursor_arg
+  nodes='[]'
+  cursor=""
+  while :; do
+    # `-F` types the literal `null` as JSON null for the first page, so
+    # `after:` is a no-op there; later pages pass the cursor as a raw string.
+    if [ -z "$cursor" ]; then cursor_arg=(-F cursor=null); else cursor_arg=(-f cursor="$cursor"); fi
+    resp=$(gh api graphql \
+      -f owner="$OWNER" -f name="$NAME" -f oid="$SHA" "${cursor_arg[@]}" \
+      -f query='
+        query($owner: String!, $name: String!, $oid: GitObjectID!, $cursor: String) {
+          repository(owner: $owner, name: $name) {
+            object(oid: $oid) {
+              ... on Commit {
+                statusCheckRollup {
+                  contexts(first: 100, after: $cursor) {
+                    pageInfo { hasNextPage endCursor }
+                    nodes {
+                      __typename
+                      ... on CheckRun {
+                        name status conclusion startedAt detailsUrl
+                        checkSuite { workflowRun { workflow { name } } }
+                      }
+                      ... on StatusContext { context state targetUrl }
                     }
-                    ... on StatusContext { context state targetUrl }
                   }
                 }
               }
             }
           }
-        }
-      }' 2>/dev/null) || return 0
+        }' 2>/dev/null) || return 0
+    page=$(printf '%s' "$resp" | jq -c \
+      '.data.repository.object.statusCheckRollup.contexts | select(. != null)' \
+      2>/dev/null) || return 0
+    [ -z "$page" ] && return 0
+    nodes=$(printf '%s' "$page" | jq -c --argjson acc "$nodes" '$acc + .nodes') || return 0
+    # A truncated walk is no rollup at all: `hasNextPage` with no cursor to
+    # follow would otherwise re-read page one forever.
+    [ "$(printf '%s' "$page" | jq -r '.pageInfo.hasNextPage')" = "true" ] || break
+    cursor=$(printf '%s' "$page" | jq -r '.pageInfo.endCursor // ""')
+    [ -z "$cursor" ] && return 0
+  done
   # A group with any non-terminal entry is pending regardless of timestamps:
   # a QUEUED replacement's startedAt cannot be relied on, and losing the
   # reduction to a stale settled entry would report a superseded verdict.
-  printf '%s' "$resp" | jq -c \
+  printf '%s' "$nodes" | jq -c \
     --arg own "/runs/${GITHUB_RUN_ID:-}/" --arg wf "${GITHUB_WORKFLOW:-}" '
-    .data.repository.object.statusCheckRollup
-    | select(. != null)
-    | if .contexts.totalCount > 100 then "OVERFLOW"
-      else
-        [.contexts.nodes[]
-         | if .__typename == "CheckRun" then
-             {name, status, conclusion: (.conclusion // ""),
-              workflow: (.checkSuite.workflowRun.workflow.name // ""),
-              url: (.detailsUrl // ""), startedAt: (.startedAt // "")}
-           else
-             {name: .context,
-              status: (if .state == "PENDING" or .state == "EXPECTED"
-                       then "PENDING" else "COMPLETED" end),
-              conclusion: .state, workflow: "", url: (.targetUrl // ""),
-              startedAt: ""}
-           end
-         | select(.url | test($own) | not)
-         | select($wf == "" or .workflow != $wf)]
-        | group_by([.name, .workflow])
-        | map(if any(.[]; .status != "COMPLETED")
-              then first(.[] | select(.status != "COMPLETED"))
-              else max_by(.startedAt) end)
-        | {pending: [.[] | select(.status != "COMPLETED") | .name],
-           failed: [.[] | select(.status == "COMPLETED")
-                    | select(.conclusion == "FAILURE" or .conclusion == "TIMED_OUT"
-                             or .conclusion == "STARTUP_FAILURE"
-                             or .conclusion == "ACTION_REQUIRED"
-                             or .conclusion == "ERROR")
-                    | "\(.name) \(.url)"]}
-      end' 2>/dev/null || true
+    [.[]
+     | if .__typename == "CheckRun" then
+         {name, status, conclusion: (.conclusion // ""),
+          workflow: (.checkSuite.workflowRun.workflow.name // ""),
+          url: (.detailsUrl // ""), startedAt: (.startedAt // "")}
+       else
+         {name: .context,
+          status: (if .state == "PENDING" or .state == "EXPECTED"
+                   then "PENDING" else "COMPLETED" end),
+          conclusion: .state, workflow: "", url: (.targetUrl // ""),
+          startedAt: ""}
+       end
+     | select(.url | test($own) | not)
+     | select($wf == "" or .workflow != $wf)]
+    | group_by([.name, .workflow])
+    | map(if any(.[]; .status != "COMPLETED")
+          then first(.[] | select(.status != "COMPLETED"))
+          else max_by(.startedAt) end)
+    | {pending: [.[] | select(.status != "COMPLETED") | .name],
+       failed: [.[] | select(.status == "COMPLETED")
+                | select(.conclusion == "FAILURE" or .conclusion == "TIMED_OUT"
+                         or .conclusion == "STARTUP_FAILURE"
+                         or .conclusion == "ACTION_REQUIRED"
+                         or .conclusion == "ERROR")
+                | "\(.name) \(.url)"]}' 2>/dev/null || true
 }
 
 # A moved head is reported as a distinct outcome, never silently absorbed:
@@ -128,12 +145,6 @@ head_note() {
   fi
 }
 
-too_many_contexts() {
-  echo "more than 100 check contexts on $SHA — beyond the query's one page, so a dropped node could hide a failure. UNVERIFIED, not green"
-  head_note
-  exit 2
-}
-
 # R keeps the last usable rollup, so a transient blip on a later iteration
 # doesn't discard what earlier polls saw — the cap report below still names
 # the pending checks.
@@ -141,7 +152,6 @@ R=""
 for _ in $(seq 1 9); do
   sleep 60
   cur=$(rollup)
-  [ "$cur" = '"OVERFLOW"' ] && too_many_contexts
   [ -z "$cur" ] && continue
   R="$cur"
   [ "$(printf '%s' "$R" | jq '.pending | length')" -gt 0 ] && continue
@@ -149,7 +159,6 @@ for _ in $(seq 1 9); do
   # two later; re-check once before trusting pending == 0.
   sleep 30
   cur=$(rollup)
-  [ "$cur" = '"OVERFLOW"' ] && too_many_contexts
   [ -z "$cur" ] && continue
   R="$cur"
   [ "$(printf '%s' "$R" | jq '.pending | length')" -gt 0 ] && continue


### PR DESCRIPTION
## Problem

`poll-pr-checks.sh` asked for `contexts(first: 100)` with no cursor and bailed `exit 2` (UNVERIFIED) whenever `totalCount` exceeded the page. A full CI matrix passes 100 contexts routinely — a dependency bump touches a lockfile, every path filter opens, and the whole matrix registers — so the poll was unavailable on exactly the PRs the bot approves autonomously, and sessions hand-rolled a replacement poller in flight, each losing the grouping and self-filtering the script exists to provide. Reported in #998 with two runs that hit it at 115 and 116 contexts.

## Solution

The query takes a `$cursor` and selects `pageInfo { hasNextPage endCursor }`; `rollup()` walks pages to exhaustion, accumulating `nodes`, and the reduction runs over the accumulated array. `totalCount` stops being load-bearing, so the `"OVERFLOW"` branch, `too_many_contexts()` and its two call sites are gone — the failure mode is removed rather than the constant raised. `hasNextPage` with no `endCursor` to follow still routes to UNVERIFIED: re-reading page one would loop forever, and a page never read could hide a failure.

## Testing

`test_paginates_past_the_first_page` puts the only failing check on page two, reachable solely through the cursor — the fake `gh` now serves later pages keyed by the cursor it is given, so a query that doesn't paginate genuinely cannot see them. It failed as a false green (exit 0) before the change and reports red after. `test_truncated_pagination_never_reads_green` covers the cursorless-`hasNextPage` case. The single-page overflow test is deleted, since the behaviour it pinned was the bug.

Verified live against the commit from the report, `PRQL/prql@0aff65a7` (115 contexts): pages 1 and 2 return 100 + 15 nodes, and the script now reports `green: every gating check … settled green` where it previously exited 2.

<details><summary>Live check</summary>

```
== page 1 (cursor null) ==
{"total": 115, "n": 100, "page": {"hasNextPage": true, "endCursor": "MTAw"}}
== page 2 (cursor MTAw) ==
{"n": 15, "page": {"hasNextPage": false, "endCursor": "MTE1"}}
```

`-F cursor=null` types the literal as JSON null, so `after:` is a no-op on the first page; later pages pass the cursor with `-f` as a raw string.

</details>

---
Closes #998 — automated triage
