### PR TITLE
test(proxy): assert --allow-hosts and the injection host sets stay in sync

### DIFF
--- a/proxy/inject_credentials.py
+++ b/proxy/inject_credentials.py
@@ -53,7 +53,9 @@ from mitmproxy import http
 # These frozensets are the credential boundary. The proxy's --allow-hosts regex
 # in setup-sandbox.sh scopes TLS interception and must list the same hosts —
 # keep the two in sync (a host here but not in the regex is never intercepted,
-# so its dummy is never swapped and auth 401s).
+# so its dummy is never swapped and auth 401s). The
+# `test_allow_hosts_regex_*` tests in test_inject_credentials.py read that
+# regex out of the script and fail on drift in either direction.
 BASIC_HOSTS = frozenset({"github.com", "codeload.github.com"})
 TOKEN_HOSTS = frozenset(
     {"api.github.com", "uploads.github.com", "raw.githubusercontent.com"}

--- a/proxy/setup-sandbox.sh
+++ b/proxy/setup-sandbox.sh
@@ -430,7 +430,9 @@ log "starting proxy"
 # BASIC_HOSTS / TOKEN_HOSTS / ANTHROPIC_HOSTS frozensets in inject_credentials.py
 # (which own the credential boundary). A host in those sets but missing here is
 # never intercepted, so its dummy is never swapped for the real secret and auth
-# fails with a 401.
+# fails with a 401. The `test_allow_hosts_regex_*` tests in
+# proxy/test_inject_credentials.py parse this flag's single-quoted argument, so
+# keep it on one line and singly quoted.
 nohup "$UVX" --from "$MITMPROXY" mitmdump \
   -s "${ACTION_PATH}/proxy/inject_credentials.py" \
   --listen-host 127.0.0.1 --listen-port "$PROXY_PORT" \

--- a/proxy/test_inject_credentials.py
+++ b/proxy/test_inject_credentials.py
@@ -40,9 +40,12 @@ def test_pinned_mitmproxy_matches_the_action() -> None:
 
 def _allow_hosts_regex() -> re.Pattern[str]:
     setup = (REPO_ROOT / "proxy" / "setup-sandbox.sh").read_text()
-    match = re.search(r"--allow-hosts '([^']*)'", setup)
-    assert match, "no single-quoted --allow-hosts flag in proxy/setup-sandbox.sh"
-    return re.compile(match.group(1))
+    # `[^']*` spans newlines, so a stray example in a comment would silently
+    # win the first match — require exactly one occurrence.
+    found = re.findall(r"--allow-hosts '([^']*)'", setup)
+    assert len(found) == 1, "expected one --allow-hosts flag in proxy/setup-sandbox.sh"
+    # mitmproxy compiles --allow-hosts with re.IGNORECASE; model that here.
+    return re.compile(found[0], re.IGNORECASE)
 
 
 def test_allow_hosts_regex_covers_every_injected_host() -> None:
@@ -51,9 +54,10 @@ def test_allow_hosts_regex_covers_every_injected_host() -> None:
     # intercepted, so its dummy is never swapped for the real secret and every
     # call to it 401s — with the proxy alive, the CA trusted and both files
     # looking correct in isolation. Both sides carry a "keep in sync" comment;
-    # only this asserts it. mitmproxy matches the pattern against the connection
-    # address, so check the bare host and the host:port form the regex's own
-    # optional port group exists to admit.
+    # only this asserts it. mitmproxy appends the port to every candidate it
+    # matches (peer address, Host header, SNI), so `host:port` is the form
+    # interception actually turns on — the bare host is extra strictness, not
+    # what production feeds the regex.
     allow_hosts = _allow_hosts_regex()
     for host in BASIC_HOSTS | TOKEN_HOSTS | ANTHROPIC_HOSTS:
         assert allow_hosts.search(host), f"{host} is injected but never intercepted"

--- a/proxy/test_inject_credentials.py
+++ b/proxy/test_inject_credentials.py
@@ -6,6 +6,7 @@ Run: ``uv run pytest`` from the repo root, which covers every Python suite.
 from __future__ import annotations
 
 import base64
+import re
 from importlib.metadata import version
 from pathlib import Path
 
@@ -13,7 +14,12 @@ import pytest
 from mitmproxy.test import tflow, tutils
 from ruamel.yaml import YAML
 
-from inject_credentials import CredentialInjector
+from inject_credentials import (
+    ANTHROPIC_HOSTS,
+    BASIC_HOSTS,
+    TOKEN_HOSTS,
+    CredentialInjector,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -30,6 +36,51 @@ def test_pinned_mitmproxy_matches_the_action() -> None:
         (REPO_ROOT / "claude" / "action.yaml").read_text()
     )
     assert version("mitmproxy") == action["inputs"]["mitmproxy_version"]["default"]
+
+
+def _allow_hosts_regex() -> re.Pattern[str]:
+    setup = (REPO_ROOT / "proxy" / "setup-sandbox.sh").read_text()
+    match = re.search(r"--allow-hosts '([^']*)'", setup)
+    assert match, "no single-quoted --allow-hosts flag in proxy/setup-sandbox.sh"
+    return re.compile(match.group(1))
+
+
+def test_allow_hosts_regex_covers_every_injected_host() -> None:
+    # The frozensets scope injection; the --allow-hosts regex in setup-sandbox.sh
+    # scopes TLS interception. A host in a frozenset the regex misses is never
+    # intercepted, so its dummy is never swapped for the real secret and every
+    # call to it 401s — with the proxy alive, the CA trusted and both files
+    # looking correct in isolation. Both sides carry a "keep in sync" comment;
+    # only this asserts it. mitmproxy matches the pattern against the connection
+    # address, so check the bare host and the host:port form the regex's own
+    # optional port group exists to admit.
+    allow_hosts = _allow_hosts_regex()
+    for host in BASIC_HOSTS | TOKEN_HOSTS | ANTHROPIC_HOSTS:
+        assert allow_hosts.search(host), f"{host} is injected but never intercepted"
+        assert allow_hosts.search(f"{host}:443"), f"{host}:443 is never intercepted"
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        # Signed, time-limited URLs; injecting there breaks the download, so the
+        # addon leaves it out of TOKEN_HOSTS and the regex must not widen
+        # interception to it either.
+        "objects.githubusercontent.com",
+        # The lookalikes the injection tests below already refuse a credential
+        # for. Interception is the outer boundary and should refuse them first.
+        "api.github.com.evil.example",
+        "raw.githubusercontent.com.evil.example",
+        "api.anthropic.com.evil.example",
+        "pypi.org",
+    ],
+)
+def test_allow_hosts_regex_intercepts_nothing_extra(host: str) -> None:
+    allow_hosts = _allow_hosts_regex()
+    assert not allow_hosts.search(host), f"{host} should not be intercepted"
+    assert not allow_hosts.search(f"{host}:443"), (
+        f"{host}:443 should not be intercepted"
+    )
 
 
 def test_addon_methods_are_real_mitmproxy_hooks() -> None:


### PR DESCRIPTION
The proxy's credential boundary is split across two files that must agree, and nothing checks that they do: `inject_credentials.py`'s `BASIC_HOSTS`/`TOKEN_HOSTS`/`ANTHROPIC_HOSTS` decide which hosts get a real secret, while the `--allow-hosts` regex in `setup-sandbox.sh` decides which hosts mitmproxy TLS-intercepts at all. Both sides carry a "keep the two in sync" comment; neither is enforced. This adds the tests that enforce it.

They're in sync today — this is a guard against future drift, not a fix for a live break.

The failure it catches is silent and fleet-wide. A host that's in a frozenset but not in the regex is never intercepted, so its dummy credential is never swapped for the real one and every call to it 401s — while the proxy is alive, the CA is trusted, the addon's own unit tests pass, and each file reads correctly on its own. Nothing else in the repo would notice: the frozensets are covered by unit tests that never see the regex, and the regex is a string in a shell script no Python test reads.

`test_allow_hosts_regex_covers_every_injected_host` parses the flag's argument out of `setup-sandbox.sh` and asserts every injected host matches, both bare and in the `host:port` form. `host:port` is the form that matters — mitmproxy appends the port to every candidate it matches, so the bare-host assertion is extra strictness rather than a form production produces. `test_allow_hosts_regex_intercepts_nothing_extra` covers the other direction over five sampled hosts, so a widening those five catch fails — notably `objects.githubusercontent.com`, which the addon deliberately leaves out because injecting a PAT there collides with the signed-URL signature. It is a sample, not a proof: a widening that misses all five (adding `gist\.`, say) still passes.

The parsed regex is compiled with `re.IGNORECASE`, which is how mitmproxy compiles it in `next_layer._ignore_connection` — so a case-only edit to the regex behaves here the way it behaves in production. The parsing is otherwise deliberately literal (one single-quoted argument on one line, and exactly one occurrence in the file), so I noted that constraint in the comment above the flag rather than leaving the coupling implicit.

<details><summary>Verification</summary>

`uv run pytest` from the repo root: 593 passed. `pre-commit run` over the changed files: all hooks pass.

Mutation-tested against a temporarily edited `setup-sandbox.sh`, restoring it after each:

- dropping `uploads\.` from the regex → `AssertionError: uploads.github.com is injected but never intercepted`
- widening `raw\.githubusercontent\.com` to `[a-z]+\.githubusercontent\.com` → `AssertionError: objects.githubusercontent.com should not be intercepted`
- adding a commented `--allow-hosts '^example\.invalid$'` example above the flag → `AssertionError: expected one --allow-hosts flag in proxy/setup-sandbox.sh` (before the one-occurrence assert, the comment's value won the match and the tests validated a regex the proxy never uses)
- a case-only edit (`github\.com` → `GitHub\.com`) → passes, matching production behavior

The mitmproxy claims are read off the installed pin: `re.compile(x, re.IGNORECASE) for x in ctx.options.allow_hosts`, and `_ignore_connection` building every candidate as `f"{host}:{port}"` (peer address, server address, Host header with the port appended when absent, SNI).

No regression test in the usual sense — there's no bug to reproduce. The mutations above are the closest equivalent: each is a drift the tests would have caught and nothing else would.

Precedent for the shape: `test_pinned_mitmproxy_matches_the_action` in the same file already asserts cross-file parity between `claude/action.yaml` and the installed distribution, and the `sandbox-env-reserved-parity` pre-commit hook does the same for `config.py` vs. `setup-sandbox.sh`. A pre-commit hook would also have worked here; a test keeps it next to the addon tests that own the same boundary.

</details>
