### PR TITLE
skills: fetch the prior rejection before re-deriving a fix

### DIFF
--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -332,6 +332,8 @@ gh issue list --state open --limit 200 --json number,title
 gh pr list --state open --limit 200 --json number,title,headRefName
 ```
 
+That projection orients you; it does not clear a finding. It omits both states a prior rejection lives in — closed PRs, and the comment bodies of an open issue — so per finding, before writing code, run the searches under **Fetch the prior rejection before re-deriving a fix** in `/tend-ci-runner:running-in-ci`.
+
 The default action is a PR, not an issue. If there's a plausible fix, make it — explain uncertainty in the PR description.
 
 For each finding:

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -179,7 +179,7 @@ BOT_LOGIN=$(gh api user --jq '.login')
 # <symbol>: the function, file, or config key the change would edit
 gh pr list --state all --search "author:$BOT_LOGIN <symbol>" --limit 100 --json number,title,state,closedAt
 gh pr view <n> --json comments,reviews --jq '[.comments[].body, .reviews[].body]'
-gh issue view <n> --json comments --jq '.comments[].body'
+gh issue view <n> --json body,comments --jq '[.body, .comments[].body]'
 ```
 
 What you find governs: a PR closed on the **code** leaves the fix available to redo, while one closed on the **approach** means the semantics are still an open maintainer question — add findings to that thread rather than opening a second implementation of it.

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -172,10 +172,12 @@ Compare by title keywords **and** the files the new PR would modify — two conc
 
 A change a maintainer already turned down leaves its verdict in two places the checks above don't fetch: the closed PR that carried it, and the comments on the issue tracking it. Search by the symbol or path the change would edit — a finding re-derived from the code has no issue number, and an attempt predating the tracking issue cites none either — then read the closed hits and the issue bodies, not just their titles.
 
+Search, don't scan. A recency-ordered listing ages a rejection out in bot-throughput time: at a few PRs a day, any `--limit` drops it within weeks, and raising the cap only moves that boundary. A symbol match stays small however many PRs have landed since.
+
 ```bash
 BOT_LOGIN=$(gh api user --jq '.login')
 # <symbol>: the function, file, or config key the change would edit
-gh pr list --state all --search "author:$BOT_LOGIN <symbol>" --json number,title,state,closedAt
+gh pr list --state all --search "author:$BOT_LOGIN <symbol>" --limit 100 --json number,title,state,closedAt
 gh pr view <n> --json comments,reviews --jq '[.comments[].body, .reviews[].body]'
 gh issue view <n> --json comments --jq '.comments[].body'
 ```

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -168,6 +168,20 @@ gh pr list --state all --search "author:$BOT_LOGIN <issue-number>" \
 
 Compare by title keywords **and** the files the new PR would modify — two concurrent fixes for the same bug typically pick different branch names, so a branch-name match is not sufficient. If a sibling bot PR overlaps in scope — whether open, closed, or already merged — **do not create**: post a comment on the triggering thread linking the existing PR and exit.
 
+### Fetch the prior rejection before re-deriving a fix
+
+A change a maintainer already turned down leaves its verdict in two places the checks above don't fetch: the closed PR that carried it, and the comments on the issue tracking it. Search by the symbol or path the change would edit — a finding re-derived from the code has no issue number, and an attempt predating the tracking issue cites none either — then read the closed hits and the issue bodies, not just their titles.
+
+```bash
+BOT_LOGIN=$(gh api user --jq '.login')
+# <symbol>: the function, file, or config key the change would edit
+gh pr list --state all --search "author:$BOT_LOGIN <symbol>" --json number,title,state,closedAt
+gh pr view <n> --json comments,reviews --jq '[.comments[].body, .reviews[].body]'
+gh issue view <n> --json comments --jq '.comments[].body'
+```
+
+What you find governs: a PR closed on the **code** leaves the fix available to redo, while one closed on the **approach** means the semantics are still an open maintainer question — add findings to that thread rather than opening a second implementation of it.
+
 ## Pushing to PR Branches
 
 Always use `git push` without specifying a remote — `gh pr checkout` configures tracking to the correct remote, including for fork PRs. Specifying `origin` explicitly can push to the wrong place.


### PR DESCRIPTION
Nightly's Step 8 dedup fetched only open PRs, and only their titles, so both places a maintainer's rejection is recorded — the closed PR that carried it, and the comments on the issue tracking it — sat outside what the check ever read. A run could re-derive a finding from the code and reopen an approach already turned down, with nothing in context to say otherwise. The searches now live in `running-in-ci` (loaded by nightly, triage, and ci-fix alike, before any `gh pr create`), matched on the symbol or path the change would edit rather than an issue number a re-derived finding doesn't have. Verified with `pre-commit run --files` on both changed files.

**This is a query fix, not a judgment rule** — worth stating up front, because #805 proposed the behavioral version of this and you closed it: _"My sense is that the models would see this principle as implicit and not require explicit guidance."_ I think that was right, and it doesn't cover this case. There, the dedup had already surfaced the rejection and the agent acted on it correctly without being told to; the rule was belt-and-suspenders. Here the rejection is never fetched at all, and no amount of inference recovers a fact that isn't in context. So what's added is three `gh` invocations and one sentence on what the result means, not a restatement of a principle the model already applies.

<details><summary>What #1013 reported, and why the existing checks miss it</summary>

Filed by PRQL's tend bot after a third repeat attempt at the same fix was closed ([PRQL/prql#6206](https://github.com/PRQL/prql/pull/6206)). The prior two artifacts both said "don't fix this": [PRQL/prql#6147](https://github.com/PRQL/prql/pull/6147), closed on the **approach** with the code reviewed as fine, and a note on [PRQL/prql#6166](https://github.com/PRQL/prql/issues/6166) written by an earlier nightly run specifically so the next run would stop.

Three gaps, all in the projection rather than the judgment:

1. `--state open` filters out the one state that carries a rejection. A closed PR on the same call site is the strongest available signal, and it's precisely what's excluded.
2. `--json number,title` carries no bodies or comments. The issue's title reads as an ordinary unclaimed bug; the hold is in its comments. A prior run's note was write-only by construction.
3. Matching by title or issue number never connects an attempt that predates the tracking issue. The reporter verified that `gh pr list --state all --search "fold_module_def_stmt"` returns all three attempts while `--search "6166"` omits the rejected one — hence searching by symbol.

The pre-`gh pr create` dedup in `running-in-ci` does use `--state all`, so the closed PR is inside the list it returns, but that section is framed entirely around concurrent siblings. A weeks-old closed PR reads as history there, and nothing said to open it and find out why it closed.

Per `/tend-ci-runner:triage`'s "Skill text fixes", I checked co-loaded skills first — no existing guidance anywhere in `plugins/` or `.claude/` covers reading a closed PR's rationale, so nothing is duplicated.

</details>

<details><summary>No regression test</summary>

Documentation-only change to two skill files; the repo has no test coverage over skill prose. The `generator/tests` hits on "skills" are regtest outputs asserting skill *names* in generated workflow YAML, unaffected here. `pre-commit run --files` on both files passes trailing-whitespace, end-of-file-fixer, typos, the bang-backtick poison guard, and the install-tend reference-sync hook.

</details>

---
Closes #1013 — automated triage
