### PR TITLE
fix(generator): validate watched_workflows and branches as string lists

### DIFF
--- a/generator/src/tend/config.py
+++ b/generator/src/tend/config.py
@@ -436,6 +436,12 @@ class Config:
                             f"workflows.{name}.{key} must be a list of "
                             f"non-empty strings (e.g. {key}: {example})"
                         )
+                if branches is not None and not branches:
+                    raise click.ClickException(
+                        f"workflows.{name}.branches: [] matches no branch — "
+                        "omit the key to default to the repository's default "
+                        "branch, or list the branches to watch."
+                    )
                 if watched is not None and len(watched) == 0 and name == "ci-fix":
                     raise click.ClickException(
                         "watched_workflows: [] is invalid for ci-fix — "

--- a/generator/src/tend/config.py
+++ b/generator/src/tend/config.py
@@ -417,6 +417,25 @@ class Config:
                 )
             if isinstance(wf_raw, dict):
                 watched = wf_raw.get("watched_workflows")
+                branches = wf_raw.get("branches")
+                # Both render straight into the `workflow_run:` trigger through
+                # `tojson`, so an unchecked value reaches the workflow file
+                # verbatim: `watched_workflows: ci` becomes `workflows: "ci"`,
+                # which GitHub matches against nothing, and ci-fix silently
+                # never fires. A number gets no further than `len()` below,
+                # which raises a bare TypeError instead of a config error.
+                for key, value, example in (
+                    ("watched_workflows", watched, '["ci"]'),
+                    ("branches", branches, '["main"]'),
+                ):
+                    if value is not None and (
+                        not isinstance(value, list)
+                        or not all(isinstance(s, str) and s for s in value)
+                    ):
+                        raise click.ClickException(
+                            f"workflows.{name}.{key} must be a list of "
+                            f"non-empty strings (e.g. {key}: {example})"
+                        )
                 if watched is not None and len(watched) == 0 and name == "ci-fix":
                     raise click.ClickException(
                         "watched_workflows: [] is invalid for ci-fix — "
@@ -494,7 +513,7 @@ class Config:
                     prompt=wf_raw.get("prompt", ""),
                     cron=wf_raw.get("cron", ""),
                     watched_workflows=watched,
-                    branches=wf_raw.get("branches"),
+                    branches=branches,
                     workflow_extra=workflow_extra,
                     jobs=jobs_raw,
                     harness=wf_harness,

--- a/generator/tests/test_config_edge_cases.py
+++ b/generator/tests/test_config_edge_cases.py
@@ -493,6 +493,22 @@ def test_workflow_list_fields_reject_non_list_of_strings(
         Config.load(path)
 
 
+def test_branches_empty_list_rejected(tmp_path: Path) -> None:
+    """branches: [] renders a trigger that matches no branch."""
+    path = _write_config(
+        tmp_path,
+        dedent("""\
+        bot_name: my-bot
+        workflows:
+          ci-fix:
+            watched_workflows: ["ci"]
+            branches: []
+    """),
+    )
+    with pytest.raises(ClickException, match="branches: .. matches no branch"):
+        Config.load(path)
+
+
 def test_branches_explicit_value(tmp_path: Path) -> None:
     """A valid `branches` list still reaches the rendered trigger."""
     path = _write_config(

--- a/generator/tests/test_config_edge_cases.py
+++ b/generator/tests/test_config_edge_cases.py
@@ -458,6 +458,58 @@ def test_watched_workflows_empty_list_rejected(tmp_path: Path) -> None:
         Config.load(path)
 
 
+@pytest.mark.parametrize(
+    "key,value",
+    [
+        # A scalar is the natural typo, and it used to render verbatim into the
+        # trigger as `workflows: "ci"` / `branches: "main"`.
+        ("watched_workflows", "ci"),
+        ("branches", "main"),
+        # A number or bool reached `len()` and raised a bare TypeError.
+        ("watched_workflows", "5"),
+        ("branches", "true"),
+        # A mapping has a length, so it passed the empty-list check and
+        # rendered as a JSON object.
+        ("watched_workflows", "{a: b}"),
+        # An element that isn't a non-empty string renders as `null` / `""`.
+        ("watched_workflows", '["ci", null]'),
+        ("branches", '["main", ""]'),
+    ],
+)
+def test_workflow_list_fields_reject_non_list_of_strings(
+    tmp_path: Path, key: str, value: str
+) -> None:
+    """`watched_workflows` and `branches` go straight into `workflow_run:`."""
+    # Only one entry per key — a duplicate mapping key is its own YAML error.
+    keys = {"watched_workflows": '["ci"]', key: value}
+    body = "".join(f"    {k}: {v}\n" for k, v in keys.items())
+    path = _write_config(
+        tmp_path,
+        f"bot_name: my-bot\nworkflows:\n  ci-fix:\n{body}",
+    )
+    with pytest.raises(
+        ClickException, match=rf"workflows\.ci-fix\.{key} must be a list"
+    ):
+        Config.load(path)
+
+
+def test_branches_explicit_value(tmp_path: Path) -> None:
+    """A valid `branches` list still reaches the rendered trigger."""
+    path = _write_config(
+        tmp_path,
+        dedent("""\
+        bot_name: my-bot
+        workflows:
+          ci-fix:
+            watched_workflows: ["ci"]
+            branches: ["main", "release"]
+    """),
+    )
+    cfg = Config.load(path)
+    workflows = {wf.filename: wf for wf in generate_all(cfg)}
+    assert 'branches: ["main", "release"]' in workflows["tend-ci-fix.yaml"].content
+
+
 def test_watched_workflows_explicit_value(tmp_path: Path) -> None:
     """Explicit watched_workflows should be used, no fallback."""
     path = _write_config(


### PR DESCRIPTION
`workflows.<name>.watched_workflows` and `workflows.<name>.branches` were the only list-typed config fields with no type validation — every other one (`protected_branches`, `sandbox_path`, `sandbox_setup`, `secrets.allowed`) checks `isinstance(..., list)` and rejects non-string elements. Both render straight into the generated `workflow_run:` trigger through `tojson`, so an unchecked value reached the adopter's workflow file verbatim. This adds the same check both fields were missing, plus regression tests.

Four concrete failures, all reproduced before the fix:

| Config | Before | After |
| --- | --- | --- |
| `watched_workflows: ci` | renders `workflows: "ci"` — matches no workflow, so `ci-fix` silently never fires | `ClickException` at `init` |
| `watched_workflows: 5` | `TypeError: object of type 'int' has no len()` — a bare traceback out of `tend init` | `ClickException` at `init` |
| `watched_workflows: {a: b}` | a mapping has a length, so it clears the existing empty-list check and renders as a JSON object | `ClickException` at `init` |
| `branches: []` | vacuously a list of non-empty strings, so it renders as `branches: []` — a trigger that matches no branch | `ClickException` at `init` |

The scalar case is the one that matters most: it is the natural typo, it passes `actionlint`, and the only symptom is that `tend-ci-fix` never runs. Per CLAUDE.md, a config problem should "fail with a clear error, not silently parse".

<details><summary>Verification</summary>

The scalar render, reproduced against `main` before the change:

```
$ cat .config/tend.yaml
bot_name: test-bot
workflows:
  ci-fix:
    watched_workflows: ci
    branches: main

$ tend init   # rendered .github/workflows/tend-ci-fix.yaml
on:
  workflow_run:
    workflows: "ci"
    types: [completed]
    branches: "main"
```

`actionlint 1.7.12` (the rev pinned in `.pre-commit-config.yaml`) accepts that file with exit 0, so nothing downstream catches it.

The eight new parametrized cases: 7 fail on `main`, all 8 pass with the fix. `test_branches_explicit_value` is the positive control — it passes both ways, confirming a valid list still reaches the trigger. Full suite: 731 passed. `ruff format --diff` and `ruff check` clean.

</details>

