### PR TITLE
skills(review-runs): make the run census a second input to the stranded-trigger drain

### DIFF
--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -211,12 +211,21 @@ After retrieving the timeout cap from the workflow file, flag any job whose dura
 A run that fails files a row on a `tend-outage`-labelled **"Bot temporarily unavailable"** issue, naming the run and the trigger it stranded. Nothing re-runs those triggers — `tend-review` fires only on `pull_request_target`, so a PR whose one review attempt died stays unreviewed until someone pushes. Drain the open issue as part of this sweep.
 
 ```bash
-# Usually empty; no open outage issue means nothing stranded.
+# Usually empty. An empty issue is not evidence nothing was stranded — see below.
 OUTAGE=$(gh issue list --state open --label tend-outage --json number,title \
   --jq '[.[] | select(.title == "Bot temporarily unavailable")][0].number // empty')
 gh issue view "$OUTAGE" --json body,comments --jq '.body, .comments[].body' \
   | grep -oE 'runs/[0-9]+|\| #[0-9]+'
 ```
+
+**The census is the second drain input, and it is the one that catches the worst cases.** The outage row is written by a step *inside* the failing job, so a run that died before reaching that step files nothing and uploads no session log — a `startup_failure` runs zero steps, and a job that never gets a runner, a wedged `actions/checkout`, or a failing `setup:` step die earlier still. They strand the same triggers, and nothing else on the record ever names them. Step 1's census already carries every run's `conclusion`, so filter that rather than re-fetching:
+
+```bash
+# `skipped` is an `if:` gate declining to run, not a failure.
+jq -c 'select(.conclusion != "success" and .conclusion != "skipped")'
+```
+
+Zero billable time (`gh api "repos/$REPO/actions/runs/<run-id>/timing" --jq .billable`) plus no artifact is the signature of a run whose agent never started, so there is nothing to diagnose and the re-run test below is the whole decision.
 
 **Diagnose first.** The nightly enrichment comment names the cause when it can. When it doesn't, read the session log — quota exhaustion surfaces as a `<synthetic>` assistant message:
 
@@ -228,12 +237,13 @@ jq -r 'select(.type == "assistant") | .message.content[]?.text // empty' /tmp/ou
 
 A cluster of these is quota exhaustion, not a bug — don't open a fix PR. The reset in the message is an upper bound on the outage, not a schedule: a weekly limit can strand most of a day, and can also clear many hours early. Gate the drain on the clean-run check below, not on the stated reset.
 
-**Re-run only what won't recover.** Scheduled workflows (`nightly`, `notifications`, `weekly`, this one) recover on their next tick. For an event-triggered run, confirm the work is still missing — a later push often re-triggers it — and that a recent run completed cleanly, or the re-run just refills the issue. Re-running the bot's own failed workflow needs no maintainer approval.
+**Re-run only what won't recover.** Scheduled workflows (`nightly`, `notifications`, `weekly`, this one) recover on their next tick. For an event-triggered run, confirm the work is still missing — a later push often re-triggers it — and that a recent run completed cleanly, or the re-run just refills the issue. A `cancelled` run is usually the designed eviction rather than an outage: `cancel-in-progress: false` replaces the *queued* sibling when events burst on one thread, and the winning run answers the whole thread, so read the thread for that answer before re-running. What never recovers is an `issues`-event triage that died — nothing re-fires the event, and the notifications poll cannot see an issue the bot never touched. Re-running the bot's own failed workflow needs no maintainer approval.
 
 ```bash
 gh pr view <n> --json state,headRefOid,reviews \
   --jq '{state, headRefOid, reviewers: [.reviews[].author.login]}'
-gh run rerun <run-id> --failed
+# Not `--failed`: a run that never started has no failed job to select.
+gh run rerun <run-id>
 ```
 
 Close the issue once every row is drained (`gh issue close "$OUTAGE"`); one left open folds the next outage into a stale incident.

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -225,7 +225,7 @@ gh issue view "$OUTAGE" --json body,comments --jq '.body, .comments[].body' \
 jq -c 'select(.conclusion != "success" and .conclusion != "skipped")'
 ```
 
-Zero billable time (`gh api "repos/$REPO/actions/runs/<run-id>/timing" --jq .billable`) plus no artifact means the agent never started, so there is nothing to diagnose — but it does not on its own mean the run stranded anything, because a designed cancellation bills zero too. The trigger is the discriminator, so the re-run test below is the whole decision.
+A run whose agent never started shows it in the jobs endpoint: no jobs at all (`gh api "repos/$REPO/actions/runs/<run-id>/jobs" --jq .total_count` → `0`, the `startup_failure` shape), or a job with `runner_name: ""` and zero `steps` — a `skipped` job is zero-step too, but reports `runner_name: null`. There is nothing to diagnose in either case, and neither shape on its own means the run stranded anything, because a designed cancellation records the same zero steps. The trigger is the discriminator, so the re-run test below is the whole decision. Don't key on billable time: public repos aren't billed for Actions, so `.billable` reports zero on healthy runs too.
 
 **Diagnose first.** The nightly enrichment comment names the cause when it can. When it doesn't, read the session log — quota exhaustion surfaces as a `<synthetic>` assistant message:
 

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -225,7 +225,7 @@ gh issue view "$OUTAGE" --json body,comments --jq '.body, .comments[].body' \
 jq -c 'select(.conclusion != "success" and .conclusion != "skipped")'
 ```
 
-Zero billable time (`gh api "repos/$REPO/actions/runs/<run-id>/timing" --jq .billable`) plus no artifact is the signature of a run whose agent never started, so there is nothing to diagnose and the re-run test below is the whole decision.
+Zero billable time (`gh api "repos/$REPO/actions/runs/<run-id>/timing" --jq .billable`) plus no artifact means the agent never started, so there is nothing to diagnose — but it does not on its own mean the run stranded anything, because a designed cancellation bills zero too. The trigger is the discriminator, so the re-run test below is the whole decision.
 
 **Diagnose first.** The nightly enrichment comment names the cause when it can. When it doesn't, read the session log — quota exhaustion surfaces as a `<synthetic>` assistant message:
 
@@ -237,7 +237,7 @@ jq -r 'select(.type == "assistant") | .message.content[]?.text // empty' /tmp/ou
 
 A cluster of these is quota exhaustion, not a bug — don't open a fix PR. The reset in the message is an upper bound on the outage, not a schedule: a weekly limit can strand most of a day, and can also clear many hours early. Gate the drain on the clean-run check below, not on the stated reset.
 
-**Re-run only what won't recover.** Scheduled workflows (`nightly`, `notifications`, `weekly`, this one) recover on their next tick. For an event-triggered run, confirm the work is still missing — a later push often re-triggers it — and that a recent run completed cleanly, or the re-run just refills the issue. A `cancelled` run is usually the designed eviction rather than an outage: `cancel-in-progress: false` replaces the *queued* sibling when events burst on one thread, and the winning run answers the whole thread, so read the thread for that answer before re-running. What never recovers is an `issues`-event triage that died — nothing re-fires the event, and the notifications poll cannot see an issue the bot never touched. Re-running the bot's own failed workflow needs no maintainer approval.
+**Re-run only what won't recover.** Scheduled workflows (`nightly`, `notifications`, `weekly`, this one) recover on their next tick. For an event-triggered run, confirm the work is still missing — a later push often re-triggers it — and that a recent run completed cleanly, or the re-run just refills the issue. A `cancelled` run is usually the designed eviction rather than an outage: `cancel-in-progress: false` replaces the *queued* sibling when events burst on one thread, and the winning run answers the whole thread, so read the thread for that answer before re-running. Two triggers never recover: an `issues`-event triage that died, since nothing re-fires the event and the notifications poll cannot see an issue the bot never touched; and a `tend-ci-fix` run on a still-red default branch, since a later push re-fires it only if CI fails again and a red `main` is a branch people stop pushing to. Re-running the bot's own failed workflow needs no maintainer approval.
 
 ```bash
 gh pr view <n> --json state,headRefOid,reviews \

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -244,7 +244,7 @@ gh pr view <n> --json state,headRefOid,reviews \
   --jq '{state, headRefOid, reviewers: [.reviews[].author.login]}'
 ```
 
-**A re-run is not the recovery for every trigger.** Two never re-fire on their own, so a row whose re-run is unavailable or refused is drained by naming what would recover it, not by closing it:
+**A re-run is not the recovery for every trigger.** Only `schedule` re-fires unaided, so a row whose re-run is unavailable or refused is drained by naming what would recover it, not by closing it:
 
 | Stranded trigger | Recovery |
 |---|---|
@@ -256,14 +256,21 @@ gh pr view <n> --json state,headRefOid,reviews \
 **A re-run replays the workflow file from the original run's commit**, so it re-uses the action ref that commit pinned. Where the outage cause was an action-version regression, the fix ships as a pin bump on the default branch and every stranded run sits behind it by construction — the re-run reproduces the failure verbatim and files a fresh outage row, so the drain re-opens what it is draining. This is the shape where the drain looks safest, because the census does show a later clean run. Compare the refs first; if they differ, report the row as needing a fresh trigger instead of re-running it.
 
 ```bash
-WF=.github/workflows/<workflow>.yaml
-HEAD_SHA=$(gh api "repos/$REPO/actions/runs/<run-id>" --jq .head_sha)
-# The contents API, not `git show`: the runner's checkout is shallow, so the
-# stranded run's commit is usually not local. The working tree is the default
+# `.path` and `.head_sha` both come from the one runs call: the census names
+# the workflow, not its file, and guessing the file name from the name is what
+# the timeout-cap step above already warns against.
+read -r WF HEAD_SHA < <(gh api "repos/$REPO/actions/runs/<run-id>" --jq '"\(.path) \(.head_sha)"')
+# The contents API, not `git show`: the stranded run's commit may not be
+# reachable locally (fork head, deleted branch). Capture rather than piping
+# straight into `diff` — an unreadable file leaves both sides empty, and `diff`
+# then exits 0, which reads as a matching ref. The working tree is the default
 # branch, so it is the other side of the comparison.
-diff <(gh api "repos/$REPO/contents/$WF?ref=$HEAD_SHA" \
-         -H 'Accept: application/vnd.github.raw' | grep 'uses: max-sixty/tend/') \
-     <(grep 'uses: max-sixty/tend/' "$WF")
+if PINNED=$(gh api "repos/$REPO/contents/$WF?ref=$HEAD_SHA" \
+              -H 'Accept: application/vnd.github.raw' | grep 'uses: max-sixty/tend/'); then
+  diff <(echo "$PINNED") <(grep 'uses: max-sixty/tend/' "$WF")
+else
+  echo "$WF unreadable at $HEAD_SHA — needs a fresh trigger, not a re-run"
+fi
 ```
 
 **Exit 0 is not a dispatch.** A run that never got a runner has no attempt to replay: `gh run rerun` succeeds, `run_attempt` stays at 1, and `status` sits at `queued` indefinitely. That also drops the run out of the census — Step 1 fetches `status=completed`, so a run left queued never surfaces again and the false all-clear is permanent, which is worse than the original silence. Re-read the run afterwards and treat an unchanged `run_attempt` as *not drained*.
@@ -271,6 +278,9 @@ diff <(gh api "repos/$REPO/contents/$WF?ref=$HEAD_SHA" \
 ```bash
 # Not `--failed`: a run that never started has no failed job to select.
 gh run rerun <run-id>
+# Sleep before reading: the new attempt record takes a few seconds to surface,
+# so an immediate re-read reports attempt 1 on a re-run that did dispatch.
+sleep 30
 gh api "repos/$REPO/actions/runs/<run-id>" --jq '{status, conclusion, run_attempt}'
 ```
 

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -237,16 +237,44 @@ jq -r 'select(.type == "assistant") | .message.content[]?.text // empty' /tmp/ou
 
 A cluster of these is quota exhaustion, not a bug — don't open a fix PR. The reset in the message is an upper bound on the outage, not a schedule: a weekly limit can strand most of a day, and can also clear many hours early. Gate the drain on the clean-run check below, not on the stated reset.
 
-**Re-run only what won't recover.** Scheduled workflows (`nightly`, `notifications`, `weekly`, this one) recover on their next tick. For an event-triggered run, confirm the work is still missing — a later push often re-triggers it — and that a recent run completed cleanly, or the re-run just refills the issue. A `cancelled` run is usually the designed eviction rather than an outage: `cancel-in-progress: false` replaces the *queued* sibling when events burst on one thread, and the winning run answers the whole thread, so read the thread for that answer before re-running. Two triggers never recover: an `issues`-event triage that died, since nothing re-fires the event and the notifications poll cannot see an issue the bot never touched; and a `tend-ci-fix` run on a still-red default branch, since a later push re-fires it only if CI fails again and a red `main` is a branch people stop pushing to. Re-running the bot's own failed workflow needs no maintainer approval.
+**Re-run only what won't recover.** Scheduled workflows (`nightly`, `notifications`, `weekly`, this one) recover on their next tick. For an event-triggered run, confirm the work is still missing — a later push often re-triggers it — and that a recent run completed cleanly, or the re-run just refills the issue. A `cancelled` run is usually the designed eviction rather than an outage: `cancel-in-progress: false` replaces the *queued* sibling when events burst on one thread, and the winning run answers the whole thread, so read the thread for that answer before re-running. Re-running the bot's own failed workflow needs no maintainer approval.
 
 ```bash
 gh pr view <n> --json state,headRefOid,reviews \
   --jq '{state, headRefOid, reviewers: [.reviews[].author.login]}'
-# Not `--failed`: a run that never started has no failed job to select.
-gh run rerun <run-id>
 ```
 
-Close the issue once every row is drained (`gh issue close "$OUTAGE"`); one left open folds the next outage into a stale incident.
+**A re-run is not the recovery for every trigger.** Two never re-fire on their own, so a row whose re-run is unavailable or refused is drained by naming what would recover it, not by closing it:
+
+| Stranded trigger | Recovery |
+|---|---|
+| `schedule` | the next tick |
+| `pull_request_target` (review) | a push, or close-and-reopen — `reopened` is in the trigger's `types` |
+| `workflow_run` (ci-fix) | another failing run of the watched workflow; a push that turns CI green re-fires nothing, and a still-red default branch is one people stop pushing to |
+| `issues: opened` (triage) | nothing re-fires it, and the notifications poll cannot see an issue the bot never touched — an `@`-mention on the issue, or a human |
+
+**A re-run replays the workflow file from the original run's commit**, so it re-uses the action ref that commit pinned. Where the outage cause was an action-version regression, the fix ships as a pin bump on the default branch and every stranded run sits behind it by construction — the re-run reproduces the failure verbatim and files a fresh outage row, so the drain re-opens what it is draining. This is the shape where the drain looks safest, because the census does show a later clean run. Compare the refs first; if they differ, report the row as needing a fresh trigger instead of re-running it.
+
+```bash
+WF=.github/workflows/<workflow>.yaml
+HEAD_SHA=$(gh api "repos/$REPO/actions/runs/<run-id>" --jq .head_sha)
+# The contents API, not `git show`: the runner's checkout is shallow, so the
+# stranded run's commit is usually not local. The working tree is the default
+# branch, so it is the other side of the comparison.
+diff <(gh api "repos/$REPO/contents/$WF?ref=$HEAD_SHA" \
+         -H 'Accept: application/vnd.github.raw' | grep 'uses: max-sixty/tend/') \
+     <(grep 'uses: max-sixty/tend/' "$WF")
+```
+
+**Exit 0 is not a dispatch.** A run that never got a runner has no attempt to replay: `gh run rerun` succeeds, `run_attempt` stays at 1, and `status` sits at `queued` indefinitely. That also drops the run out of the census — Step 1 fetches `status=completed`, so a run left queued never surfaces again and the false all-clear is permanent, which is worse than the original silence. Re-read the run afterwards and treat an unchanged `run_attempt` as *not drained*.
+
+```bash
+# Not `--failed`: a run that never started has no failed job to select.
+gh run rerun <run-id>
+gh api "repos/$REPO/actions/runs/<run-id>" --jq '{status, conclusion, run_attempt}'
+```
+
+Close the issue once every row is drained (`gh issue close "$OUTAGE"`); one left open folds the next outage into a stale incident. A row whose re-run never dispatched, or whose recovery is a fresh trigger nobody has fired, is not drained — leave the issue open and name what each needs.
 
 ## Step 2: Token usage report
 


### PR DESCRIPTION
`review-runs`'s **Drain stranded triggers** read only the `tend-outage` issue, but that row is filed by [a step inside the failing job](https://github.com/max-sixty/tend/blob/6b09a62/claude/action.yaml#L391) — so a run that dies before reaching it files nothing, uploads no session log, and is invisible to the drain, while stranding the same trigger. This adds Step 1's census as a second drain input (it already carries every run's `conclusion`), and then fixes the remedy the drain reaches for once it has a row: a bare `gh run rerun` silently fails to drain in two distinct ways.

Reported independently by two consumer repos within a minute of each other — #1066 (`max-sixty/worktrunk`: a `startup_failure` on `issues: opened` left a maintainer's bug report untriaged for 21 h) and #1067 (`PRQL/prql`: a `tend-ci-fix` job that never got a runner left `main` red for 19 h 40 m). Both windows' drains reported "nothing stranded".

<details><summary>Why the census is the only surviving signal</summary>

`Report failure` in `claude/action.yaml` is gated on `failure()`, which covers everything from the rate-limit preflight onward — [#857](https://github.com/max-sixty/tend/pull/857) widened it for exactly that reason. What it cannot cover is a job in which *no step runs at all*: a `startup_failure` executes zero steps, and a job that never gets a runner, a wedged `actions/checkout`, or a failing adopter `setup:` step die before the action is entered. Those runs also upload no artifact, so the drain's "Diagnose first" session-log path has nothing to key on either.

Step 1's census emits `{databaseId, conclusion, createdAt, updatedAt, name}` per run over the same window, so the signal is already in hand — the skill just never told a session to use it for this. The filter is one `jq` line, so no new mechanism is introduced and nothing new is fetched.

The `cancelled` caveat is what keeps the new input from misfiring: with `cancel-in-progress: false`, a burst of events on one thread replaces the *queued* sibling, and the winning run answers the whole thread. Those runs record zero steps too, and re-running them would spam threads that already got their reply. The re-run test names that case.

</details>

<details><summary>Why <code>gh run rerun</code> is not the drain</summary>

Both failures were reported on #1066 by `max-sixty/worktrunk`'s next window and re-verified here against the live API.

**Exit 0 is not a dispatch.** A run that never got a runner has no attempt to replay. `gh run rerun` exits 0, `run_attempt` stays at 1, and `status` sits at `queued` — the stranded triage run from #1066's own report is still `{"status":"queued","run_attempt":1,"conclusion":null}` two days after its re-run was issued, and the issue it stranded still has no triage comment. This is worse than the original silence, because a queued run is not `completed`, so Step 1's census drops it and it never surfaces on a later window. The row reads as drained forever. The PR adds a `run_attempt` re-read after the re-run and says an unchanged value means not drained.

**A re-run replays the original commit's workflow file**, so it re-uses whatever action ref that commit pinned. Where the outage cause was an action-version regression, the fix ships as a pin bump on the default branch and every stranded run sits behind it by construction — the re-run reproduces the failure verbatim and files a fresh outage row, so the drain re-opens what it is draining. Verified for the runs stranded by the 0.1.19 `PATH` regression (#1071): their commit pins `max-sixty/tend/claude@0.1.19` while the default branch is on `0.1.20`. This is the shape where a re-run looks safest, because the census does show a later clean run. The PR adds the ref comparison before the re-run.

The per-trigger recovery table follows from the two: for `issues: opened` there is no re-run path at all, so a row is drained by naming what would recover it — a mention or a human — rather than by closing the issue.

</details>

## Testing

Markdown-only change to a bundled skill; no test reads this file's contents and no code path changes. The `uv` and `pre-commit` gates are not available inside the agent sandbox, so they went unrun locally — CI runs both on this PR. The two `gh api` recipes added here were run against the live runs they describe before being written down.

---
Closes #1066
Closes #1067
