### PR TITLE
fix(install-tend): run tend check where it can pass

### DIFF
--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -351,8 +351,7 @@ those.) The next nightly regen
 runs `uvx tend@latest init` without the flag, and the init cleanup step
 removes the file from the default branch.
 
-Verify workflow files appear in `.github/workflows/tend-*.yaml`. Run
-`uvx tend@latest check` to validate branch protection, secrets, and bot access.
+Verify workflow files appear in `.github/workflows/tend-*.yaml`.
 
 Check for workflows using `anthropics/claude-code-action`:
 
@@ -509,9 +508,10 @@ see. If a repo keeps one on a release/deploy workflow, gate that
 Environment with required reviewers before migrating release or deploy
 secrets to it.
 
-Run `uvx tend@latest check` after this section; its
-`credential-environments` line reports any environment still reachable by
-the bot.
+Run `uvx tend@latest check` after this section. It exits non-zero until
+the later steps set the secrets and grant the bot access; read its
+`credential-environments` line, which reports any environment still
+reachable by the bot.
 
 **More complicated approaches are possible** (per-pattern tag rulesets,
 mixed bypass actors, layered no-bypass immutability rulesets for repos
@@ -957,7 +957,15 @@ else
 fi
 ```
 
-## 11. Commit and push
+## 11. Verify, commit and push
+
+Everything `check` inspects is in place by now, so this run must pass:
+
+```bash
+uvx tend@latest check
+```
+
+A failure here is a real one — fix it before committing.
 
 Stage all changes:
 
@@ -968,11 +976,10 @@ git add .
 Commit with co-author attribution. Do NOT push without explicit permission.
 
 After pushing the install PR, wait for the `tend-install-test` workflow
-to pass before merging — it verifies the bot+harness secrets are set and
-that the committed workflow files match the generator's output. Merging
-is the user's call. The file
-itself is removed on the next nightly regen, so future PRs won't trigger
-it.
+to pass before merging — it verifies that the committed workflow files
+match the generator's output, the one thing a `pull_request` run can see.
+Merging is the user's call. The file itself is removed on the next
+nightly regen, so future PRs won't trigger it.
 
 ## Summary checklist
 
@@ -991,5 +998,6 @@ line picks the row that matches the chosen harness):
 - [ ] Bot token: `TEND_BOT_TOKEN` set with `repo`+`workflow`+`notifications`+`write:discussion`+`gist`+`user` scopes
 - [ ] Bot access: repo collaborator with write access, invitation accepted
 - [ ] Bot bio: profile bio reflects the authorization stance
+- [ ] `uvx tend@latest check` passes
 - [ ] Committed (push requires explicit permission)
 - [ ] `tend-install-test` workflow passed on the install PR before merging


### PR DESCRIPTION
Step 2 of the install skill ran `uvx tend@latest check` before ref protection (step 3), the secrets (steps 7–8), or bot access (step 9) existed. It failed on every install, and nothing told the agent the failure was expected — so it had to guess whether the install had gone wrong. That call is gone.

Step 3's call stays, since it's the one that reports `credential-environments`, and now says it exits non-zero until the later steps land — the way step 7 already frames its own scoped run.

The full run moves to step 11, renamed "Verify, commit and push", where everything `check` inspects is finally in place and a failure is a real one. The Kickoff already defines a finished install as one where `check` passes, but nothing in the procedure ran it anywhere it could. A checklist row goes with it.

One more thing surfaced while reading around it: step 11 claimed `tend-install-test` verifies the bot and harness secrets are set. It doesn't. `generate_install_test` in `generator/src/tend/workflows.py` only diffs the committed workflow files against the generator's output, and its own docstring says the secrets are `tend check`'s job because a `pull_request` run can't name the `tend` environment — which is what step 2 says too, four hundred lines earlier. Corrected to what the workflow actually does.

Closes the last of the install-skill follow-ups from #1012 and #1017.

> _This was written by Claude Code on behalf of max-sixty_
