### PR TITLE
fix(nightly): leave the tend-outage tracker for review-runs to drain

### DIFF
--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -173,7 +173,10 @@ gh pr list --state open --limit 200 --json number,title,headRefName
 
 For each open issue, check whether recent commits or the current codebase state already resolve it. If resolved, comment with the evidence (commits, CI runs, or code state that resolves the issue). Close the issue with `gh issue close` when:
 
-- The bot opened the issue itself to report a transient condition (e.g., a "Nightly tests failed" report from a prior run) and the condition has clearly resolved — the fix PR is merged and the relevant CI on `main` is passing. Skip this case where closing the issue is itself a signal rather than a record of resolution: a body containing "Do not close manually" (recurring trackers with their own lifecycle), or the `tend-rate-limit` label, where a maintainer's close is what lifts the bot past its own rate limit. Closing that one as the bot lifts nothing — the preflight counts only closes by a person — but it clears a decision still waiting on one.
+- The bot opened the issue itself to report a transient condition (e.g., a "Nightly tests failed" report from a prior run) and the condition has clearly resolved — the fix PR is merged and the relevant CI on `main` is passing. Skip this case where closing the issue is itself a signal rather than a record of resolution:
+  - a body containing "Do not close manually" — recurring trackers with their own lifecycle.
+  - the `tend-outage` label. Its rows name the triggers a failed run stranded, and the close belongs to `review-runs`' drain step, which reports each row re-run or confirmed no longer needed. "Nothing has failed since" answers a different question, and nightly's cron precedes `review-runs`' under the generated defaults — closing it here drops the rows before the only step that reads them.
+  - the `tend-rate-limit` label, where a maintainer's close is what lifts the bot past its own rate limit. Closing that one as the bot lifts nothing — the preflight counts only closes by a person — but it clears a decision still waiting on one.
 - The repo's guidance (e.g., `running-tend` skill) explicitly authorizes closing issues.
 
 Otherwise, leave it open for a maintainer to close.

--- a/shared/steps/report-failure.sh
+++ b/shared/steps/report-failure.sh
@@ -14,9 +14,12 @@
 # data.
 #
 # A closed outage issue is left closed and a fresh one filed: closing it means
-# the outage was resolved, and reopening would fold the next incident into a
-# stale record. The rate-limit issue takes the opposite policy, for reasons in
-# lib/run-issue.sh.
+# the `review-runs` drain step read every row and re-ran what needed it, and
+# reopening would fold the next incident into a stale record. That drain owns
+# the close — the nightly skill's resolved-issue rule carves this label out,
+# because nightly's cron precedes review-runs' and "nothing has failed since"
+# says nothing about the stranded triggers the rows name. The rate-limit issue
+# takes the opposite policy, for reasons in lib/run-issue.sh.
 #
 # Inputs (env): GITHUB_TOKEN (for gh), GITHUB_SERVER_URL, GITHUB_REPOSITORY,
 # GITHUB_RUN_ID, GITHUB_EVENT_NAME, GITHUB_EVENT_PATH (from Actions).
@@ -126,6 +129,6 @@ else
   printf '%s\n\n%s\n\n%s\n' \
     "The bot failed to process a request. This issue tracks failures until the underlying cause is resolved." \
     "$ROW" \
-    "This issue was created automatically. Close it once the outage is resolved." \
+    "This issue was created automatically. It closes when the \`tend-review-runs\` sweep has drained every row above — each stranded trigger re-run, or confirmed no longer needed." \
     | run_issue_create_and_reconcile "$LABEL" "$TITLE" "$ROW" > /dev/null
 fi

--- a/shared/steps/report-failure.sh
+++ b/shared/steps/report-failure.sh
@@ -18,8 +18,11 @@
 # reopening would fold the next incident into a stale record. That drain owns
 # the close — the nightly skill's resolved-issue rule carves this label out,
 # because nightly's cron precedes review-runs' and "nothing has failed since"
-# says nothing about the stranded triggers the rows name. The rate-limit issue
-# takes the opposite policy, for reasons in lib/run-issue.sh.
+# says nothing about the stranded triggers the rows name. Where an adopter
+# disables `review-runs`, nothing substitutes for it and the close falls to a
+# maintainer against the same criterion — which is why the issue body states
+# the criterion rather than naming the sweep as the only route. The rate-limit
+# issue takes the opposite policy, for reasons in lib/run-issue.sh.
 #
 # Inputs (env): GITHUB_TOKEN (for gh), GITHUB_SERVER_URL, GITHUB_REPOSITORY,
 # GITHUB_RUN_ID, GITHUB_EVENT_NAME, GITHUB_EVENT_PATH (from Actions).
@@ -129,6 +132,6 @@ else
   printf '%s\n\n%s\n\n%s\n' \
     "The bot failed to process a request. This issue tracks failures until the underlying cause is resolved." \
     "$ROW" \
-    "This issue was created automatically. It closes when the \`tend-review-runs\` sweep has drained every row above — each stranded trigger re-run, or confirmed no longer needed." \
+    "This issue was created automatically. Close it once every row above is drained — each stranded trigger re-run, or confirmed no longer needed. The \`tend-review-runs\` sweep does that where it runs." \
     | run_issue_create_and_reconcile "$LABEL" "$TITLE" "$ROW" > /dev/null
 fi


### PR DESCRIPTION
## Problem

`review-runs`' **Drain stranded triggers** step is the only thing that reads the rows on the `tend-outage` "Bot temporarily unavailable" tracker — each row names a trigger a failed run stranded, and nothing re-runs those triggers on its own. But `nightly`'s Step 5 resolved-issue rule can close that tracker first, on evidence that answers a different question: "no tend run has failed since". That says nothing about whether the stranded triggers were re-run.

The ordering isn't incidental. The generated default crons are `nightly` at `17 6 * * *` and `review-runs` at `47 7 * * *` ([`workflows.py`](https://github.com/max-sixty/tend/blob/acd9d32bbcb46b23c42817dc0d4922c3044142b5/generator/src/tend/workflows.py#L381-L385)), so nightly reaches the tracker first every day, on every adopter that hasn't overridden the cron. The drain then queries `--state open`, finds nothing, and reports the night clean. The tracker body invited exactly this: "Close it once the outage is resolved" — the outage resolving is not the drain completing.

Reported in #1019 with a chain observed on a consumer repo, where the lost row pointed at a `tend-mention` run that died before the agent started, stranding a review-response dispatch whose inline suggestion never reached anyone.

## Solution

Nightly stops closing `tend-outage` issues, so the tracker's lifecycle belongs to the one step that reads its rows. This is a removal, not new machinery — the carve-out list in nightly's rule already exists for the same reason (`Do not close manually` bodies, `tend-rate-limit`), and this is a third member of that family: the close is a signal, not a record of resolution.

`report-failure.sh`'s tracker body now states the real criterion, so a maintainer closing it by hand uses the same one, and the file comment records who owns the close.

The issue's second option — widening the drain to also read outage issues closed since its window anchor — is not taken. It leaves two workflows with an interest in the same record and depends on the closure landing inside one window, where this puts the close with the only reader.

That makes `review-runs` the tracker's only automatic closer, which is a deliberate trade rather than a side effect. An adopter can disable that workflow (`workflows: review-runs: enabled: false`), and on such a repo nothing closes the tracker: `report-failure.sh` appends to the open one, so every later incident folds into a record the drain step's own closing line warns about. A carve-out for that case would need nightly to read the adopter's config before deciding whether the label is off-limits — more machinery than the case earns, and no repo in `data/consumers.json` disables the sweep. What the case does earn is wording that stays true without it: the tracker body states the criterion and names `tend-review-runs` as what satisfies it where it runs, rather than as the only route, and the file comment says the close falls to a maintainer where the sweep is absent.

`ci-fix`'s transient tracker shares the `tend-outage` label but is created and closed in the same step, so it is never open for nightly to reach; carving out the label rather than the title costs nothing.

## Testing

`uv run pytest generator/tests/test_shared_steps.py` passes (70 tests) — no assertion covers the tracker's body prose, so the string change is unasserted. `shellcheck` and `pre-commit` clean on both files, and the `printf` renders the escaped backticks as literal inline code.

The nightly half is skill prose with no test surface; the claim it rests on is the default cron table cited above and the drain's `--state open` query at [`review-runs/SKILL.md`](https://github.com/max-sixty/tend/blob/acd9d32bbcb46b23c42817dc0d4922c3044142b5/plugins/tend-ci-runner/skills/review-runs/SKILL.md#L215-L217).

---
Closes #1019 — automated triage

