### PR TITLE
Record what a run was about beside what it spent

### DIFF
--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -115,9 +115,9 @@ outputs:
       model, cost_usd, partial. `partial` is true when the run emitted no
       result event (typically a cancellation) and the counts were
       reconstructed from the session log; `cost_usd` is null in that case,
-      since only the result event carries it. Alongside those, what the run
-      was about: repo, workflow, run_id, run_attempt, event, number (the
-      PR/issue, null when the trigger has no thread), head_sha.
+      since only the result event carries it. The record also names the run
+      it came from: repo, workflow, run_id, run_attempt, event, number (the
+      PR or issue, null when the trigger has no thread), and head_sha.
     value: ${{ steps.tokens.outputs.usage }}
 
 runs:

--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -115,7 +115,9 @@ outputs:
       model, cost_usd, partial. `partial` is true when the run emitted no
       result event (typically a cancellation) and the counts were
       reconstructed from the session log; `cost_usd` is null in that case,
-      since only the result event carries it.
+      since only the result event carries it. Alongside those, what the run
+      was about: repo, workflow, run_id, run_attempt, event, number (the
+      PR/issue, null when the trigger has no thread), head_sha.
     value: ${{ steps.tokens.outputs.usage }}
 
 runs:

--- a/codex/action.yaml
+++ b/codex/action.yaml
@@ -72,10 +72,10 @@ outputs:
     description: >-
       JSON object with token usage parsed from the Codex rollout JSONL:
       input_tokens, output_tokens, cached_input_tokens, model, cost_usd.
-      cost_usd is 0 — Codex CLI doesn't surface API list prices. Alongside
-      those, what the run was about: repo, workflow, run_id, run_attempt,
-      event, number (the PR/issue, null when the trigger has no thread),
-      head_sha.
+      cost_usd is 0 — Codex CLI doesn't surface API list prices. The record
+      also names the run it came from: repo, workflow, run_id, run_attempt,
+      event, number (the PR or issue, null when the trigger has no thread),
+      and head_sha.
     value: ${{ steps.tokens.outputs.usage }}
   final_message:
     description: >-

--- a/codex/action.yaml
+++ b/codex/action.yaml
@@ -72,7 +72,10 @@ outputs:
     description: >-
       JSON object with token usage parsed from the Codex rollout JSONL:
       input_tokens, output_tokens, cached_input_tokens, model, cost_usd.
-      cost_usd is 0 — Codex CLI doesn't surface API list prices.
+      cost_usd is 0 — Codex CLI doesn't surface API list prices. Alongside
+      those, what the run was about: repo, workflow, run_id, run_attempt,
+      event, number (the PR/issue, null when the trigger has no thread),
+      head_sha.
     value: ${{ steps.tokens.outputs.usage }}
   final_message:
     description: >-

--- a/generator/tests/test_token_report.py
+++ b/generator/tests/test_token_report.py
@@ -119,6 +119,12 @@ class Report:
         )
         return self
 
+    def add_raw(self, run_id: int, body: str) -> "Report":
+        """A run whose artifact holds *body* verbatim, valid JSON or not."""
+        self.add_run_without_artifact(run_id)
+        (self._usage_dir / f"{run_id}.json").write_text(body)
+        return self
+
     def add_run_without_artifact(self, run_id: int) -> "Report":
         self._runs.append(
             {
@@ -130,20 +136,31 @@ class Report:
         )
         return self
 
-    def run(self) -> tuple[dict[str, Any], list[list[str]]]:
-        """The JSON on stdout, and the stderr summary split into cells."""
+    def run(self, *prefixes: str) -> tuple[dict[str, Any], list[list[str]]]:
+        """The JSON on stdout, and the stderr summary split into cells.
+
+        The summary's blocks — the prose header, each table, the footnotes —
+        are separated by blank lines, and ``blocks`` keeps that structure so a
+        test can address one table without a footnote sentence running into it.
+        """
         workflows = sorted({run["name"] for run in self._runs})
         Path(self._env["WF_JSON"]).write_text(
             json.dumps([{"name": name} for name in workflows])
         )
         Path(self._env["RUNS_JSON"]).write_text(json.dumps(self._runs))
         result = subprocess.run(
-            [BASH, str(SCRIPT), "168"],
+            [BASH, str(SCRIPT), "168", *prefixes],
             env=self._env,
             capture_output=True,
             text=True,
         )
         assert result.returncode == 0, result.stderr
+        self.stderr = result.stderr
+        self.blocks = [
+            cells
+            for block in result.stderr.split("\n\n")
+            if (cells := [line.split() for line in block.splitlines() if line.strip()])
+        ]
         rows = [line.split() for line in result.stderr.splitlines() if line.strip()]
         return json.loads(result.stdout), rows
 
@@ -153,15 +170,9 @@ def report(tmp_path: Path) -> Report:
     return Report(tmp_path)
 
 
-def _table(rows: list[list[str]], header: str) -> list[list[str]]:
-    """The rows under the table whose first heading is *header*."""
-    start = next(i for i, row in enumerate(rows) if row[0] == header) + 1
-    out = []
-    for row in rows[start:]:
-        if row[0] in {"WORKFLOW", "SUBJECT", "RUN"}:
-            break
-        out.append(row)
-    return out
+def _table(report: Report, header: str) -> list[list[str]]:
+    """The rows of the table whose first heading is *header*, without it."""
+    return next(block for block in report.blocks if block[0][0] == header)[1:]
 
 
 def test_the_record_carries_the_subject_so_no_join_is_needed(report: Report) -> None:
@@ -195,7 +206,7 @@ def test_repeat_runs_on_one_subject_collapse_into_one_row(report: Report) -> Non
     report.add(4, number=852, cost_usd=1.0)
     _, rows = report.run()
 
-    assert _table(rows, "SUBJECT") == [
+    assert _table(report, "SUBJECT") == [
         ["#851", "3", "$6.00", "tend-review", "30K"],
         ["#852", "1", "$1.00", "tend-review", "10K"],
     ]
@@ -212,11 +223,11 @@ def test_tables_are_ranked_by_cost_not_by_token_count(report: Report) -> None:
     report.add(2, workflow="tend-review", cost_usd=9.0, cache_read_input_tokens=1000)
     _, rows = report.run()
 
-    workflows = [row[0] for row in _table(rows, "WORKFLOW")]
+    workflows = [row[0] for row in _table(report, "WORKFLOW")]
     assert workflows == ["tend-review", "tend-nightly"], (
         "the costliest workflow leads; ranking by cache reads inverts this"
     )
-    assert _table(rows, "WORKFLOW")[0][2] == "$9.00", "cost is the second column"
+    assert _table(report, "WORKFLOW")[0][2] == "$9.00", "cost is the second column"
 
 
 def test_a_cost_unknown_run_reads_as_a_floor_not_as_free(report: Report) -> None:
@@ -233,7 +244,7 @@ def test_a_cost_unknown_run_reads_as_a_floor_not_as_free(report: Report) -> None
     total = next(row for row in rows if row[0] == "Total")
     assert total[2] == "$4.00+", "the headline cost is a floor while a run is unpriced"
     assert " ".join(total).endswith("(1 of 2 runs cost-unknown)")
-    assert _table(rows, "SUBJECT")[1] == ["#851", "1", "$0.00+", "tend-review", "10K"]
+    assert _table(report, "SUBJECT")[1] == ["#851", "1", "$0.00+", "tend-review", "10K"]
 
 
 def test_a_run_whose_record_predates_the_subject_fields(report: Report) -> None:
@@ -247,7 +258,7 @@ def test_a_run_whose_record_predates_the_subject_fields(report: Report) -> None:
 
     assert output["runs"][0]["subject"] == "?"
     assert output["totals"]["cost_usd"] == 1.0
-    assert _table(rows, "SUBJECT") == [["?", "1", "$1.00", "tend-review", "10K"]]
+    assert _table(report, "SUBJECT") == [["?", "1", "$1.00", "tend-review", "10K"]]
 
 
 def test_a_run_with_no_artifact_is_skipped(report: Report) -> None:
@@ -269,8 +280,114 @@ def test_the_subject_table_stops_at_the_top_and_says_so(report: Report) -> None:
         report.add(run_id, number=1000 + run_id, cost_usd=float(run_id))
     output, rows = report.run()
 
-    subjects = _table(rows, "SUBJECT")
+    subjects = _table(report, "SUBJECT")
     assert len(subjects) == 20
     assert subjects[0][0] == "#1025", "the costliest subject leads"
     assert len(output["runs"]) == 25
     assert any("costliest of 25" in " ".join(row) for row in rows)
+
+
+def test_one_torn_artifact_costs_its_own_run_and_no_other(report: Report) -> None:
+    """An upload cut mid-write must not take the other 200 runs with it.
+
+    `jq` exits non-zero on it inside a command substitution, and under
+    `set -euo pipefail` that ends the script before anything reaches stdout —
+    every other run's spend lost to one bad file. The loop already tolerates a
+    failed download and a missing file; this is the third way in.
+    """
+    report.add(1, cost_usd=3.0).add_raw(2, '{"input_tokens": 5,').add(3, number=852)
+    output, rows = report.run()
+
+    assert [run["run_id"] for run in output["runs"]] == [1, 3]
+    assert output["totals"]["cost_usd"] == 4.0
+    assert any("unreadable token-usage.json" in " ".join(row) for row in rows)
+
+
+def test_an_artifact_with_no_usable_object_reports_zero(report: Report) -> None:
+    """`add` over no values is null, and a null reaching the arithmetic ends it.
+
+    A whitespace-only file parses fine — `jq -s` gives `[]` — so the guard
+    above never fires, and `null * 100` in the cost rollup killed the SUBJECT
+    and RUN tables after stdout had already been written.
+    """
+    report.add_raw(1, "   \n").add(2, number=852, cost_usd=2.0)
+    output, rows = report.run()
+
+    torn = next(run for run in output["runs"] if run["run_id"] == 1)
+    assert torn["cost_usd"] == 0 and torn["cache_read_input_tokens"] == 0
+    assert [row[0] for row in _table(report, "RUN")] == ["1", "2"]
+    assert _table(report, "WORKFLOW")[0][2] == "$2.00"
+
+
+def test_cost_unknown_runs_get_their_own_ranked_table(report: Report) -> None:
+    """A cancelled run is booked at $0, so the cost sort buries it.
+
+    A subject whose runs were all cancelled would otherwise be cut from a
+    report about where the tokens went — here it holds most of the fleet's
+    cache reads and none of its priced cost.
+    """
+    for run_id in range(1, 22):
+        report.add(run_id, number=1000 + run_id, cost_usd=float(run_id))
+    for run_id in range(90, 99):
+        report.add(
+            run_id,
+            number=2222,
+            cost_usd=None,
+            partial=True,
+            cache_read_input_tokens=5_000_000,
+        )
+    _, rows = report.run()
+
+    assert "#2222" not in [row[0] for row in _table(report, "SUBJECT")], (
+        "a $0 floor cannot outrank priced work, which is why it needs its own table"
+    )
+    assert _table(report, "COST-UNKNOWN") == [
+        ["#2222", "9", "45M", "900", "tend-review"]
+    ]
+
+
+def test_a_matrix_runs_row_agrees_with_its_rollup_to_the_cent(report: Report) -> None:
+    """Per-job costs are exact to the cent; their float sum is not.
+
+    Truncating in the row and rounding in the rollup made one run's own row
+    read a cent below the workflow total it was the whole of.
+    """
+    report.add(1, cost_usd=5.13)
+    for cost in (8.57, 5.31, 8.12, 1.04):
+        (report._usage_dir / "1.json").write_text(
+            (report._usage_dir / "1.json").read_text().rstrip()
+            + "\n"
+            + json.dumps(_record(run_id=1, cost_usd=cost))
+        )
+    output, rows = report.run()
+
+    assert output["totals"]["cost_usd"] == 28.17
+    assert _table(report, "RUN")[0][3] == "$28.17"
+    assert _table(report, "WORKFLOW")[0][2] == "$28.17"
+
+
+def test_a_workflow_name_with_a_space_keeps_its_own_column(report: Report) -> None:
+    """`column -t` splits on whitespace unless told otherwise.
+
+    `EXTRA_PREFIXES` exists for hand-written workflows, whose names are not
+    held to the generator's `tend-` convention — and a shifted column reads as
+    a different metric rather than as a broken table.
+    """
+    report.add(1, workflow="review reviewers")
+    report.run("review")
+
+    lines = report.stderr.splitlines()
+    header = next(line for line in lines if line.startswith("WORKFLOW"))
+    row = lines[lines.index(header) + 1]
+    assert row[header.index("RUNS") :].split()[0] == "1", (
+        "the run count must sit under RUNS; splitting on whitespace instead of "
+        "the tab puts `reviewers` there and shifts every column right"
+    )
+
+
+def test_runs_with_no_artifact_are_counted_not_dropped(report: Report) -> None:
+    """A codex-harness repo would otherwise read a report of zero runs."""
+    report.add(1).add_run_without_artifact(2).add_run_without_artifact(3)
+    _, rows = report.run()
+
+    assert any("2 run(s) uploaded no" in " ".join(row) for row in rows)

--- a/generator/tests/test_token_report.py
+++ b/generator/tests/test_token_report.py
@@ -287,36 +287,31 @@ def test_the_subject_table_stops_at_the_top_and_says_so(report: Report) -> None:
     assert any("costliest of 25" in " ".join(row) for row in rows)
 
 
-def test_one_torn_artifact_costs_its_own_run_and_no_other(report: Report) -> None:
-    """An upload cut mid-write must not take the other 200 runs with it.
+@pytest.mark.parametrize(
+    ("body", "why"),
+    [
+        ('{"input_tokens": 5,', "cut mid-write"),
+        ("   \n", "holding nothing but whitespace"),
+    ],
+)
+def test_one_unreadable_artifact_costs_its_own_run_and_no_other(
+    report: Report, body: str, why: str
+) -> None:
+    """An artifact cut mid-write must not take the other 200 runs with it.
 
-    `jq` exits non-zero on it inside a command substitution, and under
-    `set -euo pipefail` that ends the script before anything reaches stdout —
-    every other run's spend lost to one bad file. The loop already tolerates a
-    failed download and a missing file; this is the third way in.
+    `jq` exits non-zero on it, and under `set -euo pipefail` that ends the
+    script before anything reaches stdout — every other run's spend lost to one
+    bad file. A file holding no object at all takes the same path: `jq` exits
+    0 with no output, and reporting the run as a zero would say its spend was
+    nothing when the truth is that it is unknown.
     """
-    report.add(1, cost_usd=3.0).add_raw(2, '{"input_tokens": 5,').add(3, number=852)
+    report.add(1, cost_usd=3.0).add_raw(2, body).add(3, number=852)
     output, rows = report.run()
 
-    assert [run["run_id"] for run in output["runs"]] == [1, 3]
+    assert [run["run_id"] for run in output["runs"]] == [3, 1], f"lost a run to {why}"
     assert output["totals"]["cost_usd"] == 4.0
-    assert any("unreadable token-usage.json" in " ".join(row) for row in rows)
-
-
-def test_an_artifact_with_no_usable_object_reports_zero(report: Report) -> None:
-    """`add` over no values is null, and a null reaching the arithmetic ends it.
-
-    A whitespace-only file parses fine — `jq -s` gives `[]` — so the guard
-    above never fires, and `null * 100` in the cost rollup killed the SUBJECT
-    and RUN tables after stdout had already been written.
-    """
-    report.add_raw(1, "   \n").add(2, number=852, cost_usd=2.0)
-    output, rows = report.run()
-
-    torn = next(run for run in output["runs"] if run["run_id"] == 1)
-    assert torn["cost_usd"] == 0 and torn["cache_read_input_tokens"] == 0
-    assert [row[0] for row in _table(report, "RUN")] == ["1", "2"]
-    assert _table(report, "WORKFLOW")[0][2] == "$2.00"
+    assert output["totals"]["skipped_runs"] == 1
+    assert any("1 run(s) uploaded no readable" in " ".join(row) for row in rows)
 
 
 def test_cost_unknown_runs_get_their_own_ranked_table(report: Report) -> None:
@@ -367,7 +362,7 @@ def test_a_matrix_runs_row_agrees_with_its_rollup_to_the_cent(report: Report) ->
 
 
 def test_a_workflow_name_with_a_space_keeps_its_own_column(report: Report) -> None:
-    """`column -t` splits on whitespace unless told otherwise.
+    """The summary pads its own columns, so a cell may contain spaces.
 
     `EXTRA_PREFIXES` exists for hand-written workflows, whose names are not
     held to the generator's `tend-` convention — and a shifted column reads as
@@ -380,8 +375,8 @@ def test_a_workflow_name_with_a_space_keeps_its_own_column(report: Report) -> No
     header = next(line for line in lines if line.startswith("WORKFLOW"))
     row = lines[lines.index(header) + 1]
     assert row[header.index("RUNS") :].split()[0] == "1", (
-        "the run count must sit under RUNS; splitting on whitespace instead of "
-        "the tab puts `reviewers` there and shifts every column right"
+        "the run count must sit under RUNS; a summary that split rows on "
+        "whitespace would put `reviewers` there and shift every column right"
     )
 
 
@@ -391,3 +386,27 @@ def test_runs_with_no_artifact_are_counted_not_dropped(report: Report) -> None:
     _, rows = report.run()
 
     assert any("2 run(s) uploaded no" in " ".join(row) for row in rows)
+
+
+def test_a_repo_with_no_runs_reports_the_same_empty_shape(report: Report) -> None:
+    """The empty report comes out of the ordinary path, not a special case.
+
+    It used to be a JSON literal echoed from two early exits, which is one
+    place for the totals shape to drift out of sync with the code that builds
+    it — and it had already lost `skipped_runs`.
+    """
+    output, _ = report.run()
+
+    assert output == {
+        "runs": [],
+        "totals": {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+            "turns": 0,
+            "cost_usd": 0,
+            "partial_runs": 0,
+            "skipped_runs": 0,
+        },
+    }

--- a/generator/tests/test_token_report.py
+++ b/generator/tests/test_token_report.py
@@ -1,0 +1,276 @@
+"""Tests for plugins/tend-ci-runner/scripts/token-report.sh.
+
+The report exists to answer "what did the spend go to?", so what is pinned
+here is the grouping and the ranking: subjects come off the record each run
+uploaded, and cost — not the token count — leads and orders every table.
+Cache reads are ~97% of the tokens and ~60% of the bill, so a table ranked by
+summed tokens ranks the cheapest work first; the fixtures below make the two
+orders disagree so a regression to token-ranking fails.
+
+The fake `gh` serves a run list and materialises each run's artifact into the
+`--dir` the script passes, which is the whole of what the script needs from
+GitHub. `date` is faked so the window is a fixed string.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+from tests import BASH, GH_PREAMBLE, fake_bin, tool_path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "plugins" / "tend-ci-runner" / "scripts" / "token-report.sh"
+
+FAKE_GH = (
+    GH_PREAMBLE
+    + r"""case "$1 $2" in
+  "workflow list")
+    emit "$(cat "$WF_JSON")"
+    ;;
+  "run list")
+    wf=""
+    prev=""
+    for a in "$@"; do
+      [ "$prev" = "--workflow" ] && wf="$a"
+      prev="$a"
+    done
+    emit "$(jq -c --arg wf "$wf" '[.[] | select(.name == $wf)]' "$RUNS_JSON")"
+    ;;
+  "run download")
+    # The artifact the run uploaded, or a non-zero exit for a run that has
+    # none — the script skips those.
+    dir=""
+    prev=""
+    for a in "$@"; do
+      [ "$prev" = "--dir" ] && dir="$a"
+      prev="$a"
+    done
+    [ -f "$USAGE_DIR/$3.json" ] || exit 1
+    mkdir -p "$dir/claude-session-logs-1"
+    cp "$USAGE_DIR/$3.json" "$dir/claude-session-logs-1/token-usage.json"
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+"""
+)
+
+# The window is a fixed string; nothing here depends on the real clock.
+FAKE_DATE = "#!/usr/bin/env bash\necho 2026-08-22T00:00:00Z\n"
+
+
+def _record(**over: Any) -> dict[str, Any]:
+    """One job's token-usage.json, as the "Token usage" step writes it."""
+    return {
+        "repo": "owner/repo",
+        "workflow": "tend-review",
+        "run_id": 1,
+        "run_attempt": 1,
+        "event": "pull_request_target",
+        "number": 851,
+        "head_sha": "head0000",
+        "input_tokens": 10,
+        "output_tokens": 100,
+        "cache_creation_input_tokens": 1000,
+        "cache_read_input_tokens": 10000,
+        "turns": 3,
+        "model": "opus",
+        "cost_usd": 1.0,
+        "partial": False,
+        **over,
+    }
+
+
+class Report:
+    """A configured run of the script: add runs, then read the two outputs."""
+
+    def __init__(self, tmp_path: Path) -> None:
+        self._tmp = tmp_path
+        self._runs: list[dict[str, Any]] = []
+        self._usage_dir = tmp_path / "usage"
+        self._usage_dir.mkdir()
+        self._env = {
+            "PATH": tool_path(fake_bin(tmp_path, gh=FAKE_GH, date=FAKE_DATE)),
+            "GH_CALLS": str(tmp_path / "gh-calls.log"),
+            "WF_JSON": str(tmp_path / "wf.json"),
+            "RUNS_JSON": str(tmp_path / "runs.json"),
+            "USAGE_DIR": str(self._usage_dir),
+        }
+
+    def add(
+        self, run_id: int, *, workflow: str = "tend-review", **over: Any
+    ) -> "Report":
+        """A completed run and the artifact it uploaded."""
+        self._runs.append(
+            {
+                "databaseId": run_id,
+                "conclusion": "success",
+                "createdAt": f"2026-08-2{run_id % 10}T12:00:00Z",
+                "name": workflow,
+            }
+        )
+        (self._usage_dir / f"{run_id}.json").write_text(
+            json.dumps(_record(run_id=run_id, workflow=workflow, **over))
+        )
+        return self
+
+    def add_run_without_artifact(self, run_id: int) -> "Report":
+        self._runs.append(
+            {
+                "databaseId": run_id,
+                "conclusion": "cancelled",
+                "createdAt": "2026-08-25T12:00:00Z",
+                "name": "tend-review",
+            }
+        )
+        return self
+
+    def run(self) -> tuple[dict[str, Any], list[list[str]]]:
+        """The JSON on stdout, and the stderr summary split into cells."""
+        workflows = sorted({run["name"] for run in self._runs})
+        Path(self._env["WF_JSON"]).write_text(
+            json.dumps([{"name": name} for name in workflows])
+        )
+        Path(self._env["RUNS_JSON"]).write_text(json.dumps(self._runs))
+        result = subprocess.run(
+            [BASH, str(SCRIPT), "168"],
+            env=self._env,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        rows = [line.split() for line in result.stderr.splitlines() if line.strip()]
+        return json.loads(result.stdout), rows
+
+
+@pytest.fixture
+def report(tmp_path: Path) -> Report:
+    return Report(tmp_path)
+
+
+def _table(rows: list[list[str]], header: str) -> list[list[str]]:
+    """The rows under the table whose first heading is *header*."""
+    start = next(i for i, row in enumerate(rows) if row[0] == header) + 1
+    out = []
+    for row in rows[start:]:
+        if row[0] in {"WORKFLOW", "SUBJECT", "RUN"}:
+            break
+        out.append(row)
+    return out
+
+
+def test_the_record_carries_the_subject_so_no_join_is_needed(report: Report) -> None:
+    """Each run's PR, event and commit ride on its own artifact.
+
+    Without them every question about what the spend went to costs a second
+    query per run; the run list the script already makes cannot answer them —
+    its `headSha` for a `pull_request_target` run is the base branch, not the
+    commit the workflow checked out.
+    """
+    report.add(1).add(2, number=852, head_sha="head0002")
+    output, _ = report.run()
+
+    runs = {run["run_id"]: run for run in output["runs"]}
+    assert runs[1]["number"] == 851
+    assert runs[1]["subject"] == "#851"
+    assert runs[1]["event"] == "pull_request_target"
+    assert runs[1]["repo"] == "owner/repo"
+    assert runs[1]["head_sha"] == "head0000"
+    assert runs[2]["subject"] == "#852"
+
+
+def test_repeat_runs_on_one_subject_collapse_into_one_row(report: Report) -> None:
+    """The costly pattern is many runs on one PR, which is one row with a count.
+
+    Three reviews of #851 and one of #852: the subject table has to show two
+    rows, the repeat one carrying its run count and its summed cost.
+    """
+    for run_id in (1, 2, 3):
+        report.add(run_id, cost_usd=2.0)
+    report.add(4, number=852, cost_usd=1.0)
+    _, rows = report.run()
+
+    assert _table(rows, "SUBJECT") == [
+        ["#851", "3", "$6.00", "tend-review", "30K"],
+        ["#852", "1", "$1.00", "tend-review", "10K"],
+    ]
+
+
+def test_tables_are_ranked_by_cost_not_by_token_count(report: Report) -> None:
+    """Cache reads dominate the count and not the bill, so ranking by tokens
+    ranks the cheapest work first.
+
+    `tend-nightly` here reads ten times the cache for a tenth of the cost —
+    the shape of a real fleet's spend, and the two orders are opposite.
+    """
+    report.add(1, workflow="tend-nightly", cost_usd=0.5, cache_read_input_tokens=999999)
+    report.add(2, workflow="tend-review", cost_usd=9.0, cache_read_input_tokens=1000)
+    _, rows = report.run()
+
+    workflows = [row[0] for row in _table(rows, "WORKFLOW")]
+    assert workflows == ["tend-review", "tend-nightly"], (
+        "the costliest workflow leads; ranking by cache reads inverts this"
+    )
+    assert _table(rows, "WORKFLOW")[0][2] == "$9.00", "cost is the second column"
+
+
+def test_a_cost_unknown_run_reads_as_a_floor_not_as_free(report: Report) -> None:
+    """A cancelled run's tokens are real and its cost is unrecoverable.
+
+    Cost now leads every table, so a reconstructed run must never read as
+    cheap: its cells carry `+`, and the total names how many runs it covers.
+    """
+    report.add(1, cost_usd=None, partial=True)
+    report.add(2, number=852, cost_usd=4.0)
+    output, rows = report.run()
+
+    assert output["totals"]["partial_runs"] == 1
+    total = next(row for row in rows if row[0] == "Total")
+    assert total[2] == "$4.00+", "the headline cost is a floor while a run is unpriced"
+    assert " ".join(total).endswith("(1 of 2 runs cost-unknown)")
+    assert _table(rows, "SUBJECT")[1] == ["#851", "1", "$0.00+", "tend-review", "10K"]
+
+
+def test_a_run_whose_record_predates_the_subject_fields(report: Report) -> None:
+    """An artifact still in the window from before this change still reports.
+
+    Its counts are all it has, so it groups under `?` rather than dropping out
+    of the totals.
+    """
+    report.add(1, number=None, head_sha=None, repo=None, event=None)
+    output, rows = report.run()
+
+    assert output["runs"][0]["subject"] == "?"
+    assert output["totals"]["cost_usd"] == 1.0
+    assert _table(rows, "SUBJECT") == [["?", "1", "$1.00", "tend-review", "10K"]]
+
+
+def test_a_run_with_no_artifact_is_skipped(report: Report) -> None:
+    """A run that uploaded nothing — a codex-harness run, or one killed before
+    the token step — contributes no row rather than a zero one."""
+    report.add(1).add_run_without_artifact(2)
+    output, _ = report.run()
+
+    assert [run["run_id"] for run in output["runs"]] == [1]
+
+
+def test_the_subject_table_stops_at_the_top_and_says_so(report: Report) -> None:
+    """Past the top the tail is one-run subjects; the JSON on stdout has them.
+
+    The cap and the note it prints are the same value, so a reader is never
+    told a count the table contradicts.
+    """
+    for run_id in range(1, 26):
+        report.add(run_id, number=1000 + run_id, cost_usd=float(run_id))
+    output, rows = report.run()
+
+    subjects = _table(rows, "SUBJECT")
+    assert len(subjects) == 20
+    assert subjects[0][0] == "#1025", "the costliest subject leads"
+    assert len(output["runs"]) == 25
+    assert any("costliest of 25" in " ".join(row) for row in rows)

--- a/plugins/tend-ci-runner/scripts/token-report.sh
+++ b/plugins/tend-ci-runner/scripts/token-report.sh
@@ -4,16 +4,12 @@
 # Downloads session log artifacts from GitHub Actions, extracts each run's
 # token-usage.json (written by the "Token usage" step in each harness action),
 # and outputs a JSON report to stdout. A human-readable summary is printed to
-# stderr, grouped by workflow and by subject — the PR or issue the run was
-# about, else the commit.
+# stderr, grouped by workflow and by subject.
 #
-# Cost leads every table, and every table sorts by it. Tokens do not price
-# alike: cache reads are the great majority of the count and a small minority
-# of the bill, so a ranking by summed tokens ranks the cheapest work first.
-#
-# The subject columns come from the record itself, which carries repo,
-# workflow, run, event, PR/issue number and commit alongside the counts. Runs
-# whose artifact predates those fields report a "?" subject.
+# The two rollup tables — one row per workflow, one per subject — sort by cost.
+# A cached input token is priced far below an output token, so ranking by token
+# volume, which cache reads dominate, is not ranking by spend. The per-run
+# table below them stays newest-first.
 #
 # Usage: ./token-report.sh [HOURS] [PREFIX ...]
 #   HOURS: lookback period in hours (default: 168 = 7 days)
@@ -106,6 +102,11 @@ echo >&2 "Downloading artifacts for $RUN_COUNT runs..."
 ENTRIES="$WORKDIR/entries.jsonl"
 touch "$ENTRIES"
 
+# Runs that reach the totals with nothing. Counted rather than dropped
+# silently: a codex-harness repo would otherwise read a report of zero runs
+# with no line saying why, and the same silence covers a torn upload.
+SKIPPED=0
+
 mapfile -t ROWS < <(echo "$ALL_RUNS" | jq -c '.[]')
 for row in "${ROWS[@]}"; do
   RUN_ID=$(echo "$row" | jq -r '.databaseId')
@@ -118,11 +119,13 @@ for row in "${ROWS[@]}"; do
   if ! gh run download "$RUN_ID" "${repo_args[@]}" \
       --pattern 'claude-session-logs*' \
       --dir "$RUNDIR" 2>/dev/null; then
+    SKIPPED=$((SKIPPED + 1))
     continue
   fi
 
   mapfile -t USAGE_FILES < <(find "$RUNDIR" -name "token-usage.json" -type f)
   if [ ${#USAGE_FILES[@]} -eq 0 ]; then
+    SKIPPED=$((SKIPPED + 1))
     continue
   fi
 
@@ -136,26 +139,37 @@ for row in "${ROWS[@]}"; do
   # (or an event with no thread of its own) leaves, and `first` of nothing is
   # null. `run_id` and `workflow` are deliberately not read here — the run list
   # above is already their source, and one source per field beats a fallback.
-  USAGE=$(cat "${USAGE_FILES[@]}" | jq -s '
+  # Every sum takes `// 0` for the same reason the totals below do: `add` over
+  # no values is null, and a null reaching the report's arithmetic ends it.
+  # An artifact that holds no usable object is a torn upload, and a run that
+  # reports zero still reports its identity.
+  if ! USAGE=$(cat "${USAGE_FILES[@]}" | jq -s '
     def pick(f): map(f // empty) | first;
     {
-      input_tokens: (map(.input_tokens) | add),
-      output_tokens: (map(.output_tokens) | add),
-      cache_creation_input_tokens: (map(.cache_creation_input_tokens) | add),
-      cache_read_input_tokens: (map(.cache_read_input_tokens) | add),
-      turns: (map(.turns) | add),
-      cost_usd: (map(.cost_usd // 0) | add),
+      input_tokens: (map(.input_tokens) | add // 0),
+      output_tokens: (map(.output_tokens) | add // 0),
+      cache_creation_input_tokens: (map(.cache_creation_input_tokens) | add // 0),
+      cache_read_input_tokens: (map(.cache_read_input_tokens) | add // 0),
+      turns: (map(.turns) | add // 0),
+      cost_usd: (map(.cost_usd // 0) | add // 0),
       partial: (map(.partial // false) | any),
       repo: pick(.repo),
       event: pick(.event),
       number: pick(.number),
       head_sha: pick(.head_sha)
-    }')
+    }'); then
+    # An unparsable file would otherwise abort the whole run under `set -e`,
+    # losing every other run's data with it — the loop tolerates a failed
+    # download and a missing file already.
+    echo >&2 "WARNING: run $RUN_ID has an unreadable token-usage.json — its tokens are absent from the totals below."
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
 
   # `subject` is what the run was about as one cell: the PR or issue it worked
-  # on, else the commit, else `?` — an artifact written before the record
-  # carried any of this. Computed once, here, so every reader of the report
-  # groups by the same key.
+  # on, else the commit, else `?` for a record written before these fields
+  # existed or one whose event named neither. Computed once, here, so every
+  # reader of the report groups by the same key.
   jq -c --argjson usage "$USAGE" '
     . + $usage + {run_id: .databaseId, workflow: .name, created_at: .createdAt} |
     del(.databaseId, .name, .createdAt) |
@@ -179,8 +193,7 @@ jq -s '{
   }
 }' "$ENTRIES" | tee "$WORKDIR/report.json"
 
-# How many subjects the summary shows before the tail of one-run subjects; the
-# JSON on stdout carries every one of them.
+# How many of the costliest subjects the summary shows.
 TOP_SUBJECTS=20
 
 # Shared by the programs below. The prose header is rendered on its own
@@ -192,21 +205,20 @@ JQ_DEFS='
     elif . >= 1000 then "\(. / 100 | floor | . / 10)K"
     else "\(.)" end;
 
-  def usd: tostring | if test("\\.") then split(".") | "\(.[0]).\((.[1] + "00")[:2])" else . + ".00" end | "$" + .;
+  def usd: (. * 100 | round / 100) | tostring | if test("\\.") then split(".") | "\(.[0]).\((.[1] + "00")[:2])" else . + ".00" end | "$" + .;
 
   # A partial run contributes tokens but no cost, so every cost it lands in —
   # its own row, its group row, the total — is a floor, not the spend. Mark
   # those cells with a trailing `+` so a reconstructed run never reads as free.
   def floor_marker: if . then "+" else "" end;
 
-  # The subject is a join key (a full sha, so two commits are two subjects);
-  # the column only has room for a prefix.
+  # A full sha is the join key; the column has room for a prefix.
   def short: .[:12];
 
   # Applied to a group of runs; the caller adds the columns that name it.
   def rollup: {
     n: length,
-    cost: (map(.cost_usd) | add | . * 100 | round / 100),
+    cost: (map(.cost_usd) | add),
     partial: (map(.partial // false) | any),
     i: (map(.input_tokens) | add),
     o: (map(.output_tokens) | add),
@@ -217,9 +229,6 @@ JQ_DEFS='
   def by_cost: sort_by(.cost) | reverse;
 '
 
-# Cost leads, because that is the question being asked and because the token
-# count answers a different one: cache reads are the great majority of the
-# tokens and a minority of the bill.
 jq -r "$JQ_DEFS"'
   "",
   "\(.runs | length) runs since '"$SINCE"'",
@@ -229,12 +238,14 @@ jq -r "$JQ_DEFS"'
   ""
 ' "$WORKDIR/report.json" >&2
 
-# Every table sorts by cost, for the same reason. One `column -t` per table:
-# it aligns whatever it is given as a single grid and drops the blank lines
-# between, so a single pass would run the three tables together under one set
-# of column widths.
+# One `column -t` per table: it aligns whatever it is given as a single grid
+# and drops the blank lines between, so a single pass would run the tables
+# together under one set of column widths. `-s` pins the separator to the tab
+# `@tsv` writes; the default splits on any whitespace, so a workflow name with
+# a space in it would shift every column right.
 table() {
-  jq -r --argjson top "$TOP_SUBJECTS" "$JQ_DEFS$1" "$WORKDIR/report.json" | column -t >&2
+  jq -r --argjson top "$TOP_SUBJECTS" "$JQ_DEFS$1" "$WORKDIR/report.json" |
+    column -t -s "$(printf '\t')" >&2
   echo >&2 ""
 }
 
@@ -245,14 +256,33 @@ table '
 '
 
 # Repeat work on one subject is what this table exists to show: a PR reviewed
-# nine times, or two agents racing on one commit, is one row with a high RUNS
-# count.
+# over and over, or two agents racing on one commit, is one row with a high
+# RUNS count.
 table '
   (["SUBJECT", "RUNS", "COST", "WORKFLOWS", "CACHE-READ"] | @tsv),
   (.runs | group_by(.subject) | map({s: (.[0].subject | short), wf: (map(.workflow) | unique | join(","))} + rollup)
     | by_cost | .[:$top] | .[] |
     [.s, (.n | tostring), cost_cell, .wf, (.cr | fmt)] | @tsv)
 '
+
+# A run with no result event is booked at $0, because a floor is the only
+# honest number for it — so the cost sort buries it and the cut above drops it,
+# and a subject whose runs were all cancelled disappears from a report about
+# where the tokens went. Its tokens are real, so it gets a table of its own,
+# ranked by the one number it has. Uncapped, unlike the table above: these are
+# a small fraction of runs, and a fleet where they aren't is itself the finding.
+# Pricing them instead would mean carrying a price table, which is the thing
+# the record deliberately doesn't do.
+PARTIAL_RUNS=$(jq -r '.totals.partial_runs' "$WORKDIR/report.json")
+if [ "$PARTIAL_RUNS" -gt 0 ]; then
+  table '
+    (["COST-UNKNOWN", "RUNS", "CACHE-READ", "OUTPUT", "WORKFLOWS"] | @tsv),
+    (.runs | map(select(.partial)) | group_by(.subject)
+      | map({s: (.[0].subject | short), wf: (map(.workflow) | unique | join(","))} + rollup)
+      | sort_by(.cr) | reverse | .[] |
+      [.s, (.n | tostring), (.cr | fmt), (.o | fmt), .wf] | @tsv)
+  '
+fi
 
 table '
   (["RUN", "WORKFLOW", "SUBJECT", "COST", "INPUT", "OUTPUT", "CACHE-CREATE", "CACHE-READ", "TIME"] | @tsv),
@@ -266,8 +296,10 @@ SUBJECT_COUNT=$(jq -r '[.runs[].subject] | unique | length' "$WORKDIR/report.jso
 if [ "$SUBJECT_COUNT" -gt "$TOP_SUBJECTS" ]; then
   echo >&2 "Subjects: showing the $TOP_SUBJECTS costliest of $SUBJECT_COUNT; the JSON on stdout has them all."
 fi
-PARTIAL_RUNS=$(jq -r '.totals.partial_runs' "$WORKDIR/report.json")
 if [ "$PARTIAL_RUNS" -gt 0 ]; then
-  echo >&2 "$PARTIAL_RUNS run(s) emitted no result event (typically cancelled): tokens counted, cost not recoverable. A '+' marks a cost that is a floor rather than the spend."
+  echo >&2 "COST-UNKNOWN lists the runs that emitted no result event, typically cancelled: their tokens are counted everywhere, their cost is not recoverable. A '+' marks a cost that is a floor rather than the spend."
+fi
+if [ "$SKIPPED" -gt 0 ]; then
+  echo >&2 "$SKIPPED run(s) uploaded no claude-session-logs artifact and are absent entirely: codex-harness runs, and runs that ended before the upload."
 fi
 echo >&2 "Cost at API list prices — a large multiple of the effective rate on Claude Code subscriptions."

--- a/plugins/tend-ci-runner/scripts/token-report.sh
+++ b/plugins/tend-ci-runner/scripts/token-report.sh
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
-# Reports token usage across recent tend CI runs.
+# Reports token spend across recent tend CI runs.
 #
-# Downloads session log artifacts from GitHub Actions, extracts token
-# counts from each run, and outputs a JSON report to stdout.
-# A human-readable summary is printed to stderr.
+# Downloads session log artifacts from GitHub Actions, extracts each run's
+# token-usage.json (written by the "Token usage" step in each harness action),
+# and outputs a JSON report to stdout. A human-readable summary is printed to
+# stderr, grouped by workflow and by subject — the PR or issue the run was
+# about, else the commit.
 #
-# Reads the token-usage.json file from each run's session log artifact
-# (produced by the "Token usage" step in each harness action).
+# Cost leads every table, and every table sorts by it. Tokens do not price
+# alike: cache reads are the great majority of the count and a small minority
+# of the bill, so a ranking by summed tokens ranks the cheapest work first.
+#
+# The subject columns come from the record itself, which carries repo,
+# workflow, run, event, PR/issue number and commit alongside the counts. Runs
+# whose artifact predates those fields report a "?" subject.
 #
 # Usage: ./token-report.sh [HOURS] [PREFIX ...]
 #   HOURS: lookback period in hours (default: 168 = 7 days)
@@ -123,19 +130,37 @@ for row in "${ROWS[@]}"; do
   # `partial` marks a run whose counts were reconstructed from the session log
   # because it emitted no result event — its tokens are real but its cost is
   # unrecoverable, so the cost column under-counts by however many there are.
-  USAGE=$(cat "${USAGE_FILES[@]}" | jq -s '{
-    input_tokens: (map(.input_tokens) | add),
-    output_tokens: (map(.output_tokens) | add),
-    cache_creation_input_tokens: (map(.cache_creation_input_tokens) | add),
-    cache_read_input_tokens: (map(.cache_read_input_tokens) | add),
-    turns: (map(.turns) | add),
-    cost_usd: (map(.cost_usd // 0) | add),
-    partial: (map(.partial // false) | any)
-  }')
+  #
+  # The identity fields are per-run rather than per-job, so the first job that
+  # carries one speaks for the run; `empty` drops the nulls an older artifact
+  # (or an event with no thread of its own) leaves, and `first` of nothing is
+  # null. `run_id` and `workflow` are deliberately not read here — the run list
+  # above is already their source, and one source per field beats a fallback.
+  USAGE=$(cat "${USAGE_FILES[@]}" | jq -s '
+    def pick(f): map(f // empty) | first;
+    {
+      input_tokens: (map(.input_tokens) | add),
+      output_tokens: (map(.output_tokens) | add),
+      cache_creation_input_tokens: (map(.cache_creation_input_tokens) | add),
+      cache_read_input_tokens: (map(.cache_read_input_tokens) | add),
+      turns: (map(.turns) | add),
+      cost_usd: (map(.cost_usd // 0) | add),
+      partial: (map(.partial // false) | any),
+      repo: pick(.repo),
+      event: pick(.event),
+      number: pick(.number),
+      head_sha: pick(.head_sha)
+    }')
 
+  # `subject` is what the run was about as one cell: the PR or issue it worked
+  # on, else the commit, else `?` — an artifact written before the record
+  # carried any of this. Computed once, here, so every reader of the report
+  # groups by the same key.
   jq -c --argjson usage "$USAGE" '
     . + $usage + {run_id: .databaseId, workflow: .name, created_at: .createdAt} |
-    del(.databaseId, .name, .createdAt)' <<< "$row" >> "$ENTRIES"
+    del(.databaseId, .name, .createdAt) |
+    .subject = (if .number then "#\(.number)" elif .head_sha then .head_sha else "?" end)
+    ' <<< "$row" >> "$ENTRIES"
 
   rm -rf "$RUNDIR"
 done
@@ -154,8 +179,14 @@ jq -s '{
   }
 }' "$ENTRIES" | tee "$WORKDIR/report.json"
 
-# Human-readable summary to stderr
-jq -r '
+# How many subjects the summary shows before the tail of one-run subjects; the
+# JSON on stdout carries every one of them.
+TOP_SUBJECTS=20
+
+# Shared by the programs below. The prose header is rendered on its own
+# because `column -t` splits on whitespace: a sentence run through it is
+# aligned into the tables' columns, one word per cell.
+JQ_DEFS='
   def fmt:
     if . >= 1000000 then "\(. / 100000 | floor | . / 10)M"
     elif . >= 1000 then "\(. / 100 | floor | . / 10)K"
@@ -164,34 +195,77 @@ jq -r '
   def usd: tostring | if test("\\.") then split(".") | "\(.[0]).\((.[1] + "00")[:2])" else . + ".00" end | "$" + .;
 
   # A partial run contributes tokens but no cost, so every cost it lands in —
-  # its own row, its workflow row, the total — is a floor, not the spend. Mark
+  # its own row, its group row, the total — is a floor, not the spend. Mark
   # those cells with a trailing `+` so a reconstructed run never reads as free.
   def floor_marker: if . then "+" else "" end;
 
-  "\n\(.runs | length) runs since '"$SINCE"'",
-  "Totals: \(.totals.input_tokens | fmt) in, \(.totals.output_tokens | fmt) out, \(.totals.cache_creation_input_tokens | fmt) cache-create, \(.totals.cache_read_input_tokens | fmt) cache-read, \(.totals.cost_usd | usd)\(.totals.partial_runs > 0 | floor_marker) cost",
-  "",
-  (["WORKFLOW", "RUNS", "INPUT", "OUTPUT", "CACHE-CREATE", "CACHE-READ", "COST"] | @tsv),
-  (.runs | group_by(.workflow) | map({
-    w: .[0].workflow,
+  # The subject is a join key (a full sha, so two commits are two subjects);
+  # the column only has room for a prefix.
+  def short: .[:12];
+
+  # Applied to a group of runs; the caller adds the columns that name it.
+  def rollup: {
     n: length,
+    cost: (map(.cost_usd) | add | . * 100 | round / 100),
+    partial: (map(.partial // false) | any),
     i: (map(.input_tokens) | add),
     o: (map(.output_tokens) | add),
     cc: (map(.cache_creation_input_tokens) | add),
-    cr: (map(.cache_read_input_tokens) | add),
-    cost: (map(.cost_usd) | add | . * 100 | round / 100),
-    partial: (map(.partial // false) | any)
-  }) | sort_by(.cr) | reverse | .[] |
-    [.w, (.n | tostring), (.i | fmt), (.o | fmt), (.cc | fmt), (.cr | fmt), ((.cost | usd) + (.partial | floor_marker))] | @tsv),
-  "",
-  (["RUN", "WORKFLOW", "INPUT", "OUTPUT", "CACHE-CREATE", "CACHE-READ", "COST", "TIME"] | @tsv),
-  (.runs | sort_by(.created_at) | reverse | .[] |
-    [(.run_id | tostring), .workflow, (.input_tokens | fmt), (.output_tokens | fmt), (.cache_creation_input_tokens | fmt), (.cache_read_input_tokens | fmt), ((.cost_usd | usd) + (.partial // false | floor_marker)), .created_at[:16]] | @tsv)
-' "$WORKDIR/report.json" | column -t >&2
+    cr: (map(.cache_read_input_tokens) | add)
+  };
+  def cost_cell: (.cost | usd) + (.partial | floor_marker);
+  def by_cost: sort_by(.cost) | reverse;
+'
 
-echo >&2 ""
+# Cost leads, because that is the question being asked and because the token
+# count answers a different one: cache reads are the great majority of the
+# tokens and a minority of the bill.
+jq -r "$JQ_DEFS"'
+  "",
+  "\(.runs | length) runs since '"$SINCE"'",
+  "Total cost: \(.totals.cost_usd | usd)\(.totals.partial_runs > 0 | floor_marker)"
+    + (if .totals.partial_runs > 0 then " (\(.totals.partial_runs) of \(.runs | length) runs cost-unknown)" else "" end),
+  "Tokens: \(.totals.input_tokens | fmt) in, \(.totals.output_tokens | fmt) out, \(.totals.cache_creation_input_tokens | fmt) cache-create, \(.totals.cache_read_input_tokens | fmt) cache-read",
+  ""
+' "$WORKDIR/report.json" >&2
+
+# Every table sorts by cost, for the same reason. One `column -t` per table:
+# it aligns whatever it is given as a single grid and drops the blank lines
+# between, so a single pass would run the three tables together under one set
+# of column widths.
+table() {
+  jq -r --argjson top "$TOP_SUBJECTS" "$JQ_DEFS$1" "$WORKDIR/report.json" | column -t >&2
+  echo >&2 ""
+}
+
+table '
+  (["WORKFLOW", "RUNS", "COST", "INPUT", "OUTPUT", "CACHE-CREATE", "CACHE-READ"] | @tsv),
+  (.runs | group_by(.workflow) | map({w: .[0].workflow} + rollup) | by_cost | .[] |
+    [.w, (.n | tostring), cost_cell, (.i | fmt), (.o | fmt), (.cc | fmt), (.cr | fmt)] | @tsv)
+'
+
+# Repeat work on one subject is what this table exists to show: a PR reviewed
+# nine times, or two agents racing on one commit, is one row with a high RUNS
+# count.
+table '
+  (["SUBJECT", "RUNS", "COST", "WORKFLOWS", "CACHE-READ"] | @tsv),
+  (.runs | group_by(.subject) | map({s: (.[0].subject | short), wf: (map(.workflow) | unique | join(","))} + rollup)
+    | by_cost | .[:$top] | .[] |
+    [.s, (.n | tostring), cost_cell, .wf, (.cr | fmt)] | @tsv)
+'
+
+table '
+  (["RUN", "WORKFLOW", "SUBJECT", "COST", "INPUT", "OUTPUT", "CACHE-CREATE", "CACHE-READ", "TIME"] | @tsv),
+  (.runs | sort_by(.created_at) | reverse | .[] |
+    [(.run_id | tostring), .workflow, (.subject | short), ((.cost_usd | usd) + (.partial // false | floor_marker)), (.input_tokens | fmt), (.output_tokens | fmt), (.cache_creation_input_tokens | fmt), (.cache_read_input_tokens | fmt), .created_at[:16]] | @tsv)
+'
+
 # Printed outside the table's `column -t`, which would otherwise align a prose
 # line into the table's columns.
+SUBJECT_COUNT=$(jq -r '[.runs[].subject] | unique | length' "$WORKDIR/report.json")
+if [ "$SUBJECT_COUNT" -gt "$TOP_SUBJECTS" ]; then
+  echo >&2 "Subjects: showing the $TOP_SUBJECTS costliest of $SUBJECT_COUNT; the JSON on stdout has them all."
+fi
 PARTIAL_RUNS=$(jq -r '.totals.partial_runs' "$WORKDIR/report.json")
 if [ "$PARTIAL_RUNS" -gt 0 ]; then
   echo >&2 "$PARTIAL_RUNS run(s) emitted no result event (typically cancelled): tokens counted, cost not recoverable. A '+' marks a cost that is a floor rather than the spend."

--- a/plugins/tend-ci-runner/scripts/token-report.sh
+++ b/plugins/tend-ci-runner/scripts/token-report.sh
@@ -1,27 +1,28 @@
 #!/usr/bin/env bash
 # Reports token spend across recent tend CI runs.
 #
-# Downloads session log artifacts from GitHub Actions, extracts each run's
-# token-usage.json (written by the "Token usage" step in each harness action),
-# and outputs a JSON report to stdout. A human-readable summary is printed to
-# stderr, grouped by workflow and by subject.
-#
-# The two rollup tables — one row per workflow, one per subject — sort by cost.
-# A cached input token is priced far below an output token, so ranking by token
-# volume, which cache reads dominate, is not ranking by spend. The per-run
-# table below them stays newest-first.
+# Output (stdout): JSON — { runs: [...], totals: {...} }
+# Output (stderr): a human-readable summary
 #
 # Usage: ./token-report.sh [HOURS] [PREFIX ...]
 #   HOURS: lookback period in hours (default: 168 = 7 days)
 #   PREFIX: additional workflow name prefixes to include (default: tend-)
 #
-# Output (stdout): JSON — { runs: [...], totals: {...} }
-# Output (stderr): human-readable summary table
-#
 # Environment:
 #   TARGET_REPO - query a different repo (default: current repo)
 #
 # Requires: gh, jq
+#
+# Shape: shell talks to GitHub, jq does the arithmetic, and one canonical form
+# joins them. The download loop writes one JSON line per *job* — the
+# `token-usage.json` the "Token usage" step wrote, plus the run's row from
+# `gh run list` — and everything downstream reads that stream. So there are
+# three jq programs and no shell arithmetic: the loop's one-line stamp, the
+# report (jobs to runs to totals), and the summary.
+#
+# The summary's rollup tables sort by cost. A cached input token is priced far
+# below an output token, so ranking by token volume, which cache reads
+# dominate, is not ranking by spend. The per-run table stays newest-first.
 
 set -euo pipefail
 # Disable gh's colored JSON output. NO_COLOR=1 alone is insufficient when the
@@ -46,6 +47,11 @@ fi
 WORKDIR=$(mktemp -d)
 trap 'rm -rf "$WORKDIR"' EXIT
 
+# One JSON object per job. An empty file is a report of no runs, which the two
+# programs below produce from it without a special case.
+JOBS="$WORKDIR/jobs.jsonl"
+: > "$JOBS"
+
 # Discover tend workflows (tend-* by default, plus any extra prefixes)
 PREFIXES=("tend-" "${EXTRA_PREFIXES[@]}")
 WORKFLOWS=()
@@ -55,11 +61,6 @@ for prefix in "${PREFIXES[@]}"; do
   )
   WORKFLOWS+=("${matches[@]}")
 done
-
-if [ ${#WORKFLOWS[@]} -eq 0 ]; then
-  echo '{"runs":[],"totals":{"input_tokens":0,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"turns":0,"cost_usd":0,"partial_runs":0}}'
-  exit 0
-fi
 
 # Collect all completed runs across workflows.
 #
@@ -82,7 +83,7 @@ RUN_LIMIT=1000
 ALL_RUNS="[]"
 for wf in "${WORKFLOWS[@]}"; do
   if ! runs=$(gh run list "${repo_args[@]}" --workflow "$wf" --created ">=$SINCE" --status completed \
-    --json databaseId,conclusion,createdAt,name --limit "$RUN_LIMIT" 2>/dev/null); then
+    --json databaseId,createdAt,name --limit "$RUN_LIMIT" 2>/dev/null); then
     echo >&2 "WARNING: 'gh run list' for '$wf' failed — its runs are absent from the totals below."
     runs="[]"
   elif [ "$(echo "$runs" | jq 'length')" -ge "$RUN_LIMIT" ]; then
@@ -91,215 +92,208 @@ for wf in "${WORKFLOWS[@]}"; do
   ALL_RUNS=$(echo "$ALL_RUNS" "$runs" | jq -s 'add | unique_by(.databaseId)')
 done
 
-RUN_COUNT=$(echo "$ALL_RUNS" | jq 'length')
-if [ "$RUN_COUNT" -eq 0 ]; then
-  echo '{"runs":[],"totals":{"input_tokens":0,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"turns":0,"cost_usd":0,"partial_runs":0}}'
-  exit 0
-fi
+# The run listing is the source for these three fields and the record the job
+# uploaded is the source for the rest, so they are renamed once here and
+# nothing downstream carries `gh`'s spelling.
+mapfile -t ROWS < <(
+  echo "$ALL_RUNS" | jq -c '.[] | {run_id: .databaseId, workflow: .name, created_at: .createdAt}'
+)
+echo >&2 "Downloading artifacts for ${#ROWS[@]} runs..."
 
-echo >&2 "Downloading artifacts for $RUN_COUNT runs..."
-
-ENTRIES="$WORKDIR/entries.jsonl"
-touch "$ENTRIES"
-
-# Runs that reach the totals with nothing. Counted rather than dropped
+# Runs that reach the report with nothing, counted rather than dropped
 # silently: a codex-harness repo would otherwise read a report of zero runs
 # with no line saying why, and the same silence covers a torn upload.
 SKIPPED=0
 
-mapfile -t ROWS < <(echo "$ALL_RUNS" | jq -c '.[]')
 for row in "${ROWS[@]}"; do
-  RUN_ID=$(echo "$row" | jq -r '.databaseId')
+  RUN_ID=$(echo "$row" | jq -r '.run_id')
   RUNDIR="$WORKDIR/$RUN_ID"
   mkdir -p "$RUNDIR"
 
-  # Claude runs only: the `claude` action uploads `claude-session-logs-X`.
-  # Runs on the codex harness upload `codex-session-logs-X` and are skipped
-  # by the pattern below, so a codex-only repo reports zero.
-  if ! gh run download "$RUN_ID" "${repo_args[@]}" \
-      --pattern 'claude-session-logs*' \
-      --dir "$RUNDIR" 2>/dev/null; then
-    SKIPPED=$((SKIPPED + 1))
-    continue
+  # Claude runs only: the `claude` action uploads `claude-session-logs-X`, and
+  # the pattern below leaves the codex harness's `codex-session-logs-X` alone,
+  # so a codex-only repo reports zero runs and says so.
+  if gh run download "$RUN_ID" "${repo_args[@]}" \
+      --pattern 'claude-session-logs*' --dir "$RUNDIR" 2>/dev/null; then
+    mapfile -t USAGE_FILES < <(find "$RUNDIR" -name "token-usage.json" -type f)
+  else
+    USAGE_FILES=()
   fi
 
-  mapfile -t USAGE_FILES < <(find "$RUNDIR" -name "token-usage.json" -type f)
-  if [ ${#USAGE_FILES[@]} -eq 0 ]; then
+  # Stamp the run onto each of its jobs — a matrix run uploads one file per leg
+  # — and hold the result aside until the whole run parses. jq emits as it
+  # reads, so a torn file fails only after its predecessors are out, and
+  # appending those would count a run twice. An unreadable or empty artifact
+  # therefore costs its own run and no other; without the guard `set -e` would
+  # end the script here and take every other run's data with it. jq's own
+  # error goes to stderr unsuppressed, which is what names the torn file.
+  if [ ${#USAGE_FILES[@]} -gt 0 ] &&
+    jq -c --argjson run "$row" '. + $run' "${USAGE_FILES[@]}" > "$RUNDIR/jobs.jsonl" &&
+    [ -s "$RUNDIR/jobs.jsonl" ]; then
+    cat "$RUNDIR/jobs.jsonl" >> "$JOBS"
+  else
     SKIPPED=$((SKIPPED + 1))
-    continue
   fi
-
-  # Aggregate across matrix jobs (each job produces its own token-usage.json).
-  # `partial` marks a run whose counts were reconstructed from the session log
-  # because it emitted no result event — its tokens are real but its cost is
-  # unrecoverable, so the cost column under-counts by however many there are.
-  #
-  # The identity fields are per-run rather than per-job, so the first job that
-  # carries one speaks for the run; `empty` drops the nulls an older artifact
-  # (or an event with no thread of its own) leaves, and `first` of nothing is
-  # null. `run_id` and `workflow` are deliberately not read here — the run list
-  # above is already their source, and one source per field beats a fallback.
-  # Every sum takes `// 0` for the same reason the totals below do: `add` over
-  # no values is null, and a null reaching the report's arithmetic ends it.
-  # An artifact that holds no usable object is a torn upload, and a run that
-  # reports zero still reports its identity.
-  if ! USAGE=$(cat "${USAGE_FILES[@]}" | jq -s '
-    def pick(f): map(f // empty) | first;
-    {
-      input_tokens: (map(.input_tokens) | add // 0),
-      output_tokens: (map(.output_tokens) | add // 0),
-      cache_creation_input_tokens: (map(.cache_creation_input_tokens) | add // 0),
-      cache_read_input_tokens: (map(.cache_read_input_tokens) | add // 0),
-      turns: (map(.turns) | add // 0),
-      cost_usd: (map(.cost_usd // 0) | add // 0),
-      partial: (map(.partial // false) | any),
-      repo: pick(.repo),
-      event: pick(.event),
-      number: pick(.number),
-      head_sha: pick(.head_sha)
-    }'); then
-    # An unparsable file would otherwise abort the whole run under `set -e`,
-    # losing every other run's data with it — the loop tolerates a failed
-    # download and a missing file already.
-    echo >&2 "WARNING: run $RUN_ID has an unreadable token-usage.json — its tokens are absent from the totals below."
-    SKIPPED=$((SKIPPED + 1))
-    continue
-  fi
-
-  # `subject` is what the run was about as one cell: the PR or issue it worked
-  # on, else the commit, else `?` for a record written before these fields
-  # existed or one whose event named neither. Computed once, here, so every
-  # reader of the report groups by the same key.
-  jq -c --argjson usage "$USAGE" '
-    . + $usage + {run_id: .databaseId, workflow: .name, created_at: .createdAt} |
-    del(.databaseId, .name, .createdAt) |
-    .subject = (if .number then "#\(.number)" elif .head_sha then .head_sha else "?" end)
-    ' <<< "$row" >> "$ENTRIES"
 
   rm -rf "$RUNDIR"
 done
 
-# Build final output: runs array + totals
-jq -s '{
-  runs: .,
-  totals: {
-    input_tokens: (map(.input_tokens) | add // 0),
-    output_tokens: (map(.output_tokens) | add // 0),
-    cache_creation_input_tokens: (map(.cache_creation_input_tokens) | add // 0),
-    cache_read_input_tokens: (map(.cache_read_input_tokens) | add // 0),
-    turns: (map(.turns) | add // 0),
-    cost_usd: (map(.cost_usd) | add // 0 | . * 100 | round / 100),
-    partial_runs: (map(select(.partial)) | length)
-  }
-}' "$ENTRIES" | tee "$WORKDIR/report.json"
+# Jobs to runs to totals. `partial` marks a run whose counts were reconstructed
+# from the session log because it emitted no result event: its tokens are real
+# and its cost is not recoverable, so every cost it lands in is a floor.
+jq -s --argjson skipped "$SKIPPED" '
+  def sum(f): map(f) | add // 0;
+  # The identity fields are per-run, so the first leg carrying one speaks for
+  # the run; `empty` drops the nulls an event with no thread, or an artifact
+  # written before the record carried these, leaves behind.
+  def pick(f): map(f // empty) | first;
 
-# How many of the costliest subjects the summary shows.
-TOP_SUBJECTS=20
+  def run_entry:
+    {
+      run_id: .[0].run_id,
+      workflow: .[0].workflow,
+      created_at: .[0].created_at,
+      repo: pick(.repo),
+      event: pick(.event),
+      number: pick(.number),
+      head_sha: pick(.head_sha),
+      input_tokens: sum(.input_tokens),
+      output_tokens: sum(.output_tokens),
+      cache_creation_input_tokens: sum(.cache_creation_input_tokens),
+      cache_read_input_tokens: sum(.cache_read_input_tokens),
+      turns: sum(.turns),
+      cost_usd: sum(.cost_usd),
+      partial: (map(.partial // false) | any)
+    }
+    # What the run was about, as one cell: the PR or issue it worked on, else
+    # the commit, else `?` for a record written before these fields existed or
+    # one whose event named neither. Computed once, here, so every reader of
+    # the report groups by the same key.
+    | .subject = (if .number then "#\(.number)" elif .head_sha then .head_sha else "?" end);
 
-# Shared by the programs below. The prose header is rendered on its own
-# because `column -t` splits on whitespace: a sentence run through it is
-# aligned into the tables' columns, one word per cell.
-JQ_DEFS='
+  (group_by(.run_id) | map(run_entry) | sort_by(.created_at) | reverse) as $runs
+  | {
+      runs: $runs,
+      totals: ($runs | {
+        input_tokens: sum(.input_tokens),
+        output_tokens: sum(.output_tokens),
+        cache_creation_input_tokens: sum(.cache_creation_input_tokens),
+        cache_read_input_tokens: sum(.cache_read_input_tokens),
+        turns: sum(.turns),
+        cost_usd: (sum(.cost_usd) | . * 100 | round / 100),
+        partial_runs: (map(select(.partial)) | length),
+        skipped_runs: $skipped
+      })
+    }
+' "$JOBS" | tee "$WORKDIR/report.json"
+
+jq -r --arg since "$SINCE" '
+  # How many of the costliest subjects the summary shows.
+  def top: 20;
+
   def fmt:
     if . >= 1000000 then "\(. / 100000 | floor | . / 10)M"
     elif . >= 1000 then "\(. / 100 | floor | . / 10)K"
     else "\(.)" end;
 
-  def usd: (. * 100 | round / 100) | tostring | if test("\\.") then split(".") | "\(.[0]).\((.[1] + "00")[:2])" else . + ".00" end | "$" + .;
+  # Rounds here rather than in the report, so a matrix run whose per-leg costs
+  # sum to 28.169999999999995 reads the same in its own row as in its total.
+  def usd:
+    (. * 100 | round / 100) | tostring
+    | if test("\\.") then split(".") | "\(.[0]).\((.[1] + "00")[:2])" else . + ".00" end
+    | "$" + .;
 
-  # A partial run contributes tokens but no cost, so every cost it lands in —
-  # its own row, its group row, the total — is a floor, not the spend. Mark
-  # those cells with a trailing `+` so a reconstructed run never reads as free.
+  # A cost a partial run lands in is a floor, not the spend. Marked so a
+  # reconstructed run never reads as free.
   def floor_marker: if . then "+" else "" end;
 
   # A full sha is the join key; the column has room for a prefix.
   def short: .[:12];
 
-  # Applied to a group of runs; the caller adds the columns that name it.
+  # Rows are padded here rather than piped through `column -t`, which splits on
+  # whitespace: a workflow name with a space in it would shift every column
+  # right, and one pass over the whole summary would align the prose lines into
+  # the tables and eat the blank lines between them.
+  def pad($w): . + ((" " * ($w - length)) // "");
+  def table($rows):
+    ($rows | transpose | map(map(length) | max)) as $w
+    | $rows
+    | map(. as $row
+      | [range(0; $row | length) as $i | $row[$i] | pad($w[$i])]
+      | join("  ") | sub(" +$"; ""));
+
   def rollup: {
     n: length,
-    cost: (map(.cost_usd) | add),
-    partial: (map(.partial // false) | any),
-    i: (map(.input_tokens) | add),
-    o: (map(.output_tokens) | add),
-    cc: (map(.cache_creation_input_tokens) | add),
-    cr: (map(.cache_read_input_tokens) | add)
+    cost: (map(.cost_usd) | add // 0),
+    partial: (map(.partial) | any),
+    i: (map(.input_tokens) | add // 0),
+    o: (map(.output_tokens) | add // 0),
+    cc: (map(.cache_creation_input_tokens) | add // 0),
+    cr: (map(.cache_read_input_tokens) | add // 0)
   };
   def cost_cell: (.cost | usd) + (.partial | floor_marker);
   def by_cost: sort_by(.cost) | reverse;
-'
+  def subjects:
+    group_by(.subject)
+    | map({k: (.[0].subject | short), wf: (map(.workflow) | unique | join(","))} + rollup);
 
-jq -r "$JQ_DEFS"'
-  "",
-  "\(.runs | length) runs since '"$SINCE"'",
-  "Total cost: \(.totals.cost_usd | usd)\(.totals.partial_runs > 0 | floor_marker)"
-    + (if .totals.partial_runs > 0 then " (\(.totals.partial_runs) of \(.runs | length) runs cost-unknown)" else "" end),
-  "Tokens: \(.totals.input_tokens | fmt) in, \(.totals.output_tokens | fmt) out, \(.totals.cache_creation_input_tokens | fmt) cache-create, \(.totals.cache_read_input_tokens | fmt) cache-read",
-  ""
+  .totals as $t
+  | .runs as $runs
+  | [
+      "",
+      "\($runs | length) runs since \($since)",
+      "Total cost: \($t.cost_usd | usd)\($t.partial_runs > 0 | floor_marker)"
+        + (if $t.partial_runs > 0
+           then " (\($t.partial_runs) of \($runs | length) runs cost-unknown)" else "" end),
+      "Tokens: \($t.input_tokens | fmt) in, \($t.output_tokens | fmt) out, \($t.cache_creation_input_tokens | fmt) cache-create, \($t.cache_read_input_tokens | fmt) cache-read",
+      ""
+    ]
+  + table(
+      [["WORKFLOW", "RUNS", "COST", "INPUT", "OUTPUT", "CACHE-CREATE", "CACHE-READ"]]
+      + ($runs | group_by(.workflow) | map({k: .[0].workflow} + rollup) | by_cost
+         | map([.k, (.n | tostring), cost_cell, (.i | fmt), (.o | fmt), (.cc | fmt), (.cr | fmt)]))
+    ) + [""]
+  # Repeat work on one subject is what this table exists to show: a PR reviewed
+  # over and over, or two agents racing on one commit, is one row with a high
+  # RUNS count.
+  + table(
+      [["SUBJECT", "RUNS", "COST", "WORKFLOWS", "CACHE-READ"]]
+      + ($runs | subjects | by_cost | .[:top]
+         | map([.k, (.n | tostring), cost_cell, .wf, (.cr | fmt)]))
+    ) + [""]
+  # A run with no result event is booked at $0, because a floor is the only
+  # honest number for it — so the cost sort buries it and the cut above drops
+  # it, and a subject whose runs were all cancelled disappears from a report
+  # about where the tokens went. Its tokens are real, so it gets a table of its
+  # own, ranked by the one number it has, and uncapped: these are a small
+  # fraction of runs, and a fleet where they are not is itself the finding.
+  # Pricing them instead would mean carrying a price table, which is the thing
+  # the record deliberately does not do.
+  + (if $t.partial_runs > 0 then
+      table(
+        [["COST-UNKNOWN", "RUNS", "CACHE-READ", "OUTPUT", "WORKFLOWS"]]
+        + ($runs | map(select(.partial)) | subjects | sort_by(.cr) | reverse
+           | map([.k, (.n | tostring), (.cr | fmt), (.o | fmt), .wf]))
+      ) + [""]
+     else [] end)
+  + table(
+      [["RUN", "WORKFLOW", "SUBJECT", "COST", "INPUT", "OUTPUT", "CACHE-CREATE", "CACHE-READ", "TIME"]]
+      + ($runs | map([(.run_id | tostring), .workflow, (.subject | short),
+                      ((.cost_usd | usd) + (.partial | floor_marker)),
+                      (.input_tokens | fmt), (.output_tokens | fmt),
+                      (.cache_creation_input_tokens | fmt), (.cache_read_input_tokens | fmt),
+                      .created_at[:16]]))
+    ) + [""]
+  + (($runs | map(.subject) | unique | length) as $n
+     | if $n > top
+       then ["Subjects: showing the \(top) costliest of \($n); the JSON on stdout has them all."]
+       else [] end)
+  + (if $t.partial_runs > 0 then
+      ["COST-UNKNOWN lists the runs that emitted no result event, typically cancelled: their tokens are counted everywhere, their cost is not recoverable. A '"'"'+'"'"' marks a cost that is a floor rather than the spend."]
+     else [] end)
+  + (if $t.skipped_runs > 0 then
+      ["\($t.skipped_runs) run(s) uploaded no readable claude-session-logs artifact and are absent entirely: codex-harness runs, runs that ended before the upload, and torn uploads."]
+     else [] end)
+  + ["Cost at API list prices — a large multiple of the effective rate on Claude Code subscriptions."]
+  | .[]
 ' "$WORKDIR/report.json" >&2
-
-# One `column -t` per table: it aligns whatever it is given as a single grid
-# and drops the blank lines between, so a single pass would run the tables
-# together under one set of column widths. `-s` pins the separator to the tab
-# `@tsv` writes; the default splits on any whitespace, so a workflow name with
-# a space in it would shift every column right.
-table() {
-  jq -r --argjson top "$TOP_SUBJECTS" "$JQ_DEFS$1" "$WORKDIR/report.json" |
-    column -t -s "$(printf '\t')" >&2
-  echo >&2 ""
-}
-
-table '
-  (["WORKFLOW", "RUNS", "COST", "INPUT", "OUTPUT", "CACHE-CREATE", "CACHE-READ"] | @tsv),
-  (.runs | group_by(.workflow) | map({w: .[0].workflow} + rollup) | by_cost | .[] |
-    [.w, (.n | tostring), cost_cell, (.i | fmt), (.o | fmt), (.cc | fmt), (.cr | fmt)] | @tsv)
-'
-
-# Repeat work on one subject is what this table exists to show: a PR reviewed
-# over and over, or two agents racing on one commit, is one row with a high
-# RUNS count.
-table '
-  (["SUBJECT", "RUNS", "COST", "WORKFLOWS", "CACHE-READ"] | @tsv),
-  (.runs | group_by(.subject) | map({s: (.[0].subject | short), wf: (map(.workflow) | unique | join(","))} + rollup)
-    | by_cost | .[:$top] | .[] |
-    [.s, (.n | tostring), cost_cell, .wf, (.cr | fmt)] | @tsv)
-'
-
-# A run with no result event is booked at $0, because a floor is the only
-# honest number for it — so the cost sort buries it and the cut above drops it,
-# and a subject whose runs were all cancelled disappears from a report about
-# where the tokens went. Its tokens are real, so it gets a table of its own,
-# ranked by the one number it has. Uncapped, unlike the table above: these are
-# a small fraction of runs, and a fleet where they aren't is itself the finding.
-# Pricing them instead would mean carrying a price table, which is the thing
-# the record deliberately doesn't do.
-PARTIAL_RUNS=$(jq -r '.totals.partial_runs' "$WORKDIR/report.json")
-if [ "$PARTIAL_RUNS" -gt 0 ]; then
-  table '
-    (["COST-UNKNOWN", "RUNS", "CACHE-READ", "OUTPUT", "WORKFLOWS"] | @tsv),
-    (.runs | map(select(.partial)) | group_by(.subject)
-      | map({s: (.[0].subject | short), wf: (map(.workflow) | unique | join(","))} + rollup)
-      | sort_by(.cr) | reverse | .[] |
-      [.s, (.n | tostring), (.cr | fmt), (.o | fmt), .wf] | @tsv)
-  '
-fi
-
-table '
-  (["RUN", "WORKFLOW", "SUBJECT", "COST", "INPUT", "OUTPUT", "CACHE-CREATE", "CACHE-READ", "TIME"] | @tsv),
-  (.runs | sort_by(.created_at) | reverse | .[] |
-    [(.run_id | tostring), .workflow, (.subject | short), ((.cost_usd | usd) + (.partial // false | floor_marker)), (.input_tokens | fmt), (.output_tokens | fmt), (.cache_creation_input_tokens | fmt), (.cache_read_input_tokens | fmt), .created_at[:16]] | @tsv)
-'
-
-# Printed outside the table's `column -t`, which would otherwise align a prose
-# line into the table's columns.
-SUBJECT_COUNT=$(jq -r '[.runs[].subject] | unique | length' "$WORKDIR/report.json")
-if [ "$SUBJECT_COUNT" -gt "$TOP_SUBJECTS" ]; then
-  echo >&2 "Subjects: showing the $TOP_SUBJECTS costliest of $SUBJECT_COUNT; the JSON on stdout has them all."
-fi
-if [ "$PARTIAL_RUNS" -gt 0 ]; then
-  echo >&2 "COST-UNKNOWN lists the runs that emitted no result event, typically cancelled: their tokens are counted everywhere, their cost is not recoverable. A '+' marks a cost that is a floor rather than the spend."
-fi
-if [ "$SKIPPED" -gt 0 ]; then
-  echo >&2 "$SKIPPED run(s) uploaded no claude-session-logs artifact and are absent entirely: codex-harness runs, and runs that ended before the upload."
-fi
-echo >&2 "Cost at API list prices — a large multiple of the effective rate on Claude Code subscriptions."

--- a/plugins/tend-ci-runner/scripts/token-report.sh
+++ b/plugins/tend-ci-runner/scripts/token-report.sh
@@ -17,8 +17,10 @@
 # joins them. The download loop writes one JSON line per *job* — the
 # `token-usage.json` the "Token usage" step wrote, plus the run's row from
 # `gh run list` — and everything downstream reads that stream. So there are
-# three jq programs and no shell arithmetic: the loop's one-line stamp, the
-# report (jobs to runs to totals), and the summary.
+# three jq programs: the loop's one-line stamp, the report (jobs to runs to
+# totals), and the summary. The shell keeps one count of its own, the runs that
+# reach the report with nothing — the stream cannot carry it, because those are
+# exactly the runs that put no line in it.
 #
 # The summary's rollup tables sort by cost. A cached input token is priced far
 # below an output token, so ranking by token volume, which cache reads

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -262,7 +262,7 @@ HOURS=$(( ( $(date -u +%s) - $(date -u -d "$SINCE" +%s) + 3599 ) / 3600 ))
 
 Pass the same extra prefixes Step 1 censuses (after `$HOURS`, which the script reads as its first positional arg), so the two steps agree on what the fleet is — the repo's `running-tend` skill is the source for both (e.g. `review-` for a `review-reviewers` workflow that uses the tend action but isn't named `tend-*`).
 
-Include the total cost and the per-workflow breakdown in the summary (Step 7). Rank by cost, which the report's tables already do — cache reads are most of the token count and a minority of the bill. Two shapes are worth Step 3: a run far above its workflow's usual cost, and a subject with several runs against it in the subject table, such as one PR reviewed repeatedly or two agents on one commit.
+Include the total cost and the per-workflow breakdown in the summary (Step 7). Escalate outliers to Step 3 — for example a run far above its workflow's usual cost, or a subject the subject table shows several runs against.
 
 ## Step 3: Download and analyze session logs
 

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -262,7 +262,7 @@ HOURS=$(( ( $(date -u +%s) - $(date -u -d "$SINCE" +%s) + 3599 ) / 3600 ))
 
 Pass the same extra prefixes Step 1 censuses (after `$HOURS`, which the script reads as its first positional arg), so the two steps agree on what the fleet is — the repo's `running-tend` skill is the source for both (e.g. `review-` for a `review-reviewers` workflow that uses the tend action but isn't named `tend-*`).
 
-Include the totals and per-workflow breakdown in the summary (Step 7). Flag any runs with unusually high token usage for closer inspection in Step 3.
+Include the total cost and the per-workflow breakdown in the summary (Step 7). Rank by cost, which the report's tables already do — cache reads are most of the token count and a minority of the bill. Two shapes are worth Step 3: a run far above its workflow's usual cost, and a subject with several runs against it in the subject table, such as one PR reviewed repeatedly or two agents on one commit.
 
 ## Step 3: Download and analyze session logs
 

--- a/shared/steps/_common.py
+++ b/shared/steps/_common.py
@@ -102,12 +102,10 @@ def gh_paginated(path: str) -> list[Any]:
     return [item for page in pages for item in page]
 
 
-# What the triggering event is about, per event, as the path to it in the
-# payload. `repository_dispatch` is tend-mention relaying review events through
-# a secretless job that re-posts them, so the PR number arrives in the payload
-# rather than in a `pull_request` object — and as a form field, hence a string.
-# Events absent from a table have no such subject: `schedule` and
-# `workflow_dispatch` name no thread, and the thread events name no commit.
+# Where each event keeps the number of the issue or PR it is about.
+# `repository_dispatch` is tend-mention relaying review events through a
+# secretless job that re-posts them, so its PR number arrives in the dispatch
+# payload — and as a form field, hence a string.
 _SUBJECT_NUMBER_KEYS = {
     "pull_request_target": ("pull_request", "number"),
     "pull_request_review": ("pull_request", "number"),
@@ -116,6 +114,8 @@ _SUBJECT_NUMBER_KEYS = {
     "issue_comment": ("issue", "number"),
     "repository_dispatch": ("client_payload", "pr"),
 }
+# Where each event keeps its own commit. Only the pull-request events and
+# `workflow_run` carry one; see :func:`subject_sha` for what the rest report.
 _SUBJECT_SHA_KEYS = {
     "pull_request_target": ("pull_request", "head", "sha"),
     "pull_request_review": ("pull_request", "head", "sha"),
@@ -128,9 +128,10 @@ def event_payload() -> dict[str, Any]:
     """The triggering event's payload, or ``{}`` for anything unreadable.
 
     Every caller reads a fact *about* the run — the thread it came from, the
-    commit it is on — to annotate work it is doing anyway. A missing file or a
-    body that is not JSON costs that fact its ``None``; raising would cost the
-    incident record or the usage record it was going to annotate.
+    commit it is on — to annotate work it is doing anyway. So an unreadable
+    payload leaves that fact ``None``: a missing file, a body that is not JSON,
+    or no ``GITHUB_EVENT_PATH`` at all. Raising instead would lose the whole
+    record the fact was going to annotate.
     """
     try:
         payload = json.loads(
@@ -151,13 +152,23 @@ def dig(payload: Any, *keys: str) -> Any:
 
 
 def as_int(value: Any) -> int | None:
-    """``value`` as an ``int``, or ``None`` when it is absent or isn't one.
+    """``value`` as an ``int``, or ``None`` for anything that isn't a whole one.
 
-    The same number reaches these steps as a JSON int from one payload and as
-    a string from another (``repository_dispatch``'s form-encoded
-    ``client_payload``, every ``GITHUB_*`` variable), and a consumer that
-    groups records by it must not see the two as different keys.
+    The same number reaches these steps as a JSON int in one event's payload
+    and as a string in another's (``repository_dispatch``'s form-encoded
+    ``client_payload``), and every ``GITHUB_*`` variable is a string. A
+    consumer that groups records by such a number must not see the two forms
+    as different keys.
+
+    Bools and floats are refused rather than coerced. Anyone holding
+    ``contents: write`` can POST a ``repository_dispatch`` with any JSON type
+    in ``client_payload.pr``, and ``_issue.ref()`` renders what comes back
+    into a public issue comment: ``true`` coerced to ``1``, or ``3.9`` to
+    ``3``, is a plausible-looking reference to somebody else's PR, where
+    ``None`` is no reference at all.
     """
+    if isinstance(value, (bool, float)):
+        return None
     try:
         return int(value)
     except (TypeError, ValueError):
@@ -176,18 +187,30 @@ def subject_number() -> int | None:
 
 
 def subject_sha() -> str | None:
-    """The commit the run is about: the event's subject, else ``GITHUB_SHA``.
+    """The commit the triggering event is about, when its subject is a commit.
 
-    ``GITHUB_SHA`` is the wrong commit for exactly the events that carry their
-    own: a ``pull_request_target`` run reports the base branch there while the
-    workflow checks out the PR head, and a ``workflow_run`` run reports the
-    commit it was dispatched *from*, not the failing run's. Everywhere else it
-    is the commit the job checked out and worked on, which is what a reader
-    grouping spend by commit wants; ``None`` only when it is unset too.
+    An event's subject is a thread or a commit, and this reports the commit
+    half: the payload's where the event names one, and ``GITHUB_SHA`` — the
+    ref the run was queued on — for the events that name neither a thread nor
+    a commit, ``schedule`` and ``workflow_dispatch``. An event that names a
+    thread gets ``None``, because ``GITHUB_SHA`` is the default branch's tip
+    there and the run is not about it: a mention on a PR ``gh pr checkout``s
+    the PR's head straight after. :func:`subject_number` has that subject.
+
+    ``GITHUB_SHA`` is likewise the wrong commit for the events that do carry
+    their own, which is why the payload wins: a ``pull_request_target`` run
+    reports the default branch's tip there rather than the PR head the
+    workflow checks out, and a ``workflow_run`` run reports neither the
+    failing run's commit nor its own.
     """
-    keys = _SUBJECT_SHA_KEYS.get(os.environ.get("GITHUB_EVENT_NAME", ""))
+    event = os.environ.get("GITHUB_EVENT_NAME", "")
+    keys = _SUBJECT_SHA_KEYS.get(event)
     sha = dig(event_payload(), *keys) if keys else None
-    return sha if isinstance(sha, str) and sha else os.environ.get("GITHUB_SHA") or None
+    if isinstance(sha, str) and sha:
+        return sha
+    if event in _SUBJECT_NUMBER_KEYS:
+        return None
+    return os.environ.get("GITHUB_SHA") or None
 
 
 def utcnow() -> datetime.datetime:

--- a/shared/steps/_common.py
+++ b/shared/steps/_common.py
@@ -102,6 +102,94 @@ def gh_paginated(path: str) -> list[Any]:
     return [item for page in pages for item in page]
 
 
+# What the triggering event is about, per event, as the path to it in the
+# payload. `repository_dispatch` is tend-mention relaying review events through
+# a secretless job that re-posts them, so the PR number arrives in the payload
+# rather than in a `pull_request` object — and as a form field, hence a string.
+# Events absent from a table have no such subject: `schedule` and
+# `workflow_dispatch` name no thread, and the thread events name no commit.
+_SUBJECT_NUMBER_KEYS = {
+    "pull_request_target": ("pull_request", "number"),
+    "pull_request_review": ("pull_request", "number"),
+    "pull_request_review_comment": ("pull_request", "number"),
+    "issues": ("issue", "number"),
+    "issue_comment": ("issue", "number"),
+    "repository_dispatch": ("client_payload", "pr"),
+}
+_SUBJECT_SHA_KEYS = {
+    "pull_request_target": ("pull_request", "head", "sha"),
+    "pull_request_review": ("pull_request", "head", "sha"),
+    "pull_request_review_comment": ("pull_request", "head", "sha"),
+    "workflow_run": ("workflow_run", "head_sha"),
+}
+
+
+def event_payload() -> dict[str, Any]:
+    """The triggering event's payload, or ``{}`` for anything unreadable.
+
+    Every caller reads a fact *about* the run — the thread it came from, the
+    commit it is on — to annotate work it is doing anyway. A missing file or a
+    body that is not JSON costs that fact its ``None``; raising would cost the
+    incident record or the usage record it was going to annotate.
+    """
+    try:
+        payload = json.loads(
+            Path(os.environ["GITHUB_EVENT_PATH"]).read_text(encoding="utf-8")
+        )
+    except (OSError, ValueError, KeyError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def dig(payload: Any, *keys: str) -> Any:
+    """``payload[k1][k2]…``, or ``None`` for any shape that lacks that path."""
+    for key in keys:
+        if not isinstance(payload, dict):
+            return None
+        payload = payload.get(key)
+    return payload
+
+
+def as_int(value: Any) -> int | None:
+    """``value`` as an ``int``, or ``None`` when it is absent or isn't one.
+
+    The same number reaches these steps as a JSON int from one payload and as
+    a string from another (``repository_dispatch``'s form-encoded
+    ``client_payload``, every ``GITHUB_*`` variable), and a consumer that
+    groups records by it must not see the two as different keys.
+    """
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def subject_number() -> int | None:
+    """The issue or PR number the triggering event is about, if it has one.
+
+    ``None`` for an event with no thread of its own (``schedule``,
+    ``workflow_dispatch``, ``workflow_run``) and for a payload whose shape is
+    not the one its event promises.
+    """
+    keys = _SUBJECT_NUMBER_KEYS.get(os.environ.get("GITHUB_EVENT_NAME", ""))
+    return as_int(dig(event_payload(), *keys)) if keys else None
+
+
+def subject_sha() -> str | None:
+    """The commit the run is about: the event's subject, else ``GITHUB_SHA``.
+
+    ``GITHUB_SHA`` is the wrong commit for exactly the events that carry their
+    own: a ``pull_request_target`` run reports the base branch there while the
+    workflow checks out the PR head, and a ``workflow_run`` run reports the
+    commit it was dispatched *from*, not the failing run's. Everywhere else it
+    is the commit the job checked out and worked on, which is what a reader
+    grouping spend by commit wants; ``None`` only when it is unset too.
+    """
+    keys = _SUBJECT_SHA_KEYS.get(os.environ.get("GITHUB_EVENT_NAME", ""))
+    sha = dig(event_payload(), *keys) if keys else None
+    return sha if isinstance(sha, str) and sha else os.environ.get("GITHUB_SHA") or None
+
+
 def utcnow() -> datetime.datetime:
     """The one clock the steps read, always UTC.
 

--- a/shared/steps/_issue.py
+++ b/shared/steps/_issue.py
@@ -17,10 +17,8 @@ Inputs (env, from Actions): ``GITHUB_SERVER_URL``, ``GITHUB_REPOSITORY``,
 
 from __future__ import annotations
 
-import json
 import os
 import subprocess
-from pathlib import Path
 from typing import Any
 
 import _common
@@ -31,42 +29,6 @@ PROBE_WINDOW = 10
 
 _ROW_HEADER = "| When | Run | Trigger |\n|------|-----|---------|"
 
-# The trigger's number, per event, as `(outer key, inner key)` in the event
-# payload. `repository_dispatch` is tend-mention relaying review events through
-# a secretless job that re-posts them, so the PR number arrives in the payload
-# rather than in a `pull_request` object.
-_NUMBER_KEYS = {
-    "pull_request_target": ("pull_request", "number"),
-    "pull_request_review": ("pull_request", "number"),
-    "pull_request_review_comment": ("pull_request", "number"),
-    "issues": ("issue", "number"),
-    "issue_comment": ("issue", "number"),
-    "repository_dispatch": ("client_payload", "pr"),
-}
-
-
-def _event_payload() -> dict[str, Any]:
-    """The triggering event's payload, or ``{}`` for anything unreadable.
-
-    Every caller is on a path the run has already failed or been refused on,
-    and the payload fills one cell of one row. A missing file or a body that
-    is not JSON costs that cell its ``N/A``; raising would cost the whole
-    record of the incident, which is the thing the row exists to leave behind.
-    """
-    try:
-        payload = json.loads(
-            Path(os.environ["GITHUB_EVENT_PATH"]).read_text(encoding="utf-8")
-        )
-    except (OSError, ValueError):
-        return {}
-    return payload if isinstance(payload, dict) else {}
-
-
-def _dig(payload: dict[str, Any], outer: str, inner: str) -> Any:
-    """``payload[outer][inner]``, or ``None`` for any shape that lacks it."""
-    section = payload.get(outer)
-    return section.get(inner) if isinstance(section, dict) else None
-
 
 def ref() -> str:
     """A one-line reference to the triggering context, for the Trigger column.
@@ -76,17 +38,14 @@ def ref() -> str:
     with no thread of their own (``schedule``, ``workflow_dispatch``); the
     caller renders that as ``N/A``.
     """
-    payload = _event_payload()
-    event_name = os.environ["GITHUB_EVENT_NAME"]
-    if event_name == "workflow_run":
+    if os.environ["GITHUB_EVENT_NAME"] == "workflow_run":
         # Link the run being fixed — without its id there is no way back to
         # the failure the ci-fix job was dispatched to handle.
-        run_id = _dig(payload, "workflow_run", "id")
+        run_id = _common.dig(_common.event_payload(), "workflow_run", "id")
         if not run_id:
             return "CI fix for workflow run"
         return f"CI fix for [run {run_id}]({_run_url(run_id)})"
-    keys = _NUMBER_KEYS.get(event_name)
-    number = _dig(payload, *keys) if keys else None
+    number = _common.subject_number()
     return f"#{number}" if number else ""
 
 

--- a/shared/steps/test_common.py
+++ b/shared/steps/test_common.py
@@ -131,6 +131,11 @@ def test_subject_number_is_an_int_whatever_the_payload_calls_it(
         ("schedule", {}, None),
         ("issues", {"issue": None}, None),
         ("repository_dispatch", {"client_payload": {"pr": ""}}, None),
+        # A dispatch is a POST anyone with `contents: write` can shape, and
+        # `_issue.ref()` renders the result into a public issue comment. A
+        # coerced `1` or `3` is a plausible reference to somebody else's PR.
+        ("repository_dispatch", {"client_payload": {"pr": True}}, None),
+        ("repository_dispatch", {"client_payload": {"pr": 3.9}}, None),
     ],
 )
 def test_subject_number_is_none_when_the_event_names_no_thread(
@@ -148,25 +153,33 @@ def test_subject_number_is_none_when_the_event_names_no_thread(
 @pytest.mark.parametrize(
     ("event", "payload", "expected"),
     [
-        # The two events whose GITHUB_SHA is the wrong commit: a
-        # pull_request_target run reports the base while the workflow checks
-        # out the head, and a workflow_run run reports the commit it was
-        # dispatched from rather than the failing run's.
+        # The events that carry their own commit, for which GITHUB_SHA is the
+        # default branch's tip rather than the PR head the workflow checks out
+        # or the run the ci-fix job was dispatched to fix.
         ("pull_request_target", {"pull_request": {"head": {"sha": "head0"}}}, "head0"),
         ("workflow_run", {"workflow_run": {"head_sha": "failed0"}}, "failed0"),
-        # Everywhere else GITHUB_SHA is the commit the job worked on — and it
-        # is also the fallback when the event's own path is missing or empty.
-        ("issues", {"issue": {"number": 7}}, "checkout0"),
-        ("pull_request_target", {"pull_request": {}}, "checkout0"),
+        # An event whose subject is a thread reports no commit. GITHUB_SHA is
+        # the default branch's tip, and a mention on a PR `gh pr checkout`s the
+        # PR head straight after, so recording it would name a commit the run
+        # never touched — and disagree with the review record for the same
+        # revision.
+        ("issues", {"issue": {"number": 7}}, None),
+        ("issue_comment", {"issue": {"number": 7}}, None),
+        ("repository_dispatch", {"client_payload": {"pr": 99}}, None),
+        # A pull-request payload that doesn't carry the head takes the same
+        # `None` rather than falling back to the base commit.
+        ("pull_request_target", {"pull_request": {}}, None),
+        # Nothing names a thread here, so GITHUB_SHA is the run's own ref.
+        ("schedule", {}, "checkout0"),
         ("workflow_run", {"workflow_run": {"head_sha": ""}}, "checkout0"),
     ],
 )
-def test_subject_sha_prefers_the_events_own_commit(
+def test_subject_sha_reports_only_a_commit_the_event_is_about(
     monkeypatch: pytest.MonkeyPatch,
     actions_env: Path,
     event: str,
     payload: dict,
-    expected: str,
+    expected: str | None,
 ) -> None:
     actions_env.write_text(json.dumps(payload))
     monkeypatch.setenv("GITHUB_EVENT_NAME", event)

--- a/shared/steps/test_common.py
+++ b/shared/steps/test_common.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 
@@ -107,3 +108,86 @@ def test_run_turns_an_unhandled_gh_failure_into_one_error(
         _common.run(main)
     assert caught.value.code == 1
     assert capsys.readouterr().out == "::error::gh api repos/x failed (exit 4)\n"
+
+
+def test_subject_number_is_an_int_whatever_the_payload_calls_it(
+    monkeypatch: pytest.MonkeyPatch, actions_env: Path
+) -> None:
+    """A relayed review's PR number arrives as a form string, not a JSON int.
+
+    Records are grouped by this key, and `"99"` and `99` are different keys.
+    """
+    assert _common.subject_number() == 851
+    actions_env.write_text(json.dumps({"client_payload": {"pr": "99"}}))
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "repository_dispatch")
+    assert _common.subject_number() == 99
+
+
+@pytest.mark.parametrize(
+    ("event", "payload", "expected"),
+    [
+        # No thread of its own, a payload that isn't the shape its event
+        # promises, and a number that isn't one.
+        ("schedule", {}, None),
+        ("issues", {"issue": None}, None),
+        ("repository_dispatch", {"client_payload": {"pr": ""}}, None),
+    ],
+)
+def test_subject_number_is_none_when_the_event_names_no_thread(
+    monkeypatch: pytest.MonkeyPatch,
+    actions_env: Path,
+    event: str,
+    payload: dict,
+    expected: int | None,
+) -> None:
+    actions_env.write_text(json.dumps(payload))
+    monkeypatch.setenv("GITHUB_EVENT_NAME", event)
+    assert _common.subject_number() is expected
+
+
+@pytest.mark.parametrize(
+    ("event", "payload", "expected"),
+    [
+        # The two events whose GITHUB_SHA is the wrong commit: a
+        # pull_request_target run reports the base while the workflow checks
+        # out the head, and a workflow_run run reports the commit it was
+        # dispatched from rather than the failing run's.
+        ("pull_request_target", {"pull_request": {"head": {"sha": "head0"}}}, "head0"),
+        ("workflow_run", {"workflow_run": {"head_sha": "failed0"}}, "failed0"),
+        # Everywhere else GITHUB_SHA is the commit the job worked on — and it
+        # is also the fallback when the event's own path is missing or empty.
+        ("issues", {"issue": {"number": 7}}, "checkout0"),
+        ("pull_request_target", {"pull_request": {}}, "checkout0"),
+        ("workflow_run", {"workflow_run": {"head_sha": ""}}, "checkout0"),
+    ],
+)
+def test_subject_sha_prefers_the_events_own_commit(
+    monkeypatch: pytest.MonkeyPatch,
+    actions_env: Path,
+    event: str,
+    payload: dict,
+    expected: str,
+) -> None:
+    actions_env.write_text(json.dumps(payload))
+    monkeypatch.setenv("GITHUB_EVENT_NAME", event)
+    monkeypatch.setenv("GITHUB_SHA", "checkout0")
+    assert _common.subject_sha() == expected
+
+
+def test_event_payload_survives_a_file_it_cannot_read(
+    monkeypatch: pytest.MonkeyPatch, actions_env: Path
+) -> None:
+    """The payload annotates work already under way; it may not cost it.
+
+    A GitHub blip can leave an HTML error page where the JSON should be, and
+    a step body reading this outside Actions has no GITHUB_EVENT_PATH at all.
+    """
+    actions_env.write_text("<html>not an event payload</html>")
+    assert _common.event_payload() == {}
+
+    actions_env.unlink()
+    assert _common.event_payload() == {}
+
+    monkeypatch.delenv("GITHUB_EVENT_PATH")
+    assert _common.event_payload() == {}
+    assert _common.subject_number() is None

--- a/shared/steps/test_token_usage.py
+++ b/shared/steps/test_token_usage.py
@@ -48,6 +48,18 @@ SUBAGENT_USAGE = {
 
 TRUNCATED = '{"type":"assistant","mess'
 
+# What `run_context` reads. A test that asserts an absent context has to strip
+# them, because pytest itself runs under Actions in CI.
+CONTEXT_VARS = (
+    "GITHUB_REPOSITORY",
+    "GITHUB_WORKFLOW",
+    "GITHUB_RUN_ID",
+    "GITHUB_RUN_ATTEMPT",
+    "GITHUB_EVENT_NAME",
+    "GITHUB_SHA",
+    "GITHUB_EVENT_PATH",
+)
+
 
 def _assistant(msg_id: str, usage: dict[str, int], *, final: bool) -> dict[str, object]:
     return {
@@ -331,6 +343,8 @@ def test_claude_main_publishes_the_record_three_ways(
     """
     agent_home = tmp_path / "agent-home"
     _session_jsonl(agent_home / ".claude" / "projects")
+    for name in CONTEXT_VARS:
+        monkeypatch.delenv(name, raising=False)
     monkeypatch.setenv("AGENT_HOME", str(agent_home))
     monkeypatch.setenv("RUNNER_TEMP", str(tmp_path / "runner-temp"))
     monkeypatch.setenv("MODEL", "opus")
@@ -349,6 +363,10 @@ def test_claude_main_publishes_the_record_three_ways(
     record = json.loads(github_files.outputs()["usage"])
     assert record["output_tokens"] == 4500
     assert record["partial"] is True
+    # Nothing here runs under Actions, so every context key reads as absent.
+    # An `if: always()` step publishes the record it has rather than failing
+    # on a variable it cannot read.
+    assert record["repo"] is None and record["number"] is None
     written = tmp_path / "runner-temp" / "tend-logs" / "token-usage.json"
     assert json.loads(written.read_text()) == record
     assert github_files.summary.read_text() == (
@@ -370,8 +388,23 @@ def test_claude_main_publishes_the_record_three_ways(
 def test_codex_main_publishes_the_record_three_ways(
     tmp_path: Path,
     github_files: GithubFiles,
+    actions_env: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Every published copy carries what the run was about, not just its spend.
+
+    The context keys ride on the record itself so a later question — cost per
+    PR, repeat runs on one commit — reads them off the artifact rather than
+    joining every run back to `gh run list`. `head_sha` is the PR's head, not
+    the `GITHUB_SHA` the run reports, which for a pull-request event is the
+    base branch.
+    """
+    actions_env.write_text(
+        json.dumps({"pull_request": {"number": 851, "head": {"sha": "head0"}}})
+    )
+    monkeypatch.setenv("GITHUB_WORKFLOW", "tend-review")
+    monkeypatch.setenv("GITHUB_RUN_ATTEMPT", "2")
+    monkeypatch.setenv("GITHUB_SHA", "base0")
     home = tmp_path / "home"
     _ndjson(
         home / ".codex" / "sessions" / "2026" / "08" / "25" / "rollout-a.jsonl",
@@ -388,6 +421,13 @@ def test_codex_main_publishes_the_record_three_ways(
 
     record = json.loads(github_files.outputs()["usage"])
     assert record == {
+        "repo": "owner/repo",
+        "workflow": "tend-review",
+        "run_id": 12345,
+        "run_attempt": 2,
+        "event": "pull_request_target",
+        "number": 851,
+        "head_sha": "head0",
         "input_tokens": 100,
         "output_tokens": 30,
         "cached_input_tokens": 0,

--- a/shared/steps/test_token_usage.py
+++ b/shared/steps/test_token_usage.py
@@ -9,6 +9,7 @@ subagent's transcript beside the session would add 7000.
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -48,17 +49,19 @@ SUBAGENT_USAGE = {
 
 TRUNCATED = '{"type":"assistant","mess'
 
-# What `run_context` reads. A test that asserts an absent context has to strip
-# them, because pytest itself runs under Actions in CI.
-CONTEXT_VARS = (
-    "GITHUB_REPOSITORY",
-    "GITHUB_WORKFLOW",
-    "GITHUB_RUN_ID",
-    "GITHUB_RUN_ATTEMPT",
-    "GITHUB_EVENT_NAME",
-    "GITHUB_SHA",
-    "GITHUB_EVENT_PATH",
+# The keys `run_context` contributes to the record.
+CONTEXT_KEYS = (
+    "repo",
+    "workflow",
+    "run_id",
+    "run_attempt",
+    "event",
+    "number",
+    "head_sha",
 )
+# The runner's own channels, which a test needs even with the rest of the
+# Actions environment stripped.
+GITHUB_FILE_VARS = ("GITHUB_OUTPUT", "GITHUB_ENV", "GITHUB_STEP_SUMMARY")
 
 
 def _assistant(msg_id: str, usage: dict[str, int], *, final: bool) -> dict[str, object]:
@@ -343,8 +346,12 @@ def test_claude_main_publishes_the_record_three_ways(
     """
     agent_home = tmp_path / "agent-home"
     _session_jsonl(agent_home / ".claude" / "projects")
-    for name in CONTEXT_VARS:
-        monkeypatch.delenv(name, raising=False)
+    # Every `GITHUB_*` rather than a list of the ones `run_context` reads:
+    # pytest itself runs under Actions in CI, and a hand-kept list goes stale
+    # the moment a key is added, silently reading the ambient value instead.
+    for name in [name for name in os.environ if name.startswith("GITHUB_")]:
+        if name not in GITHUB_FILE_VARS:
+            monkeypatch.delenv(name, raising=False)
     monkeypatch.setenv("AGENT_HOME", str(agent_home))
     monkeypatch.setenv("RUNNER_TEMP", str(tmp_path / "runner-temp"))
     monkeypatch.setenv("MODEL", "opus")
@@ -366,7 +373,8 @@ def test_claude_main_publishes_the_record_three_ways(
     # Nothing here runs under Actions, so every context key reads as absent.
     # An `if: always()` step publishes the record it has rather than failing
     # on a variable it cannot read.
-    assert record["repo"] is None and record["number"] is None
+    context = {key: record[key] for key in CONTEXT_KEYS}
+    assert context == dict.fromkeys(CONTEXT_KEYS)
     written = tmp_path / "runner-temp" / "tend-logs" / "token-usage.json"
     assert json.loads(written.read_text()) == record
     assert github_files.summary.read_text() == (

--- a/shared/steps/token_usage.py
+++ b/shared/steps/token_usage.py
@@ -28,10 +28,9 @@ session-log artifact), the ``usage`` step output (compact JSON), and a
 interactive harness so downstream consumers (review-reviewers' evidence gist,
 token-report.sh, dashboards) don't branch on harness.
 
-Every record carries what the run was about as well as what it spent — repo,
-workflow, run, event, PR/issue number, commit — so spend can be grouped by
-subject without a second API call. See :func:`run_context`. The job summary
-stays counts-only: the run page it is rendered on already names the run.
+Every record also names the run it came from, so spend can be grouped by
+subject; see :func:`run_context`. The job summary stays counts-only, because
+the run page it is rendered on already names the run.
 
 Claude's accounting has three paths, tried in order:
 
@@ -143,17 +142,19 @@ def main() -> int:
 
 
 def run_context() -> dict[str, Any]:
-    """What the run was *about*, alongside what it spent.
+    """The run's identity, so a record says what the spend went to.
 
-    Without these a record answers "how much?" and nothing else, so every
-    question worth asking of a fleet's spend — cost per PR, repeat runs on one
-    branch, two agents racing on one commit — costs a join against
-    ``gh run list`` and the API behind it, one call per run. They are the
-    join's keys carried on the record instead.
+    Without it a record answers "how much?" and nothing else, and the reader
+    is left joining every artifact back to a run listing to find out what it
+    was working on. Two of these keys are not on that listing at all: the
+    PR/issue ``number``, and a ``head_sha`` read from the event rather than
+    from the ref the run was queued on. The rest are, and they are here so the
+    record stands on its own — read out of a gist or a downloaded artifact,
+    away from the run that wrote it.
 
-    Read from the Actions environment and the event payload, which are free
-    and always present in a job; each degrades to ``None`` on its own so a
-    surprising event shape costs one key rather than the record.
+    Read from the Actions environment, which is always set in a job, and from
+    the event payload, which may not be readable. Each key resolves on its
+    own, so a surprising event shape costs that key rather than the record.
     """
     env = os.environ
     return {

--- a/shared/steps/token_usage.py
+++ b/shared/steps/token_usage.py
@@ -16,13 +16,22 @@ Reads (env):
                       the agent's stderr log was written
   HOME              - codex: parent of ``.codex/sessions`` and
                       ``.codex/projects``
-  GITHUB_REPOSITORY - claude: gates the raw stream-json copy to tend's own repo
+  GITHUB_REPOSITORY - the record's ``repo``; on claude it also gates the raw
+                      stream-json copy to tend's own repo
+  GITHUB_WORKFLOW, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT, GITHUB_EVENT_NAME,
+  GITHUB_SHA, GITHUB_EVENT_PATH
+                    - the rest of :func:`run_context`
 
 Writes ``token-usage.json`` into the consolidated log dir (uploaded as the
 session-log artifact), the ``usage`` step output (compact JSON), and a
 ``## Token Usage`` table in the job summary. The record's shape mirrors the
 interactive harness so downstream consumers (review-reviewers' evidence gist,
 token-report.sh, dashboards) don't branch on harness.
+
+Every record carries what the run was about as well as what it spent — repo,
+workflow, run, event, PR/issue number, commit — so spend can be grouped by
+subject without a second API call. See :func:`run_context`. The job summary
+stays counts-only: the run page it is rendered on already names the run.
 
 Claude's accounting has three paths, tried in order:
 
@@ -125,11 +134,37 @@ def main() -> int:
     else:
         usage, logs_dir = codex_step(model)
 
-    payload = json.dumps(usage, separators=(",", ":"))
+    record = {**run_context(), **usage}
+    payload = json.dumps(record, separators=(",", ":"))
     (logs_dir / "token-usage.json").write_text(payload + "\n", encoding="utf-8")
     _common.set_output("usage", payload)
     _common.append_summary(render_summary(usage, harness=harness))
     return 0
+
+
+def run_context() -> dict[str, Any]:
+    """What the run was *about*, alongside what it spent.
+
+    Without these a record answers "how much?" and nothing else, so every
+    question worth asking of a fleet's spend — cost per PR, repeat runs on one
+    branch, two agents racing on one commit — costs a join against
+    ``gh run list`` and the API behind it, one call per run. They are the
+    join's keys carried on the record instead.
+
+    Read from the Actions environment and the event payload, which are free
+    and always present in a job; each degrades to ``None`` on its own so a
+    surprising event shape costs one key rather than the record.
+    """
+    env = os.environ
+    return {
+        "repo": env.get("GITHUB_REPOSITORY") or None,
+        "workflow": env.get("GITHUB_WORKFLOW") or None,
+        "run_id": _common.as_int(env.get("GITHUB_RUN_ID")),
+        "run_attempt": _common.as_int(env.get("GITHUB_RUN_ATTEMPT")),
+        "event": env.get("GITHUB_EVENT_NAME") or None,
+        "number": _common.subject_number(),
+        "head_sha": _common.subject_sha(),
+    }
 
 
 def claude_step(model: str) -> tuple[dict[str, Any], Path]:


### PR DESCRIPTION
Every question worth asking of the fleet's spend is per-subject — cost per PR, repeat reviews of one branch, two agents racing on one commit — and `token-usage.json` recorded none of it. It carried `input_tokens`, `output_tokens`, the cache fields, `turns`, `model` and `cost_usd`, so each of those questions cost a hand-rolled join against `gh run list` and the API behind it.

## The record

`shared/steps/token_usage.py` now writes `repo`, `workflow`, `run_id`, `run_attempt`, `event`, `number` (the PR or issue) and `head_sha` alongside the counts, on both harnesses. Two of those are not on the run listing at all: the PR/issue number, and a `head_sha` read from the event rather than from the ref the run was queued on. The rest are there so the record stands on its own, read out of a gist or a downloaded artifact.

The subject fields follow one rule: an event's subject is a thread or a commit, and each field reports its own half. So a `pull_request_target` run records the PR's head rather than the default-branch commit `GITHUB_SHA` gives it, and a mention on a PR records the PR number with no commit rather than the default-branch tip it never touched. Every key resolves independently — the step is `if: always()` and may not fail the job.

The event-payload readers move from `_issue.py` to `_common.py` (`event_payload`, `dig`, `as_int`, `subject_number`, `subject_sha`), so the outage-issue row and the usage record resolve a trigger the same way.

## The report

`plugins/tend-ci-runner/scripts/token-report.sh` leads with cost, and the rollup tables sort by it — a cached input token is priced far below an output token, so the old cache-read ordering ranked volume rather than spend. A new table groups by subject, collapsing repeat work on one PR or commit into a single row with a run count. Runs that emitted no result event can't be priced, and booking them at `$0` buried them under that sort, so they get their own table ranked by tokens.

The script was also rebuilt around one canonical stream. The download loop writes one JSON line per job — the `token-usage.json` plus the run's row from `gh run list` — and two jq programs read it: jobs to runs to totals, and the summary. That replaced a per-run aggregate, an entry builder, a totals pass, a header pass, a `JQ_DEFS` shell variable concatenated into four table programs, `column -t`, three of its four bash counters, three bash conditionals for the footnotes, and two hardcoded empty-report literals.

<details>
<summary>Bugs found in review, each with a test that fails without its fix</summary>

- `head_sha` reported the default branch's tip for `issue_comment` and `repository_dispatch` — the commit a mention run leaves behind when it `gh pr checkout`s the PR head, so a mention record and a review record for the same PR revision named different commits.
- `as_int` coerced bools and floats. Anyone holding `contents: write` can POST a `repository_dispatch` with `client_payload.pr: true`, and `_issue.ref()` renders the result into a public issue comment — `#1` is a plausible reference to somebody else's PR.
- One unparseable `token-usage.json` aborted the whole report under `set -e`, losing every other run's data with it.
- An artifact holding no usable object put a null into the cost arithmetic and killed two tables after stdout had already been written. It is now skipped and counted: a torn upload's spend is unknown, not zero.
- `column -t` splits on whitespace, so a workflow name containing a space shifted every column right. The summary pads its own columns now.
- Cost truncated in the per-run row and rounded in the rollups, so a matrix run read a cent below the workflow total it was the whole of.

</details>

`conclusion` leaves the report's stdout JSON; nothing read it, and it was only there because the run row was merged in wholesale.

> _This was written by Claude Code on behalf of max-sixty_

