### PR TITLE
skills: check the default branch for a landed fix before opening a PR

### DIFF
--- a/plugins/tend-ci-runner/skills/ci-fix/SKILL.md
+++ b/plugins/tend-ci-runner/skills/ci-fix/SKILL.md
@@ -49,7 +49,7 @@ gh issue list --state open --author "$BOT_LOGIN" --search "ci-fix: in:title" \
 
 ### 3. Create PR
 
-Re-check per **Dedup recheck immediately before `gh pr create`** in `running-in-ci` — against both sources. A sibling may have opened a fix PR while you worked, and the fix may have landed as a commit on the default branch your checkout predates. If the failure no longer reproduces on the fetched default branch, don't open the PR.
+Re-check per **Dedup recheck immediately before `gh pr create`** in `running-in-ci` — against both sources — and re-run step 1's PR query, which is author-agnostic where that section's is filtered to the bot's own PRs. A sibling or a maintainer may have opened a fix PR while you worked, and the fix may have landed as a commit on the default branch your checkout predates. If the failure no longer reproduces on the fetched default branch, don't open the PR.
 
 ```bash
 git checkout -b fix/ci-<run-id>

--- a/plugins/tend-ci-runner/skills/ci-fix/SKILL.md
+++ b/plugins/tend-ci-runner/skills/ci-fix/SKILL.md
@@ -49,7 +49,7 @@ gh issue list --state open --author "$BOT_LOGIN" --search "ci-fix: in:title" \
 
 ### 3. Create PR
 
-Re-check for existing fix PRs (one may have been created while you worked).
+Re-check per **Dedup recheck immediately before `gh pr create`** in `running-in-ci` — against both sources. A sibling may have opened a fix PR while you worked, and the fix may have landed as a commit on the default branch your checkout predates. If the failure no longer reproduces on the fetched default branch, don't open the PR.
 
 ```bash
 git checkout -b fix/ci-<run-id>

--- a/plugins/tend-ci-runner/skills/ci-fix/SKILL.md
+++ b/plugins/tend-ci-runner/skills/ci-fix/SKILL.md
@@ -49,7 +49,7 @@ gh issue list --state open --author "$BOT_LOGIN" --search "ci-fix: in:title" \
 
 ### 3. Create PR
 
-Re-check per **Dedup recheck immediately before `gh pr create`** in `running-in-ci` — against both sources — and re-run step 1's PR query, which is author-agnostic where that section's is filtered to the bot's own PRs. A sibling or a maintainer may have opened a fix PR while you worked, and the fix may have landed as a commit on the default branch your checkout predates. If the failure no longer reproduces on the fetched default branch, don't open the PR.
+Re-run step 1's author-agnostic PR query, then follow **Dedup recheck immediately before `gh pr create`** in `running-in-ci` to check for a fix committed to the default branch. If the failure no longer reproduces there, don't open the PR.
 
 ```bash
 git checkout -b fix/ci-<run-id>

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -188,6 +188,16 @@ gh pr list --state all --search "author:$BOT_LOGIN <issue-number>" \
 
 Compare by title keywords **and** the files the new PR would modify — two concurrent fixes for the same bug typically pick different branch names, so a branch-name match is not sufficient. If a sibling bot PR overlaps in scope — whether open, closed, or already merged — **do not create**: post a comment on the triggering thread linking the existing PR and exit.
 
+A competing fix doesn't have to be a PR, and no `gh pr list` can see one that isn't. Your checkout is from job start and is tens of minutes stale by the time you publish, so a fix that landed as a **commit** on the default branch is missing from the working tree *and* from every query above — and where the maintainer lands directly on the default branch rather than through PRs, a commit is the only form a competing fix ever takes. Read what arrived while you worked:
+
+```bash
+DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
+git fetch origin "$DEFAULT_BRANCH"
+git log --oneline "HEAD..origin/$DEFAULT_BRANCH"
+```
+
+If a commit in that range touches the code the PR would change, read it before creating. When the problem no longer reproduces on the fetched default branch, the right output is nothing — or a comment on the triggering thread, not a PR whose stated premise is already false.
+
 ### Fetch the prior rejection before re-deriving a fix
 
 A change a maintainer already turned down leaves its verdict in two places the checks above don't fetch: the closed PR that carried it, and the comments on the issue tracking it. Search by the symbol or path the change would edit — a finding re-derived from the code has no issue number, and an attempt predating the tracking issue cites none either — then read the closed hits and the issue bodies, not just their titles.

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -188,7 +188,7 @@ gh pr list --state all --search "author:$BOT_LOGIN <issue-number>" \
 
 Compare by title keywords **and** the files the new PR would modify — two concurrent fixes for the same bug typically pick different branch names, so a branch-name match is not sufficient. If a sibling bot PR overlaps in scope — whether open, closed, or already merged — **do not create**: post a comment on the triggering thread linking the existing PR and exit.
 
-A competing fix doesn't have to be a PR, and no `gh pr list` can see one that isn't. Your checkout is from job start and is tens of minutes stale by the time you publish, so a fix that landed as a **commit** on the default branch is missing from the working tree *and* from every query above — and where the maintainer lands directly on the default branch rather than through PRs, a commit is the only form a competing fix ever takes. Read what arrived while you worked:
+A fix may have landed directly on the default branch while you worked. Fetch it immediately before creating the PR:
 
 ```bash
 DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
@@ -196,7 +196,7 @@ git fetch origin "$DEFAULT_BRANCH"
 git log --oneline "HEAD..origin/$DEFAULT_BRANCH"
 ```
 
-If a commit in that range touches the code the PR would change, read it before creating. When the problem no longer reproduces on the fetched default branch, the right output is nothing — or a comment on the triggering thread, not a PR whose stated premise is already false.
+Inspect overlapping commits and reproduce the problem on the fetched default branch. If it is fixed, don't create the PR; comment on the triggering thread when it needs a response.
 
 ### Fetch the prior rejection before re-deriving a fix
 


### PR DESCRIPTION
A fix can land on the default branch while an agent is preparing a PR. The existing PR-only dedup check cannot see a direct commit, so the agent may publish a PR for a problem that is already fixed.

The final pre-publish check now fetches the default branch and inspects the commits that arrived since the checkout. `ci-fix` points to that canonical rule while retaining its author-agnostic PR query. If the failure no longer reproduces on the fetched branch, the agent does not open the PR.

Verification: pre-commit on both changed skill files, plus the three duplicate PRs documented in #1068.

Closes #1068
