### PR TITLE
Release Tend 0.1.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ published verbatim as that version's GitHub Release notes
 0.1.1 predate this changelog; see the compare views at
 https://github.com/max-sixty/tend/compare for their history.
 
+## 0.1.22
+
+### Fixed
+
+- **Generated workflows no longer carry whitespace an adopter's pre-commit rewrites.** A multi-line `prompt:` padded its blank lines out to the block scalar's indent, so a repo running the `trailing-whitespace` or `end-of-file-fixer` hooks could never commit a file matching `init` output — and the nightly regeneration opened a PR over that difference which failed its own lint job. `tend-notifications` was the first workflow to reach it. ([#1090](https://github.com/max-sixty/tend/pull/1090))
+
 ## 0.1.21
 
 ### Improved

--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "tend"
-version = "0.1.21"
+version = "0.1.22"
 description = "An autonomous junior maintainer for GitHub repos, powered by Claude or OpenAI Codex — reviews PRs, triages issues, fixes CI"
 license = "MIT"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -958,7 +958,7 @@ wheels = [
 
 [[package]]
 name = "tend"
-version = "0.1.21"
+version = "0.1.22"
 source = { editable = "generator" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Patch release carrying one generator fix.

A multi-line `prompt:` rendered its blank lines padded out to the block
scalar's indent, so an adopter running pre-commit's `trailing-whitespace`
or `end-of-file-fixer` hooks could never commit a file matching what
`init` emits. The nightly regeneration then opened a PR over that
difference every night, and that PR's own `lint` job failed on it.

This ships urgently because 0.1.21 is the first release where the bug is
reachable: [#1074](https://github.com/max-sixty/tend/pull/1074) gave
`tend-notifications` the first multi-line prompt. Until 0.1.22 is on PyPI
every adopter's nightly regeneration produces a red PR — `uvx tend@latest`
is what the nightly runs, so merging the fix to `main` alone does not stop
it.

[#1089](https://github.com/max-sixty/tend/pull/1089) is also in the range;
it moved tend's own workflows onto 0.1.21 and has no adopter-visible
effect, so it gets no changelog bullet.

> _This was written by Claude Code on behalf of max-sixty_
