### PR TITLE
fix(nightly): confirm a resolved PR left the conflicted state before polling CI

### DIFF
--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -138,7 +138,7 @@ git config --global user.email "${BOT_ID}+${BOT_LOGIN}@users.noreply.github.com"
 For each conflicted PR authored by `$BOT_LOGIN`, dispatch a subagent to:
 
 1. Check out the PR: `gh pr checkout <number>`
-2. Merge the default branch: `git fetch origin main && git merge origin/main`. Fetch here rather than relying on the detection loop's fetch above — subagents run for minutes, and merging a stale `origin/main` produces a head that is already conflicting when it lands.
+2. Merge the default branch: `git fetch origin main && git merge origin/main` — the detection loop's fetch is minutes stale by the time a subagent runs.
 3. Resolve conflicts (read files, understand both sides), `git add`, `git commit --no-edit`
 4. Push, then confirm the pushed head actually left the conflicted state before polling anything:
 
@@ -148,7 +148,7 @@ For each conflicted PR authored by `$BOT_LOGIN`, dispatch a subagent to:
      || echo "main advanced during the resolution — merge it again and push"
    ```
 
-   Re-merge and push until that test passes; only then wait for CI per **CI Monitoring** in `/tend-ci-runner:running-in-ci`. A `CONFLICTING` PR gets **no** `pull_request` run — GitHub can't compute `refs/pull/N/merge`, so no workflow is created — and a poll pinned to that head burns its whole budget before reporting UNVERIFIED, which reads as slow CI rather than absent CI. Nothing else flags it: `pull_request_target` workflows (`tend-review`) still run, so the PR shows a green check and no red anything. If the re-merge keeps losing the race, report the PR as still conflicted rather than as a verified resolution.
+   Re-merge and push until that test passes; only then wait for CI per **CI Monitoring** in `/tend-ci-runner:running-in-ci`. A `CONFLICTING` PR gets **no** `pull_request` run — GitHub can't compute `refs/pull/N/merge` — so a poll of that head reports UNVERIFIED rather than red, and the absence reads as slow CI. If the re-merge keeps losing the race, report the PR as still conflicted rather than as a verified resolution.
 5. If conflicts are too complex, `git merge --abort` and comment explaining manual resolution is needed
 
 Run subagents in parallel. Each must work in isolation (`git worktree add /tmp/pr-<number>

--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -138,9 +138,17 @@ git config --global user.email "${BOT_ID}+${BOT_LOGIN}@users.noreply.github.com"
 For each conflicted PR authored by `$BOT_LOGIN`, dispatch a subagent to:
 
 1. Check out the PR: `gh pr checkout <number>`
-2. Merge the default branch: `git merge origin/main`
+2. Merge the default branch: `git fetch origin main && git merge origin/main`. Fetch here rather than relying on the detection loop's fetch above — subagents run for minutes, and merging a stale `origin/main` produces a head that is already conflicting when it lands.
 3. Resolve conflicts (read files, understand both sides), `git add`, `git commit --no-edit`
-4. Push, then wait for CI per **CI Monitoring** in `/tend-ci-runner:running-in-ci`
+4. Push, then confirm the pushed head actually left the conflicted state before polling anything:
+
+   ```bash
+   git fetch --quiet origin main
+   git merge-tree --write-tree origin/main HEAD >/dev/null \
+     || echo "main advanced during the resolution — merge it again and push"
+   ```
+
+   Re-merge and push until that test passes; only then wait for CI per **CI Monitoring** in `/tend-ci-runner:running-in-ci`. A `CONFLICTING` PR gets **no** `pull_request` run — GitHub can't compute `refs/pull/N/merge`, so no workflow is created — and a poll pinned to that head burns its whole budget before reporting UNVERIFIED, which reads as slow CI rather than absent CI. Nothing else flags it: `pull_request_target` workflows (`tend-review`) still run, so the PR shows a green check and no red anything. If the re-merge keeps losing the race, report the PR as still conflicted rather than as a verified resolution.
 5. If conflicts are too complex, `git merge --abort` and comment explaining manual resolution is needed
 
 Run subagents in parallel. Each must work in isolation (`git worktree add /tmp/pr-<number>


### PR DESCRIPTION
## Problem

Nightly's conflict resolver merges `origin/main` fetched by the detection loop at the top of step 3, then pushes and hands off to the CI poll. Subagents run for minutes, so `main` can advance in between — and the merge commit that lands is then conflicting on arrival. GitHub creates no `pull_request` run for a `CONFLICTING` PR (it can't compute `refs/pull/N/merge`), so the poll has nothing to find: it spends its whole ~9.5 minute budget and reports UNVERIFIED, which reads as slow CI rather than absent CI. Nothing else flags it either — `pull_request_target` workflows (`tend-review`) still run, so the PR shows a green check and no red anything. The resolution is reported as verified, and the PR stays conflicted for the next night to rediscover. Reported in #1031 with evidence from two PRs resolved two seconds apart on `max-sixty/leaf`, one mergeable and CI-verified, one conflicting with no `ci` run at all.

## Solution

Two changes in step 3's bot-authored resolution instructions:

- Fetch `origin/main` immediately before the merge instead of relying on the detection loop's fetch, which shrinks the race window from minutes to seconds.
- After the push, re-test the pushed head synchronously and re-merge until it comes back clean, before polling anything. This is the same `git merge-tree` test step 3 already uses for detection — `mergeable` is computed lazily and a cold read is not a usable signal.

```bash
git fetch --quiet origin main
git merge-tree --write-tree origin/main HEAD >/dev/null \
  || echo "main advanced during the resolution — merge it again and push"
```

If the re-merge keeps losing the race, the subagent reports the PR as still conflicted rather than as a verified resolution.

## Testing

No mechanical test — the change is skill prose, and nothing in the suite asserts on skill content. The recipe itself was verified against real git: a branch that merged a stale `main` reads clean against that stale ref and exits 1 against the advanced one, which is precisely the state GitHub reports as `CONFLICTING`.

<details><summary>Verification</summary>

```
$ git merge-tree --write-tree "$MAIN_A" pr   # the stale ref the resolver merged
exit0 clean
$ git merge-tree --write-tree main pr        # what GitHub sees after the push
exit1 conflict
```

`uvx pre-commit run --files plugins/tend-ci-runner/skills/nightly/SKILL.md` passes.

</details>

The issue's third suggestion — teaching `poll-pr-checks.sh` to distinguish "zero runs exist for this SHA" from "runs exist and are pending" — is deliberately not here. It would not have fired in the reported incident (a `tend-review` check run *was* on the commit, so the rollup was non-empty and genuinely pending), and it buys wall-clock rather than outward correctness, which `CLAUDE.md` puts a distant third. The poll's UNVERIFIED was truthful; the defect was that the resolver treated it as done.

---
Closes #1031 — automated triage
