### PR TITLE
fix(running-tend): give integration-test §5 its own timestamp

### DIFF
--- a/.claude/skills/running-tend/references/integration-test.md
+++ b/.claude/skills/running-tend/references/integration-test.md
@@ -253,6 +253,11 @@ on the session-log artifact, which the tend harness action uploads
 unconditionally on every invocation, distinguishes the two.
 
 ```bash
+# Self-contained, like §6: shell state does not survive between blocks, so
+# §4's $TS is already gone. The stamp only has to be unique per run, not to
+# match §4's — §6 finds this PR by title prefix, never by timestamp.
+TS=$(date -u +%Y%m%d-%H%M%S)
+
 WORK=$(mktemp -d)
 gh repo clone tend-agent/tend-integration "$WORK"
 cd "$WORK"


### PR DESCRIPTION
§5 of the weekly integration-test recipe builds its branch name and PR title from `$TS`, but `$TS` is set back in §4 — and shell state does not survive between fenced blocks, since the agent runs each as its own Bash call. By the time §5 runs, `$TS` is empty: the branch is a constant `integration-test-review-`, reused every week instead of stamped per run. §6 was already hardened against exactly this ("Self-contained: … does not depend on a variable set in an earlier block"); §5 was the one block that still carried a cross-block dependency.

The fix gives §5 its own `date -u` stamp. The two stamps don't need to agree — §6 locates the PR by title prefix, never by timestamp — so a fresh one is both sufficient and correct.

## Why it matters

The recipe's failure path files an issue in this repo, so a recipe defect turns into a spurious outward action. §3 normally deletes leftover branches before §5 runs, which is why this hasn't bitten yet — but that's the only thing holding it. If §3's deletion loop doesn't clear the branch (an API error, a rate limit), §5's `git push -u origin "$BRANCH"` lands on the previous week's branch and is rejected non-fast-forward, the recipe exits, and §8 opens a "Weekly integration test failed" issue describing a failure that is entirely an artifact of the constant branch name.

<details><summary>Verification</summary>

No test is feasible — this is a prose recipe in a skill reference, not executed code, so nothing in the suite exercises it. Instead I checked the property mechanically with a small awk pass that walks each fenced block, records assignments (and `for` loop variables), and reports variable uses with no assignment in the same block, ignoring comments and harness-provided `GITHUB_*`/`RUNNER_*`/`CI` names:

- **Before:** `block 5: uses $TS` — the sole hit across the whole file.
- **After:** no hits. Every block is now self-contained.

Also run: `uv run pytest` (569 passed) and `pre-commit run --files .claude/skills/running-tend/references/integration-test.md` (trailing whitespace, end-of-files, typos, bang-backtick, install-tend reference sync — all pass; the code hooks correctly skip a markdown-only change).

Found during the nightly rolling survey, which had this file in today's slice.

</details>
