### PR TITLE
chore: update tend workflows

### DIFF
--- a/.github/workflows/tend-ci-fix.yaml
+++ b/.github/workflows/tend-ci-fix.yaml
@@ -32,7 +32,7 @@ jobs:
           fetch-tags: true
           token: ${{ secrets.TEND_BOT_TOKEN }}
 
-      - uses: astral-sh/setup-uv@v9.0.0
+      - uses: astral-sh/setup-uv@v10.0.1
 
       - uses: max-sixty/tend/claude@0.1.18
         with:

--- a/.github/workflows/tend-mention.yaml
+++ b/.github/workflows/tend-mention.yaml
@@ -389,7 +389,7 @@ jobs:
           fetch-tags: true
           token: ${{ secrets.TEND_BOT_TOKEN }}
 
-      - uses: astral-sh/setup-uv@v9.0.0
+      - uses: astral-sh/setup-uv@v10.0.1
 
       - name: Check out PR branch
         if: |

--- a/.github/workflows/tend-nightly.yaml
+++ b/.github/workflows/tend-nightly.yaml
@@ -32,7 +32,7 @@ jobs:
           fetch-tags: true
           token: ${{ secrets.TEND_BOT_TOKEN }}
 
-      - uses: astral-sh/setup-uv@v9.0.0
+      - uses: astral-sh/setup-uv@v10.0.1
 
       - uses: max-sixty/tend/claude@0.1.18
         with:

--- a/.github/workflows/tend-notifications.yaml
+++ b/.github/workflows/tend-notifications.yaml
@@ -146,7 +146,7 @@ jobs:
           fetch-tags: true
           token: ${{ secrets.TEND_BOT_TOKEN }}
 
-      - uses: astral-sh/setup-uv@v9.0.0
+      - uses: astral-sh/setup-uv@v10.0.1
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'
       - uses: max-sixty/tend/claude@0.1.18
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/tend-review-runs.yaml
+++ b/.github/workflows/tend-review-runs.yaml
@@ -32,7 +32,7 @@ jobs:
           fetch-tags: true
           token: ${{ secrets.TEND_BOT_TOKEN }}
 
-      - uses: astral-sh/setup-uv@v9.0.0
+      - uses: astral-sh/setup-uv@v10.0.1
 
       - uses: max-sixty/tend/claude@0.1.18
         with:

--- a/.github/workflows/tend-review.yaml
+++ b/.github/workflows/tend-review.yaml
@@ -117,7 +117,7 @@ jobs:
           fetch-tags: true
           token: ${{ secrets.TEND_BOT_TOKEN }}
 
-      - uses: astral-sh/setup-uv@v9.0.0
+      - uses: astral-sh/setup-uv@v10.0.1
         if: steps.gate.outputs.should_run == 'true'
 
       # GitHub only materializes refs/pull/N/merge for mergeable PRs — on

--- a/.github/workflows/tend-triage.yaml
+++ b/.github/workflows/tend-triage.yaml
@@ -44,7 +44,7 @@ jobs:
           fetch-tags: true
           token: ${{ secrets.TEND_BOT_TOKEN }}
 
-      - uses: astral-sh/setup-uv@v9.0.0
+      - uses: astral-sh/setup-uv@v10.0.1
 
       - uses: max-sixty/tend/claude@0.1.18
         with:

--- a/.github/workflows/tend-weekly.yaml
+++ b/.github/workflows/tend-weekly.yaml
@@ -32,7 +32,7 @@ jobs:
           fetch-tags: true
           token: ${{ secrets.TEND_BOT_TOKEN }}
 
-      - uses: astral-sh/setup-uv@v9.0.0
+      - uses: astral-sh/setup-uv@v10.0.1
 
       - uses: max-sixty/tend/claude@0.1.18
         with:


### PR DESCRIPTION
Nightly regeneration of the tend workflow files. No tend version bump — still 0.1.18 — so this is the committed workflows catching up to a change already in `.config/tend.yaml`: #1003 bumped `astral-sh/setup-uv` to `v10.0.1` in the `setup:` section, and the generated `tend-*.yaml` files still carried `v9.0.0` in their rendered setup step. The regen moves all eight. (#1002 made the matching bump on the adopter-facing side — the generator's default `setup:` and the example configs — and never touched this repo's own config.)

The hand-maintained workflows were already on `v10.0.1`, so after this every `setup-uv` ref in `.github/workflows/` agrees, and `max-sixty/tend/claude@0.1.18` is the single tend action ref across the whole directory.

Verified by re-running `uvx tend@latest init` against this branch: it rewrites all eight files and leaves the tree clean, so the regen is complete and no other config drift is outstanding.
