### PR TITLE
fix: name the real cause when an OAuth run ends empty, and keep keys out of chat

### DIFF
--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -692,7 +692,9 @@ as 1-year), two mint paths, routed by environment rather than asked:
   value, so the token goes from the first command's output to that prompt
   and nowhere else. Don't ask for it in chat: the agent has no use for the
   value, and a token pasted there is a live credential sitting in the
-  transcript.
+  transcript. The prompt refuses an empty submission and keeps waiting, so
+  the empty-value hazard that makes the CLI path's guard load-bearing has
+  no counterpart here.
 
 For **API key**: the user takes a key from
 `https://console.anthropic.com/settings/keys` and runs this themselves,

--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -663,22 +663,43 @@ as 1-year), two mint paths, routed by environment rather than asked:
   Each run generates a fresh PKCE challenge, so a code from an earlier
   run is dead; a restart needs a fresh approval.
 
-- **Manual** — when the CLI path is unavailable or the wrapper errors
-  out: have the user run `claude setup-token` in their own terminal (any
+  The wrapper waits 15 minutes and then exits having written nothing, so
+  that window needs the user at the browser throughout it. The authorize
+  URL logs the browser out on the way in
+  (`claude.ai/login?reauth=1&from=logout`), which means an
+  already-signed-in Claude session doesn't shorten the job, and the login
+  in front of the approval is theirs — an agent driving Chrome reaches
+  that page and stops there. So start the run once they say they are at
+  the browser; one started ahead of them spends its window and takes its
+  own URL down. After a window lapses twice, stop reissuing and hand over
+  the Manual path, which has no window.
+
+- **Manual** — when the CLI path is unavailable, the wrapper errors out,
+  or the user isn't at the browser when the agent is. Hand over both
+  commands, fully substituted, for them to run in their own terminal (any
   machine with Claude Code installed; `https://claude.com/claude-code` to
-  install it) and paste the `sk-ant-oat01-…` token back. Then store it:
+  install it), whenever suits them:
 
   ```bash
-  printf '%s' "$TOKEN" | gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo "$REPO" --env tend
+  claude setup-token
   ```
 
-For **API key**:
+  ```bash
+  gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo "$REPO" --env tend
+  ```
 
-Have the user paste an `sk-ant-…` key from
-`https://console.anthropic.com/settings/keys`, then store it:
+  Given neither `--body` nor a pipe, `gh secret set` prompts for the
+  value, so the token goes from the first command's output to that prompt
+  and nowhere else. Don't ask for it in chat: the agent has no use for the
+  value, and a token pasted there is a live credential sitting in the
+  transcript.
+
+For **API key**: the user takes a key from
+`https://console.anthropic.com/settings/keys` and runs this themselves,
+substituted, pasting the key at the prompt:
 
 ```bash
-gh secret set ANTHROPIC_API_KEY --repo "$REPO" --env tend --body "$KEY"
+gh secret set ANTHROPIC_API_KEY --repo "$REPO" --env tend
 ```
 
 ### 7b. Harness = codex
@@ -694,10 +715,12 @@ auth mid-run. See ${CLAUDE_SKILL_DIR}/references/security-model.md.
 gh secret list --repo "$REPO" --env tend --json name --jq '.[].name' | grep -q OPENAI_API_KEY && echo "SET" || echo "NOT SET"
 ```
 
-If not set, have the user paste the `sk-…` key. Store it:
+If not set, the user takes a key from
+`https://platform.openai.com/api-keys` and runs this themselves,
+substituted, pasting the key at the prompt:
 
 ```bash
-gh secret set OPENAI_API_KEY --repo "$REPO" --env tend --body "$KEY"
+gh secret set OPENAI_API_KEY --repo "$REPO" --env tend
 ```
 
 ## 8. Bot token and secret

--- a/plugins/install-tend/skills/install-tend/scripts/oauth_token.py
+++ b/plugins/install-tend/skills/install-tend/scripts/oauth_token.py
@@ -89,6 +89,35 @@ def take_controlling_tty():
     fcntl.ioctl(0, termios.TIOCSCTTY, 0)
 
 
+def failure_message(code_file, typed_at):
+    """Why no token came back, in terms of what this run actually saw.
+
+    A caller that already passed `--code-file` is told to pass it, and reads
+    that as the diagnosis, so the three ways a run ends empty are named apart:
+    a code that the page refused, a window nobody approved in, and a run with
+    nowhere to receive a code.
+    """
+    if typed_at is not None:
+        return (
+            f"Error: the code from {code_file} was typed into the prompt and no "
+            "token came back, so the authorize page rejected it. A code belongs "
+            "to the run whose challenge issued it and dies with that run; "
+            "approve the URL this run printed."
+        )
+    if code_file:
+        return (
+            f"Error: no token after {TIMEOUT_SECONDS}s. Nothing was written to "
+            f"{code_file} and the browser never came back to the CLI, so the "
+            "authorize URL went unapproved. Approving takes a person at the "
+            "browser while this runs, and a rerun issues a fresh URL that "
+            "replaces this one."
+        )
+    return (
+        "Error: no sk-ant-oat01-… token in TUI output. If the browser showed "
+        "a code to copy, rerun with --code-file and write it to that path."
+    )
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--code-file", help="path to watch for a `code#state` string")
@@ -185,10 +214,7 @@ def main():
             token = final.group(0).decode()
 
     if not token:
-        sys.exit(
-            "Error: no sk-ant-oat01-… token in TUI output. If the browser showed "
-            "a code to copy, rerun with --code-file and write it to that path."
-        )
+        sys.exit(failure_message(args.code_file, typed_at))
     if len(token) > MAX_TOKEN_LENGTH:
         sys.exit(f"Error: extracted token has implausible length ({len(token)} chars)")
     print(token)

--- a/plugins/install-tend/skills/install-tend/scripts/oauth_token.py
+++ b/plugins/install-tend/skills/install-tend/scripts/oauth_token.py
@@ -89,13 +89,16 @@ def take_controlling_tty():
     fcntl.ioctl(0, termios.TIOCSCTTY, 0)
 
 
-def failure_message(code_file, typed_at):
+def failure_message(code_file, typed_at, announced):
     """Why no token came back, in terms of what this run actually saw.
 
     A caller that already passed `--code-file` is told to pass it, and reads
-    that as the diagnosis, so the three ways a run ends empty are named apart:
-    a code that the page refused, a window nobody approved in, and a run with
-    nowhere to receive a code.
+    that as the diagnosis, so the causes it can act on are named apart. The
+    loop ends three ways — the deadline, a pty the child closed, and a child
+    already exited — so a message may not assume the window passed either. A
+    run that never announced a URL ended inside `claude setup-token`, whose own
+    output this wrapper swallows, and is the one case where the fix is to go
+    look at that command rather than at the browser.
     """
     if typed_at is not None:
         return (
@@ -104,17 +107,24 @@ def failure_message(code_file, typed_at):
             "to the run whose challenge issued it and dies with that run; "
             "approve the URL this run printed."
         )
-    if code_file:
+    if not announced:
         return (
-            f"Error: no token after {TIMEOUT_SECONDS}s. Nothing was written to "
-            f"{code_file} and the browser never came back to the CLI, so the "
-            "authorize URL went unapproved. Approving takes a person at the "
-            "browser while this runs, and a rerun issues a fresh URL that "
-            "replaces this one."
+            "Error: `claude setup-token` ended without offering an authorize "
+            "URL, so it failed before the browser was ever involved. Its output "
+            "is not echoed here — the TUI carries the token — so run that "
+            "command directly to see what it said."
+        )
+    if not code_file:
+        return (
+            "Error: no sk-ant-oat01-… token in TUI output. If the browser showed "
+            "a code to copy, rerun with --code-file and write it to that path."
         )
     return (
-        "Error: no sk-ant-oat01-… token in TUI output. If the browser showed "
-        "a code to copy, rerun with --code-file and write it to that path."
+        f"Error: the authorize URL went unapproved — nothing was written to "
+        f"{code_file} and the browser never came back to the CLI. This run "
+        f"waits up to {TIMEOUT_SECONDS}s for an approval, which takes a person "
+        "at the browser throughout; a rerun issues a fresh URL that replaces "
+        "this one."
     )
 
 
@@ -214,7 +224,7 @@ def main():
             token = final.group(0).decode()
 
     if not token:
-        sys.exit(failure_message(args.code_file, typed_at))
+        sys.exit(failure_message(args.code_file, typed_at, announced))
     if len(token) > MAX_TOKEN_LENGTH:
         sys.exit(f"Error: extracted token has implausible length ({len(token)} chars)")
     print(token)

--- a/plugins/install-tend/skills/install-tend/scripts/test_oauth_token.py
+++ b/plugins/install-tend/skills/install-tend/scripts/test_oauth_token.py
@@ -11,7 +11,13 @@ them, so they are pinned here.
 
 from __future__ import annotations
 
-from oauth_token import ANSI_CSI, AUTHORIZE_URL, MAX_TOKEN_LENGTH, TIMEOUT_SECONDS, TOKEN
+from oauth_token import (
+    ANSI_CSI,
+    AUTHORIZE_URL,
+    MAX_TOKEN_LENGTH,
+    TIMEOUT_SECONDS,
+    TOKEN,
+)
 from oauth_token import complete_match, failure_message, first_url
 
 URL = (

--- a/plugins/install-tend/skills/install-tend/scripts/test_oauth_token.py
+++ b/plugins/install-tend/skills/install-tend/scripts/test_oauth_token.py
@@ -12,7 +12,7 @@ them, so they are pinned here.
 from __future__ import annotations
 
 from oauth_token import ANSI_CSI, AUTHORIZE_URL, MAX_TOKEN_LENGTH, TOKEN
-from oauth_token import complete_match, first_url
+from oauth_token import complete_match, failure_message, first_url
 
 URL = (
     b"https://claude.com/cai/oauth/authorize?code=true&client_id=9d1"
@@ -80,3 +80,20 @@ def test_overlong_token_is_not_truncated_to_the_ceiling() -> None:
 
 def test_authorize_url_pattern_stops_at_control_bytes() -> None:
     assert AUTHORIZE_URL.search(URL + b"\x1b]8;;").group(0) == URL
+
+
+def test_unapproved_run_is_not_blamed_on_the_flag_it_was_given() -> None:
+    # The skill's own invocation always passes --code-file, so a message telling
+    # the caller to pass it names the one thing that was not wrong, and the
+    # caller reruns unchanged into the same empty window.
+    message = failure_message("/tmp/tend-oauth-code", None)
+    assert "went unapproved" in message
+    assert "rerun with --code-file" not in message
+
+
+def test_a_refused_code_reads_differently_from_no_code_at_all() -> None:
+    assert "rejected it" in failure_message("/tmp/tend-oauth-code", 1.0)
+
+
+def test_a_run_with_nowhere_to_receive_a_code_is_told_to_pass_one() -> None:
+    assert "rerun with --code-file" in failure_message(None, None)

--- a/plugins/install-tend/skills/install-tend/scripts/test_oauth_token.py
+++ b/plugins/install-tend/skills/install-tend/scripts/test_oauth_token.py
@@ -11,7 +11,7 @@ them, so they are pinned here.
 
 from __future__ import annotations
 
-from oauth_token import ANSI_CSI, AUTHORIZE_URL, MAX_TOKEN_LENGTH, TOKEN
+from oauth_token import ANSI_CSI, AUTHORIZE_URL, MAX_TOKEN_LENGTH, TIMEOUT_SECONDS, TOKEN
 from oauth_token import complete_match, failure_message, first_url
 
 URL = (
@@ -86,14 +86,25 @@ def test_unapproved_run_is_not_blamed_on_the_flag_it_was_given() -> None:
     # The skill's own invocation always passes --code-file, so a message telling
     # the caller to pass it names the one thing that was not wrong, and the
     # caller reruns unchanged into the same empty window.
-    message = failure_message("/tmp/tend-oauth-code", None)
+    message = failure_message("/tmp/tend-oauth-code", None, True)
     assert "went unapproved" in message
     assert "rerun with --code-file" not in message
 
 
 def test_a_refused_code_reads_differently_from_no_code_at_all() -> None:
-    assert "rejected it" in failure_message("/tmp/tend-oauth-code", 1.0)
+    assert "rejected it" in failure_message("/tmp/tend-oauth-code", 1.0, True)
 
 
 def test_a_run_with_nowhere_to_receive_a_code_is_told_to_pass_one() -> None:
-    assert "rerun with --code-file" in failure_message(None, None)
+    assert "rerun with --code-file" in failure_message(None, None, True)
+
+
+def test_a_child_that_offered_no_url_is_not_reported_as_unapproved() -> None:
+    # The read loop also breaks on a closed pty and on an exited child, so a
+    # `claude` that dies early — no `setup-token` subcommand, a crash — reaches
+    # here in a moment. Blaming the browser there sends the caller to approve a
+    # URL that was never printed, and the child's own error is swallowed.
+    message = failure_message("/tmp/tend-oauth-code", None, False)
+    assert "run that command directly" in message
+    assert "unapproved" not in message
+    assert str(TIMEOUT_SECONDS) not in message


### PR DESCRIPTION
Found while installing tend on another repo: the OAuth step failed four times running, and the wrapper's message pointed somewhere else every time.

The wrapper answered every empty run with the same text, telling the caller to `rerun with --code-file` — which the skill's own invocation always passes. So the diagnosis named the one thing that was not wrong, and four consecutive fifteen-minute windows read as a flag problem rather than as nobody having approved. `failure_message` now separates the ways a run ends empty: a code the authorize page refused, a child that ended before offering an authorize URL at all, a window nobody approved in, and a run with nowhere to receive a code. Each is pinned by a test.

That second case came out of review here. The read loop breaks on the deadline, on a pty the child closed, and on a child already exited, so reaching the message never implied the window had passed. A `claude` that dies early — no `setup-token` subcommand, a crash — got "no token after 900s … the authorize URL went unapproved" in a fraction of a second, naming a window that had not elapsed and a URL that was never printed, while the child's own error stayed swallowed. Same shape as the bug this PR set out to fix.

Separately, the manual OAuth path and both API-key paths had the user paste a live credential to the agent, which then passed it along on a command line. Given neither `--body` nor a pipe, `gh secret set` prompts for the value, so the user runs it themselves and the token goes from `claude setup-token` to that prompt and nowhere else. The CLI path already had this right — "Piping straight into `gh` keeps the token out of the transcript" — and the fallbacks now match it. That prompt refuses an empty submission, tested through a pty against `--no-store` with a non-empty control, so the empty-value hazard that makes the CLI path's guard load-bearing has no counterpart there.

The skill also says what an OAuth window costs now. The wrapper waits fifteen minutes, and the authorize URL logs the browser out on the way in (`claude.ai/login?reauth=1&from=logout`), so approving takes the user at the browser throughout, and an agent driving Chrome reaches that login and stops.

**Testing**: the `failure_message` branches are covered. The surrounding pty loop in `main()` is not, as before — it needs a real child process and a terminal.

> _This was written by Claude Code on behalf of max-sixty_
