### PR TITLE
fix(generator): stop padding blank lines inside block prompts

### DIFF
--- a/generator/src/tend/templates/macros.yaml.j2
+++ b/generator/src/tend/templates/macros.yaml.j2
@@ -266,5 +266,5 @@
    shapes that they inline. #}
 {% macro block_prompt(prompt) -%}
 prompt: |
-<<prompt|indent(12, first=True, blank=True)>>
+<<prompt|indent(12, first=True)>>
 {%- endmacro %}

--- a/generator/src/tend/templates/macros.yaml.j2
+++ b/generator/src/tend/templates/macros.yaml.j2
@@ -266,5 +266,5 @@
    shapes that they inline. #}
 {% macro block_prompt(prompt) -%}
 prompt: |
-<<prompt|indent(12, first=True)>>
+<<prompt|indent_block(12)>>
 {%- endmacro %}

--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -98,11 +98,14 @@ def _indent_block(text: str, width: int) -> str:
     line even without it. An adopter's `trailing-whitespace` hook rewrites
     such a line, so the file they commit could never match what `init`
     emits — the next regeneration puts the padding back, and the PR the
-    nightly opens for it fails its own lint job. Trailing blank lines go for
-    the same reason; a `|` block scalar clips them, so they are pure churn.
+    nightly opens for it fails its own lint job.
+
+    Trailing blank lines go too, whether or not they carry spaces: they reach
+    the end-of-file hook instead of the trailing-whitespace one, and a `|`
+    block scalar clips them regardless, so they are churn either way.
     """
     pad = " " * width
-    return "\n".join(f"{pad}{line}".rstrip() for line in text.rstrip("\n").splitlines())
+    return "\n".join(f"{pad}{line}".rstrip() for line in text.rstrip().splitlines())
 
 
 _JINJA.filters["indent_block"] = _indent_block

--- a/generator/src/tend/workflows.py
+++ b/generator/src/tend/workflows.py
@@ -88,7 +88,25 @@ HEADER = f"""\
 # detail of that guarantee, and `tend check` creates and verifies it.
 TEND_ENVIRONMENT = "tend"
 
+
 # Available to every template without being passed to render().
+def _indent_block(text: str, width: int) -> str:
+    """Indent a multi-line prompt into a YAML block scalar at *width*.
+
+    Jinja's `indent` can't do this without emitting a whitespace-only line:
+    `blank=True` pads every blank line, and `first=True` pads a blank first
+    line even without it. An adopter's `trailing-whitespace` hook rewrites
+    such a line, so the file they commit could never match what `init`
+    emits — the next regeneration puts the padding back, and the PR the
+    nightly opens for it fails its own lint job. Trailing blank lines go for
+    the same reason; a `|` block scalar clips them, so they are pure churn.
+    """
+    pad = " " * width
+    return "\n".join(f"{pad}{line}".rstrip() for line in text.rstrip("\n").splitlines())
+
+
+_JINJA.filters["indent_block"] = _indent_block
+
 _JINJA.globals["header"] = HEADER
 _JINJA.globals["tend_version"] = _TEND_VERSION
 _JINJA.globals["tend_environment"] = TEND_ENVIRONMENT

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -179,15 +179,20 @@ def test_no_restore_step_without_a_local_setup_action(tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     "extra", ["", "setup:\n  - uses: ./.github/actions/tend-setup\n"]
 )
-def test_generated_workflows_end_with_exactly_one_newline(
+def test_generated_workflows_survive_the_whitespace_hooks(
     tmp_path: Path, extra: str
 ) -> None:
-    """A trailing blank line is pure churn in the adopter's regen diff, and the
-    repo's end-of-file-fixer rejects it in the snapshots."""
+    """Whitespace an adopter's pre-commit rewrites is pure churn in the regen
+    diff: the file it commits can never match what `init` emits. Both hooks the
+    repo runs are covered — end-of-file-fixer on the last line, and
+    trailing-whitespace on every line, which a Jinja `indent(blank=True)` trips
+    by padding the blank line inside a multi-line prompt."""
     cfg = Config.load(_minimal_config(tmp_path, extra))
     for wf in generate_all(cfg):
         assert wf.content.endswith("\n"), f"{wf.filename}: no trailing newline"
         assert not wf.content.endswith("\n\n"), f"{wf.filename}: trailing blank line"
+        for n, line in enumerate(wf.content.splitlines(), 1):
+            assert line == line.rstrip(), f"{wf.filename}:{n}: trailing whitespace"
 
 
 def test_sandbox_levers_rendered_for_claude(tmp_path: Path) -> None:

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -176,19 +176,41 @@ def test_no_restore_step_without_a_local_setup_action(tmp_path: Path) -> None:
             assert _restore_step_index(job.get("steps", [])) is None, wf.filename
 
 
+@pytest.mark.parametrize("harness", ["claude", "codex"])
 @pytest.mark.parametrize(
     "extra", ["", "setup:\n  - uses: ./.github/actions/tend-setup\n"]
 )
 def test_generated_workflows_survive_the_whitespace_hooks(
-    tmp_path: Path, extra: str
+    tmp_path: Path, extra: str, harness: str
 ) -> None:
     """Whitespace an adopter's pre-commit rewrites is pure churn in the regen
-    diff: the file it commits can never match what `init` emits. Both hooks the
+    diff: the file it commits can never match what `init` emits, and the PR the
+    nightly opens over that difference fails its own lint job. Both hooks the
     repo runs are covered — end-of-file-fixer on the last line, and
-    trailing-whitespace on every line, which a Jinja `indent(blank=True)` trips
-    by padding the blank line inside a multi-line prompt."""
+    trailing-whitespace on every line.
+
+    A prompt is the only adopter-supplied text that lands in a block scalar, so
+    the nightly's carries the blank lines that a Jinja `indent()` pads: interior
+    ones under `blank=True`, and a leading one even without it.
+    """
+    extra += (
+        f"harness: {harness}\n"
+        "workflows:\n"
+        "  ci-fix:\n"
+        '    watched_workflows: ["ci"]\n'
+        "  nightly:\n"
+        '    prompt: "\\n\\nsweep the repo\\n\\nthen stop\\n\\n"\n'
+    )
     cfg = Config.load(_minimal_config(tmp_path, extra))
-    for wf in generate_all(cfg):
+    workflows = generate_all(cfg, with_install_test=True)
+    # ci-fix and install-test are both opt-in, and neither renders without the
+    # config above; assert they are present so the coverage can't silently lapse.
+    assert {wf.filename for wf in workflows} >= {
+        "tend-ci-fix.yaml",
+        "tend-install-test.yaml",
+        "tend-nightly.yaml",
+    }
+    for wf in workflows:
         assert wf.content.endswith("\n"), f"{wf.filename}: no trailing newline"
         assert not wf.content.endswith("\n\n"), f"{wf.filename}: trailing blank line"
         for n, line in enumerate(wf.content.splitlines(), 1):

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -191,7 +191,8 @@ def test_generated_workflows_survive_the_whitespace_hooks(
 
     A prompt is the only adopter-supplied text that lands in a block scalar, so
     the nightly's carries the blank lines that a Jinja `indent()` pads: interior
-    ones under `blank=True`, and a leading one even without it.
+    ones under `blank=True`, and a leading one even without it. Its last line is
+    whitespace-only, which reaches the end-of-file hook rather than this one.
     """
     extra += (
         f"harness: {harness}\n"
@@ -199,7 +200,7 @@ def test_generated_workflows_survive_the_whitespace_hooks(
         "  ci-fix:\n"
         '    watched_workflows: ["ci"]\n'
         "  nightly:\n"
-        '    prompt: "\\n\\nsweep the repo\\n\\nthen stop\\n\\n"\n'
+        '    prompt: "\\n\\nsweep the repo\\n\\nthen stop\\n\\n   \\n"\n'
     )
     cfg = Config.load(_minimal_config(tmp_path, extra))
     workflows = generate_all(cfg, with_install_test=True)


### PR DESCRIPTION
`block_prompt` rendered its text through `indent(12, blank=True)`, which
pads a blank line out to twelve spaces. Adopters run pre-commit's
`trailing-whitespace` hook over their generated workflows, so the file
they commit could never match what `init` emits — the next regeneration
puts the padding back.

Nothing hit it until [#1074](https://github.com/max-sixty/tend/pull/1074)
gave `tend-notifications` the first multi-line prompt to go through the
macro. Every form here parses to the same string inside a YAML block
scalar, so this is churn, not a behavior change.

## Why it matters beyond the diff

`tend-nightly` regenerates with `uvx tend@latest init` and opens a PR when
`NON_STAMP_DIFF` is non-zero. That guard filters only the
`# Generated by tend X.Y.Z` header, so the `-`/`+` whitespace pair counts
2 and the PR gets created. That PR's `lint` job runs
`pre-commit/action@v3.0.1`, which defaults to `--all-files`, so
`trailing-whitespace` rewrites the file and fails the job — a valueless
red PR every night until this ships in a release.

## The whole class, not the one instance

Jinja's `indent` cannot render a block scalar without leaking one of
these, because it prepends the indent unconditionally when `first=True`:

| adopter `prompt:` | what leaks | which hook |
|---|---|---|
| `"alpha\n\nbeta"` | interior blank padded to 12 spaces | trailing-whitespace |
| `"\nalpha"` | blank *first* line padded | trailing-whitespace |
| `"alpha\n\n"` | file ends `\n\n` | end-of-file-fixer |
| `"alpha\n   \n"` | last line flattens to blank, file ends `\n\n` | end-of-file-fixer |

All four go through an `indent_block` filter that indents only non-blank
lines and clips trailing ones — which a `|` block scalar does anyway, so
no prompt value changes.

## Testing

The assertion is folded into the test that already guarded the
end-of-file-fixer hook, since both are the same failure: whitespace an
adopter's pre-commit rewrites.

That test reached seven workflows on one harness — `generate_all` skips
ci-fix without `watched_workflows` and install-test without its flag, and
codex was never exercised. It now covers all eight across both harnesses,
with a nightly prompt carrying leading, interior, and trailing blank lines
and a whitespace-only last line. Restoring `blank=True`, restoring
`first=True`, or narrowing the clip to `rstrip("\n")` each fails all four
parametrizations.

pytest-regtest normalizes trailing whitespace before comparing, so the
recorded outputs could not have caught this and do not change here.

> _This was written by Claude Code on behalf of max-sixty_
