### PR TITLE
chore: bump repo-local pins

### DIFF
--- a/.config/codex-cloud/environment.sh
+++ b/.config/codex-cloud/environment.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-WORKTRUNK_VERSION=0.74.0
+WORKTRUNK_VERSION=0.75.0
 if ! command -v wt >/dev/null 2>&1 ||
   [[ "$(wt --version)" != "wt v${WORKTRUNK_VERSION}" ]]; then
   curl --proto '=https' --tlsv1.2 -LsSf \

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,13 +15,13 @@ repos:
         args: ["--fix"]
       - id: ruff-format
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.12.5
+    rev: 0.12.7
     hooks:
       # One lockfile at the workspace root covers the generator member too.
       - id: uv-lock
         files: ^(generator/)?(pyproject\.toml|uv\.lock)$
   - repo: https://github.com/adhtruong/mirrors-typos
-    rev: v1.49.0
+    rev: v1.50.0
     hooks:
       - id: typos
   - repo: https://github.com/rhysd/actionlint

--- a/uv.lock
+++ b/uv.lock
@@ -394,14 +394,11 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.4.2"
+version = "8.5.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/0e/7fa0ef50764b67090eca4114772a2abf8b6148198475e54c660b97caeee6/click-8.5.0.tar.gz", hash = "sha256:ba0d2089de75ea0310e2dde03160e6ca10009947fb95a182f9b54021bb272e34", size = 382235, upload-time = "2026-08-26T13:33:14.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+    { url = "https://files.pythonhosted.org/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl", hash = "sha256:255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360", size = 125251, upload-time = "2026-08-26T13:33:12.928Z" },
 ]
 
 [[package]]
@@ -1040,11 +1037,11 @@ wheels = [
 
 [[package]]
 name = "wcwidth"
-version = "0.8.2"
+version = "0.8.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/34/74/c6428f875774288bec1396f5bfcbc2d925700a4dad61727fd5f2b12f249d/wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda", size = 1466253, upload-time = "2026-06-29T18:11:11.601Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/57/ed58088fafdf4c55a0ad6bde846502567645424d7ebf325230b9237f4085/wcwidth-0.8.3.tar.gz", hash = "sha256:d128512515fbf4612e0ff21fd6380399210318b7b54a9af59dff8454cf9730eb", size = 1458450, upload-time = "2026-08-28T18:10:06.875Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85", size = 323166, upload-time = "2026-06-29T18:11:09.888Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/0e/57f6bb3024a597b2e8ec4aee710ffe62ddc95af2e2bb1ee7a7abdc22c68c/wcwidth-0.8.3-py3-none-any.whl", hash = "sha256:d5b73dba6158a595ec9370350e7f2637bcac8d6c5e4fde34f30fcffb6103a5e4", size = 331669, upload-time = "2026-08-28T18:10:04.909Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The repo-local half of the weekly pin sweep: `uv-pre-commit` 0.12.5 → 0.12.7, `mirrors-typos` v1.49.0 → v1.50.0, `WORKTRUNK_VERSION` 0.74.0 → 0.75.0, and the lockfile's `click` 8.4.2 → 8.5.0 and `wcwidth` 0.8.2 → 0.8.3. Nothing here ships to adopters. `pre-commit run --all-files` and `uv run pytest` (763) pass.

`ruff-pre-commit` is deliberately held back — v0.14.11 → v0.16.5 reports 66 findings across the repo (37 auto-fixable, 29 not) plus reformatting in 3 files, so it gets its own PR rather than riding along here.

<details><summary>Worktrunk verification</summary>

Nothing in CI runs `.config/codex-cloud/environment.sh`, and it runs under `set -euo pipefail`, so the overlay asks for both of its preconditions to be checked by hand. Both were, against v0.75.0 on this runner:

- `worktrunk-installer.sh` still ships in the release assets, and the install honours `WORKTRUNK_UNMANAGED_INSTALL`.
- `wt --version` prints `wt v0.75.0`, matching the `"wt v${WORKTRUNK_VERSION}"` equality the script guards on — a format change there would reinstall on every run.
- `wt config approvals add --yes` records without a TTY: all 7 commands `.config/wt.toml` declares were approved and saved, exit 0, and `wt config approvals list` shows an empty UNAPPROVED section afterwards.

</details>
