### PR TITLE
fix(install-tend): correct why the running-tend overlay needs frontmatter

### DIFF
--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -523,10 +523,9 @@ environment protection rules on top.
 ## 4. Create skill overlay (recommended)
 
 Create `.claude/skills/running-tend/SKILL.md` with tend-specific project
-guidance. This skill is loaded by tend workflows alongside the generic
-`tend-*` skills — by skill discovery, so it must open with the
-frontmatter shown below. An existing overlay without it isn't done:
-add the frontmatter in place.
+guidance, opening with the frontmatter below so discovery lists it by
+description rather than by its first heading. An existing overlay without
+frontmatter needs it added in place.
 
 **Do NOT duplicate CLAUDE.md** and **do NOT invent project conventions.**
 
@@ -540,8 +539,8 @@ If the user picked the overlay at Kickoff, ask via `AskUserQuestion`
 - Optional nightly actions (e.g., changelog maintenance — specify file and branch)
 
 For each selected item, follow up with a free-text ask to capture the
-specifics, then write them into the overlay, opening with the same
-frontmatter as the placeholder below. Otherwise create a placeholder:
+specifics, then write them into the overlay. Otherwise create a
+placeholder:
 
 ```markdown
 ---

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -15,8 +15,6 @@ If a `running-tend` skill is listed in your available skills, load it with the S
 
 Repo-local skills are invoked by their unprefixed name — `Skill: running-tend`, not `Skill: tend-ci-runner:running-tend` (that prefix is reserved for this plugin's own skills, and trying it returns `Unknown skill`).
 
-Repo-local skills must have YAML frontmatter (`name` + `description`) to be auto-discovered.
-
 If you are going to propose a code fix for a bug, load `/tend-ci-runner:triage` first — it contains reproduction and testing gates that apply to all fix attempts, not just initial triage.
 
 ## Conduct


### PR DESCRIPTION
Step 4 of `plugins/install-tend/skills/install-tend/SKILL.md` said skill discovery needs frontmatter, so an overlay without it was never loaded. That's wrong, and #1012 put it there.

Claude Code discovers a frontmatter-less `SKILL.md` and falls back to the directory name and the file's first heading. Measured on 2.1.235 (this repo's action pins 2.1.233) by listing the available skills in a checkout of PRQL/prql, which offered its overlay as `running-tend: Running Tend in PRQL`. So those overlays were loading all along; what they lacked is the description an agent judges relevance from — which is still a reason to write frontmatter, just not the one the step gave.

Step 4 now says that in three lines instead of six, and the duplicate frontmatter instruction on the customized-overlay path is gone: the placeholder eight lines below already shows it.

The same claim also stood in `running-in-ci`, which every CI session loads, as "Repo-local skills must have YAML frontmatter (`name` + `description`) to be auto-discovered". That line is deleted rather than rewritten — discovery lists an overlay either way, and First Steps already tells the session to load a listed `running-tend`, so nothing there depends on the mechanics. The requirement to write frontmatter into a *new* overlay keeps its one home in `references/skill-pr-workflow.md`.

The two consumers that lacked frontmatter now have it — PRQL/prql#6208 and numbagg/numbagg#747.

> _This was written by Claude Code on behalf of max-sixty_
