### PR TITLE
feat(sandbox): name GITHUB_WORKFLOW for sandbox_setup commands

### DIFF
--- a/docs/tend.example.yaml
+++ b/docs/tend.example.yaml
@@ -222,6 +222,15 @@ bot_name: my-project-bot
 #       - uv tool install pre-commit
 #       - pre-commit --version
 #
+#   One block runs for every workflow. `$GITHUB_WORKFLOW` names the one this
+#   run belongs to, so a command can scope itself to the workflows that need
+#   it. It is the same string a `setup:` step matches with
+#   `if: github.workflow == '...'`, so a gated install and its assertion name
+#   the same workflows:
+#
+#     sandbox_setup:
+#       - 'if [ "$GITHUB_WORKFLOW" = tend-weekly ]; then nix --version; fi'
+#
 # The codex harness runs the agent on the runner, so its `setup:` section
 # already reaches the agent env; these keys are inert (and warn) under codex.
 

--- a/plugins/install-tend/skills/install-tend/references/tend.example.yaml
+++ b/plugins/install-tend/skills/install-tend/references/tend.example.yaml
@@ -222,6 +222,15 @@ bot_name: my-project-bot
 #       - uv tool install pre-commit
 #       - pre-commit --version
 #
+#   One block runs for every workflow. `$GITHUB_WORKFLOW` names the one this
+#   run belongs to, so a command can scope itself to the workflows that need
+#   it. It is the same string a `setup:` step matches with
+#   `if: github.workflow == '...'`, so a gated install and its assertion name
+#   the same workflows:
+#
+#     sandbox_setup:
+#       - 'if [ "$GITHUB_WORKFLOW" = tend-weekly ]; then nix --version; fi'
+#
 # The codex harness runs the agent on the runner, so its `setup:` section
 # already reaches the agent env; these keys are inert (and warn) under codex.
 

--- a/proxy/test-setup-sandbox.sh
+++ b/proxy/test-setup-sandbox.sh
@@ -128,7 +128,10 @@ verify() {
       ;;
   esac
 
-  setup_commands=$'mkdir -p ~/.local/bin\ncp ~runner/.cargo-install/tend-probe/bin/tend-probe ~/.local/bin/\ntend-probe'
+  # `sudo env` would drop GITHUB_WORKFLOW; sandbox_setup names it so a command
+  # can scope itself to one workflow. `test -n` so an empty value fails here
+  # rather than passing the grep vacuously.
+  setup_commands=$'mkdir -p ~/.local/bin\ncp ~runner/.cargo-install/tend-probe/bin/tend-probe ~/.local/bin/\ntend-probe\ntest -n "$GITHUB_WORKFLOW"\necho "sandbox_setup workflow: $GITHUB_WORKFLOW"'
   TEND_SANDBOX_SETUP="$setup_commands" \
     bash shared/steps/sandbox-setup.sh | tee "$RUNNER_TEMP/report-after.log"
   if grep 'unavailable to the agent:' "$RUNNER_TEMP/report-after.log" | grep -q tend-probe; then
@@ -136,6 +139,7 @@ verify() {
     exit 1
   fi
   test "$(sudo -u "$SANDBOX" env "${agent_env[@]}" tend-probe)" = probe
+  grep -qF "sandbox_setup workflow: $GITHUB_WORKFLOW" "$RUNNER_TEMP/report-after.log"
 }
 
 # An explicit runner-home path is the one route that could bypass the rewrite.

--- a/shared/steps/sandbox-setup.sh
+++ b/shared/steps/sandbox-setup.sh
@@ -18,7 +18,7 @@
 #
 # Inputs (env): TEND_SANDBOX_SETUP (the commands; empty → the report only),
 # SANDBOX, AGENT_ENV_FILE, AGENT_PATH and TEND_BLOCKED_PATH (exported by
-# setup-sandbox.sh via $GITHUB_ENV).
+# setup-sandbox.sh via $GITHUB_ENV), GITHUB_WORKFLOW from Actions.
 # Used by the Claude harness action.
 set -euo pipefail
 
@@ -29,8 +29,15 @@ if [ -n "${TEND_SANDBOX_SETUP:-}" ]; then
   # installer prompt, `read` — can't swallow the remaining lines and exit 0).
   # `-e` inside so a failing setup command fails the step loudly rather than
   # silently proceeding to the run.
+  # `sudo env` replaces the environment with only what is listed. GITHUB_WORKFLOW
+  # is named so it carries across. One `sandbox_setup:` block runs for every
+  # workflow, and a command scopes itself to one by its name — the same string a
+  # runner-side `setup:` step matches with `if: github.workflow == '…'`. It goes
+  # last because `env` takes the final assignment of a name, so an adopter's
+  # `sandbox_env:` cannot displace it.
   mapfile -t AGENT_ENV <"$AGENT_ENV_FILE"
-  sudo -u "$SANDBOX" env "${AGENT_ENV[@]}" bash -eo pipefail -c "$TEND_SANDBOX_SETUP"
+  sudo -u "$SANDBOX" env "${AGENT_ENV[@]}" GITHUB_WORKFLOW="$GITHUB_WORKFLOW" \
+    bash -eo pipefail -c "$TEND_SANDBOX_SETUP"
   echo "[sandbox-setup] ran adopter sandbox_setup commands as $SANDBOX"
 fi
 


### PR DESCRIPTION
`sandbox_setup:` is one block that runs for every workflow, so a command in it had no way to tell which workflow it was in. Everything around it does: a runner-side `setup:` step takes an `if: github.workflow == '…'`, and the agent itself receives the `GITHUB_*` context because the Run Claude step re-passes them. Only the `sandbox_setup:` step was missing them, since `sudo env` replaces the environment with only what is listed and that call listed the agent env file alone.

Naming `GITHUB_WORKFLOW` on that call closes the gap. An adopter who gates a heavy or rarely-used tool's install to the workflows that need it can now assert it in the same workflows, instead of choosing between installing it everywhere and dropping the assertion. That choice is a live one — it came up in worktrunk, where `nix` is installed for all eight workflows because only the weekly one uses it and the reachability probe could not be scoped to match.

It goes after the env-file arguments deliberately: `env` takes the final assignment of a name, so an adopter's `sandbox_env:` cannot displace it. Keeping it off the env file also leaves that file as what it is — the credential and routing contract shared with the plugin-install step — rather than growing a gate input that would then need reserving, guarding, and documenting alongside the dummy credentials.

<details>
<summary>What was verified, and an approach that was tried and dropped</summary>

The generator round-trips the documented example byte-identically: `'if [ "$GITHUB_WORKFLOW" = tend-weekly ]; then nix --version; fi'` renders into `tend-weekly.yaml`'s `sandbox_setup: |` block unchanged, and Actions does not interpolate `$VAR`.

Under the real invocation shape (`bash -eo pipefail -c`), a non-matching workflow skips the body and continues at exit 0, while a matching one with the tool absent exits 127 — which fails `sandbox-setup.sh` and so the tend job. `-e` exempts the `if` condition, not its body.

The trailing position was checked directly: with `GITHUB_WORKFLOW=spoofed` in the env file, `env "${AGENT_ENV[@]}" GITHUB_WORKFLOW=tend-weekly` resolves to `tend-weekly`; reversing the two resolves to `spoofed`.

The first attempt added a new `TEND_WORKFLOW` to the agent env file, with a matching `RESERVED_SANDBOX_ENV` entry, a shell `case` arm, a docs-list entry for the parity hook, a guard refusing a newline in the value, and a refusal test. It was dropped once it became clear the agent already carries `GITHUB_WORKFLOW` — that would have been a second name for a value already present, and the whole apparatus existed only because the value was passing through a line-oriented file. The version here is a third the size and uses the name the runner, the adopter's `setup:` condition, and tend's own in-sandbox scripts (`plugins/tend-ci-runner/scripts/poll-pr-checks.sh`, `list-recent-runs.sh`) already use.

</details>

## Testing

`verify` in `proxy/test-setup-sandbox.sh` now asserts the value inside the `sandbox_setup:` block itself, through the real `shared/steps/sandbox-setup.sh` invocation rather than a bare `env` splat, with a `test -n` so an empty value fails there rather than satisfying the grep. `pre-commit run --all-files` passes, including the `sandbox-env-reserved-parity` and install-tend mirror hooks; `uv run pytest generator/tests -q` reports 550 passed.

One thing this does not do: `sandbox_setup:` still does not see `GITHUB_EVENT_NAME`, `GITHUB_SHA`, or the rest of the context the agent gets. Full parity would mean either duplicating the denylist loop from `claude/action.yaml` or extracting it, which is a larger change than this case needs. Worth doing when a second case asks for it.

> _This was written by Claude Code on behalf of max-sixty_
