### PR TITLE
chore: bump claude_version to 2.1.251

### DIFF
--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -54,7 +54,7 @@ inputs:
     default: "false"
     description: Include the rendered Claude transcript in the workflow step summary.
   claude_version:
-    default: "2.1.241"
+    default: "2.1.251"
     description: >-
       Version of the `claude` binary to install via
       `https://claude.ai/install.sh`, pinned to a specific


### PR DESCRIPTION
Moves the pinned `claude` binary from 2.1.241 to 2.1.251, npm's current `latest` dist-tag (`stable` still sits at 2.1.236, and `CLAUDE.md` pins `latest`). A stale pin resolves `--model opus`/`sonnet` to a superseded alias target, so the bump is what keeps the harness on the model the workflows name. `uv run pytest` passes (763).

<details><summary>CHANGELOG skim, 2.1.242 → 2.1.251</summary>

Seven releases carry notes (2.1.243, .245, .246, .247, .248, .250, .251), skimmed for the paths this action exercises — plugin/skill loading, slash-command dispatch, headless `-p`, `--model` alias resolution, first-run onboarding, and sandboxing. **Nothing in the range changes an agent path tend exercises.** Item by item:

**Plugin and skill loading (2.1.246, 2.1.251).** Three entries look like they land on `tend-ci-runner`'s layout and none of them reaches this action. `/reload-plugins` reporting 0 skills for `skills/*/SKILL.md` plugins (2.1.246) — `/reload-plugins` appears nowhere in the repo; `shared/steps/install-tend-plugins.sh` runs `claude plugin marketplace add` then `claude plugin install`. The doubled `<plugin>:` prefix in the slash menu (2.1.246) — no `plugins/tend-ci-runner/skills/*/SKILL.md` frontmatter `name` carries the prefix, and headless `-p` renders no slash menu to double it in. The plugin-skills race (2.1.251) is scoped upstream to *background sessions* racing a concurrent marketplace refresh; the action starts one one-shot `claude -p` per job.

**2.1.245** has a single entry: a startup crash on distributions shipping glibc 2.44 (Arch, CachyOS, Fedora Rawhide). Jobs run on `ubuntu-24.04` (glibc 2.39), so it doesn't apply.

**Sandbox items (2.1.243, 2.1.251).** 2.1.243 stopped listing allowed network hosts in the sandboxed Bash prompt and stopped dropping network-violation detail when a blocked command still exits 0; 2.1.251 changed how sandboxed commands' output files are created and now requires approval for server-managed settings that route sandbox traffic through a proxy or inject credentials. All of these are Claude Code's *own* Bash sandbox. This action doesn't use it: isolation is a separate non-sudo OS user, and the proxy is wired through the environment by `proxy/setup-sandbox.sh`, not through managed settings.

**Security fixes that read as relevant (2.1.247, 2.1.251).** Marketplace names containing control or invisible characters are now rejected (2.1.247) — both tend marketplaces use plain ASCII names. The file-tool symlink swap and the plugin path-traversal fix (2.1.251) harden Claude Code's permission check, which isn't the boundary here: `claude/action.yaml` documents the run as `permissions.defaultMode: bypassPermissions`, so the non-sudo sandbox user and the proxy are what contain it.

**Project settings (2.1.251).** `.claude/settings.json` `env` no longer sets `CLAUDE_CONFIG_DIR`, `CLAUDE_CODE_TMPDIR`, or `TMPDIR`. No-op here — the repo's `.claude/settings.local.json` has no `env` block, and `shared/steps/install-claude-binary.sh` pins the XDG dirs through `sudo -u ... env`.

**Neutral to this action:** `--restricted` (2.1.248), the `PreModelSwitch`/`PostModelSwitch` hooks and `/cost` cache reporting (2.1.251), and the plan-mode fix for `claude -p --continue`/`--resume` (2.1.246), since runs here are one-shot `-p` and never resumed. 2.1.250 is "Bug fixes and reliability improvements" with no itemised notes.

</details>
