### PR TITLE
feat(sandbox): give sandbox_setup the same GitHub context as the agent

### DIFF
--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -367,26 +367,10 @@ runs:
         sudo -u "$SANDBOX" tee "$WRAPPER" < "$RUNNER_TEMP/tend-wrapper.sh" >/dev/null
         sudo -u "$SANDBOX" chmod +x "$WRAPPER"
 
-        # Pass GITHUB_* through as a denylist rather than an explicit
-        # allowlist: most GITHUB_* vars are informational (GITHUB_ACTOR,
-        # GITHUB_API_URL, GITHUB_REF_NAME, GITHUB_WORKSPACE, …) and a
-        # denylist picks up future additions automatically. Skills depend on
-        # them for run-self-reference (branch names, gist headings, dedup of
-        # own check runs) and owner-correct URL construction. Exclude:
-        #   GITHUB_TOKEN — the agent env file carries a dummy; the real
-        #     PAT lives in the proxy. (The file's dummy must not be
-        #     overridden, so the denylist entry is load-bearing.)
-        #   GITHUB_{ENV,PATH,OUTPUT,STATE,STEP_SUMMARY} — paths the
-        #     runner re-reads after this step exits; the sandbox must not
-        #     be handed a channel into later steps' env / PATH / outputs /
-        #     job summary.
-        GHA_VARS=()
-        while IFS= read -r name; do
-          case "$name" in
-            GITHUB_TOKEN|GITHUB_ENV|GITHUB_PATH|GITHUB_OUTPUT|GITHUB_STATE|GITHUB_STEP_SUMMARY) continue ;;
-          esac
-          GHA_VARS+=("$name=${!name}")
-        done < <(compgen -e | grep '^GITHUB_')
+        # The GITHUB_* context the sandbox gets — the set and its rationale
+        # are in lib/gha-context-env.sh.
+        . "${{ github.action_path }}/../shared/steps/lib/gha-context-env.sh"
+        gha_context_env
 
         # Launch the agent as the non-sudo sandbox user, backgrounded so the
         # runner can supervise it. Its launch env is $AGENT_ENV_FILE (written by
@@ -397,8 +381,8 @@ runs:
         # traffic tunnels through untouched. No real secret is in this env.
         #
         # The `sudo env VAR=...` form replaces the environment with only
-        # what's listed, so the GITHUB_* context vars are re-passed via the
-        # denylist above. They are public values, not secrets.
+        # what's listed, so the GITHUB_* context vars are re-passed via
+        # GHA_CONTEXT_ENV above. They are public values, not secrets.
         mapfile -t AGENT_ENV <"$AGENT_ENV_FILE"
         sudo -u "$SANDBOX" env \
           "${AGENT_ENV[@]}" \
@@ -407,7 +391,7 @@ runs:
           TEND_MODEL="$TEND_MODEL" TEND_ALLOWED_TOOLS="$TEND_ALLOWED_TOOLS" \
           TEND_SYSTEM_PROMPT="$TEND_SYSTEM_PROMPT" TEND_PROMPT="$TEND_PROMPT" \
           CI="${CI:-true}" \
-          "${GHA_VARS[@]}" \
+          "${GHA_CONTEXT_ENV[@]}" \
           bash "$WRAPPER" >"$STREAM_JSON" 2>"$STDERR_LOG" &
         CLAUDE_PID=$!
         echo "Claude PID: $CLAUDE_PID (running as $SANDBOX, headless claude -p)"

--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -367,10 +367,10 @@ runs:
         sudo -u "$SANDBOX" tee "$WRAPPER" < "$RUNNER_TEMP/tend-wrapper.sh" >/dev/null
         sudo -u "$SANDBOX" chmod +x "$WRAPPER"
 
-        # The GITHUB_* context the sandbox gets — the set and its rationale
-        # are in lib/gha-context-env.sh.
-        . "${{ github.action_path }}/../shared/steps/lib/gha-context-env.sh"
-        gha_context_env
+        # The sandbox's launch env: the agent env file plus the GITHUB_*
+        # context, composed in that order — see lib/sandbox-launch-env.sh.
+        . "${{ github.action_path }}/../shared/steps/lib/sandbox-launch-env.sh"
+        sandbox_launch_env "$AGENT_ENV_FILE"
 
         # Launch the agent as the non-sudo sandbox user, backgrounded so the
         # runner can supervise it. Its launch env is $AGENT_ENV_FILE (written by
@@ -381,17 +381,16 @@ runs:
         # traffic tunnels through untouched. No real secret is in this env.
         #
         # The `sudo env VAR=...` form replaces the environment with only
-        # what's listed, so the GITHUB_* context vars are re-passed via
-        # GHA_CONTEXT_ENV above. They are public values, not secrets.
-        mapfile -t AGENT_ENV <"$AGENT_ENV_FILE"
+        # what's listed, so SANDBOX_LAUNCH_ENV above carries it. tend's own
+        # assignments follow it and so win, which is what they want — none is
+        # GITHUB_*-named, so none can displace the context.
         sudo -u "$SANDBOX" env \
-          "${AGENT_ENV[@]}" \
+          "${SANDBOX_LAUNCH_ENV[@]}" \
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB="$CLAUDE_CODE_SUBPROCESS_ENV_SCRUB" \
           BOT_NAME="$BOT_NAME" BOT_ID="$BOT_ID" \
           TEND_MODEL="$TEND_MODEL" TEND_ALLOWED_TOOLS="$TEND_ALLOWED_TOOLS" \
           TEND_SYSTEM_PROMPT="$TEND_SYSTEM_PROMPT" TEND_PROMPT="$TEND_PROMPT" \
           CI="${CI:-true}" \
-          "${GHA_CONTEXT_ENV[@]}" \
           bash "$WRAPPER" >"$STREAM_JSON" 2>"$STDERR_LOG" &
         CLAUDE_PID=$!
         echo "Claude PID: $CLAUDE_PID (running as $SANDBOX, headless claude -p)"

--- a/docs/tend.example.yaml
+++ b/docs/tend.example.yaml
@@ -207,8 +207,10 @@ bot_name: my-project-bot
 #     sandbox_env:
 #       RUST_BACKTRACE: "1"
 #
-#   Setup-step env changes do not cross automatically. If a build needs one
-#   (for example `JAVA_HOME` rather than `java` on PATH), add it explicitly.
+#   Setup-step env changes do not cross automatically, except under a `GITHUB_*`
+#   name — those ride the GitHub context, so don't give a secret one. If a build
+#   needs an env change (for example `JAVA_HOME` rather than `java` on PATH),
+#   add it explicitly.
 #
 # - `sandbox_setup`: shell commands run as the sandbox user after the toolchain
 #   and plugins install and before the agent runs, with the workspace as cwd.
@@ -222,9 +224,11 @@ bot_name: my-project-bot
 #       - uv tool install pre-commit
 #       - pre-commit --version
 #
-#   One block runs for every workflow. `$GITHUB_WORKFLOW` names the one this
-#   run belongs to, so a command can scope itself to the workflows that need
-#   it. It is the same string a `setup:` step matches with
+#   One block runs for every workflow, and the commands see the same GitHub
+#   context the agent does — `$GITHUB_WORKFLOW`, `$GITHUB_EVENT_NAME`,
+#   `$GITHUB_REPOSITORY` and the rest of `GITHUB_*`, straight from Actions — so
+#   a command can scope itself to the workflows or events that need it.
+#   `$GITHUB_WORKFLOW` is the same string a `setup:` step matches with
 #   `if: github.workflow == '...'`, so a gated install and its assertion name
 #   the same workflows:
 #

--- a/generator/tests/test_repo_pins.py
+++ b/generator/tests/test_repo_pins.py
@@ -72,3 +72,50 @@ def test_action_path_references_resolve(harness: str) -> None:
         if not (REPO_ROOT / harness / ref).resolve().exists()
     ]
     assert not missing, f"{harness}/action.yaml references nothing at: {missing}"
+
+
+# The `sudo -u "$SANDBOX" env` line each adopter-facing crossing builds. Nothing
+# else covers claude/action.yaml's: its inline block is unlinted (the actionlint
+# hook is pinned to ^.github/workflows/), no workflow consumes the action with
+# `uses: ./`, and the test-sandbox job drives shared/steps/sandbox-setup.sh
+# directly without going through the action. Deleting the splat there launches
+# the agent with no PATH, no proxy routing, no CA trust and no credentials.
+CROSSINGS = ("claude/action.yaml", "shared/steps/sandbox-setup.sh")
+GITHUB_ASSIGNMENT = re.compile(r"\bGITHUB_[A-Z_]*=")
+
+
+def _sudo_env_command(body: str, path: str) -> str:
+    """The one `sudo -u "$SANDBOX" env …` command, continuations included."""
+    lines = body.splitlines()
+    starts = [i for i, line in enumerate(lines) if 'sudo -u "$SANDBOX" env' in line]
+    assert len(starts) == 1, f"{path}: expected one sudo env crossing, got {starts}"
+    i = starts[0]
+    command = [lines[i]]
+    while lines[i].rstrip().endswith("\\"):
+        i += 1
+        command.append(lines[i])
+    return "\n".join(command)
+
+
+@pytest.mark.parametrize("crossing", CROSSINGS)
+def test_the_crossing_launches_from_the_composed_env(crossing: str) -> None:
+    """The composed array is on the line, and nothing GITHUB_* follows it.
+
+    sandbox_launch_env puts the context after the agent env file, so an
+    adopter's `sandbox_env:` cannot decide what the run thinks it is. A caller
+    is free to append names of its own — tend's BOT_*/TEND_* assignments do,
+    and have to, since they must beat the file — but a GITHUB_*-named one would
+    land after the context and displace it. Scoped to the single command rather
+    than to file order, so it says "later in this argv", which is the thing that
+    decides who wins.
+    """
+    command = _sudo_env_command((REPO_ROOT / crossing).read_text(), crossing)
+
+    assert '"${SANDBOX_LAUNCH_ENV[@]}"' in command, (
+        f"{crossing}: the crossing does not carry the composed launch env"
+    )
+    trailing = command.split('"${SANDBOX_LAUNCH_ENV[@]}"', 1)[1]
+    assert not GITHUB_ASSIGNMENT.search(trailing), (
+        f"{crossing}: a GITHUB_* assignment follows the composed array, so it "
+        f"displaces the real context: {trailing.strip()}"
+    )

--- a/generator/tests/test_repo_pins.py
+++ b/generator/tests/test_repo_pins.py
@@ -99,7 +99,7 @@ def _sudo_env_command(body: str, path: str) -> str:
 
 @pytest.mark.parametrize("crossing", CROSSINGS)
 def test_the_crossing_launches_from_the_composed_env(crossing: str) -> None:
-    """The composed array is on the line, and nothing GITHUB_* follows it.
+    """Something fills the array, it is on the line, and nothing GITHUB_* follows.
 
     sandbox_launch_env puts the context after the agent env file, so an
     adopter's `sandbox_env:` cannot decide what the run thinks it is. A caller
@@ -108,9 +108,20 @@ def test_the_crossing_launches_from_the_composed_env(crossing: str) -> None:
     land after the context and displace it. Scoped to the single command rather
     than to file order, so it says "later in this argv", which is the thing that
     decides who wins.
-    """
-    command = _sudo_env_command((REPO_ROOT / crossing).read_text(), crossing)
 
+    The call is asserted separately because bash expands `"${arr[@]}"` on an
+    UNSET array to nothing and exits 0, `set -u` included, so a splat with
+    nothing filling it is not an error the shell reports: the crossing would
+    launch with an empty environment — no PATH, no proxy routing, no CA trust,
+    no credentials — and only the child's exit code would say so.
+    """
+    body = (REPO_ROOT / crossing).read_text()
+    command = _sudo_env_command(body, crossing)
+
+    assert 'sandbox_launch_env "$AGENT_ENV_FILE"' in body, (
+        f"{crossing}: nothing composes the launch env, and an unset array "
+        f"splats to nothing, so the crossing would launch with an empty one"
+    )
     assert '"${SANDBOX_LAUNCH_ENV[@]}"' in command, (
         f"{crossing}: the crossing does not carry the composed launch env"
     )

--- a/generator/tests/test_repo_pins.py
+++ b/generator/tests/test_repo_pins.py
@@ -7,9 +7,11 @@ the pair.
 
 from __future__ import annotations
 
+import re
 import tomllib
 from pathlib import Path
 
+import pytest
 from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
 from packaging.version import Version
@@ -47,3 +49,26 @@ def test_uv_build_range_admits_the_pinned_uv() -> None:
         f"uv this repo pins ({uv_version}); `uv build` warns and the wheel is "
         "built by a backend a release older than the uv building it"
     )
+
+
+# Every `${{ github.action_path }}/…` reference in the two composite actions.
+# Nothing else reads them: the pre-commit actionlint hook is pinned to
+# ^.github/workflows/, so neither action.yaml is linted at all, and no workflow
+# here consumes the actions with `uses: ./` — they pin a released ref, so an
+# edited body first runs in an adopter's job. A path that resolves nowhere fails
+# its step, for every adopter, on the first run after a release.
+ACTION_PATH_REF = re.compile(r"\$\{\{\s*github\.action_path\s*\}\}/?([^\s\"')]*)")
+
+
+@pytest.mark.parametrize("harness", ["claude", "codex"])
+def test_action_path_references_resolve(harness: str) -> None:
+    body = (REPO_ROOT / harness / "action.yaml").read_text()
+    matched = ACTION_PATH_REF.findall(body)
+
+    assert matched, f"{harness}/action.yaml: no github.action_path references"
+    missing = [
+        ref
+        for ref in sorted(set(matched))
+        if not (REPO_ROOT / harness / ref).resolve().exists()
+    ]
+    assert not missing, f"{harness}/action.yaml references nothing at: {missing}"

--- a/generator/tests/test_shared_steps.py
+++ b/generator/tests/test_shared_steps.py
@@ -2467,12 +2467,15 @@ def test_report_failure_leaves_a_human_comment_naming_the_run(
     )
 
 
-# The GITHUB_* context that crosses into the sandbox. The denylist is the only
+# The environment the sandbox user is launched with. The denylist is the only
 # thing keeping the real PAT and the runner's own command-file paths out of a
 # uid that runs adopter code, and `proxy/test-setup-sandbox.sh` represents all
 # five withheld paths with GITHUB_ENV alone — so drop one of the other four from
-# the `case` and that suite still passes. These pin every name on both sides.
-GHA_CONTEXT_ENV_LIB = REPO_ROOT / "shared" / "steps" / "lib" / "gha-context-env.sh"
+# the `case` and that suite still passes. These pin every name on both sides,
+# and the order the two halves are composed in.
+SANDBOX_LAUNCH_ENV_LIB = (
+    REPO_ROOT / "shared" / "steps" / "lib" / "sandbox-launch-env.sh"
+)
 
 WITHHELD = (
     "GITHUB_TOKEN",
@@ -2484,18 +2487,23 @@ WITHHELD = (
 )
 
 
-def _gha_context_env(env: dict[str, str]) -> list[str]:
-    """The NAME=VALUE pairs the lib would hand `sudo … env`, given `env`.
+def _sandbox_launch_env(
+    tmp_path: Path, env: dict[str, str], env_file: str = ""
+) -> list[str]:
+    """The argv the lib would hand `sudo … env`, given the file and `env`.
 
     Under the callers' own `set -euo pipefail`, and NUL-separated bytes because
     a carried value may itself contain a newline.
     """
+    path = tmp_path / "agent-env"
+    path.write_text(env_file)
     result = subprocess.run(
         [
             BASH,
             "-c",
-            f'set -euo pipefail; . "{GHA_CONTEXT_ENV_LIB}"; gha_context_env'
-            '; printf "%s\\0" "${GHA_CONTEXT_ENV[@]}"',
+            f'set -euo pipefail; . "{SANDBOX_LAUNCH_ENV_LIB}"'
+            f'; sandbox_launch_env "{path}"'
+            '; printf "%s\\0" "${SANDBOX_LAUNCH_ENV[@]}"',
         ],
         env={"PATH": "/usr/bin:/bin", **env},
         capture_output=True,
@@ -2504,7 +2512,29 @@ def _gha_context_env(env: dict[str, str]) -> list[str]:
     return [pair.decode() for pair in result.stdout.split(b"\0") if pair]
 
 
-def test_gha_context_env_withholds_every_denied_name() -> None:
+def test_sandbox_launch_env_puts_the_context_after_the_file(tmp_path: Path) -> None:
+    """`sandbox_env:` cannot decide what the run thinks it is.
+
+    An adopter's additions reach the file, and `env` takes the final assignment
+    of a name — so a `sandbox_env: {GITHUB_WORKFLOW: …}` would displace the real
+    one if the halves were composed the other way round. Composing them here is
+    what makes that the function's postcondition rather than a rule each caller
+    has to remember.
+    """
+    pairs = _sandbox_launch_env(
+        tmp_path,
+        {"GITHUB_WORKFLOW": "tend-weekly"},
+        env_file="HOME=/sandbox\nGITHUB_WORKFLOW=spoofed-by-sandbox-env\n",
+    )
+
+    assert pairs == [
+        "HOME=/sandbox",
+        "GITHUB_WORKFLOW=spoofed-by-sandbox-env",
+        "GITHUB_WORKFLOW=tend-weekly",
+    ]
+
+
+def test_sandbox_launch_env_withholds_every_denied_name(tmp_path: Path) -> None:
     """Each of the six is dropped, and dropping it is the only thing that is."""
     carried = {
         "GITHUB_WORKFLOW": "tend-weekly",
@@ -2513,47 +2543,52 @@ def test_gha_context_env_withholds_every_denied_name() -> None:
     }
     env = {**carried, **{name: f"secret-{name}" for name in WITHHELD}}
 
-    pairs = _gha_context_env(env)
+    pairs = _sandbox_launch_env(tmp_path, env)
 
     assert sorted(pairs) == sorted(f"{k}={v}" for k, v in carried.items())
 
 
-def test_gha_context_env_carries_a_name_the_denylist_never_heard_of() -> None:
+def test_sandbox_launch_env_carries_a_name_the_denylist_never_heard_of(
+    tmp_path: Path,
+) -> None:
     """A denylist, not an allowlist: a GITHUB_* Actions adds later crosses.
 
     Losing this is the failure that hides — the agent and the setup commands
     would each be missing a name nobody notices until a skill reaches for it.
     """
-    pairs = _gha_context_env({"GITHUB_A_NAME_FROM_2030": "value"})
+    pairs = _sandbox_launch_env(tmp_path, {"GITHUB_A_NAME_FROM_2030": "value"})
 
     assert pairs == ["GITHUB_A_NAME_FROM_2030=value"]
 
 
-def test_gha_context_env_is_anchored_to_the_prefix() -> None:
+def test_sandbox_launch_env_is_anchored_to_the_prefix(tmp_path: Path) -> None:
     """`^GITHUB_`, so a name that merely contains it stays on the runner.
 
     `MY_GITHUB_TOKEN` and `GITHUBBER_TOKEN` are the shapes that matter: an
     adopter `setup:` step is free to export either, and neither may ride across
     on a prefix the pattern got wrong at one end or the other.
     """
-    pairs = _gha_context_env(
+    pairs = _sandbox_launch_env(
+        tmp_path,
         {
             "MY_GITHUB_TOKEN": "real",
             "GITHUBBER_TOKEN": "also-real",
             "NOT_GITHUB": "x",
             "GITHUB_ACTOR": "someone",
-        }
+        },
     )
 
     assert pairs == ["GITHUB_ACTOR=someone"]
 
 
-def test_gha_context_env_survives_values_a_line_oriented_carrier_could_not() -> None:
+def test_sandbox_launch_env_survives_values_a_line_oriented_carrier_could_not(
+    tmp_path: Path,
+) -> None:
     """Spaces, newlines and globs arrive byte-identical.
 
-    This is what makes an argv array the right carrier: the agent env file is
-    newline-delimited, so a multi-line value there would split into a second
-    line past `sandbox_env`'s reserved-name guard.
+    This is what makes an argv array the right carrier for the context: the
+    agent env file is newline-delimited, so a multi-line value there would split
+    into a second line past `sandbox_env`'s reserved-name guard.
     """
     hostile = {
         "GITHUB_EVENT_NAME": "two\nlines",
@@ -2561,6 +2596,6 @@ def test_gha_context_env_survives_values_a_line_oriented_carrier_could_not() -> 
         "GITHUB_REF_NAME": "*",
     }
 
-    pairs = _gha_context_env(hostile)
+    pairs = _sandbox_launch_env(tmp_path, hostile)
 
     assert sorted(pairs) == sorted(f"{k}={v}" for k, v in hostile.items())

--- a/generator/tests/test_shared_steps.py
+++ b/generator/tests/test_shared_steps.py
@@ -2465,3 +2465,102 @@ def test_report_failure_leaves_a_human_comment_naming_the_run(
         f"deleted a human comment that merely named the run: "
         f"{_deleted(report_failure_env)}"
     )
+
+
+# The GITHUB_* context that crosses into the sandbox. The denylist is the only
+# thing keeping the real PAT and the runner's own command-file paths out of a
+# uid that runs adopter code, and `proxy/test-setup-sandbox.sh` represents all
+# five withheld paths with GITHUB_ENV alone — so drop one of the other four from
+# the `case` and that suite still passes. These pin every name on both sides.
+GHA_CONTEXT_ENV_LIB = REPO_ROOT / "shared" / "steps" / "lib" / "gha-context-env.sh"
+
+WITHHELD = (
+    "GITHUB_TOKEN",
+    "GITHUB_ENV",
+    "GITHUB_PATH",
+    "GITHUB_OUTPUT",
+    "GITHUB_STATE",
+    "GITHUB_STEP_SUMMARY",
+)
+
+
+def _gha_context_env(env: dict[str, str]) -> list[str]:
+    """The NAME=VALUE pairs the lib would hand `sudo … env`, given `env`.
+
+    Under the callers' own `set -euo pipefail`, and NUL-separated bytes because
+    a carried value may itself contain a newline.
+    """
+    result = subprocess.run(
+        [
+            BASH,
+            "-c",
+            f'set -euo pipefail; . "{GHA_CONTEXT_ENV_LIB}"; gha_context_env'
+            '; printf "%s\\0" "${GHA_CONTEXT_ENV[@]}"',
+        ],
+        env={"PATH": "/usr/bin:/bin", **env},
+        capture_output=True,
+    )
+    assert result.returncode == 0, result.stderr.decode()
+    return [pair.decode() for pair in result.stdout.split(b"\0") if pair]
+
+
+def test_gha_context_env_withholds_every_denied_name() -> None:
+    """Each of the six is dropped, and dropping it is the only thing that is."""
+    carried = {
+        "GITHUB_WORKFLOW": "tend-weekly",
+        "GITHUB_EVENT_NAME": "schedule",
+        "GITHUB_REPOSITORY": "max-sixty/tend",
+    }
+    env = {**carried, **{name: f"secret-{name}" for name in WITHHELD}}
+
+    pairs = _gha_context_env(env)
+
+    assert sorted(pairs) == sorted(f"{k}={v}" for k, v in carried.items())
+
+
+def test_gha_context_env_carries_a_name_the_denylist_never_heard_of() -> None:
+    """A denylist, not an allowlist: a GITHUB_* Actions adds later crosses.
+
+    Losing this is the failure that hides — the agent and the setup commands
+    would each be missing a name nobody notices until a skill reaches for it.
+    """
+    pairs = _gha_context_env({"GITHUB_A_NAME_FROM_2030": "value"})
+
+    assert pairs == ["GITHUB_A_NAME_FROM_2030=value"]
+
+
+def test_gha_context_env_is_anchored_to_the_prefix() -> None:
+    """`^GITHUB_`, so a name that merely contains it stays on the runner.
+
+    `MY_GITHUB_TOKEN` and `GITHUBBER_TOKEN` are the shapes that matter: an
+    adopter `setup:` step is free to export either, and neither may ride across
+    on a prefix the pattern got wrong at one end or the other.
+    """
+    pairs = _gha_context_env(
+        {
+            "MY_GITHUB_TOKEN": "real",
+            "GITHUBBER_TOKEN": "also-real",
+            "NOT_GITHUB": "x",
+            "GITHUB_ACTOR": "someone",
+        }
+    )
+
+    assert pairs == ["GITHUB_ACTOR=someone"]
+
+
+def test_gha_context_env_survives_values_a_line_oriented_carrier_could_not() -> None:
+    """Spaces, newlines and globs arrive byte-identical.
+
+    This is what makes an argv array the right carrier: the agent env file is
+    newline-delimited, so a multi-line value there would split into a second
+    line past `sandbox_env`'s reserved-name guard.
+    """
+    hostile = {
+        "GITHUB_EVENT_NAME": "two\nlines",
+        "GITHUB_HEAD_REF": "a b  c",
+        "GITHUB_REF_NAME": "*",
+    }
+
+    pairs = _gha_context_env(hostile)
+
+    assert sorted(pairs) == sorted(f"{k}={v}" for k, v in hostile.items())

--- a/plugins/install-tend/skills/install-tend/references/tend.example.yaml
+++ b/plugins/install-tend/skills/install-tend/references/tend.example.yaml
@@ -207,8 +207,10 @@ bot_name: my-project-bot
 #     sandbox_env:
 #       RUST_BACKTRACE: "1"
 #
-#   Setup-step env changes do not cross automatically. If a build needs one
-#   (for example `JAVA_HOME` rather than `java` on PATH), add it explicitly.
+#   Setup-step env changes do not cross automatically, except under a `GITHUB_*`
+#   name — those ride the GitHub context, so don't give a secret one. If a build
+#   needs an env change (for example `JAVA_HOME` rather than `java` on PATH),
+#   add it explicitly.
 #
 # - `sandbox_setup`: shell commands run as the sandbox user after the toolchain
 #   and plugins install and before the agent runs, with the workspace as cwd.
@@ -222,9 +224,11 @@ bot_name: my-project-bot
 #       - uv tool install pre-commit
 #       - pre-commit --version
 #
-#   One block runs for every workflow. `$GITHUB_WORKFLOW` names the one this
-#   run belongs to, so a command can scope itself to the workflows that need
-#   it. It is the same string a `setup:` step matches with
+#   One block runs for every workflow, and the commands see the same GitHub
+#   context the agent does — `$GITHUB_WORKFLOW`, `$GITHUB_EVENT_NAME`,
+#   `$GITHUB_REPOSITORY` and the rest of `GITHUB_*`, straight from Actions — so
+#   a command can scope itself to the workflows or events that need it.
+#   `$GITHUB_WORKFLOW` is the same string a `setup:` step matches with
 #   `if: github.workflow == '...'`, so a gated install and its assertion name
 #   the same workflows:
 #

--- a/proxy/setup-sandbox.sh
+++ b/proxy/setup-sandbox.sh
@@ -118,9 +118,11 @@ else
   ANTHROPIC_DUMMY="ANTHROPIC_API_KEY=sk-ant-api03-tendproxydummy0000000000000000000000000000"
 fi
 
-# The agent's launch environment, one NAME=VALUE per line, consumed by every
-# step that runs something as the sandbox user (mapfile -t + `env "${arr[@]}"`).
-# One file so the plugin-install and Run Claude steps cannot drift. Contents:
+# The agent's launch environment, one NAME=VALUE per line. The two crossings
+# that carry adopter code compose it with the GITHUB_* context, in that order,
+# via shared/steps/lib/sandbox-launch-env.sh; the plugin install reads it
+# straight (mapfile -t + `env "${arr[@]}"`) and takes no context. One file so
+# none of them can drift. Contents:
 # the proxy routing, CA trust for every client family (system store for
 # gh/git/curl is implicit; NODE_EXTRA_CA_CERTS for claude (Node ignores the
 # system store); SSL_CERT_FILE/REQUESTS_CA_BUNDLE for uv and certifi-based

--- a/proxy/test-setup-sandbox.sh
+++ b/proxy/test-setup-sandbox.sh
@@ -62,6 +62,11 @@ setup() {
   # sandbox home. The configured directory may be populated later.
   # shellcheck disable=SC2088
   export TEND_SANDBOX_PATH="$GITHUB_WORKSPACE/.tend-explicit/bin"$'\n~/.tend-tilde/bin'
+  # `sandbox_env` reserves the credential and routing names, not the GITHUB_*
+  # context, so this entry is accepted and lands in $AGENT_ENV_FILE — earlier on
+  # the `env` line than the context array. verify()'s workflow-name grep is what
+  # holds the array in its trailing position: swap the two and this value wins.
+  export TEND_SANDBOX_ENV="GITHUB_WORKFLOW=spoofed-by-sandbox-env"
   MITMPROXY_VERSION=$(yq -e '.inputs.mitmproxy_version.default' claude/action.yaml)
   export MITMPROXY_VERSION
   UV_VERSION=$(yq -e '.inputs.uv_version.default' claude/action.yaml) \
@@ -98,7 +103,7 @@ setup() {
 }
 
 verify() {
-  local blocked_output rc report setup_commands
+  local blocked_output rc report setup_commands dummy_token
   local -a agent_env
   mapfile -t agent_env <"$AGENT_ENV_FILE"
   blocked_output=$(sudo -u "$SANDBOX" env "${agent_env[@]}" tend-probe 2>&1) \
@@ -128,11 +133,26 @@ verify() {
       ;;
   esac
 
-  # `sudo env` would drop GITHUB_WORKFLOW; sandbox_setup names it so a command
-  # can scope itself to one workflow. `test -n` so an empty value fails here
-  # rather than passing the grep vacuously.
-  setup_commands=$'mkdir -p ~/.local/bin\ncp ~runner/.cargo-install/tend-probe/bin/tend-probe ~/.local/bin/\ntend-probe\ntest -n "$GITHUB_WORKFLOW"\necho "sandbox_setup workflow: $GITHUB_WORKFLOW"'
-  TEND_SANDBOX_SETUP="$setup_commands" \
+  # Both halves of the set lib/gha-context-env.sh defines, asserted from inside
+  # the sandbox. `test -n` on the carried names so an empty value fails here
+  # rather than passing the grep below vacuously; GITHUB_ENV for the withheld
+  # ones, non-vacuous because Actions sets it on the runner. The env file's
+  # dummy token must survive a real one on the runner, so this call supplies a
+  # distinct value and the sandbox asserts it still sees the file's.
+  dummy_token=$(sed -n 's/^GITHUB_TOKEN=//p' "$AGENT_ENV_FILE")
+  test -n "$dummy_token"
+  test -n "$GITHUB_ENV"
+  setup_commands=$(printf '%s\n' \
+    'mkdir -p ~/.local/bin' \
+    'cp ~runner/.cargo-install/tend-probe/bin/tend-probe ~/.local/bin/' \
+    'tend-probe' \
+    'test -n "$GITHUB_WORKFLOW"' \
+    'test -n "$GITHUB_EVENT_NAME"' \
+    'test -z "${GITHUB_ENV:-}"' \
+    "test \"\$GITHUB_TOKEN\" = \"$dummy_token\"" \
+    'echo "sandbox_setup workflow: $GITHUB_WORKFLOW"')
+  GITHUB_TOKEN=runner-token-must-not-cross \
+    TEND_SANDBOX_SETUP="$setup_commands" \
     bash shared/steps/sandbox-setup.sh | tee "$RUNNER_TEMP/report-after.log"
   if grep 'unavailable to the agent:' "$RUNNER_TEMP/report-after.log" | grep -q tend-probe; then
     echo "::error::sandbox_setup did not close the tool gap"

--- a/proxy/test-setup-sandbox.sh
+++ b/proxy/test-setup-sandbox.sh
@@ -63,9 +63,11 @@ setup() {
   # shellcheck disable=SC2088
   export TEND_SANDBOX_PATH="$GITHUB_WORKSPACE/.tend-explicit/bin"$'\n~/.tend-tilde/bin'
   # `sandbox_env` reserves the credential and routing names, not the GITHUB_*
-  # context, so this entry is accepted and lands in $AGENT_ENV_FILE — earlier on
-  # the `env` line than the context array. verify()'s workflow-name grep is what
-  # holds the array in its trailing position: swap the two and this value wins.
+  # context, so this entry is accepted and lands in $AGENT_ENV_FILE. That the
+  # real workflow name then beats it is lib/sandbox-launch-env.sh's
+  # postcondition, unit-tested there; what this adds is the whole path — a
+  # config value threaded through setup-sandbox.sh into the file, composed by
+  # the lib, landing in a real sandbox under a real uid.
   export TEND_SANDBOX_ENV="GITHUB_WORKFLOW=spoofed-by-sandbox-env"
   MITMPROXY_VERSION=$(yq -e '.inputs.mitmproxy_version.default' claude/action.yaml)
   export MITMPROXY_VERSION
@@ -133,12 +135,12 @@ verify() {
       ;;
   esac
 
-  # Both halves of the set lib/gha-context-env.sh defines, asserted from inside
-  # the sandbox. `test -n` on the carried names so an empty value fails here
-  # rather than passing the grep below vacuously; GITHUB_ENV for the withheld
-  # ones, non-vacuous because Actions sets it on the runner. The env file's
-  # dummy token must survive a real one on the runner, so this call supplies a
-  # distinct value and the sandbox asserts it still sees the file's.
+  # Both halves of the set lib/sandbox-launch-env.sh defines, asserted from
+  # inside the sandbox. `test -n` on the carried names so an empty value fails
+  # here rather than passing the grep below vacuously; GITHUB_ENV for the
+  # withheld ones, non-vacuous because Actions sets it on the runner. The env
+  # file's dummy token must survive a real one on the runner, so this call
+  # supplies a distinct value and the sandbox asserts it still sees the file's.
   dummy_token=$(sed -n 's/^GITHUB_TOKEN=//p' "$AGENT_ENV_FILE")
   test -n "$dummy_token"
   test -n "$GITHUB_ENV"

--- a/shared/steps/lib/gha-context-env.sh
+++ b/shared/steps/lib/gha-context-env.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# The GitHub context handed to the sandbox user. Sourced, not executed.
+#
+# Every step that hands the sandbox an environment does so through
+# `sudo -u "$SANDBOX" env`: `env_reset` drops the runner's, so only the names on
+# that line reach the child. The two crossings that put the ADOPTER's code on
+# the far side share this definition — the agent launch (claude/action.yaml) and
+# their `sandbox_setup:` commands (sandbox-setup.sh) — so a `sandbox_setup:`
+# command can gate an install on the variable the skill it installs for will
+# read. The crossings that run tend's own code take none. Which side of that
+# line a new crossing falls on is who wrote what runs there, not how much
+# context looks useful.
+#
+# Pass GITHUB_* through as a denylist rather than an explicit allowlist: most
+# GITHUB_* vars are informational (GITHUB_ACTOR, GITHUB_API_URL,
+# GITHUB_REF_NAME, GITHUB_WORKSPACE, …) and a denylist picks up future
+# additions automatically. Skills depend on them for run-self-reference (branch
+# names, gist headings, dedup of own check runs) and owner-correct URL
+# construction. Apart from the exclusions below, every GITHUB_* Actions defines
+# is public rather than a secret; a GITHUB_*-named variable an adopter's
+# `setup:` step writes to $GITHUB_ENV crosses on the same rule, so a secret must
+# not be given a GITHUB_* name. Exclude:
+#   GITHUB_TOKEN — the agent env file carries a dummy; the real PAT lives in
+#     the proxy. (The file's dummy must not be overridden, so the denylist
+#     entry is load-bearing.)
+#   GITHUB_{ENV,PATH,OUTPUT,STATE,STEP_SUMMARY} — paths the runner re-reads
+#     after the step exits; the sandbox must not be handed a channel into
+#     later steps' env / PATH / outputs / job summary.
+
+# gha_context_env — set GHA_CONTEXT_ENV to the NAME=VALUE arguments for the
+# `sudo … env` that crosses the boundary. It reads the environment at call
+# time, so call it in the step that forwards it, and place the array LAST on
+# that command line: `env` takes the final assignment of a name, so a trailing
+# position keeps an adopter's `sandbox_env:` from displacing the real context
+# with a value of its own.
+gha_context_env() {
+  local name
+  GHA_CONTEXT_ENV=()
+  while IFS= read -r name; do
+    case "$name" in
+      GITHUB_TOKEN | GITHUB_ENV | GITHUB_PATH | GITHUB_OUTPUT | GITHUB_STATE | GITHUB_STEP_SUMMARY)
+        continue
+        ;;
+    esac
+    GHA_CONTEXT_ENV+=("$name=${!name}")
+  done < <(compgen -e | grep '^GITHUB_')
+}

--- a/shared/steps/lib/sandbox-launch-env.sh
+++ b/shared/steps/lib/sandbox-launch-env.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
-# The GitHub context handed to the sandbox user. Sourced, not executed.
+# The environment the sandbox user is launched with. Sourced, not executed.
 #
 # Every step that hands the sandbox an environment does so through
 # `sudo -u "$SANDBOX" env`: `env_reset` drops the runner's, so only the names on
 # that line reach the child. The two crossings that put the ADOPTER's code on
-# the far side share this definition — the agent launch (claude/action.yaml) and
+# the far side build that line here — the agent launch (claude/action.yaml) and
 # their `sandbox_setup:` commands (sandbox-setup.sh) — so a `sandbox_setup:`
 # command can gate an install on the variable the skill it installs for will
-# read. The crossings that run tend's own code take none. Which side of that
-# line a new crossing falls on is who wrote what runs there, not how much
-# context looks useful.
+# read. The crossings that run tend's own code take no GitHub context. Which
+# side of that line a new crossing falls on is who wrote what runs there, not
+# how much context looks useful.
 #
 # Pass GITHUB_* through as a denylist rather than an explicit allowlist: most
 # GITHUB_* vars are informational (GITHUB_ACTOR, GITHUB_API_URL,
@@ -27,21 +27,31 @@
 #     after the step exits; the sandbox must not be handed a channel into
 #     later steps' env / PATH / outputs / job summary.
 
-# gha_context_env — set GHA_CONTEXT_ENV to the NAME=VALUE arguments for the
-# `sudo … env` that crosses the boundary. It reads the environment at call
-# time, so call it in the step that forwards it, and place the array LAST on
-# that command line: `env` takes the final assignment of a name, so a trailing
-# position keeps an adopter's `sandbox_env:` from displacing the real context
-# with a value of its own.
-gha_context_env() {
+# sandbox_launch_env <agent-env-file> — set SANDBOX_LAUNCH_ENV to the
+# NAME=VALUE arguments for `sudo -u "$SANDBOX" env`: the file's lines (proxy
+# routing, CA trust, dummy credentials, and the adopter's own `sandbox_env:`
+# additions), then the GitHub context.
+#
+# That order is the reason this composes both halves rather than handing back
+# the context alone. `env` takes the final assignment of a name, and the file is
+# the half an adopter writes, so the context has to follow it or a
+# `sandbox_env: {GITHUB_WORKFLOW: …}` would decide what the run thinks it is. As
+# two arrays that was a rule each caller had to remember; here it is the
+# function's postcondition. A caller may append names of its own afterwards —
+# they win, which is what tend's own BOT_*/TEND_* assignments want, since those
+# have to beat the file — provided none is GITHUB_*-named or a key the file
+# defines, which would put the context or the sandbox's routing back in play.
+#
+# Reads the environment when called, so call it in the step that forwards it.
+sandbox_launch_env() {
   local name
-  GHA_CONTEXT_ENV=()
+  mapfile -t SANDBOX_LAUNCH_ENV <"$1"
   while IFS= read -r name; do
     case "$name" in
       GITHUB_TOKEN | GITHUB_ENV | GITHUB_PATH | GITHUB_OUTPUT | GITHUB_STATE | GITHUB_STEP_SUMMARY)
         continue
         ;;
     esac
-    GHA_CONTEXT_ENV+=("$name=${!name}")
+    SANDBOX_LAUNCH_ENV+=("$name=${!name}")
   done < <(compgen -e | grep '^GITHUB_')
 }

--- a/shared/steps/sandbox-setup.sh
+++ b/shared/steps/sandbox-setup.sh
@@ -23,8 +23,8 @@
 set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-# shellcheck source=lib/gha-context-env.sh
-. "${SCRIPT_DIR}/lib/gha-context-env.sh"
+# shellcheck source=lib/sandbox-launch-env.sh
+. "${SCRIPT_DIR}/lib/sandbox-launch-env.sh"
 
 if [ -n "${TEND_SANDBOX_SETUP:-}" ]; then
   # Run as the sandbox user with the agent's launch env. The commands go through
@@ -33,13 +33,13 @@ if [ -n "${TEND_SANDBOX_SETUP:-}" ]; then
   # installer prompt, `read` — can't swallow the remaining lines and exit 0).
   # `-e` inside so a failing setup command fails the step loudly rather than
   # silently proceeding to the run.
-  # `sudo env` replaces the environment with only what is listed, so the
-  # GITHUB_* context is re-passed from lib/gha-context-env.sh: one
-  # `sandbox_setup:` block runs for every workflow and event, and a command
-  # scopes itself with $GITHUB_WORKFLOW or $GITHUB_EVENT_NAME.
-  mapfile -t AGENT_ENV <"$AGENT_ENV_FILE"
-  gha_context_env
-  sudo -u "$SANDBOX" env "${AGENT_ENV[@]}" "${GHA_CONTEXT_ENV[@]}" \
+  # `sudo env` replaces the environment with only what is listed, so the launch
+  # env is rebuilt from lib/sandbox-launch-env.sh — the same composition the
+  # agent gets, GITHUB_* context included: one `sandbox_setup:` block runs for
+  # every workflow and event, and a command scopes itself with $GITHUB_WORKFLOW
+  # or $GITHUB_EVENT_NAME.
+  sandbox_launch_env "$AGENT_ENV_FILE"
+  sudo -u "$SANDBOX" env "${SANDBOX_LAUNCH_ENV[@]}" \
     bash -eo pipefail -c "$TEND_SANDBOX_SETUP"
   echo "[sandbox-setup] ran adopter sandbox_setup commands as $SANDBOX"
 fi

--- a/shared/steps/sandbox-setup.sh
+++ b/shared/steps/sandbox-setup.sh
@@ -18,9 +18,13 @@
 #
 # Inputs (env): TEND_SANDBOX_SETUP (the commands; empty → the report only),
 # SANDBOX, AGENT_ENV_FILE, AGENT_PATH and TEND_BLOCKED_PATH (exported by
-# setup-sandbox.sh via $GITHUB_ENV), GITHUB_WORKFLOW from Actions.
+# setup-sandbox.sh via $GITHUB_ENV), plus the GITHUB_* context from Actions.
 # Used by the Claude harness action.
 set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib/gha-context-env.sh
+. "${SCRIPT_DIR}/lib/gha-context-env.sh"
 
 if [ -n "${TEND_SANDBOX_SETUP:-}" ]; then
   # Run as the sandbox user with the agent's launch env. The commands go through
@@ -29,14 +33,13 @@ if [ -n "${TEND_SANDBOX_SETUP:-}" ]; then
   # installer prompt, `read` — can't swallow the remaining lines and exit 0).
   # `-e` inside so a failing setup command fails the step loudly rather than
   # silently proceeding to the run.
-  # `sudo env` replaces the environment with only what is listed. GITHUB_WORKFLOW
-  # is named so it carries across. One `sandbox_setup:` block runs for every
-  # workflow, and a command scopes itself to one by its name — the same string a
-  # runner-side `setup:` step matches with `if: github.workflow == '…'`. It goes
-  # last because `env` takes the final assignment of a name, so an adopter's
-  # `sandbox_env:` cannot displace it.
+  # `sudo env` replaces the environment with only what is listed, so the
+  # GITHUB_* context is re-passed from lib/gha-context-env.sh: one
+  # `sandbox_setup:` block runs for every workflow and event, and a command
+  # scopes itself with $GITHUB_WORKFLOW or $GITHUB_EVENT_NAME.
   mapfile -t AGENT_ENV <"$AGENT_ENV_FILE"
-  sudo -u "$SANDBOX" env "${AGENT_ENV[@]}" GITHUB_WORKFLOW="$GITHUB_WORKFLOW" \
+  gha_context_env
+  sudo -u "$SANDBOX" env "${AGENT_ENV[@]}" "${GHA_CONTEXT_ENV[@]}" \
     bash -eo pipefail -c "$TEND_SANDBOX_SETUP"
   echo "[sandbox-setup] ran adopter sandbox_setup commands as $SANDBOX"
 fi


### PR DESCRIPTION
`sandbox_setup:` runs the adopter's own commands, as the sandbox user, in the agent's launch env, immediately before the agent starts. The agent has always received the runner's `GITHUB_*` context across that UID boundary minus a six-name denylist; `sandbox_setup:` received one name of it, because #1057 named the one name its case needed and said extraction was the fix when a second case asked. That left an arbitrary one-item allowlist beside a crossing otherwise governed by a rule, so the step that prepares a session could not answer questions the session can.

`shared/steps/lib/sandbox-launch-env.sh` now holds `sandbox_launch_env <agent-env-file>`, and both crossings that carry adopter-written code source it. Which side of that line a crossing falls on is who wrote the code on the far side: `install-tend-plugins.sh` runs tend's own code from a marketplace already copied to local disk and takes no context.

The function composes the whole launch env rather than handing back the context alone, because the order is the load-bearing part. `env` takes the final assignment of a name and the env file is the half an adopter writes (`sandbox_env:`), so the context has to follow it or a `sandbox_env: {GITHUB_WORKFLOW: …}` decides what the run thinks it is. As two arrays that was a rule both call sites had to remember; here it is the function's postcondition, and a unit test holds it. The inverse is forced the same way: tend's `TEND_*`/`BOT_*`/`CI` assignments must beat the env file, since `TEND_*` is not in `RESERVED_SANDBOX_ENV` and `sandbox_env: {TEND_PROMPT: …}` would otherwise set the agent's prompt.

Two things the denylist's comment claimed turned out to need saying more carefully, and this file is now their only home. `GITHUB_TOKEN` is excluded but is not *withheld* from an adopter's point of view — `proxy/inject_credentials.py` rewrites `Authorization` to the real PAT for GitHub hosts, so a `sandbox_setup:` command's `gh` authenticates. And "all are public values, not secrets" holds for what Actions defines, not for a `GITHUB_*`-named variable an adopter's `setup:` step writes to `$GITHUB_ENV`, which crosses on the same rule — so a secret must not be given a `GITHUB_*` name. Both are stated in the lib and in `tend.example.yaml`.

## Motivating case

A `sandbox_setup:` block scoping work to a scheduled run. `$GITHUB_EVENT_NAME` never crossed, so the test compared against an empty string, the `if` silently took the else branch, and the failure surfaced later as a missing tool with an unrelated-looking error:

```yaml
sandbox_setup:
  - 'if [ "$GITHUB_WORKFLOW" = tend-weekly ]; then nix --version; fi'    # worked
  - 'if [ "$GITHUB_EVENT_NAME" = schedule ]; then ./warm-cache.sh; fi'   # never fired
```

Both work now, along with `$GITHUB_REPOSITORY`, `$GITHUB_REF_NAME`, `$GITHUB_BASE_REF` and the rest.

## Invariants that were stated and unasserted

Three, of which two were reachable by a wrong edit and one by a wrong deletion.

**The denylist's names.** `proxy/test-setup-sandbox.sh` represented all five withheld paths with `GITHUB_ENV` alone, so dropping `GITHUB_STEP_SUMMARY` from the `case` passed everything. So did dropping the `_` from `^GITHUB_`, which is the mutation with a direction: it would carry an adopter's `GITHUBBER_TOKEN` across the boundary. Five unit tests pin both sides.

**The composition order**, at unit level and again over the single backslash-continued `sudo -u "$SANDBOX" env` command at each crossing — scoped to the command rather than to file order, since "later in this argv" is what decides who wins. That second test also asserts the array is both filled and splatted, either of which nothing caught before: bash expands `"${arr[@]}"` on an unset array to nothing and exits 0, `set -u` included, so losing the composing call is not an error the shell reports — the crossing would launch with no PATH, no proxy routing, no CA trust and no credentials.

**Every `${{ github.action_path }}/…` reference in both composite actions.** Nothing checked these at all: the pre-commit `actionlint` hook is pinned to `^\.github/workflows/`, so neither `action.yaml` is linted, and no workflow consumes them with `uses: ./`, so an edited body first executes in an adopter's job after a release.

<details>
<summary>Verification beyond the suite</summary>

A 12-mutation matrix, all caught, baseline green: dropping `GITHUB_STEP_SUMMARY`; dropping `GITHUB_TOKEN`; `grep 'GITHUB_'` unanchored; `grep '^GITHUB'` with the `_` dropped; the denylist inverted to an allowlist; unquoting the array append; mistyping the lib path in `claude/action.yaml`; composing the file after the context; deleting the splat at either crossing; appending a `GITHUB_*` assignment at either.

A vacuity check with the test helper's `PATH` pointed at `/nonexistent`, where all five unit tests fail — none passes when the code under test never ran. An earlier version of one of them did: its `== []` was satisfied by total failure, and it survived both review and the mutation matrix, because both assume the code executed.

An end-to-end rehearsal of the real `shared/steps/sandbox-setup.sh` under a `sudo` stand-in that strips `-u <user>` then `exec env -i "$@"`, emulating `env_reset`: the full context reaches the sandbox, `GITHUB_ENV`/`GITHUB_STEP_SUMMARY` are withheld, the env file's dummy token survives a distinct runner-side `GITHUB_TOKEN`, a `sandbox_env` spoof of `GITHUB_WORKFLOW` loses to the real value, a non-matching workflow gate skips at exit 0, and a matching gate whose tool is missing exits 1.

</details>

## Gaps

`proxy/test-setup-sandbox.sh` needs a Linux runner with a second uid and sudo, so it has never executed against these changes — the `test-sandbox` job here is its first real run. And nothing anywhere executes `claude/action.yaml`'s Run Claude block: this repo's CI does not, and the two tests covering it are static assertions over its text. That gap is the reason both of those tests exist, and retiring them would mean a smoke job that runs the composite end to end — worth doing, larger than this.

Which crossings take the context is still convention. The composition order is a postcondition; a new crossing has nothing forcing it to call this.

> _This was written by Claude Code on behalf of max-sixty_

