### PR TITLE
skills(review-runs): treat the quota reset as an upper bound, not a schedule

### DIFF
--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -226,7 +226,7 @@ jq -r 'select(.type == "assistant") | .message.content[]?.text // empty' /tmp/ou
 # → You've hit your weekly limit · resets 12am (UTC)
 ```
 
-A cluster of these is quota exhaustion, not a bug — don't open a fix PR, and read the reset off the message: a weekly limit can strand most of a day.
+A cluster of these is quota exhaustion, not a bug — don't open a fix PR. The reset in the message is an upper bound on the outage, not a schedule: a weekly limit can strand most of a day, and can also clear many hours early. Gate the drain on the clean-run check below, not on the stated reset.
 
 **Re-run only what won't recover.** Scheduled workflows (`nightly`, `notifications`, `weekly`, this one) recover on their next tick. For an event-triggered run, confirm the work is still missing — a later push often re-triggers it — and that a recent run completed cleanly, or the re-run just refills the issue. Re-running the bot's own failed workflow needs no maintainer approval.
 


### PR DESCRIPTION
## Problem

`review-runs` → **Drain stranded triggers** told the sweep to "read the reset off the message" of a quota `<synthetic>` turn, framing the stated reset as when the quota returns. It isn't — it bounds the outage from above. On max-sixty/worktrunk, a `tend-review` pair died at `2026-08-25T04:44Z` with `resets 12am (UTC)` (i.e. 2026-08-26T00:00Z), and a `tend-notifications` session booted the agent normally at [05:01:15Z](https://github.com/max-sixty/worktrunk/actions/runs/32811105601) — ~19h before the stated reset. The same shape on 2026-08-11: failures at `14:57Z`/`15:06Z` with `resets 2am (UTC)`, then a clean [15:40Z run](https://github.com/max-sixty/worktrunk/actions/runs/31508307913), ~10h early. A third window (2026-08-04) did run to its stated reset, so the long case is real too.

Wrong in both directions: waiting for the clock strands an event-triggered review for a day (nothing re-fires `tend-review` without a push), and assuming a short clock re-runs into a live outage, appending fresh rows to the public `tend-outage` issue the drain is meant to clear.

## Solution

Replace the falsified clause with the upper-bound framing and point at the check the section already performs one paragraph down ("confirm … that a recent run completed cleanly"). One sentence swapped, no new mechanism.

## Testing

Prose-only change to a skill; no code path to test. The claim it drops was checked against run metadata for the runs #1051 cites — failure timestamps, the stated reset in each message, and the first following run whose `max-sixty/tend/claude` step ran to a successful agent session (verified via the run's step list, so a gate-exit can't pass as a boot). `pre-commit run --files plugins/tend-ci-runner/skills/review-runs/SKILL.md` passes.

---
Closes #1051 — automated triage
