### PR TITLE
chore: bump claude_version to 2.1.241

### DIFF
--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -54,7 +54,7 @@ inputs:
     default: "true"
     description: Include the rendered Claude transcript in the workflow step summary.
   claude_version:
-    default: "2.1.233"
+    default: "2.1.241"
     description: >-
       Version of the `claude` binary to install via
       `https://claude.ai/install.sh`, pinned to a specific


### PR DESCRIPTION
Weekly pin sweep, ships-to-adopters bucket. `claude_version` moves to npm's current `latest` dist-tag, 2.1.241. A stale binary resolves `--model opus`/`sonnet` to a superseded alias target, so this pin drifting is a silent model downgrade, not just missing fixes.

Nothing in 2.1.234–2.1.241 changes an agent path tend depends on, but three entries touch the surfaces worth naming:

- **Headless `-p` exit behavior** (2.1.236): SIGTERM in print/SDK mode no longer records an interrupted turn or synthetic tool denials before exiting. The process still terminates running commands and still exits 143, so the action's "completion is the exit code" contract is unchanged — what changes is that a timed-out session's uploaded log no longer ends in a fabricated denial.
- **Slash-command resolution** (2.1.236): a typo'd or unavailable slash command now reports an error instead of running the closest fuzzy match. Prefixes and aliases still resolve, so `/tend-ci-runner:<name>` invocations are unaffected — but a future skill rename now fails loudly rather than silently running a neighbour.
- **Skill loading** (2.1.239): skills, agents, and commands whose `.md` starts with a UTF-8 BOM are no longer silently ignored. None of tend's bundled skill files carry a BOM, so this is a no-op here; it matters for adopter overlays authored on Windows.

Also checked and not applicable: the 2.1.239 marketplace `metadata.pluginRoot` fix — neither `.claude-plugin/marketplace.json` nor `.agents/plugins/marketplace.json` sets `pluginRoot`. No `--model` alias-resolution changes in the range. The remaining entries are interactive-TUI, IDE, and Remote Control fixes that headless CI never reaches.

`uv run pytest` passes (571).
