### PR TITLE
fix(worker): fold every bot into one Search query per bucket

### DIFF
--- a/worker/README.md
+++ b/worker/README.md
@@ -17,7 +17,7 @@ Base URL: `https://api.tend-src.com`. `Access-Control-Allow-Origin: *`
 Unauthenticated GitHub REST is 60 req/hour/IP and the Search API is 10
 req/min/IP — both shared across everyone behind a NAT. A single
 currently-tending poll fans out one `actions/runs` call per consumer repo every
-30 s; `/activity` fans out one Search query per bucket per bot. One browser tab
+30 s; `/activity` issues one Search query per bucket. One browser tab
 would exhaust those quotas in minutes. The Worker holds an authenticated token
 (5,000 req/hour, 30 Search req/min) and caches each route at the colo, so
 origin load is bounded by the freshness budget, not by viewer count. Static
@@ -54,15 +54,31 @@ not the data layer.
 ### `/activity`
 
 Recent things tend has done, in primitive buckets — one Search query per
-bucket per bot (`sort=updated`): the page yields both the `recent` items and
-the lifetime `count` (`total_count`); `count_this_week` is counted off the
-page, so it saturates around one page (~100) per bot per bucket — fine for a
-headline number. The fanout is 4·N concurrent Search requests against the
-30 req/min Search cap, so a single fanout stays clear up to ~7 bots. The KV
-sharing tier (see [Caching](#caching)) bounds how often a fanout fires by the
-freshness budget network-wide rather than letting it scale with colo count or
-traffic, so near-simultaneous fanouts that would stack against the cap stay
-rare.
+bucket (`sort=updated`): the page yields both the `recent` items and the
+lifetime `count` (`total_count`); `count_this_week` is counted off the page,
+so it saturates around one page (~100) per bucket — fine for a headline
+number.
+
+Each query covers every bot at once. Repeating a qualifier ORs it
+(`author:a author:b` matches either), so the consumer list folds into a single
+query and a refresh costs **4 Search requests regardless of how many consumers
+there are**. That bound is the point: the cap is 30 req/min, so the earlier
+one-query-per-bot shape (4·N) crossed it at 8 consumers. Nothing about that
+failure is loud — `searchIssues` throws on a non-OK status and the throw sinks
+the whole refresh, the `activity` fallback TTL is 30 s so it re-attempts about
+twice a minute and never drains, and the site hides a section whose fetch
+returned nothing rather than erroring. The visible result would have been a
+blank stat strip. The KV sharing tier (see [Caching](#caching)) still bounds
+how often a refresh fires, but it is no longer what keeps the burst under the
+cap.
+
+Two consequences of combining, both benign at present. A `count` no longer
+double-counts an item two bots both touched (possible for `reviews` and
+`comments`, not for `author:`-keyed buckets, and unobserved — each bot works
+in its own repo). And the matching bot is no longer named in the result, so
+the deep-link follow-up below matches the whole consumer list instead of one
+login; it reads the same single page either way, so it costs no extra
+requests.
 
 ```jsonc
 {
@@ -89,12 +105,16 @@ reviews — the inline-comment endpoint, since tend's reviews are
 parent URL if the follow-up fails. For `prs` and `issues`, `url` is the
 parent issue/PR — that is what the bot created.
 
-| bucket | Search query | "the bot …" |
+`<bots>` below stands for the qualifier repeated once per consumer bot. Negated
+qualifiers AND rather than OR, so `comments` excludes anything authored or
+reviewed by *any* bot, not just the one that commented.
+
+| bucket | Search query | "some bot …" |
 | --- | --- | --- |
-| `prs` | `author:<bot> is:pr` | opened these PRs (any state) |
-| `issues` | `author:<bot> is:issue` minus five bookkeeping labels (`tend-outage`, `tend-rate-limit`, `review-runs-tracking`, `review-reviewers-tracking`, `nightly-cleanup`) | opened these issues, filed against the repo — tend's own outage and tracking issues are excluded |
-| `reviews` | `reviewed-by:<bot>` | reviewed these PRs (approve / request-changes / review comment) — by volume, tend's main action |
-| `comments` | `commenter:<bot> -author:<bot> -reviewed-by:<bot>` | commented on these PRs/issues — excludes its own threads and items already in `reviews` |
+| `prs` | `author:<bots> is:pr` | opened these PRs (any state) |
+| `issues` | `author:<bots> is:issue` minus five bookkeeping labels (`tend-outage`, `tend-rate-limit`, `review-runs-tracking`, `review-reviewers-tracking`, `nightly-cleanup`) | opened these issues, filed against the repo — tend's own outage and tracking issues are excluded |
+| `reviews` | `reviewed-by:<bots>` | reviewed these PRs (approve / request-changes / review comment) — by volume, tend's main action |
+| `comments` | `commenter:<bots> -author:<bots> -reviewed-by:<bots>` | commented on these PRs/issues — excludes bots' own threads and items already in `reviews` |
 
 > **TODO — Phase 2:** a consumer (a scheduled job, or the Worker calling Claude)
 > reads `/activity` and writes a short prose summary of what tend's been up to;
@@ -144,8 +164,10 @@ out to GitHub on its own. `/activity` adds a **KV tier** (`activity:v1`)
 behind the hot tier: a refresh publishes its rendered payload to KV, a global
 store, so a refresh in one colo serves every other colo. The GitHub fanout
 then fires about once per freshness budget across the whole network instead of
-once per colo. That keeps the 4·N Search burst clear of the 30 req/min cap
-whatever the colo count. KV survives deploys and outlives the colo cache, so a
+once per colo. With the burst itself fixed at 4 requests, that is now headroom
+rather than the thing keeping it under the 30 req/min cap — it bounds how many
+near-simultaneous refreshes can stack, whatever the colo count. KV survives
+deploys and outlives the colo cache, so a
 viewer waits on the fanout only when colo cache and KV are both empty: the
 first request ever, or after an idle longer than KV's retention.
 `/currently-tending` skips KV; its 30 s budget is under KV's 60 s floor, and
@@ -182,7 +204,7 @@ data/consumers.json on main
 Cloudflare Worker (tend-website)
   ├─ reads data/consumers.json via raw URL (KV-cached 1 h)
   ├─ /currently-tending: fans out actions/runs per repo (in-progress, tend-*)
-  ├─ /activity:          fans out one Search query per bucket per bot,
+  ├─ /activity:          one Search query per bucket, all bots OR'd (4 total),
   │                      payload shared across colos via KV (activity:v1)
   └─ each route stale-while-revalidate from the colo cache, served at api.tend-src.com
 ```
@@ -251,8 +273,9 @@ out.
 
 For `/currently-tending` a cold colo cache costs the full N actions/runs
 fanout, bounded to one cold refresh per budget per colo. For `/activity` the
-KV tier collapses that to roughly one 4·N Search fanout per budget across the
-whole network: a cold or stale colo reads `activity:v1` first and fans out only
+KV tier collapses that to roughly one 4-request Search refresh per budget
+across the whole network: a cold or stale colo reads `activity:v1` first and
+refreshes only
 when KV is stale too, so neither colo count nor traffic multiplies the GitHub
 load.
 

--- a/worker/README.md
+++ b/worker/README.md
@@ -72,6 +72,14 @@ blank stat strip. The KV sharing tier (see [Caching](#caching)) still bounds
 how often a refresh fires, but it is no longer what keeps the burst under the
 cap.
 
+The request count is now constant, but query *length* still grows with the
+consumer list — `comments` is the longest at three qualifiers per bot, and
+measured ~570 characters at 8 consumers. That is the ceiling this shape has
+left, replacing the old ~7-bot one; it fails the same silent way, so if the
+consumer list grows several times over, check a `comments` query against live
+Search before assuming it still returns 200. The 20-consumer test asserts the
+request count against a mocked `fetch` and says nothing about that.
+
 Two consequences of combining, both benign at present. A `count` no longer
 double-counts an item two bots both touched (possible for `reviews` and
 `comments`, not for `author:`-keyed buckets, and unobserved — each bot works
@@ -125,9 +133,10 @@ reviewed by *any* bot, not just the one that commented.
 
 ### Multi-bot semantics
 
-Everything is **merged across bots**: each `/activity` bucket sums `count` and
-`count_this_week` over all tend bots, and its `recent` list is the union of all
-bots' recent items, sorted newest-first; `currently_tending` is the union of all
+Everything is **merged across bots**: each `/activity` bucket is one Search
+query covering every bot, so `count` and `count_this_week` are union counts
+over all tend bots rather than per-bot sums, and its `recent` list is the
+newest items across all of them; `currently_tending` is the union of all
 bots' in-progress runs. Activity is *not* scoped to consumer repos — `count`
 comes from Search's `total_count`, which can't be filtered post-hoc — but a tend
 bot only acts in its own repo, so this is a distinction without a difference in

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -88,8 +88,8 @@ interface RecentItem {
 }
 
 interface ActivityBucket {
-  count: number; // lifetime — Search total_count, summed across bots
-  count_this_week: number; // last 7 days; saturates ~one page per bot per bucket
+  count: number; // lifetime — the combined query's Search total_count
+  count_this_week: number; // last 7 days; saturates ~one page (100) per bucket
   recent: RecentItem[]; // newest-first, merged across bots
 }
 
@@ -130,9 +130,9 @@ const WORKFLOW_PREFIX = "tend-";
 // repo, then we filter to tend-* client-side. 30 (GitHub's default) is
 // cheap and avoids tend runs being pushed off by busier non-tend traffic.
 const PER_PAGE_RUNS = 30;
-// /activity: one Search page per bucket per bot. 100 is Search's max page
-// and one request; we keep the newest RECENT_PER_BUCKET for the feed and
-// count the rest of the page towards "this week".
+// /activity: one Search page per bucket, covering every bot. 100 is Search's
+// max page and one request; we keep the newest RECENT_PER_BUCKET for the feed
+// and count the rest of the page towards "this week".
 const SEARCH_PAGE = 100;
 const RECENT_PER_BUCKET = 10;
 const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
@@ -151,7 +151,13 @@ const BOOKKEEPING_LABELS = [
   "review-reviewers-tracking",
   "nightly-cleanup",
 ];
-const ISSUE_LABEL_FILTER = BOOKKEEPING_LABELS.map((l) => `-label:${l}`).join(" ");
+// Repeat a Search qualifier once per value. Positive qualifiers OR
+// (`author:a author:b` matches either); negated ones AND (`-label:x -label:y`
+// excludes both).
+const qualify = (qualifier: string, values: string[]) =>
+  values.map((v) => `${qualifier}:${v}`).join(" ");
+
+const ISSUE_LABEL_FILTER = qualify("-label", BOOKKEEPING_LABELS);
 
 // Why primitive buckets, not a job taxonomy: GitHub records mechanical facts
 // (PR opened, review submitted, comment created), but tend's jobs (review /
@@ -163,24 +169,25 @@ const ISSUE_LABEL_FILTER = BOOKKEEPING_LABELS.map((l) => `-label:${l}`).join(" "
 // "what's tend been up to" narrative is deferred to a Phase 2 LLM summary
 // (see TODO.md).
 //
-// Each bucket is ONE Search request covering every bot, not one per bot.
-// Repeating a qualifier ORs it (`author:a author:b` = either), so the whole
-// consumer list folds into a single query and the refresh costs 4 Search
-// requests regardless of how many consumers there are. That bound is the
+// Each bucket is ONE Search request covering every bot, not one per bot: the
+// whole consumer list folds into a single query via `qualify`, so a refresh
+// costs 4 Search requests whatever the consumer count. That bound is the
 // point: Search allows 30 requests/minute, so the old bot-by-bot fanout
 // (4·N) crossed the limit at 8 consumers and every refresh after that would
-// have sunk — see searchIssues. Negated qualifiers still AND, so the
+// have sunk — see searchIssues. Negated qualifiers AND rather than OR, so the
 // `comments` exclusions drop anything authored/reviewed by *any* bot.
-const or = (bots: string[], qualifier: string) =>
-  bots.map((b) => `${qualifier}:${b}`).join(" ");
-
+//
+// What still grows with the consumer count is query *length* — `comments` is
+// the longest at three qualifiers per bot, ~570 characters at 8 consumers.
+// That, not the request count, is what bounds this shape now.
+//
 // `q` for each /activity bucket — "some bot …":
 const BUCKET_QUERIES: Record<ActivityBucketName, (bots: string[]) => string> = {
-  prs: (bs) => `${or(bs, "author")} is:pr`, // …opened these PRs
-  issues: (bs) => `${or(bs, "author")} is:issue ${ISSUE_LABEL_FILTER}`, // …opened these issues (minus its own bookkeeping)
-  reviews: (bs) => or(bs, "reviewed-by"), // …reviewed these PRs (approve / request-changes / review comment)
+  prs: (bs) => `${qualify("author", bs)} is:pr`, // …opened these PRs
+  issues: (bs) => `${qualify("author", bs)} is:issue ${ISSUE_LABEL_FILTER}`, // …opened these issues (minus its own bookkeeping)
+  reviews: (bs) => qualify("reviewed-by", bs), // …reviewed these PRs (approve / request-changes / review comment)
   comments: (bs) =>
-    `${or(bs, "commenter")} ${or(bs, "-author")} ${or(bs, "-reviewed-by")}`, // …commented on these PRs/issues (not a bot's own, not folded in from a review)
+    `${qualify("commenter", bs)} ${qualify("-author", bs)} ${qualify("-reviewed-by", bs)}`, // …commented on these PRs/issues (not a bot's own, not folded in from a review)
 };
 
 // Per-route freshness budgets, in seconds. `ok` applies to a good refresh;
@@ -601,7 +608,8 @@ async function toRecentItem(
   return { ...base, url: it.html_url };
 }
 
-// Latest inline review comment on a PR authored by `bot` — `created_at` desc.
+// Latest inline review comment on a PR authored by one of `bots` —
+// `created_at` desc.
 // We deliberately don't anchor on the review summary (`#pullrequestreview-…`):
 // tend's reviews are typically `COMMENTED` with an empty body wrapping inline
 // comments, so the review anchor scrolls nowhere on the conversation page.

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -163,12 +163,24 @@ const ISSUE_LABEL_FILTER = BOOKKEEPING_LABELS.map((l) => `-label:${l}`).join(" "
 // "what's tend been up to" narrative is deferred to a Phase 2 LLM summary
 // (see TODO.md).
 //
-// `q` for each /activity bucket — "the bot …":
-const BUCKET_QUERIES: Record<ActivityBucketName, (bot: string) => string> = {
-  prs: (b) => `author:${b} is:pr`, // …opened these PRs
-  issues: (b) => `author:${b} is:issue ${ISSUE_LABEL_FILTER}`, // …opened these issues (minus its own bookkeeping)
-  reviews: (b) => `reviewed-by:${b}`, // …reviewed these PRs (approve / request-changes / review comment)
-  comments: (b) => `commenter:${b} -author:${b} -reviewed-by:${b}`, // …commented on these PRs/issues (not its own, not folded in from a review)
+// Each bucket is ONE Search request covering every bot, not one per bot.
+// Repeating a qualifier ORs it (`author:a author:b` = either), so the whole
+// consumer list folds into a single query and the refresh costs 4 Search
+// requests regardless of how many consumers there are. That bound is the
+// point: Search allows 30 requests/minute, so the old bot-by-bot fanout
+// (4·N) crossed the limit at 8 consumers and every refresh after that would
+// have sunk — see searchIssues. Negated qualifiers still AND, so the
+// `comments` exclusions drop anything authored/reviewed by *any* bot.
+const or = (bots: string[], qualifier: string) =>
+  bots.map((b) => `${qualifier}:${b}`).join(" ");
+
+// `q` for each /activity bucket — "some bot …":
+const BUCKET_QUERIES: Record<ActivityBucketName, (bots: string[]) => string> = {
+  prs: (bs) => `${or(bs, "author")} is:pr`, // …opened these PRs
+  issues: (bs) => `${or(bs, "author")} is:issue ${ISSUE_LABEL_FILTER}`, // …opened these issues (minus its own bookkeeping)
+  reviews: (bs) => or(bs, "reviewed-by"), // …reviewed these PRs (approve / request-changes / review comment)
+  comments: (bs) =>
+    `${or(bs, "commenter")} ${or(bs, "-author")} ${or(bs, "-reviewed-by")}`, // …commented on these PRs/issues (not a bot's own, not folded in from a review)
 };
 
 // Per-route freshness budgets, in seconds. `ok` applies to a good refresh;
@@ -534,30 +546,24 @@ async function refreshActivity(env: Env): Promise<ActivityResponse> {
 
   await Promise.all(
     (Object.keys(BUCKET_QUERIES) as ActivityBucketName[]).map(async (name) => {
-      const pages = await Promise.all(
-        bots.map(async (b) => ({
-          bot: b,
-          page: await searchIssues(BUCKET_QUERIES[name](b), env.GITHUB_TOKEN),
-        })),
-      );
-      const items: Array<SearchItem & { bot: string }> = [];
-      let count = 0;
+      const page = await searchIssues(BUCKET_QUERIES[name](bots), env.GITHUB_TOKEN);
+      const items = page.items ?? [];
       let countThisWeek = 0;
-      for (const { bot, page } of pages) {
-        count += page.total_count ?? 0;
-        for (const it of page.items ?? []) {
-          items.push({ ...it, bot });
-          if (Date.parse(it.updated_at) >= weekAgoMs) countThisWeek++;
-        }
+      for (const it of items) {
+        if (Date.parse(it.updated_at) >= weekAgoMs) countThisWeek++;
       }
       items.sort((a, b) =>
         a.updated_at < b.updated_at ? 1 : a.updated_at > b.updated_at ? -1 : 0,
       );
       const top = items.slice(0, RECENT_PER_BUCKET);
       const recent = await Promise.all(
-        top.map((it) => toRecentItem(name, it, env.GITHUB_TOKEN)),
+        top.map((it) => toRecentItem(name, it, bots, env.GITHUB_TOKEN)),
       );
-      out[name] = { count, count_this_week: countThisWeek, recent };
+      out[name] = {
+        count: page.total_count ?? 0,
+        count_this_week: countThisWeek,
+        recent,
+      };
     }),
   );
   return out;
@@ -569,9 +575,13 @@ async function refreshActivity(env: Env): Promise<ActivityResponse> {
 // Follow-up failure (404, transient error, race where Search saw the action
 // but the comment isn't queryable yet) falls back to the parent URL — better
 // than dropping the row.
+// A combined query doesn't say which bot matched, so the follow-up matches
+// against the whole consumer list. It reads the same single page either way —
+// no extra requests — and only one bot acts in a given repo in practice.
 async function toRecentItem(
   bucket: ActivityBucketName,
-  it: SearchItem & { bot: string },
+  it: SearchItem,
+  bots: string[],
   token: string,
 ): Promise<RecentItem> {
   const repo = repoFromApiUrl(it.repository_url);
@@ -581,11 +591,11 @@ async function toRecentItem(
     at: it.updated_at,
   };
   if (bucket === "reviews") {
-    const deep = await findBotReviewUrl(repo, it.number, it.bot, token);
+    const deep = await findBotReviewUrl(repo, it.number, bots, token);
     return { ...base, url: deep ?? it.html_url };
   }
   if (bucket === "comments") {
-    const deep = await findBotCommentUrl(repo, it.number, it.bot, token);
+    const deep = await findBotCommentUrl(repo, it.number, bots, token);
     return { ...base, url: deep ?? it.html_url };
   }
   return { ...base, url: it.html_url };
@@ -601,7 +611,7 @@ async function toRecentItem(
 async function findBotReviewUrl(
   repo: string,
   n: number,
-  bot: string,
+  bots: string[],
   token: string,
 ): Promise<string | null> {
   const url = `${GITHUB_API}/repos/${repo}/pulls/${n}/comments?per_page=100`;
@@ -614,7 +624,7 @@ async function findBotReviewUrl(
     const comments = (await resp.json()) as IssueCommentObject[];
     return latestByBot(
       comments,
-      bot,
+      bots,
       (c) => c.created_at,
       (c) => c.html_url,
     );
@@ -624,14 +634,14 @@ async function findBotReviewUrl(
   }
 }
 
-// Latest issue/PR-conversation comment authored by `bot` — `created_at` desc.
-// (Inline PR review comments live at a different endpoint; the comments
-// bucket excludes `reviewed-by:<bot>`, so the bot's contribution is an
-// issue-style comment.) Returns null on failure (caller falls back).
+// Latest issue/PR-conversation comment authored by one of `bots` —
+// `created_at` desc. (Inline PR review comments live at a different endpoint;
+// the comments bucket excludes `reviewed-by:<bot>`, so the bot's contribution
+// is an issue-style comment.) Returns null on failure (caller falls back).
 async function findBotCommentUrl(
   repo: string,
   n: number,
-  bot: string,
+  bots: string[],
   token: string,
 ): Promise<string | null> {
   const url = `${GITHUB_API}/repos/${repo}/issues/${n}/comments?per_page=100`;
@@ -644,7 +654,7 @@ async function findBotCommentUrl(
     const comments = (await resp.json()) as IssueCommentObject[];
     return latestByBot(
       comments,
-      bot,
+      bots,
       (c) => c.created_at,
       (c) => c.html_url,
     );
@@ -656,14 +666,15 @@ async function findBotCommentUrl(
 
 function latestByBot<T extends { user?: { login?: string } | null }>(
   entries: T[],
-  bot: string,
+  bots: string[],
   ts: (e: T) => string | undefined,
   href: (e: T) => string | undefined,
 ): string | null {
   let bestTs = "";
   let bestUrl: string | null = null;
   for (const e of entries) {
-    if (e.user?.login !== bot) continue;
+    const login = e.user?.login;
+    if (login === undefined || !bots.includes(login)) continue;
     const t = ts(e);
     const h = href(e);
     if (typeof t !== "string" || typeof h !== "string") continue;
@@ -700,8 +711,15 @@ function repoFromApiUrl(repositoryUrl: string): string {
 // short-fallbacks (30s) and retries. We do NOT degrade a failure to `{}` —
 // that cached an all-zero payload as a successful refresh at the full budget,
 // pinning "0 PRs / 0 reviews / …" on the site for up to the stale-serve window
-// on a transient Search error (429 from the 4·N fanout, a 5xx blip). A real
-// empty bucket is a 200 with `total_count: 0`, so genuine zeros still pass.
+// on a transient Search error (a 429, a 5xx blip). A real empty bucket is a
+// 200 with `total_count: 0`, so genuine zeros still pass.
+//
+// Refusing to degrade only survives a *transient* failure: the fallback TTL
+// is 30s, so a structural failure re-attempts about twice a minute and never
+// drains. That is why BUCKET_QUERIES keeps the refresh at 4 requests — a
+// fanout that sits above Search's 30/minute sinks every refresh, and the
+// site's sections hide themselves rather than erroring, so it shows as a
+// blank page rather than an alarm.
 async function searchIssues(query: string, token: string): Promise<SearchResponse> {
   const params = new URLSearchParams({
     q: query,

--- a/worker/test/worker.test.ts
+++ b/worker/test/worker.test.ts
@@ -196,7 +196,7 @@ describe("refreshActivity", () => {
   const ISSUE_FILTER =
     "-label:tend-outage -label:tend-rate-limit -label:review-runs-tracking -label:review-reviewers-tracking -label:nightly-cleanup";
 
-  it("fans out one Search query per bucket per bot — sums counts, merges + sorts recent, counts this week", async () => {
+  it("issues one Search query per bucket covering every bot — merges + sorts recent, counts this week", async () => {
     const { __test } = await import("../src/index");
     const nowMs = Date.now();
     const daysAgo = (n: number) => new Date(nowMs - n * 86_400_000).toISOString();
@@ -252,15 +252,13 @@ describe("refreshActivity", () => {
           { repo: "o/b", bot_name: "bot-b" },
         ],
       ],
-      // bots sorted → bot-a, bot-b. Buckets in declared order: prs, issues, reviews, comments.
-      [searchUrl("author:bot-a is:pr"), { total_count: 7, items: [item("o/a", 1, "pull", recentA), item("o/a", 2, "pull", oldA)] }],
-      [searchUrl("author:bot-b is:pr"), { total_count: 3, items: [item("o/b", 9, "pull", oldB)] }],
-      [searchUrl(`author:bot-a is:issue ${ISSUE_FILTER}`), { total_count: 2, items: [item("o/a", 5, "issues", recentB)] }],
-      [searchUrl(`author:bot-b is:issue ${ISSUE_FILTER}`), { total_count: 0, items: [] }],
-      [searchUrl("reviewed-by:bot-a"), { total_count: 9, items: [item("o/a", 4, "pull", recentA)] }],
-      [searchUrl("reviewed-by:bot-b"), { total_count: 5, items: [item("o/b", 7, "pull", oldB)] }],
-      [searchUrl("commenter:bot-a -author:bot-a -reviewed-by:bot-a"), { total_count: 12, items: [item("o/a", 3, "pull", recentA)] }],
-      [searchUrl("commenter:bot-b -author:bot-b -reviewed-by:bot-b"), { total_count: 4, items: [item("o/b", 8, "issues", recentB)] }],
+      // bots sorted → bot-a, bot-b, folded into ONE query per bucket via
+      // repeated (OR'd) qualifiers. Buckets in declared order: prs, issues,
+      // reviews, comments. Four Search requests total, not 4×2.
+      [searchUrl("author:bot-a author:bot-b is:pr"), { total_count: 10, items: [item("o/a", 1, "pull", recentA), item("o/a", 2, "pull", oldA), item("o/b", 9, "pull", oldB)] }],
+      [searchUrl(`author:bot-a author:bot-b is:issue ${ISSUE_FILTER}`), { total_count: 2, items: [item("o/a", 5, "issues", recentB)] }],
+      [searchUrl("reviewed-by:bot-a reviewed-by:bot-b"), { total_count: 14, items: [item("o/a", 4, "pull", recentA), item("o/b", 7, "pull", oldB)] }],
+      [searchUrl("commenter:bot-a commenter:bot-b -author:bot-a -author:bot-b -reviewed-by:bot-a -reviewed-by:bot-b"), { total_count: 16, items: [item("o/a", 3, "pull", recentA), item("o/b", 8, "issues", recentB)] }],
       // Follow-ups: pick the latest entry by the bot; the worker should land on the deepest URL.
       [reviewCommentUrl("o/a", 4), [
         reviewComment("o/a", 4, "someone-else", 100, recentB),
@@ -285,7 +283,7 @@ describe("refreshActivity", () => {
     const out = await __test.refreshActivity(env);
 
     expect(out.prs).toEqual({
-      count: 10, // 7 + 3
+      count: 10, // the combined query's total_count
       count_this_week: 1, // o/a#1 recent; o/a#2 and o/b#9 old
       recent: [
         { repo: "o/a", title: "o/a#1", url: "https://github.com/o/a/pull/1", at: recentA },
@@ -301,7 +299,7 @@ describe("refreshActivity", () => {
       ],
     });
     expect(out.reviews).toEqual({
-      count: 14, // 9 + 5
+      count: 14,
       count_this_week: 1, // o/a#4 recent; o/b#7 old
       recent: [
         // url resolved to the bot's most recent inline comment, not the PR top.
@@ -310,7 +308,7 @@ describe("refreshActivity", () => {
       ],
     });
     expect(out.comments).toEqual({
-      count: 16, // 12 + 4
+      count: 16,
       count_this_week: 2,
       recent: [
         // newest comment by the bot wins (302 vs 301).
@@ -319,6 +317,42 @@ describe("refreshActivity", () => {
       ],
     });
     expect(out.generated_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+  });
+
+  it("spends 4 Search requests regardless of consumer count — Search allows 30/minute", async () => {
+    const { __test } = await import("../src/index");
+    // The bound is the reason the queries are combined: one request per bot
+    // per bucket crossed 30/minute at 8 consumers, and because the fallback
+    // TTL is 30s a structurally oversized refresh re-attempts forever instead
+    // of draining. 20 consumers here — 4·N would be 80.
+    const consumers = Array.from({ length: 20 }, (_, i) => ({
+      repo: `o/r${i}`,
+      bot_name: `bot-${i}`,
+    }));
+    let searchCalls = 0;
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.endsWith("/data/consumers.json")) {
+        return new Response(JSON.stringify(consumers), { status: 200 });
+      }
+      if (url.includes("/search/issues")) {
+        searchCalls++;
+        return new Response(JSON.stringify({ total_count: 0, items: [] }), {
+          status: 200,
+        });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }) as unknown as typeof fetch;
+
+    const env = {
+      GITHUB_TOKEN: "tok",
+      CACHE: makeFakeKv(),
+      ALLOWED_ORIGIN: "*",
+      REPOS_URL:
+        "https://raw.githubusercontent.com/max-sixty/tend/main/data/consumers.json",
+    };
+    await __test.refreshActivity(env);
+    expect(searchCalls).toBe(4);
   });
 
   it("falls back to the parent URL when the follow-up fetch fails", async () => {


### PR DESCRIPTION
`/activity` issued one Search query per bot per bucket, so a refresh cost 4·N Search requests against a 30/minute cap. #1036 takes the consumer list to 8, which puts every refresh structurally over the limit. This folds all bots into one query per bucket via repeated (OR'd) qualifiers, so a refresh is 4 requests regardless of consumer count. Verified against live Search that the combined counts equal the per-bot sums exactly.

The `worker/README.md` already named the ceiling this crosses — "a single fanout stays clear up to ~7 bots" — so the 8th consumer is the documented breaking point, not a surprise.

## Why it would have been silent

`searchIssues` throws on a non-OK status and the throw escapes both `Promise.all`s, sinking the whole refresh rather than one bucket. That refusal to degrade is deliberate and right for a transient blip, but it only survives a *transient* failure: the `activity` fallback TTL is 30 s, so a structurally oversized burst re-attempts about twice a minute and never lets the rate-limit window drain. Per `worker/README.md` the site renders the stat strip and activity feed only when the fetch returns data, so the visible result is blank sections rather than an error.

## Verification

Combined queries return exactly the per-bot sums, checked against live Search:

<details><summary>Live checks</summary>

`author:` across all 8 bots — combined `total_count` 1901, and the per-bot sum:

```
cargo-affected-bot 35 · dormouse-bot 101 · leaf-agent 19 · numbagg-bot 62
prql-bot 452 · tend-agent 421 · tend-jakobtfaber 24 · worktrunk-bot 787
sum = 1901
```

`reviewed-by:` — `tend-agent` 571, `numbagg-bot` 130, combined 701.

The `comments` bucket's query is the longest (three qualifiers per bot); it returned 200 at 566 characters for 8 bots, so there is headroom, though query length is what will eventually bound this shape rather than request count.

</details>

A new test asserts the invariant directly: 20 consumers still produce exactly 4 Search requests, where the old shape would have produced 80. The other `refreshActivity` tests use a single consumer, where the combined query is byte-identical to the old one, so they pass unchanged — the two-bot test was updated to the combined form and its expected output is unchanged, which is the useful signal that this preserves behaviour.

`npm run typecheck` and `npm test` (32 tests) pass.

## Behaviour notes

Both benign, both recorded in the README:

- A `count` no longer double-counts an item two bots both touched. Possible for `reviews`/`comments`, impossible for the `author:`-keyed buckets, and unobserved — each bot works in its own repo.
- The matching bot is no longer named in the result, so the deep-link follow-up matches the whole consumer list instead of one login. It reads the same single page either way, so it costs no extra requests.

## On the alternative

Sequencing the four buckets or capping concurrency would not have fixed this — the Search limit is 30 requests **per minute**, not 30 concurrent, so 32 requests exceed it however they are spaced within a refresh. Reducing the request *count* was the only option that works, and it has the advantage of being constant in N rather than merely buying a few more consumers.

Should land before #1036, or with it.
