### PR TITLE
chore: bump uv_version to 0.12.5

### DIFF
--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -77,7 +77,7 @@ inputs:
       Pinned `mitmproxy` version for the credential-injection proxy. Pinned
       so the uv download cache key is stable; bump to upgrade.
   uv_version:
-    default: "0.12.1"
+    default: "0.12.5"
     description: >-
       Pinned `uv` version used to run the credential-injection proxy. Installed
       into a tend-owned dir off $PATH, so it neither shadows nor is shadowed by


### PR DESCRIPTION
Weekly pin sweep: `uv_version` 0.12.1 → 0.12.5, the current PyPI release. This uv only installs and launches the credential-injection proxy in a tend-owned dir off `$PATH`; the agent never sees it, and skills needing uv install their own.

`mitmproxy_version` normally moves with it, but 12.2.3 is already the latest PyPI release, so this bump is uv alone. CI smokes the pair together, so a version of uv that can't launch the pinned mitmproxy fails on this PR.

`generator/pyproject.toml`'s `uv_build>=0.12,<0.13` still contains the build-time uv, and `uv lock --upgrade --dry-run` reports no lockfile changes.
