### PR TITLE
Release Tend 0.1.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ published verbatim as that version's GitHub Release notes
 0.1.1 predate this changelog; see the compare views at
 https://github.com/max-sixty/tend/compare for their history.
 
+## 0.1.20
+
+### Fixed
+
+- **Claude sandbox setup keeps tools installed by adopter setup actions.** The action now carries the runner's original `PATH` across its fixed-path privilege boundary as data, so tools added through `GITHUB_PATH` remain available to `sandbox_setup:` and the agent. The hosted sandbox test executes the action's production launcher, closing the test gap that allowed 0.1.19 to discard those paths. ([#1071](https://github.com/max-sixty/tend/pull/1071))
+
 ## 0.1.19
 
 ### Improved

--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "tend"
-version = "0.1.19"
+version = "0.1.20"
 description = "An autonomous junior maintainer for GitHub repos, powered by Claude or OpenAI Codex — reviews PRs, triages issues, fixes CI"
 license = "MIT"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -958,7 +958,7 @@ wheels = [
 
 [[package]]
 name = "tend"
-version = "0.1.19"
+version = "0.1.20"
 source = { editable = "generator" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Releases the sandbox PATH fix from #1071 as 0.1.20. The package version and lockfile move together, and the changelog contains the release note GitHub will publish from the tag.

Verified with `wt test`, `pre-commit run --all-files`, `uv build --package tend`, and `twine check dist/*`. The fix PR's hosted `test-sandbox` job also passed against the production composite-action launcher.

> _This was written by Codex on behalf of max-sixty_
