### PR TITLE
skills(running-in-ci): route a generic correction upstream, not to the consumer overlay

### DIFF
--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -497,7 +497,9 @@ Read logs, code, and API data before drawing conclusions. Show evidence: cite lo
 
 ## Learning from Feedback
 
-When a maintainer corrects the bot's behavior during a run — a repo convention, a repeated mistake, a preference the bot should have known — propose a follow-up PR against the consuming repo's `.claude/skills/running-tend/SKILL.md`, turning a one-off correction into durable guidance for future runs in *this* repo. Follow `references/skill-pr-workflow.md`: it carries the bar the feedback has to clear, when the fix belongs in tend instead, and the branch/PR mechanics. Open the PR and exit — don't merge, don't wait, don't ping for review.
+When a maintainer corrects the bot's behavior during a run — a repo convention, a repeated mistake, a preference the bot should have known — turn the correction into durable guidance. Route it before you write it: **would every tend consumer want this rule?** If yes it belongs in tend's bundled skills — a PR when this repo *is* tend, otherwise an issue there per **Other Repos**. A bundled skill that is silent on the behavior is a gap upstream, not a signal the rule is local; nor is an upstream fix that has merged but not yet reached the pinned release. The overlay at `.claude/skills/running-tend/SKILL.md` is for what is true of this repo alone: its branch and landing conventions, its test topology, its trackers and labels, its standing exceptions.
+
+Follow `references/skill-pr-workflow.md`: it carries the bar the feedback has to clear, the routing signals in full, and the branch/PR mechanics. Open the PR and exit — don't merge, don't wait, don't ping for review.
 
 ## Tone
 

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -499,7 +499,7 @@ Read logs, code, and API data before drawing conclusions. Show evidence: cite lo
 
 When a maintainer corrects the bot's behavior during a run — a repo convention, a repeated mistake, a preference the bot should have known — turn the correction into durable guidance. Route it before you write it: **would every tend consumer want this rule?** If yes it belongs in tend's bundled skills — a PR when this repo *is* tend, otherwise an issue there per **Other Repos**. A bundled skill that is silent on the behavior is a gap upstream, not a signal the rule is local; nor is an upstream fix that has merged but not yet reached the pinned release. The overlay at `.claude/skills/running-tend/SKILL.md` is for what is true of this repo alone: its branch and landing conventions, its test topology, its trackers and labels, its standing exceptions.
 
-Follow `references/skill-pr-workflow.md`: it carries the bar the feedback has to clear, the routing signals in full, and the branch/PR mechanics. Open the PR and exit — don't merge, don't wait, don't ping for review.
+Follow `references/skill-pr-workflow.md`: it carries the bar the feedback has to clear, the routing signals in full, and the branch/PR mechanics. Open it — PR or issue — and exit: don't merge, don't wait, don't ping for review.
 
 ## Tone
 

--- a/plugins/tend-ci-runner/skills/running-in-ci/references/skill-pr-workflow.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/references/skill-pr-workflow.md
@@ -57,7 +57,11 @@ issues** in `other-repos.md`. Running on tend itself, it means a PR here.
 
 ## Mechanics
 
-For the overlay path. An upstream fix follows `other-repos.md` instead.
+For the overlay path, and for an upstream PR on tend itself — with the bundled
+skill file as step 2's dedup target, and without step 3's read-only-mount
+workaround, since bundled skills live under `plugins/` rather than
+`.claude/skills/`. Filing upstream from a consumer repo follows
+`other-repos.md` instead.
 
 1. **Complete the current task first.** The skill update is always a separate
    PR.

--- a/plugins/tend-ci-runner/skills/running-in-ci/references/skill-pr-workflow.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/references/skill-pr-workflow.md
@@ -1,8 +1,8 @@
 # Opening a skill PR from CI
 
 Turning a maintainer's correction into durable guidance: whether it clears the
-bar, and the mechanics of proposing it against the consuming repo's
-`.claude/skills/running-tend/SKILL.md`.
+bar, whether it lands upstream in tend or in the consuming repo's
+`.claude/skills/running-tend/SKILL.md`, and the mechanics of proposing it.
 
 ## Whether to propose
 
@@ -24,20 +24,40 @@ Signals pointing at a generalizable rule: the correction names a pattern
 rather than a task detail, or references a repo convention ("we use
 conventional commits", "PRs go to `develop`").
 
-Don't propose when the feedback is task-specific, when a bundled tend skill
-already covers the lesson (that changes through a PR against tend — see
-**Filing issues** in `other-repos.md`), when confidence that it
+Don't propose when the feedback is task-specific, when confidence that it
 generalizes is low (ask instead), or when it comes from a non-maintainer —
 check `author_association`. Non-maintainers can raise preferences, but only a
 maintainer authorizes codifying them; note the pattern in a reply and let one
 confirm.
 
-When the correction identifies a gap in a **bundled** skill — the same root
-cause would fire in every tend consumer — the fix belongs in tend rather than
-the overlay. Signals: the fix reads as generic guidance any consumer would
-want, and the corrected behavior comes from bundled skill text.
+## Where it lands
+
+Settle the destination before drafting a line, and settle it on one question:
+**would every tend consumer want this rule?** If yes it belongs in tend's
+bundled skills, and what the bundled text currently says doesn't change that:
+
+- **Bundled text is wrong or unclear** — fix it upstream.
+- **Bundled text is silent** — the same gap, usually a wider one, since
+  nothing is enforcing the rule for any consumer. Silence is not evidence the
+  rule is local; it is the commonest reason a maintainer had to correct
+  generic behavior in the first place.
+- **The rule is already merged upstream, but not in the pinned release** — the
+  fix is a release, not a local copy. The lag is temporary and overlay text is
+  permanent: once the release ships, every consumer that forked the rule
+  carries a duplicate someone has to notice and delete, and until then the two
+  copies drift.
+
+The overlay is for what is true of one repo alone — its branch and landing
+conventions, its test topology, its trackers and labels, its standing
+exceptions. A rule that reads as generic guidance goes upstream even when
+writing it locally would be quicker.
+
+From a consumer repo, upstream means an issue on tend, filed per **Filing
+issues** in `other-repos.md`. Running on tend itself, it means a PR here.
 
 ## Mechanics
+
+For the overlay path. An upstream fix follows `other-repos.md` instead.
 
 1. **Complete the current task first.** The skill update is always a separate
    PR.


### PR DESCRIPTION
## Problem

**Learning from Feedback** in `running-in-ci` opens by naming the destination — "propose a follow-up PR against the consuming repo's `.claude/skills/running-tend/SKILL.md`" — so a session that has already decided the correction clears the bar never re-opens the question of where it belongs. The upstream alternative sat two levels down in `references/skill-pr-workflow.md`, and it was conditioned on bundled text existing: "the fix reads as generic guidance any consumer would want, **and** the corrected behavior comes from bundled skill text." That conjunction fails exactly when a bundled skill is silent, which is the commonest reason a maintainer has to correct generic behavior at all. Nothing addressed the third case either: an upstream fix that has merged but not yet reached the consumer's pinned release, which reads as license to write a local copy that outlives the lag.

## Solution

Docs only, in the two files.

- `running-in-ci` → **Learning from Feedback** now leads with the routing question ("would every tend consumer want this rule?") rather than the destination, states that bundled silence and an unreleased upstream fix are both gaps upstream, and describes the overlay by what actually belongs in it — branch and landing conventions, test topology, trackers and labels, standing exceptions.
- `skill-pr-workflow.md` gains a **Where it lands** section that splits the old conjunction into three cases (bundled text wrong, bundled text silent, rule merged but unreleased) and names the upstream path per repo: an issue on tend from a consumer, a PR when running on tend itself. The stale routing clause in **Whether to propose** is dropped so the bar and the destination stop competing, and **Mechanics** is marked as the overlay path.

## Testing

No behavioral code changed; skill prose has no test to fail. `uvx pre-commit run --files <the two files>` passes (typos, trailing whitespace, the plugin-skill backtick check, and the install-tend reference sync).

---
Closes #1061 — automated triage
