### PR TITLE
skills(running-tend): stop the consumers refresh deleting repos the search missed

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -134,16 +134,30 @@ because the workflow files are public.
 #    hits on `max-sixty/tend` itself crowd out tend's own workflow files
 #    past the 100-result cap, dropping tend from its own consumers.json.
 #    The `.github/workflows/tend-` path filter below bounds precision.
-mapfile -t REPOS < <(
+mapfile -t DISCOVERED < <(
   gh search code 'max-sixty/tend' --extension yaml --limit 100 --json repository,path \
     | jq -r '.[] | select(.path | startswith(".github/workflows/tend-")) | .repository.nameWithOwner' \
     | sort -u
 )
 
-# 2. Resolve bot_name from each repo's .config/tend.yaml.
+# 2. Union with the repos already listed. Code search recall is partial — a
+#    repo carrying a full set of tend-*.yaml files can return zero hits — so
+#    rebuilding from the search alone deletes live consumers from the file the
+#    website renders. The search finds *new* consumers; step 3 decides who stays.
+mapfile -t REPOS < <(
+  { printf '%s\n' "${DISCOVERED[@]}"
+    jq -r '.[].repo' data/consumers.json 2>/dev/null; } | sort -u
+)
+
+# 3. Keep a repo while it still has generated tend workflows, and resolve
+#    bot_name from its .config/tend.yaml. These are the authoritative checks:
+#    an uninstall drops out here, never by going missing from a search.
 mkdir -p data
 {
   for repo in "${REPOS[@]}"; do
+    workflows=$(gh api "repos/$repo/contents/.github/workflows" \
+      --jq '[.[] | select(.name | startswith("tend-"))] | length' 2>/dev/null) || workflows=0
+    [ "${workflows:-0}" -gt 0 ] || continue
     bot=$(gh api "repos/$repo/contents/.config/tend.yaml" --jq '.content' 2>/dev/null \
       | base64 -d 2>/dev/null \
       | yq '.bot_name // ""' 2>/dev/null)

--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -150,8 +150,10 @@ mapfile -t REPOS < <(
 )
 
 # 3. Keep a repo while it still has generated tend workflows, and resolve
-#    bot_name from its .config/tend.yaml. These are the authoritative checks:
-#    an uninstall drops out here, never by going missing from a search.
+#    bot_name from its .config/tend.yaml. An uninstall drops out here rather
+#    than by going missing from a search — but so does a repo whose `gh api`
+#    call hit a 403 or a 5xx, and nothing re-adds a repo the code index can't
+#    see. Never land a removal without re-checking that repo by hand.
 mkdir -p data
 {
   for repo in "${REPOS[@]}"; do


### PR DESCRIPTION
The weekly `consumers.json` refresh rebuilds the file wholesale from `gh search code`, so the file inherits the search's recall. Today's search returned 6 of the 8 listed consumers, and running the recipe as written would have deleted `jakobtfaber/Faber2026` and `max-sixty/cargo-affected` — both live, both still carrying eight `tend-*.yaml` files — from the data the public site renders. This makes the search a discovery step only: candidates are the union of the search hits and the repos already listed, and a per-repo API check decides who stays.

<details><summary>Evidence and verification</summary>

**The miss is in the index, not the query or the cap.** The search returns 52 hits against a 100 cap, so nothing is crowded out; both repos simply return zero hits for `max-sixty/tend` while their workflow files demonstrably contain the ref:

```
$ gh search code 'max-sixty/tend' --repo max-sixty/cargo-affected
(no results)
$ gh api repos/max-sixty/cargo-affected/contents/.github/workflows/tend-review.yaml | ... | grep uses:
      - uses: max-sixty/tend/claude@0.1.14
```

`max-sixty/cargo-affected` returns nothing for a bare `tend` query either — the repo is absent from the code index, not stale in it. #1093 observed the same 6-of-8 result independently and named this as out of scope for that PR.

**Not a retry.** #345 was closed on the principle that a retry wrapper around a transient search blip isn't worth keeping. This adds no retry and re-queries nothing: it stops treating search absence as evidence of removal, and moves the keep/drop decision onto an authoritative per-repo API check that an uninstall actually fails.

**Verified.** The recipe was extracted verbatim from the file and run under `set -euo pipefail` against real GitHub: 6 discovered, 8 candidates, 8 retained, output byte-identical to the committed `data/consumers.json`. The drop path was exercised separately against a repo with no matching workflows (`octocat/Hello-World` → `count=0`, dropped). `uv run pytest` passes (763), as does `pre-commit` on the changed file.

**Out of scope, worth its own look:** `max-sixty/tend-integration` satisfies both filters — 3 `tend-*.yaml` files and `bot_name: tend-agent` — and is absent from the list only because code search does not index it either. If it is ever indexed, the weekly refresh adds the test fixture to the public site's adopter list.

</details>
