### PR TITLE
chore: bump codex_version to 0.151.0

### DIFF
--- a/codex/action.yaml
+++ b/codex/action.yaml
@@ -53,7 +53,7 @@ inputs:
     default: danger-full-access
     description: Codex sandbox mode (workspace-write, read-only, danger-full-access)
   codex_version:
-    default: "0.149.0"
+    default: "0.151.0"
     description: >-
       `@openai/codex` npm version to install. Must ship
       the `codex plugin add` subcommand (PR #21396, first released in


### PR DESCRIPTION
Moves the pinned `@openai/codex` from 0.149.0 to 0.151.0, npm's current `latest` dist-tag. CI's `test-codex-surface` job installs whatever is pinned and asserts the CLI surface this action depends on, so a bump that breaks `codex plugin add`, `codex exec`, or `--output-last-message` fails on this PR.

<details><summary>Release-notes skim, 0.150.0 and 0.151.0</summary>

Read for the three things the overlay asks about — model availability, sandbox behaviour, and `--output-last-message`. Nothing in either release touches `--output-last-message`, and no model was withdrawn.

**Worth watching: project-level `AGENTS.md` under an untrusted project.** 0.150.0 — *"Untrusted projects no longer supply project-level `AGENTS.md` instructions"* ([#39837](https://github.com/openai/codex/pull/39837), [#40004](https://github.com/openai/codex/pull/40004)). This action stages its own `AGENTS.md` into `$CODEX_HOME`, which is unaffected, but the adopter's repo-root `AGENTS.md` is read from the working directory and is not. `codex exec` here runs with `--sandbox` and no explicit trust configuration, so whether a CI checkout counts as trusted is not something this repo can determine from the notes. No `OPENAI_API_KEY` reaches this repo's runs, so a live session stays unverified either way — flagging it as the item to watch if a Codex adopter reports repo instructions going unread.

**Relevant to the plugin install step:** 0.151.0 — plugin catalogs now combine per-repository configuration and report invalid project marketplaces without hiding valid ones. The install step's `codex plugin marketplace add` + `codex plugin add tend-ci-runner@tend` pair is what `test-codex-surface` exercises.

**Sandbox:** 0.151.0 restores permission profiles across TUI turns and stops `/cd` weakening sandbox restrictions, and improves remote-sandbox enforcement using the executor's real home directory and OS conventions. The TUI and `/cd` items don't apply to `codex exec`.

**Neutral:** `@`-mentions of Codex tasks, `/copy`, `/rename`, `Interrupt` hooks, Windows sandbox setup, Bedrock compaction, MCP grace periods and extension hooks.

`uv run pytest` passes (763); the codex surface assertion runs in this PR's CI.

</details>
