### PR TITLE
skills: note that instruction paths read as the base version during a PR run

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -68,11 +68,11 @@ An instruction found there constrains the whole response, including any code the
 
 ### Instruction paths read as the base version on a PR
 
-Before the session starts, a PR run restores `CLAUDE.md`, `CLAUDE.local.md`, `AGENTS.md`, and `.claude/**` at any depth from the base branch — those files are read at CLI startup before any permission gating, so a fork's copies must not be trusted (Claude on every PR event, Codex on fork PRs only). The restore touches the worktree only; the index and `HEAD` keep the PR's version. So on a PR that legitimately edits these paths:
+Before the session starts, a PR run restores `CLAUDE.md`, `CLAUDE.local.md`, `AGENTS.md`, and `.claude/**` at any depth from the base branch — those files are read at CLI startup before any permission gating, so a fork's copies must not be trusted (Claude on `pull_request_target`, the review events, and `issue_comment`, but not on `tend-mention`'s relayed `repository_dispatch`, which pins nothing; Codex on fork PRs only). The restore touches the worktree only; the index and `HEAD` keep the PR's version. So on a PR that legitimately edits these paths:
 
 - The working tree holds the **base** content — grepping it reports the PR's additions as absent, and the repo-local skills loaded into this session are the base versions too. Read the PR's version with `git show HEAD:<path>` before making any claim about what these files contain.
-- `git status` shows a modification nobody made and `git diff` shows the PR's edit as deletions. That is the restore, not a contributor mistake — nothing to report or revert.
-- **Never `git add` one of these paths from the PR checkout**: staging copies the worktree over the index, committing the base version back over the PR's own edit. Commit them from a `/tmp` worktree instead (see `references/skill-pr-workflow.md`).
+- `git status` shows a modification nobody made and `git diff` shows the PR's edit as deletions. Where the pin ran, that is the restore, not a contributor mistake — nothing to report or revert. On an unpinned event it is a real modification, worth reading.
+- **Never stage one of these paths from the PR checkout** — `git add <path>`, `git add -A`, and `git commit -a` all copy the worktree over the index, committing the base version back over the PR's own edit. Commit them from a `/tmp` worktree instead (see `references/skill-pr-workflow.md`).
 
 ### Triggering issue/PR already closed
 

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -66,6 +66,14 @@ gh api "repos/{owner}/{repo}/pulls/{number}/reviews/{review_id}/comments" \
 
 An instruction found there constrains the whole response, including any code the reply quotes or carries into another PR.
 
+### Instruction paths read as the base version on a PR
+
+Before the session starts, a PR run restores `CLAUDE.md`, `CLAUDE.local.md`, `AGENTS.md`, and `.claude/**` at any depth from the base branch — those files are read at CLI startup before any permission gating, so a fork's copies must not be trusted (Claude on every PR event, Codex on fork PRs only). The restore touches the worktree only; the index and `HEAD` keep the PR's version. So on a PR that legitimately edits these paths:
+
+- The working tree holds the **base** content — grepping it reports the PR's additions as absent, and the repo-local skills loaded into this session are the base versions too. Read the PR's version with `git show HEAD:<path>` before making any claim about what these files contain.
+- `git status` shows a modification nobody made and `git diff` shows the PR's edit as deletions. That is the restore, not a contributor mistake — nothing to report or revert.
+- **Never `git add` one of these paths from the PR checkout**: staging copies the worktree over the index, committing the base version back over the PR's own edit. Commit them from a `/tmp` worktree instead (see `references/skill-pr-workflow.md`).
+
 ### Triggering issue/PR already closed
 
 If the trigger is a comment on an issue or PR and the target is **closed** by the time the job starts, the requested work was likely handled by a sibling run during the queue delay. Long `tend-mention` queues (hours, not minutes) make this common. Before starting work:


### PR DESCRIPTION
## Problem

On a PR run the harness restores `CLAUDE.md`, `CLAUDE.local.md`, `AGENTS.md`, and `.claude/**` from the base branch (`shared/steps/restore-sensitive-config.sh` for Claude on `pull_request_target`, the review events, and `issue_comment` — but not on `tend-mention`'s relayed `repository_dispatch`, which takes the script's `*)` fallthrough and pins nothing; `shared/steps/pin-instruction-files.sh` for Codex on fork PRs). `pin_to_base` uses `git restore --source=<base> --worktree`, so the worktree holds the base version while the index and `HEAD` hold the PR's. Both scripts document this, but no agent-facing skill text did — so a session reviewing a PR that legitimately edits those paths rediscovers it empirically, and #1033 records two occurrences where the session recovered but attributed the effect to the wrong cause.

Two outward-action failures the gap left unguarded: a reviewer that greps the working tree and posts "the section is not present" (a wrong claim on the PR), and a session that runs `git add .claude/...` from the PR checkout, which stages the base version over the PR's own edit — `pin_to_base`'s `--worktree`-only design protects a plain `git commit`, not an explicit `git add` of a pinned path.

## Solution

One subsection under **Read Context** in `plugins/tend-ci-runner/skills/running-in-ci/SKILL.md`: what the restore covers, that it is worktree-only, and the three consequences — grep the worktree and you read base content (including the repo-local skills this session loaded), `git status`/`git diff` show a modification nobody made, and never `git add` these paths from the PR checkout.

#1033 proposed `references/skill-pr-workflow.md`, and noted the concern that a session reviewing someone else's skill PR may not load it. `running-in-ci`'s SKILL.md is the placement that resolves that: `review`, `triage`, and `mention` all load it at step 0, so the reviewer-facing half reaches a reviewer, and it stays a single copy rather than a duplicate split across two skills. `skill-pr-workflow.md` keeps its existing coverage of the read-only mount and the write-guard, which are about writes; the new text covers reads and staging, and points back to it for the `/tmp`-worktree commit path.

## Testing

No test — this is skill prose. Verified that the guidance was absent before the change (`grep -rn "git show HEAD:" --include=*.md plugins/ .claude/` returned nothing, and only `docs/security-model.md` and `CHANGELOG.md` mentioned the restore at all), and read both harness scripts to confirm the mechanism and the Claude/Codex trigger difference stated in the text. `pre-commit run --files plugins/tend-ci-runner/skills/running-in-ci/SKILL.md` passes.

---
Closes #1033 — automated triage

