### PR TITLE
site: correct the stale animation note in global.css

### DIFF
--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -1,6 +1,7 @@
 /*
  * Tend — sibling of worktrunk, pulled toward garden / herbarium / field-notes.
- * One accent (moss), one animation (logo unfurl), restraint over polish.
+ * One accent (moss), motion only where it carries meaning (the live-run pulse
+ * below; the logo unfurl in Logo.astro), restraint over polish.
  */
 
 :root {


### PR DESCRIPTION
`global.css`'s header claims the site has "one animation (logo unfurl)". Neither half is true any more: the logo animations live in `Logo.astro`, and this file itself defines a second one — `now-pulse`, driving the currently-tending dot and the activity feed's tending badge. Nightly survey finding; the header dates from the original site prototype, and the pulse landed after it.

The comment now names what each file actually holds, so a reader landing on the header isn't sent looking for a logo animation that was never here. Comment-only change — no test, nothing to exercise.

<details><summary>Provenance</summary>

- Header introduced in max-sixty/tend#412 (`2136f21`, 2026-05-10), when the logo unfurl was the only animation on the site.
- `now-pulse` added later, in max-sixty/tend#433 and extended in max-sixty/tend#463.
- Current keyframes: `now-pulse` at [`site/src/styles/global.css#L329`](https://github.com/max-sixty/tend/blob/8cf262826adba8d0e1291eb6aa645b52412f56d2/site/src/styles/global.css#L329); `logo-draw` / `logo-sfade` / `logo-breathe` in [`site/src/components/Logo.astro`](https://github.com/max-sixty/tend/blob/8cf262826adba8d0e1291eb6aa645b52412f56d2/site/src/components/Logo.astro).

</details>
