### PR TITLE
chore: bump codex_version to 0.149.0

### DIFF
--- a/codex/action.yaml
+++ b/codex/action.yaml
@@ -55,7 +55,7 @@ inputs:
   codex_version:
     default: "0.149.0"
     description: >-
-      `@openai/codex` npm version to install (e.g. `0.147.0`). Must ship
+      `@openai/codex` npm version to install. Must ship
       the `codex plugin add` subcommand (PR #21396, first released in
       `rust-v0.131.0-alpha.17`). That was `alpha`-only when the pin was
       first set; stable carries it now, so this tracks `latest`. CI's

--- a/codex/action.yaml
+++ b/codex/action.yaml
@@ -53,7 +53,7 @@ inputs:
     default: danger-full-access
     description: Codex sandbox mode (workspace-write, read-only, danger-full-access)
   codex_version:
-    default: "0.147.0"
+    default: "0.149.0"
     description: >-
       `@openai/codex` npm version to install (e.g. `0.147.0`). Must ship
       the `codex plugin add` subcommand (PR #21396, first released in


### PR DESCRIPTION
Weekly pin sweep, ships-to-adopters bucket. `codex_version` moves to npm's current `latest`, 0.149.0, crossing two releases (0.148.0 and 0.149.0).

Reviewed across the bump for the three surfaces the action depends on:

- **Sandbox behavior** — 0.148.0 made sandbox restrictions fail closed for denied or unreadable paths on Linux and Windows (#37875, #38026, #38416, #38660), and isolated external editor buffers from sandbox-writable paths (#38830). tend runs `codex exec --sandbox danger-full-access`, which opts out of the restrictions these harden, so the fail-closed change can't tighten anything under the mode the action passes. An adopter who overrides `sandbox:` to `workspace-write` or `read-only` gets the stricter behavior — that's the intended direction, but it's the one place this bump could change an existing run.
- **`--output-last-message`** — unchanged across both releases; still the documented way to capture the final message. Also unchanged: `--model`, `--sandbox`, and `--config`, the other flags the `Run Codex` step passes.
- **Model availability** — no model removed or renamed. 0.148.0 added Amazon Bedrock Runtime as a built-in provider with GPT-5.6 routing; tend doesn't route through Bedrock, so it's additive here.

One entry worth flagging for the plugin path: 0.148.0's "Support plugin roots in the host skill loader" (#37267) touches how skills resolve, which is how `/tend-ci-runner:<name>` reaches Codex via the staged `AGENTS.md`. CI's `test-codex-surface` job asserts the `codex plugin add` output still prints a parseable `Installed plugin root:` and that both `skills/` and `scripts/` materialize under it, so a regression there fails on this PR rather than in an adopter's job.

<details><summary>Verification limits</summary>

`test-codex-surface` installs the pinned CLI and asserts the flag and plugin surface, so an install or interface break fails here. It does not cover a live agent session: no `OPENAI_API_KEY` reaches this repo's runs, so model selection under a real key, sandbox behavior during a session, and whether the final message actually lands in `--output-last-message` stay unverified by CI. The changelog skim above is the substitute.

`uv run pytest` passes (571).

</details>
