### PR TITLE
docs(README): name .husky among the pinned config paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ running in the session can't read the real secrets. The Codex harness passes
 them directly.
 
 **Config pinning** — the action restores `.mcp.json`, `.claude.json`,
-`.gitmodules`, `.ripgreprc`, and every `CLAUDE.md`, `CLAUDE.local.md`,
+`.gitmodules`, `.ripgreprc`, `.husky`, and every `CLAUDE.md`, `CLAUDE.local.md`,
 `AGENTS.md`, and `.claude/` in the tree, at any depth, from the base branch
 before the agent starts, blocking both startup-time code execution and prompt
 injection from a PR's own copy of those files.

--- a/generator/tests/test_shared_steps.py
+++ b/generator/tests/test_shared_steps.py
@@ -12,6 +12,7 @@ themselves beside their modules in shared/steps/test_*.py.
 from __future__ import annotations
 
 import json
+import re
 import shutil
 import subprocess
 from collections.abc import Callable
@@ -636,3 +637,27 @@ def test_notifications_check_tolerates_an_html_200(
 
     assert result.returncode == 0, result.stderr
     assert _output(notifications_env, "count") == "0"
+
+
+def test_sensitive_paths_are_documented_where_adopters_read_them() -> None:
+    """The pinned root paths are a security claim, so the docs have to name all
+    of them. The list drifted once already: `.husky` sat in the script and in
+    the threat model while the README enumerated four of the five, understating
+    the surface for the only audience that reads the README.
+    """
+    script = RESTORE_SENSITIVE_CONFIG.read_text()
+    sensitive = re.search(r"^SENSITIVE=\((.*?)\)$", script, re.M)
+    assert sensitive, "SENSITIVE array not found — did the script's shape change?"
+    paths = sensitive.group(1).split()
+    assert paths, "SENSITIVE is empty"
+
+    # Scope to the paragraph making the claim; a stray mention elsewhere in the
+    # file (README's own repo layout, say) must not satisfy it.
+    readme = REPO_ROOT / "README.md"
+    claim = re.search(r"\*\*Config pinning\*\*.*?(?=\n\n)", readme.read_text(), re.S)
+    assert claim, "README's config-pinning paragraph not found"
+
+    threat_model = (REPO_ROOT / "docs" / "security-model.md").read_text()
+    for path in paths:
+        assert f"`{path}`" in claim.group(0), f"{path} missing from README"
+        assert f"`{path}`" in threat_model, f"{path} missing from security-model.md"


### PR DESCRIPTION
The README's **Config pinning** bullet lists four of the five root paths the action restores from the base branch, omitting `.husky`. That understates the protection to the audience most likely to be evaluating it: `.husky/` holds git hooks, so a fork's copy is a code-execution path, and pinning it is exactly the kind of thing a reader of that paragraph is checking for.

The implementation and the threat model have both been right the whole time — `SENSITIVE=(.mcp.json .claude.json .gitmodules .ripgreprc .husky)` in `shared/steps/restore-sensitive-config.sh`, and `docs/security-model.md` names all five. Only the README drifted, and it has been wrong since `.husky` was added.

This adds `.husky` to the README list and pins the three-way agreement with a test: it parses the `SENSITIVE` array out of the script and asserts every entry is named in the README's config-pinning paragraph and in `docs/security-model.md`. The next path added to that array now fails the suite until both docs name it.

<details><summary>Verification</summary>

The test fails on the pre-fix README and passes after:

```
FAILED generator/tests/test_shared_steps.py::test_sensitive_paths_are_documented_where_adopters_read_them
AssertionError: .husky missing from README
```

The README match is scoped to the config-pinning paragraph rather than the whole file, so a mention elsewhere can't satisfy the claim.

`uv run pytest` — 733 passed. `pre-commit` clean on both changed files.

`.husky` has been in `SENSITIVE` since it was introduced; `git log -S'.husky'` on the script and the two docs returns only the commits that added it to the script, never one that added it to the README.

</details>
