### PR TITLE
fix(scripts): reject an unusable SHA before the poll loop

### DIFF
--- a/generator/tests/test_poll_scripts.py
+++ b/generator/tests/test_poll_scripts.py
@@ -397,6 +397,29 @@ def test_waits_out_pending_then_reports_green(env: dict[str, str]) -> None:
     assert Path(env["GRAPHQL_CALLS"]).read_text().strip() == "3"
 
 
+def test_abbreviated_sha_is_rejected_at_entry(env: dict[str, str]) -> None:
+    """GraphQL's `GitObjectID!` rejects an abbreviated OID at coercion time, and
+    rollup() cannot tell that from a transient failure — so the loop would sleep
+    through its whole budget before reporting a caller bug, and head_note's
+    string compare would then claim the branch advanced to the very commit that
+    was passed in. Reject the argument before any API call."""
+    _serve(env, _resp(_check_run("tests")))
+
+    result = subprocess.run(
+        [BASH, str(POLL_PR_CHECKS), "7", HEAD_SHA[:7]],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 2, out
+    assert "UNVERIFIED, not green" in out
+    assert HEAD_SHA[:7] in out
+    assert "branch advanced" not in out, "head_note fired on the rejected argument"
+    assert not Path(env["GH_CALLS"]).exists(), "the bad argument reached the API"
+
+
 def test_moved_head_is_reported_not_absorbed(env: dict[str, str]) -> None:
     """Another actor pushing while we poll must not retarget the verdict: the
     result stays the pinned SHA's, with the move called out."""

--- a/generator/tests/test_poll_scripts.py
+++ b/generator/tests/test_poll_scripts.py
@@ -420,6 +420,27 @@ def test_abbreviated_sha_is_rejected_at_entry(env: dict[str, str]) -> None:
     assert not Path(env["GH_CALLS"]).exists(), "the bad argument reached the API"
 
 
+def test_uppercase_sha_is_rejected_at_entry(env: dict[str, str]) -> None:
+    """GraphQL coerces an uppercase OID happily, but head_note compares it
+    against `headRefOid`, which comes back lowercase — so an uppercase argument
+    would poll its own commit successfully and then trail every verdict with a
+    spurious "branch advanced" note pointing at that same commit."""
+    _serve(env, _resp(_check_run("tests")))
+
+    result = subprocess.run(
+        [BASH, str(POLL_PR_CHECKS), "7", HEAD_SHA.upper()],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 2, out
+    assert "UNVERIFIED, not green" in out
+    assert "branch advanced" not in out, "head_note fired on the rejected argument"
+    assert not Path(env["GH_CALLS"]).exists(), "the bad argument reached the API"
+
+
 def test_omitted_sha_is_rejected_not_reported_red(env: dict[str, str]) -> None:
     """Omitting <sha> is the likelier arity mistake, and `set -u` would kill the
     script with exit 1 — the code this file documents as red, which sends the

--- a/generator/tests/test_poll_scripts.py
+++ b/generator/tests/test_poll_scripts.py
@@ -420,6 +420,27 @@ def test_abbreviated_sha_is_rejected_at_entry(env: dict[str, str]) -> None:
     assert not Path(env["GH_CALLS"]).exists(), "the bad argument reached the API"
 
 
+def test_omitted_sha_is_rejected_not_reported_red(env: dict[str, str]) -> None:
+    """Omitting <sha> is the likelier arity mistake, and `set -u` would kill the
+    script with exit 1 — the code this file documents as red, which sends the
+    caller off to diagnose a CI failure that never happened. It has to land on
+    the same UNVERIFIED path as any other unusable argument."""
+    _serve(env, _resp(_check_run("tests")))
+
+    result = subprocess.run(
+        [BASH, str(POLL_PR_CHECKS), "7"],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 2, out
+    assert "UNVERIFIED, not green" in out
+    assert "unbound variable" not in out
+    assert not Path(env["GH_CALLS"]).exists(), "the short call reached the API"
+
+
 def test_moved_head_is_reported_not_absorbed(env: dict[str, str]) -> None:
     """Another actor pushing while we poll must not retarget the verdict: the
     result stays the pinned SHA's, with the move called out."""

--- a/plugins/tend-ci-runner/scripts/poll-pr-checks.sh
+++ b/plugins/tend-ci-runner/scripts/poll-pr-checks.sh
@@ -43,21 +43,22 @@
 
 set -euo pipefail
 
-PR="$1"
-SHA="$2"
+# Both default rather than relying on `set -u`: an omitted <sha> is the likelier
+# arity mistake, and unbound-variable death exits 1 — the code documented above
+# as red, sending the caller off to diagnose a CI failure that never happened.
+# Defaulting routes a short call into the guard below instead.
+PR="${1:-}"
+SHA="${2:-}"
 OWNER="${GITHUB_REPOSITORY%/*}"
 
 # GraphQL's `GitObjectID!` rejects an abbreviated OID at coercion time, which
 # rollup() cannot tell from a transient failure: without this the loop sleeps
 # through its whole budget before reporting a caller bug, and head_note's
 # string compare then claims the branch advanced to the very commit that was
-# passed in. Rejecting here is also what keeps that note honest — a non-full
-# OID is the only way it can misfire.
-case "$SHA" in
-  "" | *[!0-9a-fA-F]*) SHA_OK=0 ;;
-  *) [ "${#SHA}" -eq 40 ] && SHA_OK=1 || SHA_OK=0 ;;
-esac
-if [ "$SHA_OK" -ne 1 ]; then
+# passed in. head_note can still misfire on the other exit-2 causes above — an
+# unresolvable OID and a merge-ref commit are both full-length and neither is
+# the branch head — so this narrows that note rather than fixing it.
+if [[ ! $SHA =~ ^[0-9a-fA-F]{40}$ ]]; then
   echo "poll-pr-checks.sh: <sha> must be a full 40-char commit OID, got '$SHA' — UNVERIFIED, not green" >&2
   exit 2
 fi

--- a/plugins/tend-ci-runner/scripts/poll-pr-checks.sh
+++ b/plugins/tend-ci-runner/scripts/poll-pr-checks.sh
@@ -33,7 +33,7 @@
 #   0  every gating check on <sha> settled green
 #   1  red — failing checks and their run URLs on stdout
 #   2  no usable rollup for <sha> — UNVERIFIED, not green. A <sha> that isn't
-#      a full 40-hex OID, rejected at entry; an unresolvable OID; an
+#      a full 40-char lowercase OID, rejected at entry; an unresolvable OID; an
 #      ephemeral merge-ref commit, which carries none; a commit with
 #      zero checks and zero statuses (a push every workflow's paths filter
 #      excludes — the rollup is null then too, so "nothing to gate on" is
@@ -55,11 +55,17 @@ OWNER="${GITHUB_REPOSITORY%/*}"
 # rollup() cannot tell from a transient failure: without this the loop sleeps
 # through its whole budget before reporting a caller bug, and head_note's
 # string compare then claims the branch advanced to the very commit that was
-# passed in. head_note can still misfire on the other exit-2 causes above — an
-# unresolvable OID and a merge-ref commit are both full-length and neither is
-# the branch head — so this narrows that note rather than fixing it.
-if [[ ! $SHA =~ ^[0-9a-fA-F]{40}$ ]]; then
-  echo "poll-pr-checks.sh: <sha> must be a full 40-char commit OID, got '$SHA' — UNVERIFIED, not green" >&2
+# passed in. Lowercase-only for the same reason from the other direction:
+# GraphQL coerces an uppercase OID happily, but head_note compares it against
+# `headRefOid`, which comes back lowercase — so an uppercase argument
+# mismatches its own commit and trails every verdict with that spurious note.
+# Nothing here emits uppercase (`git rev-parse` and `headRefOid` are both
+# lowercase), so rejecting it costs no real caller. head_note can still
+# misfire on the other exit-2 causes above — an unresolvable OID and a
+# merge-ref commit are both full-length and neither is the branch head — so
+# this narrows that note rather than fixing it.
+if [[ ! $SHA =~ ^[0-9a-f]{40}$ ]]; then
+  echo "poll-pr-checks.sh: <sha> must be a full 40-char lowercase commit OID, got '$SHA' — UNVERIFIED, not green" >&2
   exit 2
 fi
 NAME="${GITHUB_REPOSITORY#*/}"

--- a/plugins/tend-ci-runner/scripts/poll-pr-checks.sh
+++ b/plugins/tend-ci-runner/scripts/poll-pr-checks.sh
@@ -32,8 +32,9 @@
 # Exit codes:
 #   0  every gating check on <sha> settled green
 #   1  red — failing checks and their run URLs on stdout
-#   2  no usable rollup for <sha> — UNVERIFIED, not green. An unresolvable
-#      OID; an ephemeral merge-ref commit, which carries none; a commit with
+#   2  no usable rollup for <sha> — UNVERIFIED, not green. A <sha> that isn't
+#      a full 40-hex OID, rejected at entry; an unresolvable OID; an
+#      ephemeral merge-ref commit, which carries none; a commit with
 #      zero checks and zero statuses (a push every workflow's paths filter
 #      excludes — the rollup is null then too, so "nothing to gate on" is
 #      indistinguishable from "nothing answered"); or a page walk that could
@@ -45,6 +46,21 @@ set -euo pipefail
 PR="$1"
 SHA="$2"
 OWNER="${GITHUB_REPOSITORY%/*}"
+
+# GraphQL's `GitObjectID!` rejects an abbreviated OID at coercion time, which
+# rollup() cannot tell from a transient failure: without this the loop sleeps
+# through its whole budget before reporting a caller bug, and head_note's
+# string compare then claims the branch advanced to the very commit that was
+# passed in. Rejecting here is also what keeps that note honest — a non-full
+# OID is the only way it can misfire.
+case "$SHA" in
+  "" | *[!0-9a-fA-F]*) SHA_OK=0 ;;
+  *) [ "${#SHA}" -eq 40 ] && SHA_OK=1 || SHA_OK=0 ;;
+esac
+if [ "$SHA_OK" -ne 1 ]; then
+  echo "poll-pr-checks.sh: <sha> must be a full 40-char commit OID, got '$SHA' — UNVERIFIED, not green" >&2
+  exit 2
+fi
 NAME="${GITHUB_REPOSITORY#*/}"
 
 # One query returns check runs *and* legacy status contexts, a page at a


### PR DESCRIPTION
## Problem

`poll-pr-checks.sh` took an abbreviated SHA as far as the API. GraphQL's `GitObjectID!` rejects a non-40-hex OID at variable coercion, `rollup()` maps that errors envelope to empty output, and the loop reads empty as "transient, retry" — so a caller bug burned all nine `sleep 60` iterations before exiting 2. Worse, `head_note` string-compares the caller's `$SHA` against the PR's full `headRefOid`, so an abbreviated argument always tripped the branch-advanced line: the script printed a false claim that a sibling pushed, naming the very commit it was handed. That is the shape `running-in-ci` tells sessions to act on, so a session relaying it would post a fabricated push into a PR thread. Reported in #1045 with two occurrences on a consumer repo.

## Solution

Validate `<sha>` at entry against `^[0-9a-f]{40}$` and exit 2 with a message that names the cause instead of an unreachable API. The exit code and the `UNVERIFIED, not green` wording are unchanged, so no caller needs to change; the verdict just arrives in milliseconds. Both positional args default (`${1:-}` / `${2:-}`) so an omitted `<sha>` lands on that same guard rather than dying at `set -u` with exit 1 — the code this file documents as red, which would send the caller off to diagnose a CI failure that never happened.

Lowercase-only in the class, not `[0-9a-fA-F]`: GraphQL coerces an uppercase OID happily, so it would poll successfully and *then* mismatch `headRefOid` — which comes back lowercase — trailing every verdict with a spurious branch-advanced note pointing at its own commit. Nothing in the repo emits uppercase (`git rev-parse` and `headRefOid` are both lowercase), so rejecting it costs no real caller.

The guard narrows `head_note`'s false positives rather than eliminating them: it still fires on the other exit-2 causes, since an unresolvable OID and an ephemeral `refs/pull/N/merge` commit are both full-length and neither is the branch head. `head_note` is deliberately not called on the reject path — there is no verdict above it to qualify.

## Testing

Three guard tests in `generator/tests/test_poll_scripts.py` — abbreviated, uppercase, and omitted `<sha>` — each asserting exit 2, the cause in the message, no `branch advanced` line, and no `gh` call at all. Against the pre-fix script the abbreviated case failed with `green: every gating check on aaaa111 settled green` plus the false branch-advanced note; the fake `gh` doesn't enforce coercion, so the test reproduces the wrong-claim half directly and the guard covers both halves. Full `uv run pytest` is green (587 passed).

---

Closes #1045 — automated triage
