### PR TITLE
fix(generator): cap every generated job with timeout-minutes

### DIFF
--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -70,7 +70,9 @@ inputs:
       overhead (observed ~2 minutes) with margin, so a run that fills its
       budget still gets the supervisor's clean kill and failure report
       instead of GitHub's own silent one. Short tasks finish well before
-      the cap regardless.
+      the cap regardless. Generated workflows always pass a value, derived
+      from their job's own `timeout-minutes` by the same 10-minute margin,
+      so this default applies only to a caller that declares no job cap.
   mitmproxy_version:
     default: "12.2.3"
     description: >-

--- a/docs/tend.example.yaml
+++ b/docs/tend.example.yaml
@@ -347,7 +347,10 @@ bot_name: my-project-bot
 # `handle`; 180 for nightly; 10 for mention's `relay` and `verify`. The cap
 # covers the whole job, `setup:` included, which is the only bound that
 # reaches steps running before the harness action is entered. Override it
-# where a job legitimately needs longer:
+# where a job legitimately needs longer — note that the override moves the job
+# cap only: the Claude harness's own session budget is generated 10 minutes
+# under the default cap, so a much larger override leaves the session bounded
+# where it was (reported as a failure, not silently cancelled).
 #
 # workflows:
 #   review:

--- a/docs/tend.example.yaml
+++ b/docs/tend.example.yaml
@@ -342,6 +342,13 @@ bot_name: my-project-bot
 #
 # ### Example: longer timeout on a specific job
 #
+# Every generated job ships a `timeout-minutes` default — 60 for ci-fix,
+# notifications and weekly; 120 for review, triage, review-runs and mention's
+# `handle`; 180 for nightly; 10 for mention's `relay` and `verify`. The cap
+# covers the whole job, `setup:` included, which is the only bound that
+# reaches steps running before the harness action is entered. Override it
+# where a job legitimately needs longer:
+#
 # workflows:
 #   review:
 #     jobs:

--- a/docs/tend.example.yaml
+++ b/docs/tend.example.yaml
@@ -349,8 +349,10 @@ bot_name: my-project-bot
 # reaches steps running before the harness action is entered. Override it
 # where a job legitimately needs longer — note that the override moves the job
 # cap only: the Claude harness's own session budget is generated 10 minutes
-# under the default cap, so a much larger override leaves the session bounded
-# where it was (reported as a failure, not silently cancelled).
+# under the default cap. Raising the cap leaves the session bounded where it
+# was (reported as a failure, not silently cancelled); lowering it below that
+# budget puts the supervisor out of reach again, and an overrunning session
+# goes back to being cancelled silently.
 #
 # workflows:
 #   review:

--- a/generator/src/tend/templates/ci-fix.yaml.j2
+++ b/generator/src/tend/templates/ci-fix.yaml.j2
@@ -15,6 +15,7 @@ jobs:
   fix-ci:
     if: <<fork_guard_prefix(cfg)>>github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-24.04
+<<job_timeout(60)>>
 <<environment()>>
     permissions:
 <<permissions(issues=False)>>

--- a/generator/src/tend/templates/ci-fix.yaml.j2
+++ b/generator/src/tend/templates/ci-fix.yaml.j2
@@ -15,11 +15,11 @@ jobs:
   fix-ci:
     if: <<fork_guard_prefix(cfg)>>github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-24.04
-<<job_timeout(60)>>
+<<job_timeout(timeout_minutes)>>
 <<environment()>>
     permissions:
 <<permissions(issues=False)>>
     steps:
 <<checkout(cfg, ref=cfg.default_branch)>>
 <<setup>>
-<<agent_step(cfg, prompt_body)>>
+<<agent_step(cfg, prompt_body, timeout_minutes)>>

--- a/generator/src/tend/templates/macros.yaml.j2
+++ b/generator/src/tend/templates/macros.yaml.j2
@@ -13,8 +13,24 @@
    active credential through its credential proxy (OAuth wins when both are
    present), treating empty as absent. Codex takes a single `openai_api_key` —
    the subscription `auth.json` path is incompatible with tend's concurrent
-   workflows and is not exposed. #}
-{% macro agent_step(cfg, prompt_body, if_condition='') %}
+   workflows and is not exposed.
+
+   `timeout_minutes` is the enclosing job's cap, and the claude branch spends
+   it: the supervisor's budget is set 10 minutes under it so the two kills stay
+   ordered. They are not equivalent — the supervisor exits 1, which paints the
+   job `failure` and so runs the action's `failure()`-gated `Report failure`
+   step, filing the `tend-outage` row that `review-runs` drains to re-run
+   stranded triggers; GitHub's `timeout-minutes` kill yields `cancelled`, where
+   `failure()` steps are skipped and an overrun goes unreported. Leaving the
+   action's 21000s default in place would put every job cap below it and make
+   the supervisor unreachable. The ordering holds while the steps ahead of the
+   agent — checkout, `setup:`, the CLI installers — fit inside that 10-minute
+   margin; past it the job cap wins and the kill is silent again, but that is
+   the pre-agent region `timeout-minutes` exists to bound in the first place.
+
+   Codex has no supervisor timeout, so its branch emits nothing and the job cap
+   is that harness's only bound. #}
+{% macro agent_step(cfg, prompt_body, timeout_minutes, if_condition='') %}
 {% if cfg.harness == 'claude' %}
       - uses: max-sixty/tend/claude@<<tend_version>>
 {% else %}
@@ -37,6 +53,10 @@
           bot_name: <<cfg.bot_name>>
           model: <<cfg.model>>
 {% if cfg.harness == 'claude' %}
+          # 10 minutes under the job cap, so an overrunning session takes the
+          # harness's kill — job red, failure reported — rather than GitHub's,
+          # which cancels the job and skips the report.
+          timeout_seconds: <<(timeout_minutes - 10) * 60>>
 {% if cfg.sandbox_path %}
           sandbox_path: |
 {% for dir in cfg.sandbox_path %}
@@ -90,9 +110,17 @@
    someone pushes, so a wedged review is a review that never happens.
 
    Values are sized above observed healthy durations, not near the supervisor
-   budget: a cap that only restates GitHub's default bounds nothing. Adopters
-   who need more override per job —
-   `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml. #}
+   budget: a cap that only restates GitHub's default bounds nothing. The same
+   value sets the agent step's `timeout_seconds` 10 minutes lower (see
+   `agent_step`), so the supervisor still owns an agent-session overrun and
+   this cap backstops the region it cannot reach. Both come from
+   `_JOB_TIMEOUT_MINUTES` in workflows.py — one number per workflow, so the two
+   cannot drift apart. Adopters who need more override per job —
+   `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml. That
+   override moves the job cap alone — step inputs take no override, so the
+   supervisor budget stays at the generated value and an adopter who raises
+   the cap gets a session still bounded by the default. Reported, not silent:
+   the supervisor's kill is the one that files the outage row. #}
 {% macro job_timeout(minutes) %}
     # Bounds the whole job, adopter `setup:` included. Override with
     # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.

--- a/generator/src/tend/templates/macros.yaml.j2
+++ b/generator/src/tend/templates/macros.yaml.j2
@@ -79,6 +79,26 @@
       deployment: false
 {%- endmacro %}
 
+{# Job timeout at column 4. A job cap is the only bound that reaches the whole
+   job: the harness supervisor's `timeout_seconds` starts once the action is
+   entered, so every step before it — checkout, the adopter's `setup:`, the
+   CLI installers — is otherwise bounded only by GitHub's 360-minute default.
+   Observed wedges live in exactly that region (an unbounded `apt-get update`
+   in an adopter setup composite, killed at 360 minutes), and a wedge on a job
+   with `cancel-in-progress: false` holds its concurrency queue for the same
+   six hours. On `pull_request_target` there is no successor run unless
+   someone pushes, so a wedged review is a review that never happens.
+
+   Values are sized above observed healthy durations, not near the supervisor
+   budget: a cap that only restates GitHub's default bounds nothing. Adopters
+   who need more override per job —
+   `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml. #}
+{% macro job_timeout(minutes) %}
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: <<minutes>>
+{%- endmacro %}
+
 {# Permissions block at column 6. `issues` defaults to True because every
    workflow except ci-fix needs it. The trailing inline conditional avoids
    the trim_blocks-eats-the-separator issue between `actions: read` and

--- a/generator/src/tend/templates/macros.yaml.j2
+++ b/generator/src/tend/templates/macros.yaml.j2
@@ -118,9 +118,11 @@
    cannot drift apart. Adopters who need more override per job —
    `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml. That
    override moves the job cap alone — step inputs take no override, so the
-   supervisor budget stays at the generated value and an adopter who raises
-   the cap gets a session still bounded by the default. Reported, not silent:
-   the supervisor's kill is the one that files the outage row. #}
+   supervisor budget stays at the generated value. Raising the cap therefore
+   leaves the session bounded where it was, and reported rather than silent:
+   the supervisor's kill is the one that files the outage row. Lowering it
+   under that budget puts the supervisor out of reach again, and an overrun
+   goes back to being cancelled silently. #}
 {% macro job_timeout(minutes) %}
     # Bounds the whole job, adopter `setup:` included. Override with
     # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.

--- a/generator/src/tend/templates/mention.yaml.j2
+++ b/generator/src/tend/templates/mention.yaml.j2
@@ -170,7 +170,7 @@ jobs:
       group: ${{ github.workflow }}-handle-${{ github.event.issue.number || github.event.client_payload.pr }}
       cancel-in-progress: false
     runs-on: ubuntu-24.04
-<<job_timeout(120)>>
+<<job_timeout(timeout_minutes)>>
 <<environment()>>
     permissions:
 <<permissions()>>
@@ -219,6 +219,6 @@ jobs:
           # the API record — the dispatch payload never carries one to spoof.
           EVENT_TS: ${{ github.event.comment.updated_at || needs.verify.outputs.ts || github.event.issue.updated_at }}
 
-<<agent_step(cfg, prompt_body)>><<restore_local_actions(local_actions)>>
+<<agent_step(cfg, prompt_body, timeout_minutes)>><<restore_local_actions(local_actions)>>
 
 <<unreact_eyes(cfg, reaction_target, if_condition="always()\n&& " ~ summoned(cfg.bot_name, 'needs.verify.outputs.reason'))>>

--- a/generator/src/tend/templates/mention.yaml.j2
+++ b/generator/src/tend/templates/mention.yaml.j2
@@ -94,6 +94,7 @@ jobs:
        github.event_name == 'pull_request_review_comment') &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
+<<job_timeout(10)>>
     # No secrets here. `contents: write` is what the dispatch POST needs, and
     # is the whole of what this token can do — probed both ways on a live
     # repo: an otherwise identical same-repo run declaring `contents: read`
@@ -135,6 +136,7 @@ jobs:
       (github.event_name == 'issue_comment' &&
         <<not_bookkeeping()>>)
     runs-on: ubuntu-24.04
+<<job_timeout(10)>>
 <<environment()>>
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
@@ -168,6 +170,7 @@ jobs:
       group: ${{ github.workflow }}-handle-${{ github.event.issue.number || github.event.client_payload.pr }}
       cancel-in-progress: false
     runs-on: ubuntu-24.04
+<<job_timeout(120)>>
 <<environment()>>
     permissions:
 <<permissions()>>

--- a/generator/src/tend/templates/notifications.yaml.j2
+++ b/generator/src/tend/templates/notifications.yaml.j2
@@ -8,6 +8,7 @@ on:
 jobs:
   notifications:
 <<fork_guard_if(cfg)>>    runs-on: ubuntu-24.04
+<<job_timeout(60)>>
 <<environment()>>
     permissions:
 <<permissions()>>

--- a/generator/src/tend/templates/notifications.yaml.j2
+++ b/generator/src/tend/templates/notifications.yaml.j2
@@ -8,7 +8,7 @@ on:
 jobs:
   notifications:
 <<fork_guard_if(cfg)>>    runs-on: ubuntu-24.04
-<<job_timeout(60)>>
+<<job_timeout(timeout_minutes)>>
 <<environment()>>
     permissions:
 <<permissions()>>
@@ -22,4 +22,4 @@ jobs:
 <<check_script|indent(10, first=True)>>
 
 <<checkout(cfg, ref=cfg.default_branch, if_condition=skip_condition)>>
-<<setup>><<agent_step(cfg, block_prompt(prompt), if_condition=skip_condition)>>
+<<setup>><<agent_step(cfg, block_prompt(prompt), timeout_minutes, if_condition=skip_condition)>>

--- a/generator/src/tend/templates/review.yaml.j2
+++ b/generator/src/tend/templates/review.yaml.j2
@@ -21,6 +21,7 @@ jobs:
       # booting an agent when its HEAD is already covered.
       cancel-in-progress: false
     runs-on: ubuntu-24.04
+<<job_timeout(120)>>
 <<environment()>>
     permissions:
 <<permissions()>>

--- a/generator/src/tend/templates/review.yaml.j2
+++ b/generator/src/tend/templates/review.yaml.j2
@@ -21,7 +21,7 @@ jobs:
       # booting an agent when its HEAD is already covered.
       cancel-in-progress: false
     runs-on: ubuntu-24.04
-<<job_timeout(120)>>
+<<job_timeout(timeout_minutes)>>
 <<environment()>>
     permissions:
 <<permissions()>>
@@ -64,6 +64,6 @@ jobs:
           fi
 <<checkout(cfg, ref='${{ steps.pr_ref.outputs.ref }}', if_condition=skip_condition, allow_unsafe_pr_checkout=True, clean=not has_setup)>>
 
-<<agent_step(cfg, prompt_body, if_condition=skip_condition)>><<restore_local_actions(local_actions, if_condition=skip_condition)>>
+<<agent_step(cfg, prompt_body, timeout_minutes, if_condition=skip_condition)>><<restore_local_actions(local_actions, if_condition=skip_condition)>>
 
 <<unreact_eyes(cfg, 'issues/${{ github.event.pull_request.number }}', if_condition='always() && (' ~ skip_condition ~ ')')>>

--- a/generator/src/tend/templates/scheduled.yaml.j2
+++ b/generator/src/tend/templates/scheduled.yaml.j2
@@ -15,4 +15,4 @@ jobs:
     steps:
 <<checkout(cfg, ref=cfg.default_branch)>>
 <<setup>>
-<<agent_step(cfg, block_prompt(prompt))>>
+<<agent_step(cfg, block_prompt(prompt), timeout_minutes)>>

--- a/generator/src/tend/templates/scheduled.yaml.j2
+++ b/generator/src/tend/templates/scheduled.yaml.j2
@@ -8,6 +8,7 @@ on:
 jobs:
   <<name>>:
 <<fork_guard_if(cfg)>>    runs-on: ubuntu-24.04
+<<job_timeout(timeout_minutes)>>
 <<environment()>>
     permissions:
 <<permissions()>>

--- a/generator/src/tend/templates/triage.yaml.j2
+++ b/generator/src/tend/templates/triage.yaml.j2
@@ -12,6 +12,7 @@ jobs:
   triage:
     if: <<fork_guard_prefix(cfg)>><<not_bookkeeping()>>
     runs-on: ubuntu-24.04
+<<job_timeout(120)>>
 <<environment()>>
     permissions:
 <<permissions()>>

--- a/generator/src/tend/templates/triage.yaml.j2
+++ b/generator/src/tend/templates/triage.yaml.j2
@@ -12,7 +12,7 @@ jobs:
   triage:
     if: <<fork_guard_prefix(cfg)>><<not_bookkeeping()>>
     runs-on: ubuntu-24.04
-<<job_timeout(120)>>
+<<job_timeout(timeout_minutes)>>
 <<environment()>>
     permissions:
 <<permissions()>>
@@ -21,6 +21,6 @@ jobs:
 
 <<checkout(cfg, ref=cfg.default_branch)>>
 <<setup>>
-<<agent_step(cfg, block_prompt(prompt))>>
+<<agent_step(cfg, block_prompt(prompt), timeout_minutes)>>
 
 <<unreact_eyes(cfg, 'issues/${{ github.event.issue.number }}', if_condition='always()')>>

--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -107,6 +107,26 @@ _JINJA.globals["openai_key_secret"] = OPENAI_KEY_SECRET
 BOOKKEEPING_LABELS = ("tend-outage", "tend-rate-limit")
 _JINJA.globals["bookkeeping_labels"] = BOOKKEEPING_LABELS
 
+# Job cap per workflow, sized above the durations these workloads actually run:
+# nightly's sweep is the longest, the short-session workflows the cheapest to
+# bound. The `job_timeout` macro carries why they are capped at all, and
+# `agent_step` spends the same number a second time — the supervisor budget is
+# derived from it, so one entry here moves both bounds together.
+#
+# Keyed by workflow, not by job, because only the agent-running job of each
+# takes a value from here: mention's secretless relay and verify jobs do
+# seconds of API work and carry a literal 10 in the template.
+_JOB_TIMEOUT_MINUTES = {
+    "ci-fix": 60,
+    "notifications": 60,
+    "weekly": 60,
+    "review": 120,
+    "mention": 120,
+    "triage": 120,
+    "review-runs": 120,
+    "nightly": 180,
+}
+
 
 # Register every macro defined in `macros.yaml.j2` as a Jinja global so
 # workflow templates can call `agent_step(...)` directly, without an
@@ -282,6 +302,7 @@ def generate_review(cfg: Config) -> GeneratedWorkflow:
 
     content = _REVIEW_TMPL.render(
         cfg=eff,
+        timeout_minutes=_JOB_TIMEOUT_MINUTES["review"],
         setup=_setup_yaml(eff, condition=skip_condition),
         local_actions=_restore_local_actions_run(eff),
         prompt_expr=prompt_expr,
@@ -308,6 +329,7 @@ def generate_mention(cfg: Config) -> GeneratedWorkflow:
 
     content = _MENTION_TMPL.render(
         cfg=eff,
+        timeout_minutes=_JOB_TIMEOUT_MINUTES["mention"],
         setup=_setup_yaml(eff),
         local_actions=_restore_local_actions_run(eff),
         check_script=check_script.rstrip("\n"),
@@ -330,7 +352,12 @@ def generate_triage(cfg: Config) -> GeneratedWorkflow:
         "{issue_number}", "${{ github.event.issue.number }}"
     )
 
-    content = _TRIAGE_TMPL.render(cfg=eff, setup=_setup_yaml(eff), prompt=prompt)
+    content = _TRIAGE_TMPL.render(
+        cfg=eff,
+        timeout_minutes=_JOB_TIMEOUT_MINUTES["triage"],
+        setup=_setup_yaml(eff),
+        prompt=prompt,
+    )
     return GeneratedWorkflow(filename="tend-triage.yaml", content=content)
 
 
@@ -360,6 +387,7 @@ def generate_ci_fix(cfg: Config) -> GeneratedWorkflow:
 
     content = _CI_FIX_TMPL.render(
         cfg=eff,
+        timeout_minutes=_JOB_TIMEOUT_MINUTES["ci-fix"],
         watched=watched,
         branches=branches,
         setup=_setup_yaml(eff),
@@ -384,15 +412,6 @@ _SCHEDULED_DEFAULT_CRON = {
     "review-runs": "47 7 * * *",
 }
 
-# One template, three workloads of different length: nightly's sweep is the
-# longest, weekly's dependency pass the shortest. See the `job_timeout` macro
-# for why these are capped at all.
-_SCHEDULED_TIMEOUT_MINUTES = {
-    "nightly": 180,
-    "weekly": 60,
-    "review-runs": 120,
-}
-
 
 def _generate_scheduled(cfg: Config, name: str) -> GeneratedWorkflow:
     wf = cfg.workflows.get(name, WorkflowConfig())
@@ -404,7 +423,7 @@ def _generate_scheduled(cfg: Config, name: str) -> GeneratedWorkflow:
         cfg=eff,
         name=name,
         cron=cron,
-        timeout_minutes=_SCHEDULED_TIMEOUT_MINUTES[name],
+        timeout_minutes=_JOB_TIMEOUT_MINUTES[name],
         setup=_setup_yaml(eff),
         prompt=prompt,
     )
@@ -429,6 +448,7 @@ def generate_notifications(cfg: Config) -> GeneratedWorkflow:
 
     content = _NOTIFICATIONS_TMPL.render(
         cfg=eff,
+        timeout_minutes=_JOB_TIMEOUT_MINUTES["notifications"],
         cron=cron,
         skip_condition=skip_condition,
         setup=_setup_yaml(eff, condition=skip_condition),

--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -384,6 +384,15 @@ _SCHEDULED_DEFAULT_CRON = {
     "review-runs": "47 7 * * *",
 }
 
+# One template, three workloads of different length: nightly's sweep is the
+# longest, weekly's dependency pass the shortest. See the `job_timeout` macro
+# for why these are capped at all.
+_SCHEDULED_TIMEOUT_MINUTES = {
+    "nightly": 180,
+    "weekly": 60,
+    "review-runs": 120,
+}
+
 
 def _generate_scheduled(cfg: Config, name: str) -> GeneratedWorkflow:
     wf = cfg.workflows.get(name, WorkflowConfig())
@@ -395,6 +404,7 @@ def _generate_scheduled(cfg: Config, name: str) -> GeneratedWorkflow:
         cfg=eff,
         name=name,
         cron=cron,
+        timeout_minutes=_SCHEDULED_TIMEOUT_MINUTES[name],
         setup=_setup_yaml(eff),
         prompt=prompt,
     )

--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -531,6 +531,9 @@ jobs:
     # validation isn't worth special-casing.
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:

--- a/generator/tests/_regtest_outputs/test_generate.test_extras_apply_path_regtest.out
+++ b/generator/tests/_regtest_outputs/test_generate.test_extras_apply_path_regtest.out
@@ -146,6 +146,10 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
+          # 10 minutes under the job cap, so an overrunning session takes the
+          # harness's kill ? job red, failure reported ? rather than GitHub's,
+          # which cancels the job and skips the report.
+          timeout_seconds: 6600
           prompt: >-
             ${{ format('/tend-ci-runner:review {0}', github.event.pull_request.number) }}
 

--- a/generator/tests/_regtest_outputs/test_generate.test_extras_apply_path_regtest.out
+++ b/generator/tests/_regtest_outputs/test_generate.test_extras_apply_path_regtest.out
@@ -21,6 +21,9 @@ jobs:
       # booting an agent when its HEAD is already covered.
       cancel-in-progress: false
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 240
     environment:
       name: tend
       deployment: false
@@ -161,6 +164,5 @@ jobs:
           TARGET: issues/${{ github.event.pull_request.number }}
           BOT_NAME: test-bot
           GITHUB_TOKEN: ${{ secrets.TEND_BOT_TOKEN }}
-    timeout-minutes: 240
 env:
   FOO: bar

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-ci-fix.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-ci-fix.yaml].out
@@ -42,6 +42,10 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
+          # 10 minutes under the job cap, so an overrunning session takes the
+          # harness's kill ? job red, failure reported ? rather than GitHub's,
+          # which cancels the job and skips the report.
+          timeout_seconds: 3000
           prompt: |
             /tend-ci-runner:ci-fix ${{ github.event.workflow_run.id }}
             - Run URL: ${{ github.event.workflow_run.html_url }}

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-ci-fix.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-ci-fix.yaml].out
@@ -17,6 +17,9 @@ jobs:
   fix-ci:
     if: github.repository_owner == 'test-owner' && github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 60
     environment:
       name: tend
       deployment: false

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-nightly.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-nightly.yaml].out
@@ -16,6 +16,9 @@ jobs:
   nightly:
     if: github.repository_owner == 'test-owner'
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 180
     environment:
       name: tend
       deployment: false

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-nightly.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-nightly.yaml].out
@@ -42,5 +42,9 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
+          # 10 minutes under the job cap, so an overrunning session takes the
+          # harness's kill ? job red, failure reported ? rather than GitHub's,
+          # which cancels the job and skips the report.
+          timeout_seconds: 10200
           prompt: |
             /tend-ci-runner:nightly

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
@@ -156,5 +156,9 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
+          # 10 minutes under the job cap, so an overrunning session takes the
+          # harness's kill ? job red, failure reported ? rather than GitHub's,
+          # which cancels the job and skips the report.
+          timeout_seconds: 3000
           prompt: |
             /tend-ci-runner:notifications

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
@@ -16,6 +16,9 @@ jobs:
   notifications:
     if: github.repository_owner == 'test-owner'
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 60
     environment:
       name: tend
       deployment: false

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-review-runs.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-review-runs.yaml].out
@@ -16,6 +16,9 @@ jobs:
   review-runs:
     if: github.repository_owner == 'test-owner'
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 120
     environment:
       name: tend
       deployment: false

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-review-runs.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-review-runs.yaml].out
@@ -42,5 +42,9 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
+          # 10 minutes under the job cap, so an overrunning session takes the
+          # harness's kill ? job red, failure reported ? rather than GitHub's,
+          # which cancels the job and skips the report.
+          timeout_seconds: 6600
           prompt: |
             /tend-ci-runner:review-runs

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-triage.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-triage.yaml].out
@@ -19,6 +19,9 @@ jobs:
   triage:
     if: github.repository_owner == 'test-owner' && contains(github.event.issue.labels.*.name, 'tend-outage') == false && contains(github.event.issue.labels.*.name, 'tend-rate-limit') == false
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 120
     environment:
       name: tend
       deployment: false

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-triage.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-triage.yaml].out
@@ -54,6 +54,10 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
+          # 10 minutes under the job cap, so an overrunning session takes the
+          # harness's kill ? job red, failure reported ? rather than GitHub's,
+          # which cancels the job and skips the report.
+          timeout_seconds: 6600
           prompt: |
             /tend-ci-runner:triage ${{ github.event.issue.number }}
 

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-weekly.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-weekly.yaml].out
@@ -42,5 +42,9 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
+          # 10 minutes under the job cap, so an overrunning session takes the
+          # harness's kill ? job red, failure reported ? rather than GitHub's,
+          # which cancels the job and skips the report.
+          timeout_seconds: 3000
           prompt: |
             /tend-ci-runner:weekly

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-weekly.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-weekly.yaml].out
@@ -16,6 +16,9 @@ jobs:
   weekly:
     if: github.repository_owner == 'test-owner'
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 60
     environment:
       name: tend
       deployment: false

--- a/generator/tests/_regtest_outputs/test_generate.test_install_test_workflow_regtest[claude].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_install_test_workflow_regtest[claude].out
@@ -20,6 +20,9 @@ jobs:
     # validation isn't worth special-casing.
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:

--- a/generator/tests/_regtest_outputs/test_generate.test_install_test_workflow_regtest[codex].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_install_test_workflow_regtest[codex].out
@@ -20,6 +20,9 @@ jobs:
     # validation isn't worth special-casing.
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:

--- a/generator/tests/_regtest_outputs/test_generate.test_sandbox_levers_regtest.out
+++ b/generator/tests/_regtest_outputs/test_generate.test_sandbox_levers_regtest.out
@@ -434,6 +434,10 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
+          # 10 minutes under the job cap, so an overrunning session takes the
+          # harness's kill ? job red, failure reported ? rather than GitHub's,
+          # which cancels the job and skips the report.
+          timeout_seconds: 6600
           sandbox_path: |
             ~/.cargo/bin
             /opt/tools/bin

--- a/generator/tests/_regtest_outputs/test_generate.test_sandbox_levers_regtest.out
+++ b/generator/tests/_regtest_outputs/test_generate.test_sandbox_levers_regtest.out
@@ -64,6 +64,9 @@ jobs:
        github.event_name == 'pull_request_review_comment') &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 10
     # No secrets here. `contents: write` is what the dispatch POST needs, and
     # is the whole of what this token can do ? probed both ways on a live
     # repo: an otherwise identical same-repo run declaring `contents: read`
@@ -105,6 +108,9 @@ jobs:
       (github.event_name == 'issue_comment' &&
         contains(github.event.issue.labels.*.name, 'tend-outage') == false && contains(github.event.issue.labels.*.name, 'tend-rate-limit') == false)
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 10
     environment:
       name: tend
       deployment: false
@@ -348,6 +354,9 @@ jobs:
       group: ${{ github.workflow }}-handle-${{ github.event.issue.number || github.event.client_payload.pr }}
       cancel-in-progress: false
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 120
     environment:
       name: tend
       deployment: false

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[ci-fix].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[ci-fix].out
@@ -17,6 +17,9 @@ jobs:
   fix-ci:
     if: github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 60
     environment:
       name: tend
       deployment: false

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[mention].out
@@ -64,6 +64,9 @@ jobs:
        github.event_name == 'pull_request_review_comment') &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 10
     # No secrets here. `contents: write` is what the dispatch POST needs, and
     # is the whole of what this token can do ? probed both ways on a live
     # repo: an otherwise identical same-repo run declaring `contents: read`
@@ -105,6 +108,9 @@ jobs:
       (github.event_name == 'issue_comment' &&
         contains(github.event.issue.labels.*.name, 'tend-outage') == false && contains(github.event.issue.labels.*.name, 'tend-rate-limit') == false)
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 10
     environment:
       name: tend
       deployment: false
@@ -348,6 +354,9 @@ jobs:
       group: ${{ github.workflow }}-handle-${{ github.event.issue.number || github.event.client_payload.pr }}
       cancel-in-progress: false
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 120
     environment:
       name: tend
       deployment: false

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[nightly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[nightly].out
@@ -15,6 +15,9 @@ on:
 jobs:
   nightly:
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 180
     environment:
       name: tend
       deployment: false

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[notifications].out
@@ -15,6 +15,9 @@ on:
 jobs:
   notifications:
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 60
     environment:
       name: tend
       deployment: false

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[review-runs].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[review-runs].out
@@ -15,6 +15,9 @@ on:
 jobs:
   review-runs:
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 120
     environment:
       name: tend
       deployment: false

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[review].out
@@ -21,6 +21,9 @@ jobs:
       # booting an agent when its HEAD is already covered.
       cancel-in-progress: false
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 120
     environment:
       name: tend
       deployment: false

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[triage].out
@@ -19,6 +19,9 @@ jobs:
   triage:
     if: contains(github.event.issue.labels.*.name, 'tend-outage') == false && contains(github.event.issue.labels.*.name, 'tend-rate-limit') == false
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 120
     environment:
       name: tend
       deployment: false

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[weekly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[weekly].out
@@ -15,6 +15,9 @@ on:
 jobs:
   weekly:
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 60
     environment:
       name: tend
       deployment: false

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[ci-fix].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[ci-fix].out
@@ -42,6 +42,10 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
+          # 10 minutes under the job cap, so an overrunning session takes the
+          # harness's kill ? job red, failure reported ? rather than GitHub's,
+          # which cancels the job and skips the report.
+          timeout_seconds: 3000
           prompt: |
             /tend-ci-runner:ci-fix ${{ github.event.workflow_run.id }}
             - Run URL: ${{ github.event.workflow_run.html_url }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[ci-fix].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[ci-fix].out
@@ -17,6 +17,9 @@ jobs:
   fix-ci:
     if: github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 60
     environment:
       name: tend
       deployment: false

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
@@ -434,6 +434,10 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
+          # 10 minutes under the job cap, so an overrunning session takes the
+          # harness's kill ? job red, failure reported ? rather than GitHub's,
+          # which cancels the job and skips the report.
+          timeout_seconds: 6600
           prompt: >-
             ${{ steps.delay.outputs.seconds
             && format('This job started {0}s after the triggering event (over ~40s means it was queued). ',

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[mention].out
@@ -64,6 +64,9 @@ jobs:
        github.event_name == 'pull_request_review_comment') &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 10
     # No secrets here. `contents: write` is what the dispatch POST needs, and
     # is the whole of what this token can do ? probed both ways on a live
     # repo: an otherwise identical same-repo run declaring `contents: read`
@@ -105,6 +108,9 @@ jobs:
       (github.event_name == 'issue_comment' &&
         contains(github.event.issue.labels.*.name, 'tend-outage') == false && contains(github.event.issue.labels.*.name, 'tend-rate-limit') == false)
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 10
     environment:
       name: tend
       deployment: false
@@ -348,6 +354,9 @@ jobs:
       group: ${{ github.workflow }}-handle-${{ github.event.issue.number || github.event.client_payload.pr }}
       cancel-in-progress: false
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 120
     environment:
       name: tend
       deployment: false

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[nightly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[nightly].out
@@ -41,5 +41,9 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
+          # 10 minutes under the job cap, so an overrunning session takes the
+          # harness's kill ? job red, failure reported ? rather than GitHub's,
+          # which cancels the job and skips the report.
+          timeout_seconds: 10200
           prompt: |
             /tend-ci-runner:nightly

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[nightly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[nightly].out
@@ -15,6 +15,9 @@ on:
 jobs:
   nightly:
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 180
     environment:
       name: tend
       deployment: false

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
@@ -15,6 +15,9 @@ on:
 jobs:
   notifications:
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 60
     environment:
       name: tend
       deployment: false

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
@@ -155,5 +155,9 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
+          # 10 minutes under the job cap, so an overrunning session takes the
+          # harness's kill ? job red, failure reported ? rather than GitHub's,
+          # which cancels the job and skips the report.
+          timeout_seconds: 3000
           prompt: |
             /tend-ci-runner:notifications

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review-runs].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review-runs].out
@@ -15,6 +15,9 @@ on:
 jobs:
   review-runs:
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 120
     environment:
       name: tend
       deployment: false

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review-runs].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review-runs].out
@@ -41,5 +41,9 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
+          # 10 minutes under the job cap, so an overrunning session takes the
+          # harness's kill ? job red, failure reported ? rather than GitHub's,
+          # which cancels the job and skips the report.
+          timeout_seconds: 6600
           prompt: |
             /tend-ci-runner:review-runs

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review].out
@@ -145,6 +145,10 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
+          # 10 minutes under the job cap, so an overrunning session takes the
+          # harness's kill ? job red, failure reported ? rather than GitHub's,
+          # which cancels the job and skips the report.
+          timeout_seconds: 6600
           prompt: >-
             ${{ format('/tend-ci-runner:review {0}', github.event.pull_request.number) }}
 

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[review].out
@@ -21,6 +21,9 @@ jobs:
       # booting an agent when its HEAD is already covered.
       cancel-in-progress: false
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 120
     environment:
       name: tend
       deployment: false

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[triage].out
@@ -19,6 +19,9 @@ jobs:
   triage:
     if: contains(github.event.issue.labels.*.name, 'tend-outage') == false && contains(github.event.issue.labels.*.name, 'tend-rate-limit') == false
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 120
     environment:
       name: tend
       deployment: false

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[triage].out
@@ -54,6 +54,10 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
+          # 10 minutes under the job cap, so an overrunning session takes the
+          # harness's kill ? job red, failure reported ? rather than GitHub's,
+          # which cancels the job and skips the report.
+          timeout_seconds: 6600
           prompt: |
             /tend-ci-runner:triage ${{ github.event.issue.number }}
 

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[weekly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[weekly].out
@@ -15,6 +15,9 @@ on:
 jobs:
   weekly:
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 60
     environment:
       name: tend
       deployment: false

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[weekly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[weekly].out
@@ -41,5 +41,9 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
+          # 10 minutes under the job cap, so an overrunning session takes the
+          # harness's kill ? job red, failure reported ? rather than GitHub's,
+          # which cancels the job and skips the report.
+          timeout_seconds: 3000
           prompt: |
             /tend-ci-runner:weekly

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_local_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_local_setup_regtest[mention].out
@@ -436,6 +436,10 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
+          # 10 minutes under the job cap, so an overrunning session takes the
+          # harness's kill ? job red, failure reported ? rather than GitHub's,
+          # which cancels the job and skips the report.
+          timeout_seconds: 6600
           prompt: >-
             ${{ steps.delay.outputs.seconds
             && format('This job started {0}s after the triggering event (over ~40s means it was queued). ',

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_local_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_local_setup_regtest[mention].out
@@ -64,6 +64,9 @@ jobs:
        github.event_name == 'pull_request_review_comment') &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 10
     # No secrets here. `contents: write` is what the dispatch POST needs, and
     # is the whole of what this token can do ? probed both ways on a live
     # repo: an otherwise identical same-repo run declaring `contents: read`
@@ -105,6 +108,9 @@ jobs:
       (github.event_name == 'issue_comment' &&
         contains(github.event.issue.labels.*.name, 'tend-outage') == false && contains(github.event.issue.labels.*.name, 'tend-rate-limit') == false)
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 10
     environment:
       name: tend
       deployment: false
@@ -348,6 +354,9 @@ jobs:
       group: ${{ github.workflow }}-handle-${{ github.event.issue.number || github.event.client_payload.pr }}
       cancel-in-progress: false
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 120
     environment:
       name: tend
       deployment: false

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_local_setup_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_local_setup_regtest[review].out
@@ -159,6 +159,10 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
+          # 10 minutes under the job cap, so an overrunning session takes the
+          # harness's kill ? job red, failure reported ? rather than GitHub's,
+          # which cancels the job and skips the report.
+          timeout_seconds: 6600
           prompt: >-
             ${{ format('/tend-ci-runner:review {0}', github.event.pull_request.number) }}
 

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_local_setup_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_local_setup_regtest[review].out
@@ -21,6 +21,9 @@ jobs:
       # booting an agent when its HEAD is already covered.
       cancel-in-progress: false
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 120
     environment:
       name: tend
       deployment: false

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[ci-fix].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[ci-fix].out
@@ -17,6 +17,9 @@ jobs:
   fix-ci:
     if: github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 60
     environment:
       name: tend
       deployment: false

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[ci-fix].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[ci-fix].out
@@ -44,6 +44,10 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
+          # 10 minutes under the job cap, so an overrunning session takes the
+          # harness's kill ? job red, failure reported ? rather than GitHub's,
+          # which cancels the job and skips the report.
+          timeout_seconds: 3000
           prompt: |
             /tend-ci-runner:ci-fix ${{ github.event.workflow_run.id }}
             - Run URL: ${{ github.event.workflow_run.html_url }}

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
@@ -436,6 +436,10 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
+          # 10 minutes under the job cap, so an overrunning session takes the
+          # harness's kill ? job red, failure reported ? rather than GitHub's,
+          # which cancels the job and skips the report.
+          timeout_seconds: 6600
           prompt: >-
             ${{ steps.delay.outputs.seconds
             && format('This job started {0}s after the triggering event (over ~40s means it was queued). ',

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[mention].out
@@ -64,6 +64,9 @@ jobs:
        github.event_name == 'pull_request_review_comment') &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 10
     # No secrets here. `contents: write` is what the dispatch POST needs, and
     # is the whole of what this token can do ? probed both ways on a live
     # repo: an otherwise identical same-repo run declaring `contents: read`
@@ -105,6 +108,9 @@ jobs:
       (github.event_name == 'issue_comment' &&
         contains(github.event.issue.labels.*.name, 'tend-outage') == false && contains(github.event.issue.labels.*.name, 'tend-rate-limit') == false)
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 10
     environment:
       name: tend
       deployment: false
@@ -348,6 +354,9 @@ jobs:
       group: ${{ github.workflow }}-handle-${{ github.event.issue.number || github.event.client_payload.pr }}
       cancel-in-progress: false
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 120
     environment:
       name: tend
       deployment: false

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[nightly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[nightly].out
@@ -43,5 +43,9 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
+          # 10 minutes under the job cap, so an overrunning session takes the
+          # harness's kill ? job red, failure reported ? rather than GitHub's,
+          # which cancels the job and skips the report.
+          timeout_seconds: 10200
           prompt: |
             /tend-ci-runner:nightly

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[nightly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[nightly].out
@@ -15,6 +15,9 @@ on:
 jobs:
   nightly:
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 180
     environment:
       name: tend
       deployment: false

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
@@ -15,6 +15,9 @@ on:
 jobs:
   notifications:
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 60
     environment:
       name: tend
       deployment: false

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
@@ -158,5 +158,9 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
+          # 10 minutes under the job cap, so an overrunning session takes the
+          # harness's kill ? job red, failure reported ? rather than GitHub's,
+          # which cancels the job and skips the report.
+          timeout_seconds: 3000
           prompt: |
             /tend-ci-runner:notifications

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review-runs].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review-runs].out
@@ -43,5 +43,9 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
+          # 10 minutes under the job cap, so an overrunning session takes the
+          # harness's kill ? job red, failure reported ? rather than GitHub's,
+          # which cancels the job and skips the report.
+          timeout_seconds: 6600
           prompt: |
             /tend-ci-runner:review-runs

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review-runs].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review-runs].out
@@ -15,6 +15,9 @@ on:
 jobs:
   review-runs:
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 120
     environment:
       name: tend
       deployment: false

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review].out
@@ -159,6 +159,10 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
+          # 10 minutes under the job cap, so an overrunning session takes the
+          # harness's kill ? job red, failure reported ? rather than GitHub's,
+          # which cancels the job and skips the report.
+          timeout_seconds: 6600
           prompt: >-
             ${{ format('/tend-ci-runner:review {0}', github.event.pull_request.number) }}
 

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[review].out
@@ -21,6 +21,9 @@ jobs:
       # booting an agent when its HEAD is already covered.
       cancel-in-progress: false
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 120
     environment:
       name: tend
       deployment: false

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[triage].out
@@ -19,6 +19,9 @@ jobs:
   triage:
     if: contains(github.event.issue.labels.*.name, 'tend-outage') == false && contains(github.event.issue.labels.*.name, 'tend-rate-limit') == false
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 120
     environment:
       name: tend
       deployment: false

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[triage].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[triage].out
@@ -56,6 +56,10 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
+          # 10 minutes under the job cap, so an overrunning session takes the
+          # harness's kill ? job red, failure reported ? rather than GitHub's,
+          # which cancels the job and skips the report.
+          timeout_seconds: 6600
           prompt: |
             /tend-ci-runner:triage ${{ github.event.issue.number }}
 

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[weekly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[weekly].out
@@ -15,6 +15,9 @@ on:
 jobs:
   weekly:
     runs-on: ubuntu-24.04
+    # Bounds the whole job, adopter `setup:` included. Override with
+    # `workflows.<name>.jobs.<job>.timeout-minutes` in .config/tend.yaml.
+    timeout-minutes: 60
     environment:
       name: tend
       deployment: false

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[weekly].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[weekly].out
@@ -43,5 +43,9 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: test-bot
           model: opus
+          # 10 minutes under the job cap, so an overrunning session takes the
+          # harness's kill ? job red, failure reported ? rather than GitHub's,
+          # which cancels the job and skips the report.
+          timeout_seconds: 3000
           prompt: |
             /tend-ci-runner:weekly

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -109,7 +109,11 @@ def test_agent_budget_expires_before_the_job_cap(tmp_path: Path) -> None:
                     continue
                 budget = int(step["with"]["timeout_seconds"])
                 cap = job["timeout-minutes"] * 60
-                assert budget < cap, f"{wf.filename}:{name} {budget}s vs {cap}s cap"
+                # Lower bound too: a `_JOB_TIMEOUT_MINUTES` entry of 10 or less
+                # renders a budget of zero or negative, which doesn't disable
+                # the supervisor but inverts it — its elapsed-vs-budget poll is
+                # true on the first iteration, killing every session at ~0s.
+                assert 0 < budget < cap, f"{wf.filename}:{name} {budget}s vs {cap}s cap"
                 checked.add(wf.filename)
     # Every workflow `generate_all` yields runs an agent, so a name missing
     # here means the step shape changed and the loop above matched nothing.
@@ -120,12 +124,21 @@ def test_agent_budget_expires_before_the_job_cap(tmp_path: Path) -> None:
 
 def test_codex_agent_step_takes_no_supervisor_budget(tmp_path: Path) -> None:
     """Codex has no supervisor timeout — the job cap is that harness's bound."""
-    cfg = Config.load(_minimal_config(tmp_path, "harness: codex\nmodel: gpt-5.5\n"))
+    extra = (
+        "harness: codex\nmodel: gpt-5.5\n"
+        'workflows:\n  ci-fix:\n    watched_workflows: ["ci"]\n'
+    )
+    cfg = Config.load(_minimal_config(tmp_path, extra))
+    checked = set()
     for wf in generate_all(cfg):
         for job in yaml.safe_load(wf.content)["jobs"].values():
             for step in job["steps"]:
                 if "max-sixty/tend/codex@" in step.get("uses", ""):
                     assert "timeout_seconds" not in step["with"]
+                    checked.add(wf.filename)
+    # Same corpus pin as the claude test above: without it, a change to the
+    # codex step's shape matches nothing and the assertion passes vacuously.
+    assert checked == {f"tend-{name}.yaml" for name in GENERATORS}
 
 
 def test_disabled_workflow_not_generated(tmp_path: Path) -> None:

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -69,11 +69,19 @@ def test_every_job_declares_a_timeout(tmp_path: Path) -> None:
 
     That default is long enough for a wedged setup step to hold a
     `cancel-in-progress: false` concurrency queue for six hours, so a new job
-    shipping uncapped is the regression this guards.
+    shipping uncapped is the regression this guards. ci-fix is enabled and
+    install-test opted in so the corpus is every workflow: both are skipped by
+    default, and a skipped workflow is one this invariant silently stops
+    covering — install-test runs `uvx tend init` behind `setup-uv`, the same
+    pre-agent install region the observed wedges came from.
     """
     extra = 'workflows:\n  ci-fix:\n    watched_workflows: ["ci"]\n'
     cfg = Config.load(_minimal_config(tmp_path, extra))
-    for wf in generate_all(cfg):
+    generated = generate_all(cfg, with_install_test=True)
+    assert {wf.filename for wf in generated} == {
+        f"tend-{name}.yaml" for name in GENERATORS
+    } | {"tend-install-test.yaml"}
+    for wf in generated:
         for name, job in yaml.safe_load(wf.content)["jobs"].items():
             cap = job.get("timeout-minutes")
             assert cap is not None, f"{wf.filename}:{name} has no timeout-minutes"

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -64,6 +64,23 @@ def test_generated_yaml_is_valid(tmp_path: Path) -> None:
         assert "jobs" in data, f"{wf.filename} missing jobs"
 
 
+def test_every_job_declares_a_timeout(tmp_path: Path) -> None:
+    """A job with no cap is bounded only by GitHub's 360-minute default.
+
+    That default is long enough for a wedged setup step to hold a
+    `cancel-in-progress: false` concurrency queue for six hours, so a new job
+    shipping uncapped is the regression this guards.
+    """
+    extra = 'workflows:\n  ci-fix:\n    watched_workflows: ["ci"]\n'
+    cfg = Config.load(_minimal_config(tmp_path, extra))
+    for wf in generate_all(cfg):
+        for name, job in yaml.safe_load(wf.content)["jobs"].items():
+            cap = job.get("timeout-minutes")
+            assert cap is not None, f"{wf.filename}:{name} has no timeout-minutes"
+            # Above the cap and GitHub's default is the operative bound again.
+            assert 0 < cap < 360, f"{wf.filename}:{name} timeout-minutes={cap}"
+
+
 def test_disabled_workflow_not_generated(tmp_path: Path) -> None:
     cfg = Config.load(
         _minimal_config(tmp_path, "workflows:\n  weekly:\n    enabled: false\n")
@@ -1267,8 +1284,10 @@ def test_mention_job_extras_target_specific_job(tmp_path: Path) -> None:
     cfg = Config.load(_minimal_config(tmp_path, extra))
     workflows = {wf.filename: wf for wf in generate_all(cfg)}
     data = yaml.safe_load(workflows["tend-mention.yaml"].content)
+    # Both jobs ship a default cap, so "untouched" is the default surviving on
+    # `verify` rather than the key being absent.
     assert data["jobs"]["handle"]["timeout-minutes"] == 180
-    assert "timeout-minutes" not in data["jobs"]["verify"]
+    assert data["jobs"]["verify"]["timeout-minutes"] == 10
 
 
 def test_extras_preserve_header(tmp_path: Path) -> None:

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -89,6 +89,45 @@ def test_every_job_declares_a_timeout(tmp_path: Path) -> None:
             assert 0 < cap < 360, f"{wf.filename}:{name} timeout-minutes={cap}"
 
 
+def test_agent_budget_expires_before_the_job_cap(tmp_path: Path) -> None:
+    """The supervisor must get an overrunning session before GitHub does.
+
+    The two kills are not interchangeable: the supervisor exits 1, so the job
+    is `failure` and the action's `failure()`-gated `Report failure` step files
+    the `tend-outage` row that `review-runs` drains. GitHub's `timeout-minutes`
+    kill yields `cancelled`, where `failure()` steps are skipped and the
+    overrun goes unreported. A `timeout_seconds` at or above the job cap — the
+    action's 21000s default included — puts the supervisor out of reach.
+    """
+    extra = 'workflows:\n  ci-fix:\n    watched_workflows: ["ci"]\n'
+    cfg = Config.load(_minimal_config(tmp_path, extra))
+    checked = set()
+    for wf in generate_all(cfg):
+        for name, job in yaml.safe_load(wf.content)["jobs"].items():
+            for step in job["steps"]:
+                if "max-sixty/tend/claude@" not in step.get("uses", ""):
+                    continue
+                budget = int(step["with"]["timeout_seconds"])
+                cap = job["timeout-minutes"] * 60
+                assert budget < cap, f"{wf.filename}:{name} {budget}s vs {cap}s cap"
+                checked.add(wf.filename)
+    # Every workflow `generate_all` yields runs an agent, so a name missing
+    # here means the step shape changed and the loop above matched nothing.
+    # install-test is deliberately outside the corpus: it renders no agent
+    # step, so it has a job cap and no supervisor budget to order against.
+    assert checked == {f"tend-{name}.yaml" for name in GENERATORS}
+
+
+def test_codex_agent_step_takes_no_supervisor_budget(tmp_path: Path) -> None:
+    """Codex has no supervisor timeout — the job cap is that harness's bound."""
+    cfg = Config.load(_minimal_config(tmp_path, "harness: codex\nmodel: gpt-5.5\n"))
+    for wf in generate_all(cfg):
+        for job in yaml.safe_load(wf.content)["jobs"].values():
+            for step in job["steps"]:
+                if "max-sixty/tend/codex@" in step.get("uses", ""):
+                    assert "timeout_seconds" not in step["with"]
+
+
 def test_disabled_workflow_not_generated(tmp_path: Path) -> None:
     cfg = Config.load(
         _minimal_config(tmp_path, "workflows:\n  weekly:\n    enabled: false\n")

--- a/plugins/install-tend/skills/install-tend/references/tend.example.yaml
+++ b/plugins/install-tend/skills/install-tend/references/tend.example.yaml
@@ -347,7 +347,10 @@ bot_name: my-project-bot
 # `handle`; 180 for nightly; 10 for mention's `relay` and `verify`. The cap
 # covers the whole job, `setup:` included, which is the only bound that
 # reaches steps running before the harness action is entered. Override it
-# where a job legitimately needs longer:
+# where a job legitimately needs longer — note that the override moves the job
+# cap only: the Claude harness's own session budget is generated 10 minutes
+# under the default cap, so a much larger override leaves the session bounded
+# where it was (reported as a failure, not silently cancelled).
 #
 # workflows:
 #   review:

--- a/plugins/install-tend/skills/install-tend/references/tend.example.yaml
+++ b/plugins/install-tend/skills/install-tend/references/tend.example.yaml
@@ -342,6 +342,13 @@ bot_name: my-project-bot
 #
 # ### Example: longer timeout on a specific job
 #
+# Every generated job ships a `timeout-minutes` default — 60 for ci-fix,
+# notifications and weekly; 120 for review, triage, review-runs and mention's
+# `handle`; 180 for nightly; 10 for mention's `relay` and `verify`. The cap
+# covers the whole job, `setup:` included, which is the only bound that
+# reaches steps running before the harness action is entered. Override it
+# where a job legitimately needs longer:
+#
 # workflows:
 #   review:
 #     jobs:

--- a/plugins/install-tend/skills/install-tend/references/tend.example.yaml
+++ b/plugins/install-tend/skills/install-tend/references/tend.example.yaml
@@ -349,8 +349,10 @@ bot_name: my-project-bot
 # reaches steps running before the harness action is entered. Override it
 # where a job legitimately needs longer — note that the override moves the job
 # cap only: the Claude harness's own session budget is generated 10 minutes
-# under the default cap, so a much larger override leaves the session bounded
-# where it was (reported as a failure, not silently cancelled).
+# under the default cap. Raising the cap leaves the session bounded where it
+# was (reported as a failure, not silently cancelled); lowering it below that
+# budget puts the supervisor out of reach again, and an overrunning session
+# goes back to being cancelled silently.
 #
 # workflows:
 #   review:


### PR DESCRIPTION
No generated job declared `timeout-minutes`, so a step that wedged rather than ended was bounded only by GitHub's 360-minute default — and on a job with `cancel-in-progress: false` it held the concurrency queue for the same six hours. This stamps a job-level cap on all eleven generated jobs, using the measured values from [PRQL/prql#6215](https://github.com/PRQL/prql/pull/6215), and derives the Claude harness's own session budget from each cap so the two kills stay ordered. Verified by rendering every workflow and asserting each job's cap and each agent step's budget (`uv run pytest`, 572 passed; `pre-commit run --all-files` clean).

A job cap is the only bound that reaches the whole job. The harness supervisor's `timeout_seconds` starts once the action is entered, so checkout, the adopter's `setup:`, and the CLI installers sit outside it — which is exactly where the five observed six-hour wedges in #962 landed, in an adopter setup composite's unbounded `apt-get update`. `timeout-minutes` is not accepted on a step inside a composite action, so the generated job is the only lever that reaches there.

The cap alone would have made the supervisor unreachable, since every value sits below the claude action's 21000s `timeout_seconds` default — and the two kills are not equivalent. The supervisor exits 1, so the job is `failure` and the action's `failure()`-gated `Report failure` step files the `tend-outage` row that `review-runs` drains to re-run stranded triggers; GitHub's `timeout-minutes` kill yields `cancelled`, where `failure()` steps are skipped and the overrun goes unreported. So the cap is also threaded into `agent_step`, which emits `timeout_seconds` 10 minutes under it: the supervisor still owns an agent-session overrun, and the job cap backstops the pre-agent region it cannot reach.

Adopter overrides are unchanged and still win: `workflows.<name>.jobs.<job>.timeout-minutes` now replaces the default in place rather than appending, so an override lands next to the comment documenting what it replaced. It moves the job cap alone — step inputs take no override, so the generated supervisor budget stays put, which degrades to the reported kill rather than the silent one.

Closes #962.

<details><summary>Caps, budgets, and how they're wired</summary>

| workflow | job | `timeout-minutes` | `timeout_seconds` (claude) |
|---|---|---|---|
| `tend-ci-fix` | `fix-ci` | 60 | 3000 |
| `tend-notifications` | `notifications` | 60 | 3000 |
| `tend-weekly` | `weekly` | 60 | 3000 |
| `tend-review` | `review` | 120 | 6600 |
| `tend-mention` | `handle` | 120 | 6600 |
| `tend-triage` | `triage` | 120 | 6600 |
| `tend-review-runs` | `review-runs` | 120 | 6600 |
| `tend-nightly` | `nightly` | 180 | 10200 |
| `tend-mention` | `relay` | 10 | — |
| `tend-mention` | `verify` | 10 | — |
| `tend-install-test` | `install-test` | 10 | — |

Both numbers come from a single `_JOB_TIMEOUT_MINUTES` entry per workflow in `workflows.py`, so the cap and the budget cannot drift apart. A `job_timeout(minutes)` macro in `macros.yaml.j2` emits the cap plus a two-line override pointer, and `agent_step` takes the same value and emits the derived budget inside its claude branch; codex emits nothing, having no supervisor timeout. The three jobs with no agent step take a literal cap in their template.

The ordering the derivation buys holds while the steps ahead of the agent fit inside the 10-minute margin; past that the job cap wins and the kill is silent again — but that is the pre-agent region `timeout-minutes` exists to bound in the first place, and it is the case this PR was written for.

Test changes:

- `test_every_job_declares_a_timeout` — every generated job must carry a cap under 360, since at or above that GitHub's default is the operative bound again. The corpus opts in `ci-fix` and `install-test` and asserts it is every workflow, so a skipped one can't quietly fall out of coverage.
- `test_agent_budget_expires_before_the_job_cap` — every claude agent step's `timeout_seconds` must be under its job's cap, with the corpus pinned to `GENERATORS`.
- `test_codex_agent_step_takes_no_supervisor_budget` — the codex branch emits no `timeout_seconds`.
- `test_mention_job_extras_target_specific_job` probed "extras hit only the named job" by asserting `timeout-minutes` was *absent* from `verify`. With a default on both jobs, untouched now means the default survives, so it asserts `verify` is still 10 while `handle` takes the override's 180.

Snapshot churn is the eleven caps, the eight budgets, and their comments; the one non-additive line is the extras snapshot, where the override moved from the end of the job to the base key's position.

This repo's own `.github/workflows/tend-*.yaml` are deliberately not regenerated here — per CLAUDE.md the action ref pins the generator's own version, so regenerating in-tree would stamp an unreleased tag. They pick this up at the next release plus nightly regen.

</details>
