### PR TITLE
Preserve setup-added tool paths in the Claude sandbox

### DIFF
--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -247,7 +247,7 @@ runs:
         # the agent env file. sandbox_setup (commands) runs in a later step.
         TEND_SANDBOX_PATH: ${{ inputs.sandbox_path }}
         TEND_SANDBOX_ENV: ${{ inputs.sandbox_env }}
-      run: PATH=/usr/sbin:/usr/bin:/sbin:/bin /usr/bin/bash "${{ github.action_path }}/../proxy/setup-sandbox.sh"
+      run: /usr/bin/env TEND_RUNNER_TOOL_PATH="$PATH" PATH=/usr/sbin:/usr/bin:/sbin:/bin /usr/bin/bash "${{ github.action_path }}/../proxy/setup-sandbox.sh"
 
     # Install the claude binary into the sandbox user's home. Nothing else —
     # a language toolchain here would shadow the adopter's on the sandbox PATH.

--- a/proxy/setup-sandbox.sh
+++ b/proxy/setup-sandbox.sh
@@ -25,7 +25,9 @@
 # api.anthropic.com), ACTION_PATH (this action's checkout), MITMPROXY_VERSION
 # (pinned mitmproxy version), TEND_UV_DIR (tend's own pinned uv, installed by
 # shared/steps/install-proxy-uv.sh). GITHUB_WORKSPACE / RUNNER_TEMP /
-# UV_CACHE_DIR come from Actions. Optional adopter levers (from
+# UV_CACHE_DIR come from Actions. TEND_RUNNER_TOOL_PATH carries the runner PATH
+# as data while this process resolves commands from fixed system directories.
+# Optional adopter levers (from
 # .config/tend.yaml): TEND_SANDBOX_PATH
 # (newline-separated dirs prepended to the sandbox PATH) and TEND_SANDBOX_ENV
 # (newline-separated NAME=VALUE pairs added to the agent env; reserved keys
@@ -37,7 +39,8 @@ set -euo pipefail
 # but never resolve a privileged setup utility through it while real credentials
 # are in this process. The hosted image supplies every command this script uses
 # from these system directories.
-RUNNER_TOOL_PATH="${PATH}"
+RUNNER_TOOL_PATH="${TEND_RUNNER_TOOL_PATH:-${PATH}}"
+unset TEND_RUNNER_TOOL_PATH
 PATH=/usr/sbin:/usr/bin:/sbin:/bin
 export PATH
 

--- a/proxy/test-setup-sandbox.sh
+++ b/proxy/test-setup-sandbox.sh
@@ -56,7 +56,7 @@ plant() {
 }
 
 setup() {
-  local agent_path path_entry
+  local action_run agent_path path_entry
   set_inputs
   # The workspace path leads; a literal `~` exercises expansion against the
   # sandbox home. The configured directory may be populated later.
@@ -73,7 +73,12 @@ setup() {
   export MITMPROXY_VERSION
   UV_VERSION=$(yq -e '.inputs.uv_version.default' claude/action.yaml) \
     bash shared/steps/install-proxy-uv.sh
-  bash proxy/setup-sandbox.sh | tee "$RUNNER_TEMP/setup.log"
+  # Exercise the composite action's entrypoint rather than calling the setup
+  # script directly. The boundary depends on the PATH the action passes in.
+  action_run=$(yq -er '.runs.steps[] | select(.name == "Set up credential-isolation sandbox") | .run' claude/action.yaml)
+  action_run=${action_run//'${{ github.action_path }}'/"$GITHUB_WORKSPACE/claude"}
+  /usr/bin/bash --noprofile --norc -eo pipefail -c "$action_run" \
+    | tee "$RUNNER_TEMP/setup.log"
 
   agent_path=$(sed -n 's/^\[setup-sandbox\] sandbox PATH: //p' "$RUNNER_TEMP/setup.log")
   test -n "$agent_path"


### PR DESCRIPTION
## What changed

The Claude action now carries the runner's original `PATH` into sandbox setup as data while continuing to resolve privileged setup commands from fixed system directories. The setup script consumes and unsets that transport variable before running external commands.

The hosted sandbox test now executes the exact `run:` command from `claude/action.yaml`. This closes the gap that let v0.1.19 pass CI even though production discarded every path added by earlier setup actions through `GITHUB_PATH`.

## Why

Worktrunk's Tend workflows install `uv` with `astral-sh/setup-uv`, then invoke it from `sandbox_setup`. v0.1.19 erased the toolcache path before constructing `AGENT_PATH`, so triage and notification-recovery runs failed before the agent started.

## Verification

- `wt test` (717 Python tests, worker tests, and worker typecheck)
- `pre-commit run --all-files`
- independent review of the privilege boundary, quoting, and regression-test shape

The PR's hosted `test-sandbox` job exercises the second UID, `sudo`, and `GITHUB_PATH` behavior that macOS cannot reproduce locally.

> _This was written by Codex on behalf of max-sixty_
