### PR TITLE
fix(review-runs): collect Step 4's outcome signals in a tested script

### DIFF
--- a/generator/tests/test_review_runs_corrections.py
+++ b/generator/tests/test_review_runs_corrections.py
@@ -1,0 +1,282 @@
+"""Tests for plugins/tend-ci-runner/scripts/review-runs-corrections.sh.
+
+Step 4 of review-runs decides whether the tracking issue records "no
+maintainer corrections", which later runs read as ground truth under Gate 1.
+Every filter here fails open when its input is empty — an unset anchor
+compares less than every timestamp, `--author ""` applies no author filter —
+so an empty result is only trustworthy if the inputs were checked. These pin
+that, plus the three window edges the query has to get right: the bot's own
+output excluded, the empty-bodied review container GitHub synthesises for an
+inline reply excluded, and a review on an in-window PR that was itself
+submitted before the window excluded.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from tests import BASH, GH_PREAMBLE, fake_bin, tool_path
+
+SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "plugins"
+    / "tend-ci-runner"
+    / "scripts"
+    / "review-runs-corrections.sh"
+)
+
+BOT = "tend-bot"
+HUMAN = "maintainer"
+SINCE = "2026-01-02T00:00:00Z"
+IN_WINDOW = "2026-01-02T12:00:00Z"
+BEFORE = "2026-01-01T12:00:00Z"
+
+FAKE_GH = (
+    GH_PREAMBLE
+    + r"""
+case "$*" in
+  "api user"*)             emit '{"login":"'"$BOT_LOGIN"'"}' ;;
+  # The reviews candidate list is the only `pr list` carrying --search.
+  "pr list"*--search*)     emit "$(cat "$CANDIDATES_JSON")" ;;
+  "pr list"*)              emit "$(cat "$BOT_PRS_JSON")" ;;
+  *"/issues/comments"*)    emit "$(cat "$ISSUE_COMMENTS_JSON")" ;;
+  *"/pulls/comments"*)     emit "$(cat "$PR_COMMENTS_JSON")" ;;
+  *"/pulls/"*"/reviews"*)  emit "$(cat "$REVIEWS_JSON")" ;;
+  *) exit 1 ;;
+esac
+"""
+)
+
+
+@pytest.fixture
+def env(tmp_path: Path) -> dict[str, str]:
+    """Fake `gh` plus fixtures for a repo with nothing in the window."""
+    bindir = fake_bin(tmp_path, gh=FAKE_GH)
+    fixtures = {
+        "BOT_PRS_JSON": [],
+        "CANDIDATES_JSON": [],
+        "ISSUE_COMMENTS_JSON": [],
+        "PR_COMMENTS_JSON": [],
+        "REVIEWS_JSON": [],
+    }
+    paths = {}
+    for key, value in fixtures.items():
+        path = tmp_path / f"{key.lower()}.json"
+        path.write_text(json.dumps(value))
+        paths[key] = str(path)
+    return {
+        "PATH": tool_path(bindir),
+        "GH_CALLS": str(tmp_path / "gh-calls.log"),
+        "GITHUB_REPOSITORY": "owner/repo",
+        "BOT_LOGIN": BOT,
+        **paths,
+    }
+
+
+def _run(env: dict[str, str], *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [BASH, str(SCRIPT), *args], env=env, capture_output=True, text=True
+    )
+
+
+def _collect(env: dict[str, str], since: str = SINCE) -> dict:
+    result = _run(env, since)
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def _write(env: dict[str, str], key: str, value: object) -> None:
+    Path(env[key]).write_text(json.dumps(value))
+
+
+def _comment(at: str, *, author: str = HUMAN, updated: str | None = None) -> dict:
+    return {
+        "user": {"login": author},
+        "created_at": at,
+        "updated_at": updated or at,
+        "html_url": f"https://github.com/owner/repo/issues/1#c{at}",
+        "body": "that is not what the code does",
+    }
+
+
+def _review(at: str, *, author: str = HUMAN, body: str = "wrong", **kw) -> dict:
+    return {
+        "user": {"login": author},
+        "submitted_at": at,
+        "state": kw.get("state", "CHANGES_REQUESTED"),
+        "html_url": f"https://github.com/owner/repo/pull/1#r{at}",
+        "body": body,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fail loudly rather than reporting an empty window
+# ---------------------------------------------------------------------------
+
+
+def test_a_missing_anchor_is_an_error_not_an_empty_window(env: dict[str, str]) -> None:
+    """Unset, `$SINCE` compares less than every timestamp, so the window would
+    silently widen to everything — and a caller that dropped the anchor gets no
+    signal it did."""
+    result = _run(env)
+
+    assert result.returncode == 2
+    assert "usage" in result.stderr
+    assert not Path(env["GH_CALLS"]).exists()
+
+
+def test_an_unresolvable_bot_login_is_an_error(env: dict[str, str]) -> None:
+    """`--author ""` applies no author filter and `.user.login != ""` is true
+    for everyone, so an empty login reports the bot's own output as maintainer
+    corrections."""
+    env["BOT_LOGIN"] = ""
+
+    result = _run(env, SINCE)
+
+    assert result.returncode == 2
+    assert "bot login" in result.stderr
+
+
+def test_a_quiet_window_reports_empty_lists(env: dict[str, str]) -> None:
+    out = _collect(env)
+
+    assert out == {
+        "since": SINCE,
+        "bot": BOT,
+        "dispositions": [],
+        "comments": [],
+        "reviews": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Dispositions
+# ---------------------------------------------------------------------------
+
+
+def test_dispositions_are_windowed_and_open_prs_excluded(env: dict[str, str]) -> None:
+    """`closedAt` is null on an open PR, and null compares less than the
+    anchor, so an open PR is not a disposition."""
+    _write(
+        env,
+        "BOT_PRS_JSON",
+        [
+            {
+                "number": 1,
+                "title": "merged in",
+                "state": "MERGED",
+                "closedAt": IN_WINDOW,
+            },
+            {
+                "number": 2,
+                "title": "closed before",
+                "state": "CLOSED",
+                "closedAt": BEFORE,
+            },
+            {"number": 3, "title": "still open", "state": "OPEN", "closedAt": None},
+        ],
+    )
+
+    out = _collect(env)
+
+    assert [d["number"] for d in out["dispositions"]] == [1]
+
+
+# ---------------------------------------------------------------------------
+# Thread comments
+# ---------------------------------------------------------------------------
+
+
+def test_bot_comments_are_excluded_from_both_endpoints(env: dict[str, str]) -> None:
+    _write(env, "ISSUE_COMMENTS_JSON", [_comment(IN_WINDOW, author=BOT)])
+    _write(env, "PR_COMMENTS_JSON", [_comment(IN_WINDOW, author=BOT)])
+
+    assert _collect(env)["comments"] == []
+
+
+def test_both_comment_endpoints_are_read_and_paginated(env: dict[str, str]) -> None:
+    """The response is ascending by `created_at`, so a single unpaginated page
+    drops the newest comments — the ones a fresh correction sits in."""
+    _write(env, "ISSUE_COMMENTS_JSON", [_comment(IN_WINDOW)])
+    _write(env, "PR_COMMENTS_JSON", [_comment(IN_WINDOW)])
+
+    assert len(_collect(env)["comments"]) == 2
+
+    calls = Path(env["GH_CALLS"]).read_text().splitlines()
+    for endpoint in ("issues", "pulls"):
+        assert any(
+            "--paginate" in c and f"repos/owner/repo/{endpoint}/comments" in c
+            for c in calls
+        ), endpoint
+
+
+def test_an_edited_older_comment_reports_both_timestamps(env: dict[str, str]) -> None:
+    """`since` filters on `updated_at`, so a comment created before the window
+    and edited inside it is a real hit — the projection has to show why."""
+    _write(env, "ISSUE_COMMENTS_JSON", [_comment(BEFORE, updated=IN_WINDOW)])
+
+    (row,) = _collect(env)["comments"]
+
+    assert row["created"] == BEFORE
+    assert row["updated"] == IN_WINDOW
+
+
+# ---------------------------------------------------------------------------
+# Review bodies — the signal neither comment endpoint returns
+# ---------------------------------------------------------------------------
+
+
+def test_a_human_review_body_is_collected(env: dict[str, str]) -> None:
+    _write(env, "CANDIDATES_JSON", [{"number": 7}])
+    _write(env, "REVIEWS_JSON", [_review(IN_WINDOW)])
+
+    (row,) = _collect(env)["reviews"]
+
+    assert row["state"] == "CHANGES_REQUESTED"
+    assert row["at"] == IN_WINDOW
+
+
+def test_an_empty_bodied_review_container_is_not_a_correction(
+    env: dict[str, str],
+) -> None:
+    """GitHub wraps a standalone inline reply in an empty-bodied review, so
+    without the body check every thread where anyone replied inline reports a
+    correction."""
+    _write(env, "CANDIDATES_JSON", [{"number": 7}])
+    _write(env, "REVIEWS_JSON", [_review(IN_WINDOW, body="", state="COMMENTED")])
+
+    assert _collect(env)["reviews"] == []
+
+
+def test_an_out_of_window_review_on_an_in_window_pr_is_excluded(
+    env: dict[str, str],
+) -> None:
+    """`updated:` windows the PR, not the review: a PR touched today surfaces
+    its whole review history, so `submitted_at` is what makes the window
+    exact."""
+    _write(env, "CANDIDATES_JSON", [{"number": 7}])
+    _write(env, "REVIEWS_JSON", [_review(BEFORE), _review(IN_WINDOW)])
+
+    assert [r["at"] for r in _collect(env)["reviews"]] == [IN_WINDOW]
+
+
+def test_bot_reviews_are_excluded(env: dict[str, str]) -> None:
+    """Every tend-review COMMENT body would otherwise read as the maintainer
+    telling the bot it was wrong."""
+    _write(env, "CANDIDATES_JSON", [{"number": 7}])
+    _write(env, "REVIEWS_JSON", [_review(IN_WINDOW, author=BOT)])
+
+    assert _collect(env)["reviews"] == []
+
+
+def test_no_candidate_prs_leaves_reviews_empty(env: dict[str, str]) -> None:
+    """With no PR updated in the window the loop body never runs, so the
+    reviews aggregation reduces over an empty stream."""
+    out = _collect(env)
+
+    assert out["reviews"] == []
+    calls = Path(env["GH_CALLS"]).read_text()
+    assert "/reviews" not in calls

--- a/generator/tests/test_review_runs_corrections.py
+++ b/generator/tests/test_review_runs_corrections.py
@@ -40,7 +40,9 @@ FAKE_GH = (
 case "$*" in
   "api user"*)             emit '{"login":"'"$BOT_LOGIN"'"}' ;;
   # The reviews candidate list is the only `pr list` carrying --search.
-  "pr list"*--search*)     emit "$(cat "$CANDIDATES_JSON")" ;;
+  "pr list"*--search*)
+    [ -n "${SEARCH_FAILS:-}" ] && { echo "API rate limit exceeded" >&2; exit 1; }
+    emit "$(cat "$CANDIDATES_JSON")" ;;
   "pr list"*)              emit "$(cat "$BOT_PRS_JSON")" ;;
   *"/issues/comments"*)    emit "$(cat "$ISSUE_COMMENTS_JSON")" ;;
   *"/pulls/comments"*)     emit "$(cat "$PR_COMMENTS_JSON")" ;;
@@ -138,6 +140,20 @@ def test_an_unresolvable_bot_login_is_an_error(env: dict[str, str]) -> None:
 
     assert result.returncode == 2
     assert "bot login" in result.stderr
+
+
+def test_a_failed_candidate_search_aborts_rather_than_reporting_no_reviews(
+    env: dict[str, str],
+) -> None:
+    """The candidate query runs on the search API's 30 req/min budget, so it is
+    the call most likely to fail — and inline in the `for` list its failure is
+    invisible to `set -e`, leaving `reviews: []` to read as an all-clear."""
+    env["SEARCH_FAILS"] = "1"
+
+    result = _run(env, SINCE)
+
+    assert result.returncode != 0
+    assert result.stdout == ""
 
 
 def test_a_quiet_window_reports_empty_lists(env: dict[str, str]) -> None:

--- a/plugins/tend-ci-runner/scripts/review-runs-corrections.sh
+++ b/plugins/tend-ci-runner/scripts/review-runs-corrections.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Collects every in-window signal that a maintainer corrected the bot, as one
+# JSON object.
+#
+# Usage: review-runs-corrections.sh <since>
+#   <since>  RFC3339 window anchor — review-runs Step 1's, via
+#            /tmp/review-runs-since
+#
+# Output (one object, all keys always present):
+#   since         the anchor, echoed back
+#   bot           the login every list below filters out
+#   dispositions  bot PRs merged or closed in the window
+#   comments      non-bot comments on any issue or PR thread in the window
+#   reviews       non-bot review bodies submitted in the window
+#
+# Both filters fail open when empty — `--author ""` applies no author filter,
+# `.user.login != ""` is true for every entry, and an empty anchor compares
+# less than every non-null timestamp — so a missing one turns the whole query
+# into the bot reading its own output as maintainer corrections. Neither is
+# defaulted: an empty result here becomes "no maintainer corrections" in the
+# tracking issue, which later runs read as ground truth.
+#
+# env: GITHUB_REPOSITORY (optional; falls back to the checkout's remote)
+
+set -euo pipefail
+
+SINCE="${1:-}"
+if [ -z "$SINCE" ]; then
+  echo "usage: $(basename "$0") <since>   # RFC3339, e.g. \$(cat /tmp/review-runs-since)" >&2
+  exit 2
+fi
+
+REPO="${GITHUB_REPOSITORY:-$(gh repo view --json nameWithOwner --jq '.nameWithOwner')}"
+BOT=$(gh api user --jq '.login')
+if [ -z "$BOT" ]; then
+  echo "could not resolve the bot login from \`gh api user\`" >&2
+  exit 2
+fi
+
+DISPOSITIONS=$(gh pr list --repo "$REPO" --author "$BOT" --state all --limit 200 \
+  --json number,title,state,closedAt \
+  | jq --arg since "$SINCE" '[.[] | select(.closedAt > $since)]')
+
+# Both comment endpoints are repo-wide and take `since`, so this is two calls
+# regardless of thread count. `--paginate` is required, not cosmetic: the
+# response is ascending by `created_at`, so a single 100-item page drops the
+# *newest* comments — the ones a fresh correction sits in — and the bot's own
+# comments consume that budget first. `since` filters on `updated_at`, so an
+# older comment edited inside the window is a real hit, not a broken filter;
+# both timestamps are reported so the reason a row qualified is visible.
+COMMENTS=$(
+  for endpoint in issues pulls; do
+    gh api --paginate "repos/$REPO/$endpoint/comments?since=$SINCE&per_page=100"
+  done | jq -s --arg bot "$BOT" '
+    [(add // [])[] | select(.user.login != $bot)
+     | {created: .created_at, updated: .updated_at, url: .html_url,
+        body: .body[0:300]}]'
+)
+
+# Review bodies, which neither endpoint above returns — `pulls/comments`
+# carries inline comments only. There is no repo-wide `since` endpoint for
+# reviews, so loop the PRs updated in the window. `updated:` windows the PR
+# rather than the review, so the `submitted_at` filter is what makes the review
+# window exact; `(.body | length) > 0` drops the empty-bodied review GitHub
+# wraps around a standalone inline reply, which would otherwise report a
+# correction on every thread where anyone replied inline.
+REVIEWS=$(
+  for pr in $(gh pr list --repo "$REPO" --state all --limit 200 \
+                --search "updated:>=$SINCE" --json number --jq '.[].number'); do
+    gh api --paginate "repos/$REPO/pulls/$pr/reviews?per_page=100"
+  done | jq -s --arg bot "$BOT" --arg since "$SINCE" '
+    [(add // [])[] | select(.user.login != $bot and .submitted_at >= $since
+                            and (.body | length) > 0)
+     | {at: .submitted_at, state: .state, url: .html_url, body: .body[0:300]}]'
+)
+
+jq -n --arg since "$SINCE" --arg bot "$BOT" \
+  --argjson dispositions "$DISPOSITIONS" \
+  --argjson comments "$COMMENTS" \
+  --argjson reviews "$REVIEWS" \
+  '{since: $since, bot: $bot, dispositions: $dispositions,
+    comments: $comments, reviews: $reviews}'

--- a/plugins/tend-ci-runner/scripts/review-runs-corrections.sh
+++ b/plugins/tend-ci-runner/scripts/review-runs-corrections.sh
@@ -64,9 +64,16 @@ COMMENTS=$(
 # window exact; `(.body | length) > 0` drops the empty-bodied review GitHub
 # wraps around a standalone inline reply, which would otherwise report a
 # correction on every thread where anyone replied inline.
+#
+# The candidate list is its own assignment because `set -e` checks an
+# assignment's command substitution but not a `for` word list's: inline, a
+# failed `--search` — the search API's 30 req/min, not the 5000/h core budget —
+# would yield an empty list, skip the loop, and report `reviews: []` as an
+# all-clear.
+CANDIDATES=$(gh pr list --repo "$REPO" --state all --limit 200 \
+  --search "updated:>=$SINCE" --json number --jq '.[].number')
 REVIEWS=$(
-  for pr in $(gh pr list --repo "$REPO" --state all --limit 200 \
-                --search "updated:>=$SINCE" --json number --jq '.[].number'); do
+  for pr in $CANDIDATES; do
     gh api --paginate "repos/$REPO/pulls/$pr/reviews?per_page=100"
   done | jq -s --arg bot "$BOT" --arg since "$SINCE" '
     [(add // [])[] | select(.user.login != $bot and .submitted_at >= $since

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -275,8 +275,9 @@ mention, notifications, weekly, and review-reviewers runs get the same treatment
 ```bash
 # Bot PR dispositions — merged or closed in the window. Shell variables don't
 # survive between tool calls, so every block in this step re-establishes both:
-# unset, `$SINCE` compares less than every non-null `closedAt` and `$BOT_LOGIN`
-# matches nobody, and each filter silently stops filtering.
+# unset, `$SINCE` compares less than every non-null `closedAt`, and an empty
+# `$BOT_LOGIN` stops restricting rather than matching nobody — `--author ""`
+# applies no author filter, and `.user.login != ""` is true for every entry.
 SINCE=$(cat /tmp/review-runs-since)
 BOT_LOGIN=$(gh api user --jq '.login')
 gh pr list --author "$BOT_LOGIN" --state all --limit 200 --json number,title,state,closedAt \

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -278,7 +278,7 @@ Dispositions — merged, closed, relabeled, reverted — are only half the signa
 "${CLAUDE_PLUGIN_ROOT}/scripts/review-runs-corrections.sh" "$(cat /tmp/review-runs-since)"
 ```
 
-Read every row: a correction is a maintainer contradicting a bot claim, not merely replying. Empty `dispositions`, `comments`, and `reviews` is the all-clear.
+Read every row: a correction is a maintainer contradicting a bot claim, not merely replying. Comment rows carry both timestamps because the window filters on `updated_at` — a `created` before the anchor is an older comment edited inside the window, a real hit rather than a broken filter. Empty `dispositions`, `comments`, and `reviews` is the all-clear.
 
 Write "no maintainer corrections" into the tracking issue only after the script ran and returned empty — future runs read the phrase as ground truth when counting occurrences under Gate 1, so an unchecked all-clear suppresses the evidence it exists to accumulate. The script exits non-zero rather than reporting an empty window when the anchor or the bot login is missing, since both filters fail open.
 

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -272,46 +272,15 @@ For each analyzed run, compare what the bot did against what happened next. The 
 
 mention, notifications, weekly, and review-reviewers runs get the same treatment: find the bot's output and check whether it was accepted.
 
-Dispositions — merged, closed, relabeled, reverted — are only half the signal. A maintainer replying in-thread that a bot claim was wrong, or requesting changes on a bot PR, leaves labels and state untouched and is equally a correction; where the bot authors most of the PRs, a review body is the *first* place a maintainer writes. Three queries, one block, so the anchor and the login are established once:
+Dispositions — merged, closed, relabeled, reverted — are only half the signal. A maintainer replying in-thread that a bot claim was wrong, or requesting changes on a bot PR, leaves labels and state untouched and is equally a correction; where the bot authors most of the PRs, a review body is the *first* place a maintainer writes. The script collects all three — dispositions, thread comments, review bodies — for the window:
 
 ```bash
-# Both filters fail open when unset — `--author ""` applies no author filter,
-# `.user.login != ""` is true for every entry, and an empty `$SINCE` compares
-# less than every non-null `closedAt`. Exported so jq can read them as `$ENV`.
-SINCE=$(cat /tmp/review-runs-since)
-BOT_LOGIN=$(gh api user --jq '.login')
-export SINCE BOT_LOGIN
-
-# Bot PR dispositions — merged or closed in the window.
-gh pr list --author "$BOT_LOGIN" --state all --limit 200 --json number,title,state,closedAt \
-  --jq '.[] | select(.closedAt > $ENV.SINCE)'
-
-# Human replies on any issue or PR thread. Both endpoints are repo-wide and
-# take `since`, so this is two calls regardless of thread count. `--paginate`
-# is required, not cosmetic: the response is ascending by `created_at`, so a
-# single 100-item page drops the *newest* comments — the ones a fresh
-# correction sits in — and the bot's own comments consume that budget first.
-for endpoint in issues pulls; do
-  gh api --paginate "repos/$REPO/$endpoint/comments?since=$SINCE&per_page=100" \
-    --jq '.[] | select(.user.login != $ENV.BOT_LOGIN)
-          | {created: .created_at, updated: .updated_at, url: .html_url, body: .body[0:300]}'
-done
-
-# Review bodies, which neither endpoint above returns: `pulls/comments`
-# carries inline comments only. There is no repo-wide `since` endpoint for
-# reviews, so loop over the PRs updated in the window.
-for p in $(gh pr list --state all --limit 200 --search "updated:>=$SINCE" \
-             --json number --jq '.[].number'); do
-  gh api --paginate "repos/$REPO/pulls/$p/reviews?per_page=100" \
-    --jq '.[] | select(.user.login != $ENV.BOT_LOGIN and .submitted_at >= $ENV.SINCE
-                       and (.body | length) > 0)
-          | {at: .submitted_at, state: .state, url: .html_url, body: .body[0:300]}'
-done
+"${CLAUDE_PLUGIN_ROOT}/scripts/review-runs-corrections.sh" "$(cat /tmp/review-runs-since)"
 ```
 
-`since` filters on `updated_at`, so an older comment edited inside the window is a real hit, not a broken filter — worth having, and the projection reports both timestamps so the reason a row qualified is visible. `(.body | length) > 0` is load-bearing: GitHub wraps a standalone inline reply in an empty-bodied review container, so without it every thread where anyone replied inline reports a correction. `updated:` windows the PR rather than the review, so the `submitted_at` filter inside the loop is what makes the review window exact.
+Read every row: a correction is a maintainer contradicting a bot claim, not merely replying. Empty `dispositions`, `comments`, and `reviews` is the all-clear.
 
-Write "no maintainer corrections" into the tracking issue only after all three queries ran — future runs read the phrase as ground truth when counting occurrences under Gate 1, so an unchecked all-clear suppresses the evidence it exists to accumulate.
+Write "no maintainer corrections" into the tracking issue only after the script ran and returned empty — future runs read the phrase as ground truth when counting occurrences under Gate 1, so an unchecked all-clear suppresses the evidence it exists to accumulate. The script exits non-zero rather than reporting an empty window when the anchor or the bot login is missing, since both filters fail open.
 
 ## Step 5: Deduplicate
 

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -272,54 +272,44 @@ For each analyzed run, compare what the bot did against what happened next. The 
 
 mention, notifications, weekly, and review-reviewers runs get the same treatment: find the bot's output and check whether it was accepted.
 
+Dispositions — merged, closed, relabeled, reverted — are only half the signal. A maintainer replying in-thread that a bot claim was wrong, or requesting changes on a bot PR, leaves labels and state untouched and is equally a correction; where the bot authors most of the PRs, a review body is the *first* place a maintainer writes. Three queries, one block, so the anchor and the login are established once:
+
 ```bash
-# Bot PR dispositions — merged or closed in the window. Shell variables don't
-# survive between tool calls, so every block in this step re-establishes both:
-# unset, `$SINCE` compares less than every non-null `closedAt`, and an empty
-# `$BOT_LOGIN` stops restricting rather than matching nobody — `--author ""`
-# applies no author filter, and `.user.login != ""` is true for every entry.
+# Both filters fail open when unset — `--author ""` applies no author filter,
+# `.user.login != ""` is true for every entry, and an empty `$SINCE` compares
+# less than every non-null `closedAt`. Exported so jq can read them as `$ENV`.
 SINCE=$(cat /tmp/review-runs-since)
 BOT_LOGIN=$(gh api user --jq '.login')
+export SINCE BOT_LOGIN
+
+# Bot PR dispositions — merged or closed in the window.
 gh pr list --author "$BOT_LOGIN" --state all --limit 200 --json number,title,state,closedAt \
-  --jq '.[] | select(.closedAt > "'$SINCE'")'
-```
+  --jq '.[] | select(.closedAt > $ENV.SINCE)'
 
-Dispositions — merged, closed, relabeled, reverted — are only half the signal. A maintainer replying in-thread that a bot claim was wrong, leaving labels and state untouched, is equally a correction, and on an issue-heavy repo it is the most common one. A `CHANGES_REQUESTED` review on a bot PR leaves labels and state untouched too, and where the bot authors most of the PRs it is the *first* place a maintainer writes. No disposition query can see either. Read the threads where the bot commented in the window and count a contradiction as a finding:
-
-```bash
-# Human replies in the window, on any issue or PR thread. Both endpoints are
-# repo-wide and take `since`, so this is two calls regardless of thread count.
-# `--paginate` is required, not cosmetic: the response is ascending by
-# `created_at`, so a single 100-item page drops the *newest* comments — the
-# ones a fresh correction sits in. The bot's own comments consume that budget
-# before the filter runs, so a busy day truncates with nothing in the output
-# to say so.
-SINCE=$(cat /tmp/review-runs-since)
-BOT_LOGIN=$(gh api user --jq '.login')
+# Human replies on any issue or PR thread. Both endpoints are repo-wide and
+# take `since`, so this is two calls regardless of thread count. `--paginate`
+# is required, not cosmetic: the response is ascending by `created_at`, so a
+# single 100-item page drops the *newest* comments — the ones a fresh
+# correction sits in — and the bot's own comments consume that budget first.
 for endpoint in issues pulls; do
   gh api --paginate "repos/$REPO/$endpoint/comments?since=$SINCE&per_page=100" \
-    --jq '.[] | select(.user.login != "'"$BOT_LOGIN"'")
+    --jq '.[] | select(.user.login != $ENV.BOT_LOGIN)
           | {created: .created_at, updated: .updated_at, url: .html_url, body: .body[0:300]}'
 done
-```
 
-`since` filters on `updated_at`, not `created_at`, so results include older comments edited inside the window — a comment created days before `$SINCE` is a real hit, not a broken filter. That is worth having (an edited claim is still a correction); the projection reports both timestamps so the reason a row qualified is visible.
-
-Neither endpoint above returns a review **body**: `pulls/comments` carries inline review comments only, and a review's body lives at `pulls/{n}/reviews`. So a `CHANGES_REQUESTED` whose correction is written in the body returns nothing from both calls — not less, nothing. There is no repo-wide `since` endpoint for reviews, so loop over the PRs updated in the window:
-
-```bash
-SINCE=$(cat /tmp/review-runs-since)
-BOT_LOGIN=$(gh api user --jq '.login')
+# Review bodies, which neither endpoint above returns: `pulls/comments`
+# carries inline comments only. There is no repo-wide `since` endpoint for
+# reviews, so loop over the PRs updated in the window.
 for p in $(gh pr list --state all --limit 200 --search "updated:>=$SINCE" \
              --json number --jq '.[].number'); do
   gh api --paginate "repos/$REPO/pulls/$p/reviews?per_page=100" \
-    --jq ".[] | select(.user.login != \"$BOT_LOGIN\" and .submitted_at >= \"$SINCE\"
+    --jq '.[] | select(.user.login != $ENV.BOT_LOGIN and .submitted_at >= $ENV.SINCE
                        and (.body | length) > 0)
-          | {pr: $p, at: .submitted_at, state: .state, url: .html_url, body: .body[0:300]}"
+          | {at: .submitted_at, state: .state, url: .html_url, body: .body[0:300]}'
 done
 ```
 
-`(.body | length) > 0` is load-bearing: GitHub wraps a standalone inline reply in an empty-bodied review container, so without it every thread where anyone replied inline reports a correction. `updated:` matches the PR's own `updated_at`, so the candidate list is only approximately windowed — a PR touched inside the window can carry an older review; the exact `submitted_at` filter inside the loop is what excludes it.
+`since` filters on `updated_at`, so an older comment edited inside the window is a real hit, not a broken filter — worth having, and the projection reports both timestamps so the reason a row qualified is visible. `(.body | length) > 0` is load-bearing: GitHub wraps a standalone inline reply in an empty-bodied review container, so without it every thread where anyone replied inline reports a correction. `updated:` windows the PR rather than the review, so the `submitted_at` filter inside the loop is what makes the review window exact.
 
 Write "no maintainer corrections" into the tracking issue only after all three queries ran — future runs read the phrase as ground truth when counting occurrences under Gate 1, so an unchecked all-clear suppresses the evidence it exists to accumulate.
 

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -273,10 +273,12 @@ For each analyzed run, compare what the bot did against what happened next. The 
 mention, notifications, weekly, and review-reviewers runs get the same treatment: find the bot's output and check whether it was accepted.
 
 ```bash
-# Bot PR dispositions — merged or closed in the window. Re-read Step 1's
-# anchor: unset here, an empty string compares less than every non-null
-# `closedAt` and the check silently stops being windowed at all.
+# Bot PR dispositions — merged or closed in the window. Shell variables don't
+# survive between tool calls, so every block in this step re-establishes both:
+# unset, `$SINCE` compares less than every non-null `closedAt` and `$BOT_LOGIN`
+# matches nobody, and each filter silently stops filtering.
 SINCE=$(cat /tmp/review-runs-since)
+BOT_LOGIN=$(gh api user --jq '.login')
 gh pr list --author "$BOT_LOGIN" --state all --limit 200 --json number,title,state,closedAt \
   --jq '.[] | select(.closedAt > "'$SINCE'")'
 ```
@@ -291,6 +293,8 @@ Dispositions — merged, closed, relabeled, reverted — are only half the signa
 # ones a fresh correction sits in. The bot's own comments consume that budget
 # before the filter runs, so a busy day truncates with nothing in the output
 # to say so.
+SINCE=$(cat /tmp/review-runs-since)
+BOT_LOGIN=$(gh api user --jq '.login')
 for endpoint in issues pulls; do
   gh api --paginate "repos/$REPO/$endpoint/comments?since=$SINCE&per_page=100" \
     --jq '.[] | select(.user.login != "'"$BOT_LOGIN"'")
@@ -304,7 +308,8 @@ Neither endpoint above returns a review **body**: `pulls/comments` carries inlin
 
 ```bash
 SINCE=$(cat /tmp/review-runs-since)
-for p in $(gh pr list --state all --limit 200 --search "updated:>=${SINCE%T*}" \
+BOT_LOGIN=$(gh api user --jq '.login')
+for p in $(gh pr list --state all --limit 200 --search "updated:>=$SINCE" \
              --json number --jq '.[].number'); do
   gh api --paginate "repos/$REPO/pulls/$p/reviews?per_page=100" \
     --jq ".[] | select(.user.login != \"$BOT_LOGIN\" and .submitted_at >= \"$SINCE\"
@@ -313,7 +318,7 @@ for p in $(gh pr list --state all --limit 200 --search "updated:>=${SINCE%T*}" \
 done
 ```
 
-`(.body | length) > 0` is load-bearing: GitHub wraps a standalone inline reply in an empty-bodied review container, so without it every thread where anyone replied inline reports a correction. `--search` takes a date, not a timestamp — hence `${SINCE%T*}`; it over-selects by up to a day, and the exact `submitted_at` filter inside the loop is what windows the result.
+`(.body | length) > 0` is load-bearing: GitHub wraps a standalone inline reply in an empty-bodied review container, so without it every thread where anyone replied inline reports a correction. `updated:` matches the PR's own `updated_at`, so the candidate list is only approximately windowed — a PR touched inside the window can carry an older review; the exact `submitted_at` filter inside the loop is what excludes it.
 
 Write "no maintainer corrections" into the tracking issue only after all three queries ran — future runs read the phrase as ground truth when counting occurrences under Gate 1, so an unchecked all-clear suppresses the evidence it exists to accumulate.
 

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -281,7 +281,7 @@ gh pr list --author "$BOT_LOGIN" --state all --limit 200 --json number,title,sta
   --jq '.[] | select(.closedAt > "'$SINCE'")'
 ```
 
-Dispositions — merged, closed, relabeled, reverted — are only half the signal. A maintainer replying in-thread that a bot claim was wrong, leaving labels and state untouched, is equally a correction, and on an issue-heavy repo it is the most common one. No disposition query can see it. Read the threads where the bot commented in the window and count a contradiction as a finding:
+Dispositions — merged, closed, relabeled, reverted — are only half the signal. A maintainer replying in-thread that a bot claim was wrong, leaving labels and state untouched, is equally a correction, and on an issue-heavy repo it is the most common one. A `CHANGES_REQUESTED` review on a bot PR leaves labels and state untouched too, and where the bot authors most of the PRs it is the *first* place a maintainer writes. No disposition query can see either. Read the threads where the bot commented in the window and count a contradiction as a finding:
 
 ```bash
 # Human replies in the window, on any issue or PR thread. Both endpoints are
@@ -300,7 +300,22 @@ done
 
 `since` filters on `updated_at`, not `created_at`, so results include older comments edited inside the window — a comment created days before `$SINCE` is a real hit, not a broken filter. That is worth having (an edited claim is still a correction); the projection reports both timestamps so the reason a row qualified is visible.
 
-Write "no maintainer corrections" into the tracking issue only after that query ran — future runs read the phrase as ground truth when counting occurrences under Gate 1, so an unchecked all-clear suppresses the evidence it exists to accumulate.
+Neither endpoint above returns a review **body**: `pulls/comments` carries inline review comments only, and a review's body lives at `pulls/{n}/reviews`. So a `CHANGES_REQUESTED` whose correction is written in the body returns nothing from both calls — not less, nothing. There is no repo-wide `since` endpoint for reviews, so loop over the PRs updated in the window:
+
+```bash
+SINCE=$(cat /tmp/review-runs-since)
+for p in $(gh pr list --state all --limit 200 --search "updated:>=${SINCE%T*}" \
+             --json number --jq '.[].number'); do
+  gh api --paginate "repos/$REPO/pulls/$p/reviews?per_page=100" \
+    --jq ".[] | select(.user.login != \"$BOT_LOGIN\" and .submitted_at >= \"$SINCE\"
+                       and (.body | length) > 0)
+          | {pr: $p, at: .submitted_at, state: .state, url: .html_url, body: .body[0:300]}"
+done
+```
+
+`(.body | length) > 0` is load-bearing: GitHub wraps a standalone inline reply in an empty-bodied review container, so without it every thread where anyone replied inline reports a correction. `--search` takes a date, not a timestamp — hence `${SINCE%T*}`; it over-selects by up to a day, and the exact `submitted_at` filter inside the loop is what windows the result.
+
+Write "no maintainer corrections" into the tracking issue only after all three queries ran — future runs read the phrase as ground truth when counting occurrences under Gate 1, so an unchecked all-clear suppresses the evidence it exists to accumulate.
 
 ## Step 5: Deduplicate
 


### PR DESCRIPTION
`review-runs` Step 4 cross-checks outcomes with `issues/comments` and `pulls/comments`, neither of which returns a review **body** — `pulls/comments` carries inline review comments only. A maintainer `CHANGES_REQUESTED` whose correction is written in the body therefore returns *nothing* from both calls, and the run writes "no maintainer corrections" with corrections sitting in the window.

Step 4's three queries — dispositions, thread comments, and the missing review bodies — now live in `plugins/tend-ci-runner/scripts/review-runs-corrections.sh`, with `generator/tests/test_review_runs_corrections.py` pinning the window edges. The skill is a one-line invocation, net −20 lines. Extraction also closes the fail-open class the prose kept patching: an unset anchor compares less than every timestamp and `--author ""` applies no author filter, so the script exits 2 on a missing anchor or login rather than reporting an empty window that reads as an all-clear.

Verified against live API data (details below), and the script run against both this repo and `max-sixty/leaf`.

<details><summary>Verification</summary>

**Review bodies are absent from `pulls/comments`.** Review `4988584496` on #1024 (`COMMENTED`, non-empty body, submitted inside the window) has no representation in the repo-wide review-comments endpoint — not by review id, not by body text:

```
$ gh api --paginate "repos/max-sixty/tend/pulls/comments?since=$SINCE&per_page=100" > /tmp/pc.json
$ jq 'length' /tmp/pc.json
35
$ jq '[.[] | select(.pull_request_review_id == 4988584496)] | length' /tmp/pc.json
0
$ jq --arg b "${BODY:0:60}" '[.[] | select(.body | contains($b))] | length' /tmp/pc.json
0
```

Every entry the endpoint does return carries a `path` — inline comments, each belonging to a review record.

**The script returns the missed reviews.** Pointed at `max-sixty/leaf` over the window in #1026 (where both prescribed queries returned zero non-bot entries), the `reviews` key carries the two `CHANGES_REQUESTED` rows this PR exists to catch. On this repo over an 18h window it returns 1 disposition, 2 non-bot comments, 0 bodied non-bot reviews, in 4.3s.

**`(.body | length) > 0` is load-bearing.** Empty-bodied review containers from a human exist on this repo today — e.g. review `4988620443` (`max-sixty`, #1024) and `4987925324` (`max-sixty`, #1022), both `COMMENTED` with no body. GitHub creates one per standalone inline reply, so without the filter every thread where anyone replied inline reports a correction with no text in it.

**`updated:` takes a full timestamp.** An earlier revision truncated `$SINCE` to a date on the claim that the qualifier accepts no time component. It does. On this repo with `SINCE=2026-08-20T07:59:59Z`: full `Z` form returns 9 PRs, the `+00:00` form 9, date-only 10, unqualified `gh pr list` 200. The extra PR the date-only form admits is #1018, updated `2026-08-20T01:28:24Z` — before the cutoff — so the time component is honoured at sub-day granularity rather than silently truncated. The sibling recipe in `review-reviewers` (`--search "updated:>$WINDOW_START"`) already passes the full timestamp.

**Two deltas from the recipe proposed in the issue:** `--paginate` with `per_page=100` on the reviews call (reviews page at 30 oldest-first, so the unpaginated call drops the newest — exactly where a window's reviews are), and the `submitted_at` filter inside the loop, since `updated:` windows the PR rather than the review.

**Tests.** 12 cases over a fake `gh` running the script's real filters: missing anchor and unresolvable login both exit 2 before any API call; open PRs excluded from dispositions (`closedAt` null); bot entries excluded from all three lists; `--paginate` asserted on both comment endpoints; an older comment edited into the window reported with both timestamps; the empty-bodied container excluded; a pre-window review on an in-window PR excluded.

`review-reviewers` — flagged in the issue as possibly sharing the blind spot — does not: it already calls `pulls/{n}/reviews` per PR in both its bot-output census and its acceptance check.

`uv run pytest` (581 passed) and `uvx pre-commit run --files …` both pass.

</details>

---

Closes #1026 — automated triage
