### PR TITLE
Release Tend 0.1.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ https://github.com/max-sixty/tend/compare for their history.
 - **`poll-pr-checks.sh` no longer waits on itself.** A pending `tend-review` can't gate its own poll, and an unresolvable commit fails fast instead of polling a SHA that does not exist. ([#1053](https://github.com/max-sixty/tend/pull/1053), [#1055](https://github.com/max-sixty/tend/pull/1055))
 - **`ci-fix` checks the default branch for an already-landed fix** before opening a PR. ([#1070](https://github.com/max-sixty/tend/pull/1070))
 
+### Documentation
+
+- **The README names `.husky` among the config paths restored from the base branch.** It held git hooks — a code-execution path on a fork PR — and the action had always pinned it; only the README's list was short. A test now asserts the script's `SENSITIVE` array, the README, and `docs/security-model.md` agree. ([#1077](https://github.com/max-sixty/tend/pull/1077))
+
 ### Internal
 
 - Event-payload readers move to `shared/steps/_common.py`, so the outage-issue row and the usage record resolve a trigger the same way. ([#1081](https://github.com/max-sixty/tend/pull/1081))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ published verbatim as that version's GitHub Release notes
 0.1.1 predate this changelog; see the compare views at
 https://github.com/max-sixty/tend/compare for their history.
 
+## 0.1.21
+
+**Improved**
+
+- A review session whose PR gains a commit mid-run re-targets its findings onto the new head and posts there, instead of discarding the review and leaving the queued run to redo it. Every posted review now pins `commit_id` to the commit it read, so the anchor names code the session actually saw and the queued run recognises that head as reviewed. ([#1082](https://github.com/max-sixty/tend/pull/1082))
+- Review runs no longer add a PR-scoped commit status or render their transcript in the job summary, so they stay out of a reviewed commit's check list. Raw session artifacts remain for deliberate diagnosis. ([#1078](https://github.com/max-sixty/tend/pull/1078))
+- `token-usage.json` records `repo`, `workflow`, `run_id`, `run_attempt`, `event`, the PR or issue number, and `head_sha` beside the counts, so spend groups by subject without a hand-rolled join against the runs API. `token-report.sh` leads with cost and adds a per-subject table. ([#1081](https://github.com/max-sixty/tend/pull/1081))
+- Installation and every notification poll enable repository watching, and the poll captures every unread page before its cutoff rather than the first, so work missed while the bot was unsubscribed is recoverable. ([#1074](https://github.com/max-sixty/tend/pull/1074))
+- `review-runs` reads the run census as a second input when draining stranded triggers. ([#1073](https://github.com/max-sixty/tend/pull/1073))
+
+**Fixed**
+
+- `watched_workflows` and `branches` are validated as lists of strings, so a scalar or a nested list fails at `init` with a clear error instead of rendering a broken workflow. ([#1076](https://github.com/max-sixty/tend/pull/1076))
+- `poll-pr-checks.sh` no longer lets a pending `tend-review` gate its own poll, and fails fast when a commit cannot be resolved instead of polling a SHA that does not exist. ([#1053](https://github.com/max-sixty/tend/pull/1053), [#1055](https://github.com/max-sixty/tend/pull/1055))
+- `ci-fix` checks the default branch for an already-landed fix before opening a PR. ([#1070](https://github.com/max-sixty/tend/pull/1070))
+
+**Internal**
+
+- Event-payload readers move to `shared/steps/_common.py`, so the outage-issue row and the usage record resolve a trigger the same way. ([#1081](https://github.com/max-sixty/tend/pull/1081))
+
 ## 0.1.20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,21 +8,21 @@ https://github.com/max-sixty/tend/compare for their history.
 
 ## 0.1.21
 
-**Improved**
+### Improved
 
-- A review session whose PR gains a commit mid-run re-targets its findings onto the new head and posts there, instead of discarding the review and leaving the queued run to redo it. Every posted review now pins `commit_id` to the commit it read, so the anchor names code the session actually saw and the queued run recognises that head as reviewed. ([#1082](https://github.com/max-sixty/tend/pull/1082))
-- Review runs no longer add a PR-scoped commit status or render their transcript in the job summary, so they stay out of a reviewed commit's check list. Raw session artifacts remain for deliberate diagnosis. ([#1078](https://github.com/max-sixty/tend/pull/1078))
-- `token-usage.json` records `repo`, `workflow`, `run_id`, `run_attempt`, `event`, the PR or issue number, and `head_sha` beside the counts, so spend groups by subject without a hand-rolled join against the runs API. `token-report.sh` leads with cost and adds a per-subject table. ([#1081](https://github.com/max-sixty/tend/pull/1081))
-- Installation and every notification poll enable repository watching, and the poll captures every unread page before its cutoff rather than the first, so work missed while the bot was unsubscribed is recoverable. ([#1074](https://github.com/max-sixty/tend/pull/1074))
-- `review-runs` reads the run census as a second input when draining stranded triggers. ([#1073](https://github.com/max-sixty/tend/pull/1073))
+- **A review survives a push that lands while it runs.** The session re-targets its findings onto the new head and posts there, instead of discarding the review and leaving the queued run to redo it. Every posted review now pins `commit_id` to the commit it read, so the anchor names code the session actually saw and the queued run recognises that head as reviewed. ([#1082](https://github.com/max-sixty/tend/pull/1082))
+- **Review runs are less visible, and Claude transcripts are now opt-in everywhere.** A review no longer adds a PR-scoped commit status, so it stays out of a reviewed commit's check list. Rendering the transcript into the job summary became opt-in for *every* Claude workflow, not just review — `show_full_output` on the action now defaults to `false`. Raw session artifacts remain for deliberate diagnosis. The same change removed `tend-review`'s pre-boot pre-check, which read that commit status: `setup:` steps now run on every review event, and a redundant queued run boots the agent to exit early rather than skipping. ([#1078](https://github.com/max-sixty/tend/pull/1078))
+- **Spend groups by subject without a hand-rolled join.** `token-usage.json` records `repo`, `workflow`, `run_id`, `run_attempt`, `event`, the PR or issue number, and `head_sha` beside the counts. `token-report.sh` leads with cost and adds a per-subject table. ([#1081](https://github.com/max-sixty/tend/pull/1081))
+- **Notification work missed while the bot was unsubscribed is recoverable.** Installation and every poll enable repository watching, and the poll captures every unread page before its cutoff rather than the first. ([#1074](https://github.com/max-sixty/tend/pull/1074))
+- **`review-runs` reads the run census as a second input** when draining stranded triggers. ([#1073](https://github.com/max-sixty/tend/pull/1073))
 
-**Fixed**
+### Fixed
 
-- `watched_workflows` and `branches` are validated as lists of strings, so a scalar or a nested list fails at `init` with a clear error instead of rendering a broken workflow. ([#1076](https://github.com/max-sixty/tend/pull/1076))
-- `poll-pr-checks.sh` no longer lets a pending `tend-review` gate its own poll, and fails fast when a commit cannot be resolved instead of polling a SHA that does not exist. ([#1053](https://github.com/max-sixty/tend/pull/1053), [#1055](https://github.com/max-sixty/tend/pull/1055))
-- `ci-fix` checks the default branch for an already-landed fix before opening a PR. ([#1070](https://github.com/max-sixty/tend/pull/1070))
+- **A malformed `watched_workflows` or `branches` fails at `init`, not at runtime.** Both are validated as lists of strings, so a scalar or a nested list produces a clear error instead of a broken workflow. ([#1076](https://github.com/max-sixty/tend/pull/1076))
+- **`poll-pr-checks.sh` no longer waits on itself.** A pending `tend-review` can't gate its own poll, and an unresolvable commit fails fast instead of polling a SHA that does not exist. ([#1053](https://github.com/max-sixty/tend/pull/1053), [#1055](https://github.com/max-sixty/tend/pull/1055))
+- **`ci-fix` checks the default branch for an already-landed fix** before opening a PR. ([#1070](https://github.com/max-sixty/tend/pull/1070))
 
-**Internal**
+### Internal
 
 - Event-payload readers move to `shared/steps/_common.py`, so the outage-issue row and the usage record resolve a trigger the same way. ([#1081](https://github.com/max-sixty/tend/pull/1081))
 

--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "tend"
-version = "0.1.20"
+version = "0.1.21"
 description = "An autonomous junior maintainer for GitHub repos, powered by Claude or OpenAI Codex — reviews PRs, triages issues, fixes CI"
 license = "MIT"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -958,7 +958,7 @@ wheels = [
 
 [[package]]
 name = "tend"
-version = "0.1.20"
+version = "0.1.21"
 source = { editable = "generator" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Version bump, lockfile, and the 0.1.21 CHANGELOG section, which the release workflow publishes verbatim as the GitHub Release notes.

11 commits since 0.1.20. The headline is [#1082](https://github.com/max-sixty/tend/pull/1082): a review session whose PR gains a commit mid-run now re-targets its findings onto the new head and posts there, instead of discarding the whole review for the queued run to redo. Over a week across three repos that discard cost 128 runs and $482.

Not in this release: the `tend-ci-fix` concurrency key, and the `token-report.sh` download-failure fix.

> _This was written by Claude Code on behalf of max-sixty_
