### PR TITLE
chore: bump astral-sh/setup-uv to v10.0.1

### DIFF
--- a/docs/tend.example.yaml
+++ b/docs/tend.example.yaml
@@ -121,18 +121,18 @@ bot_name: my-project-bot
 # `uses`:
 #
 #     setup:
-#       - uses: astral-sh/setup-uv@v9.0.0
+#       - uses: astral-sh/setup-uv@v10.0.1
 #
 #     # renders as (in tend-notifications):
-#     #   - uses: astral-sh/setup-uv@v9.0.0
+#     #   - uses: astral-sh/setup-uv@v10.0.1
 #     #     if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'
 #     #
 #     # in tend-review:
-#     #   - uses: astral-sh/setup-uv@v9.0.0
+#     #   - uses: astral-sh/setup-uv@v10.0.1
 #     #     if: steps.gate.outputs.should_run == 'true'
 #     #
 #     # and in other workflows:
-#     #   - uses: astral-sh/setup-uv@v9.0.0
+#     #   - uses: astral-sh/setup-uv@v10.0.1
 #
 # `uses` with action inputs and step-level env:
 #

--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -525,7 +525,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v9.0.0
+      - uses: astral-sh/setup-uv@v10.0.1
       - name: Verify generator output matches committed files
         env:
           GH_TOKEN: ${{{{ github.token }}}}

--- a/generator/tests/_regtest_outputs/test_generate.test_install_test_workflow_regtest[claude].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_install_test_workflow_regtest[claude].out
@@ -24,7 +24,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v9.0.0
+      - uses: astral-sh/setup-uv@v10.0.1
       - name: Verify generator output matches committed files
         env:
           GH_TOKEN: ${{ github.token }}

--- a/generator/tests/_regtest_outputs/test_generate.test_install_test_workflow_regtest[codex].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_install_test_workflow_regtest[codex].out
@@ -24,7 +24,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v9.0.0
+      - uses: astral-sh/setup-uv@v10.0.1
       - name: Verify generator output matches committed files
         env:
           GH_TOKEN: ${{ github.token }}

--- a/plugins/install-tend/skills/install-tend/references/tend.example.yaml
+++ b/plugins/install-tend/skills/install-tend/references/tend.example.yaml
@@ -121,18 +121,18 @@ bot_name: my-project-bot
 # `uses`:
 #
 #     setup:
-#       - uses: astral-sh/setup-uv@v9.0.0
+#       - uses: astral-sh/setup-uv@v10.0.1
 #
 #     # renders as (in tend-notifications):
-#     #   - uses: astral-sh/setup-uv@v9.0.0
+#     #   - uses: astral-sh/setup-uv@v10.0.1
 #     #     if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'
 #     #
 #     # in tend-review:
-#     #   - uses: astral-sh/setup-uv@v9.0.0
+#     #   - uses: astral-sh/setup-uv@v10.0.1
 #     #     if: steps.gate.outputs.should_run == 'true'
 #     #
 #     # and in other workflows:
-#     #   - uses: astral-sh/setup-uv@v9.0.0
+#     #   - uses: astral-sh/setup-uv@v10.0.1
 #
 # `uses` with action inputs and step-level env:
 #


### PR DESCRIPTION
Weekly `uses:` sweep: `astral-sh/setup-uv` v9.0.0 → v10.0.1, crossing one major. This is the adopter-facing half — the ref the generator renders into every adopter's `tend-install-test` workflow, plus the `setup:` examples adopters copy from. The repo's own hand-maintained workflows and `.config/tend.yaml` move in a separate PR.

v10's one breaking change is that `enable-cache: auto` (the default, and what every rendered call uses) now **disables** the uv cache on `pull_request_target`, `workflow_run`, and `release` events, to close a cache-poisoning path ([setup-uv#984](https://github.com/astral-sh/setup-uv/issues/984)). Two tend triggers are on that list: `tend-review` runs on `pull_request_target` and `tend-ci-fix` on `workflow_run`, so an adopter whose `setup:` installs uv this way loses cache restores in those two jobs and pays a cold uv download instead. That is the safer default for exactly the reason it was changed — a `pull_request_target` job runs with the base repo's permissions against PR-authored code — and an adopter who wants the cache back can set `enable-cache: true` on their own `setup:` step.

The generator's own `tend-install-test` workflow (`workflows.py`) is `pull_request`-triggered, which is not on the sensitive list, so its caching is unaffected.

<details><summary>What else changed across v9 → v10.0.1</summary>

- `version: latest-known` installs the newest uv whose checksum the action itself ships, trading currency for supply-chain verification. Not adopted here — nothing in tend pins uv through this action.
- `version-file` now also sets the Python version when `.tool-versions` defines one.
- v10.0.1: tolerates transient manifest timeouts, and refreshes known checksums through uv 0.12.4.

`uv run pytest` passes (564); the two `test_install_test_workflow_regtest` outputs are regenerated for the new ref.

</details>
