### PR TITLE
chore: bump repo-local pins

### DIFF
--- a/.config/tend.yaml
+++ b/.config/tend.yaml
@@ -1,7 +1,7 @@
 bot_name: tend-agent
 
 setup:
-  - uses: astral-sh/setup-uv@v9.0.0
+  - uses: astral-sh/setup-uv@v10.0.1
 
 workflows:
   ci-fix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v9.0.0
+      - uses: astral-sh/setup-uv@v10.0.1
       - run: uv run pytest
       # pypi-release.yaml only fires on a tag push, and the tag is immutable by
       # ruleset, so a build that breaks there costs a manual publish. Run the
@@ -29,7 +29,7 @@ jobs:
         working-directory: proxy
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v9.0.0
+      - uses: astral-sh/setup-uv@v10.0.1
       # mitmdump starts the way setup-sandbox.sh starts it, so a release that
       # drops a flag, moves the CA file, or breaks the addon's import fails
       # here rather than on every adopter's next run. It goes through the
@@ -100,8 +100,8 @@ jobs:
   test-codex-surface:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: "20"
       # `yq -e` exits non-zero if the input is ever renamed, rather than
@@ -184,5 +184,5 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v9.0.0
+      - uses: astral-sh/setup-uv@v10.0.1
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9.0.0
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,13 +15,13 @@ repos:
         args: ["--fix"]
       - id: ruff-format
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.7.12
+    rev: 0.12.5
     hooks:
       # One lockfile at the workspace root covers the generator member too.
       - id: uv-lock
         files: ^(generator/)?(pyproject\.toml|uv\.lock)$
   - repo: https://github.com/adhtruong/mirrors-typos
-    rev: v1.42.0
+    rev: v1.49.0
     hooks:
       - id: typos
   - repo: https://github.com/rhysd/actionlint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,8 @@ dev = [
   # whether a version satisfies it. Only ever arrives transitively otherwise.
   "packaging>=25",
 ]
+
+# `certifi` is the PyPI package name, which typos 1.49 started reading as a
+# misspelling of "certify".
+[tool.typos.default.extend-words]
+certifi = "certifi"


### PR DESCRIPTION
Weekly pin sweep, the "ours alone" bucket — nothing here reaches an adopter's job. The `claude_version`, `uv_version`, and adopter-facing `setup-uv` bumps are in #1000, #1001, and #1002.

- **`uv-pre-commit` 0.7.12 → 0.12.5** — the `uv-lock` hook, five minors behind. `uv lock --upgrade --dry-run` reports no lockfile changes, and the hook passes.
- **`typos` v1.42.0 → v1.49.0** — 1.49 reads `certifi` (in a `proxy/setup-sandbox.sh` comment) as a misspelling of "certify". It's the PyPI package name, so the bump carries a `[tool.typos.default.extend-words]` entry allowing it. This is the repo's first typos config; the hook had run configless until now.
- **`astral-sh/setup-uv` v9.0.0 → v10.0.1** in `.config/tend.yaml`'s `setup:`, `ci.yaml`, and `pypi-release.yaml`. The generated `tend-*.yaml` take the new ref from `.config/tend.yaml` at the next nightly regen — they aren't hand-edited here. `pypi-release.yaml` sets `enable-cache: true` explicitly, so v10's new "disable the cache on sensitive events" default doesn't reach it; #1002 covers what that default means for adopters.
- **`actions/checkout` v6 → v7 and `actions/setup-node` v4 → v7** in `ci.yaml`'s `test-codex-surface` job. Straggler drift, not a deliberate dual-major pin: the job arrived at v6/v4 in #923 and every other step in the file is already on v7, with no comment claiming an older behavior.

`uvx pre-commit run --all-files` and `uv run pytest` (564) both pass.

## Held: ruff 0.14.11 → 0.16.3

`pre-commit autoupdate` also offers ruff 0.16.3, and it does not belong in a sweep — 0.16 **widens ruff's default rule set**, so a repo with no `[tool.ruff]` config (this one) inherits rule families it never opted into. `ruff@0.16.3 check --statistics` on current `main`:

| Rule | Count | |
|---|---|---|
| `PLW1510` subprocess-run-without-check | 19 | |
| `I001` unsorted-imports | 13 | fixable |
| `PIE810` multiple-starts-ends-with | 2 | |
| `ISC004`, `LOG015`, `PERF102`, `PLW1509`, `UP017` | 1 each | |

39 findings, 14 auto-fixable, plus one file reformatted. At least two look deliberate rather than accidental — `PLW1509` (`preexec_fn`) and `LOG015` (root-logger call) are both in the proxy, where the current spelling is what the code wants. The decision this needs is whether to take the new families and fix through them or pin the selection with a `[tool.ruff.lint]` block, and that's yours, not a sweep's. Left on 0.14.11 until then.

## Held: astro 5 → 7 (`site/`)

`npm --prefix site outdated` reports `astro` wanted 5.18.2, latest 7.2.2 — the range in `site/package.json` is `^5.14.0`, so this needs the range moved across two majors, with the migration notes and a `npm run build` behind it. Its own PR, not this one. `npm --prefix worker outdated` is clean.
