### PR TITLE
docs: name shared/steps/ in the lists of suites root pytest collects

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -29,10 +29,10 @@ server = "wt step tether -C site -- npm run dev -- --port {{ branch | hash_port 
 url = "http://localhost:{{ branch | hash_port }}"
 
 # `wt test` is the whole suite: one pytest from the repo root covers every
-# Python test (generator/, proxy/, the install-tend scripts), and worker/ runs
-# its vitest suite and typecheck. Arguments narrow pytest (`wt test -k render`)
-# and nothing else — every step still runs, so reach for `uv run pytest` when
-# the Python half is all you want.
+# Python test (generator/, proxy/, shared/steps/, the install-tend scripts),
+# and worker/ runs its vitest suite and typecheck. Arguments narrow pytest
+# (`wt test -k render`) and nothing else — every step still runs, so reach for
+# `uv run pytest` when the Python half is all you want.
 #
 # One command per block makes each child finish and get reaped before the next
 # starts. A step's failure stops the blocks after it.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,9 +5,10 @@ on:
   pull_request:
 
 jobs:
-  # Every Python test in the repo — pytest collects generator/, proxy/, and the
-  # install-tend scripts from the root — in the root workspace's environment,
-  # whose dev group holds the pinned mitmproxy the proxy addon imports.
+  # Every Python test in the repo — pytest collects generator/, proxy/,
+  # shared/steps/, and the install-tend scripts from the root — in the root
+  # workspace's environment, whose dev group holds the pinned mitmproxy the
+  # proxy addon imports.
   test:
     runs-on: ubuntu-24.04
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ pre-commit run --all-files         # lint: ruff, typos, actionlint, shellcheck, 
 ```
 
 The repo root is a uv workspace, and pytest run from it collects every Python
-test — generator/, proxy/, and the install-tend scripts — so one `pytest` is
+test — generator/, proxy/, shared/steps/, and the install-tend scripts — so one `pytest` is
 the whole Python run. `wt test` (defined in [`.config/wt.toml`](.config/wt.toml))
 adds worker/'s vitest suite and typecheck. Its arguments narrow pytest and
 nothing else, so a filtered run still pays for worker/; `uv run pytest -k render`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,10 +30,11 @@ pre-commit run --all-files         # lint: ruff, typos, actionlint, shellcheck, 
 ```
 
 The repo root is a uv workspace, and pytest run from it collects every Python
-test — generator/, proxy/, shared/steps/, and the install-tend scripts — so one `pytest` is
-the whole Python run. `wt test` (defined in [`.config/wt.toml`](.config/wt.toml))
-adds worker/'s vitest suite and typecheck. Its arguments narrow pytest and
-nothing else, so a filtered run still pays for worker/; `uv run pytest -k render`
+test — generator/, proxy/, shared/steps/, and the install-tend scripts — so
+one `pytest` is the whole Python run. `wt test` (defined in
+[`.config/wt.toml`](.config/wt.toml)) adds worker/'s vitest suite and
+typecheck. Its arguments narrow pytest and nothing else, so a filtered run
+still pays for worker/; `uv run pytest -k render`
 is the Python half on its own.
 
 ## Architecture

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,12 +3,12 @@
 # every Python suite in the repo shares one environment, which makes plain
 # `uv run pytest` from the repo root the whole Python test run: pytest needs no
 # config of its own, since collecting from the root reaches generator/, proxy/,
-# and the install-tend scripts, and its default `norecursedirs` already skips
-# node_modules and dot-dirs. proxy/, shared/steps/ and the install-tend scripts
-# dir aren't packages, so pytest's prepend import mode names their test modules
-# by basename alone — keep those basenames distinct or collection aborts, and
-# never `from conftest import …` (two dirs have one; shared/steps/_fakes.py is
-# the importable home for its doubles).
+# shared/steps/, and the install-tend scripts, and its default `norecursedirs`
+# already skips node_modules and dot-dirs. proxy/, shared/steps/ and the
+# install-tend scripts dir aren't packages, so pytest's prepend import mode
+# names their test modules by basename alone — keep those basenames distinct or
+# collection aborts, and never `from conftest import …` (two dirs have one;
+# shared/steps/_fakes.py is the importable home for its doubles).
 #
 # The floor is 3.12 because mitmproxy needs it; the published package still
 # supports 3.11 (see generator/pyproject.toml), which nothing here can lower.


### PR DESCRIPTION
## Problem

Four live files enumerate the suites a root `uv run pytest` collects, and all four still describe the pre-port set — "generator/, proxy/, and the install-tend scripts". The bash→Python port of the composite-action step bodies (`9a330b8`, `374f1b1`) added a fifth directory, `shared/steps/`, whose `test_*.py` files contribute 164 of the 717 tests the root run now collects, about 23% of the Python suite.

Those lists are the repo's own statement of what one `pytest` covers, and a session reading any of them comes away thinking the step bodies — the security preflight, the rate-limit gate, the agent supervisor, the outage tracker — are tested somewhere else, or not at all. `pyproject.toml`'s is the sharpest case: it's the file that configures the collection, and its comment contradicts itself two lines apart, naming `shared/steps/` in the sentence right after the list that omits it.

## Fix

Add `shared/steps/` to all four, and reflow the paragraphs that the added words pushed past their files' wrap width.

- [`CLAUDE.md`](https://github.com/max-sixty/tend/blob/7a7a34c/CLAUDE.md#L32-L38) — the Commands section
- [`pyproject.toml`](https://github.com/max-sixty/tend/blob/7a7a34c/pyproject.toml#L1-L11) — the workspace-root header comment
- [`.github/workflows/ci.yaml`](https://github.com/max-sixty/tend/blob/7a7a34c/.github/workflows/ci.yaml#L8-L11) — the comment above the `test:` job
- [`.config/wt.toml`](https://github.com/max-sixty/tend/blob/7a7a34c/.config/wt.toml#L31-L35) — the comment above `[[aliases.test]]`

`CHANGELOG.md`'s [#977](https://github.com/max-sixty/tend/pull/977) entry carries the same list and is left alone — it records what was true at that release.

## Verification

```
$ uv run pytest --collect-only -q | grep -c '^shared/steps'
164
$ uv run pytest -q
717 passed
```

That run was from the first commit's session; `uv` isn't on the PATH in this repo's agent sandbox, so the follow-up commit's verification is CI's own `test` job. Every change in it is a comment or prose line — no Python, no YAML key, no `wt` step body — and nothing under `generator/tests` or `shared/steps` asserts on these strings (`grep -rn 'install-tend scripts\|Every Python test' --include='*.py'` is empty).

No regression test: the change is a noun in four documentation lists. A test tying those sentences to the set of directories pytest actually collects is the kind of machinery `CLAUDE.md` itself rules out — complexity earns its place by preventing a wrong outward action, and a stale doc sentence is not one.
