### PR TITLE
chore: bump uv_version to 0.12.7

### DIFF
--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -77,7 +77,7 @@ inputs:
       Pinned `mitmproxy` version for the credential-injection proxy. Pinned
       so the uv download cache key is stable; bump to upgrade.
   uv_version:
-    default: "0.12.5"
+    default: "0.12.7"
     description: >-
       Pinned `uv` version used to run the credential-injection proxy. Installed
       into a tend-owned dir off $PATH, so it neither shadows nor is shadowed by


### PR DESCRIPTION
Moves the pinned `uv` that launches the credential-injection proxy from 0.12.5 to 0.12.7, PyPI's current release. `mitmproxy` is already at its latest (12.2.3), so the paired pin in the root `pyproject.toml` doesn't move with it this time — `uv` goes alone, as it did the last time the two diverged.

This `uv` only runs `mitmdump`; the agent never sees it, and skills that need `uv` install their own. CI smokes the pair together, so a `uv` that can no longer launch the pinned mitmproxy fails on this PR. `uv run pytest` passes (763).
