### PR TITLE
chore: bump claude_version to 2.1.233

### DIFF
--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -54,7 +54,7 @@ inputs:
     default: "true"
     description: Include the rendered Claude transcript in the workflow step summary.
   claude_version:
-    default: "2.1.226"
+    default: "2.1.233"
     description: >-
       Version of the `claude` binary to install via
       `https://claude.ai/install.sh`, pinned to a specific


### PR DESCRIPTION
Weekly pin sweep: `claude_version` was 7 releases behind npm's `latest` dist-tag (2.1.226 → 2.1.233). A stale binary resolves `--model opus`/`sonnet` to a superseded alias target, so the drift silently downgrades the model every adopter's session runs on.

Two entries in the range fix bugs on the paths tend's own runs take, both in 2.1.233: bundled skill aliases reporting `Unknown command` under headless `-p` when a user or project skill shadows the bundled one — tend loads plugin skills in every run and ships a repo-local `running-tend` overlay — and skill/command argument substitution re-expanding argument values as template markers.

<details><summary>CHANGELOG skim, 2.1.226 → 2.1.233</summary>

Filtered to the agent paths the action exercises: first-run onboarding, `--model` alias resolution, headless `-p` result events, Stop-hook behavior, slash-command and Skill-tool handling.

**Slash commands / skills**
- 2.1.233: fixed bundled skill aliases (`/checkup`, `/review`) reporting "Unknown command" in `-p` mode or with plugins/MCP loaded when a user or project skill shadows the bundled skill.
- 2.1.233: fixed skill/command argument substitution so argument values are no longer re-expanded as template markers.
- 2.1.232: `/plugin install plugin@marketplace` now refreshes the marketplace first, so a newly published plugin installs without a manual marketplace update.
- 2.1.232: fixed a startup race that could silently unregister a plugin marketplace due to concurrent writes to `known_marketplaces.json`.
- 2.1.229: fixed one-shot `claude plugin` commands leaving a stray liveness file that could block cleanup of outdated plugin versions.

**Headless `-p` / model resolution**
- 2.1.233: print mode now writes a `[claude-code:unrecognized_model]` line to stderr when a request goes out for a model ID Claude Code doesn't recognize.
- 2.1.233: todo/task-tracking tools (TaskCreate/Get/Update/List, TodoWrite) are no longer available on Opus 4.8, Sonnet 5, Fable 5, Mythos 5, and newer; `CLAUDE_CODE_ENABLE_TODO_TOOLS=1` restores them. Nothing in tend's skills depends on them (no `TodoWrite`/`Task*` reference anywhere in the repo, and `allowed_tools` never listed them).
- 2.1.229: fixed SDK and `--input-format stream-json` sessions getting a 400 on a whitespace-only message.
- 2.1.229: fixed a crash to the error screen when a tool call had a non-string `glob`, `file_path`, or `command` value.

**Sandbox** — the action runs the binary as a non-sudo sandbox user behind the proxy, so these land on tend's own configuration:
- 2.1.232: hardened the Linux filesystem sandbox against a protected-path bypass.
- 2.1.232: hardened the auto-generated cross-session messaging socket directory on shared `/tmp` — a pre-planted symlink or another user's directory is refused rather than used.
- 2.1.232: `sandbox.ripgrep` is now honored only from user, managed, and `--settings` settings; project settings can no longer override the sandbox's ripgrep binary.
- 2.1.233: fixed idle sessions on Linux sometimes pinning a CPU core at 100% with sandboxing enabled.
- 2.1.229: sandbox IPv6 literals in network domain lists are now bracketed, and ambiguous spellings fail closed.

Nothing in the range touches first-run onboarding or Stop-hook behavior in a way the action depends on. No breaking change to the `claude -p` invocation.

</details>

