### PR TITLE
chore: refresh consumers.json

### DIFF
--- a/data/consumers.json
+++ b/data/consumers.json
@@ -4,12 +4,20 @@
     "bot_name": "prql-bot"
   },
   {
+    "repo": "diffplug/dormouse",
+    "bot_name": "dormouse-bot"
+  },
+  {
     "repo": "jakobtfaber/Faber2026",
     "bot_name": "tend-jakobtfaber"
   },
   {
     "repo": "max-sixty/cargo-affected",
     "bot_name": "cargo-affected-bot"
+  },
+  {
+    "repo": "max-sixty/leaf",
+    "bot_name": "leaf-agent"
   },
   {
     "repo": "max-sixty/tend",


### PR DESCRIPTION
Weekly refresh of the consumer list the site's data Worker reads. Code search picked up two repos that weren't in the file: `diffplug/dormouse` (`dormouse-bot`) and `max-sixty/leaf` (`leaf-agent`). No entries dropped.

Generated by the recipe in the `running-tend` overlay — `gh search code 'max-sixty/tend' --extension yaml`, filtered to `.github/workflows/tend-` paths, with each repo's `bot_name` resolved from its `.config/tend.yaml`.
