### PR TITLE
chore: bump ruff to v0.16.5, and clear its new default rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
   # only meant that each new Python directory arrived unlinted and stayed that
   # way until someone noticed.
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.11
+    rev: v0.16.5
     hooks:
       - id: ruff-check
         args: ["--fix"]

--- a/generator/src/tend/checks.py
+++ b/generator/src/tend/checks.py
@@ -40,7 +40,6 @@ from tend.config import (
 )
 from tend.workflows import TEND_ENVIRONMENT
 
-
 # GitHub's base repository role IDs, as they appear in a ruleset's
 # `bypass_actors`. The IDs are not ordered by privilege — maintain (2) sits
 # below write (4) — so the plausible guess for "maintain" is in fact the bot's
@@ -105,6 +104,7 @@ def _gh(
             text=True,
             timeout=30,
             input=input,
+            check=False,
         )
     except subprocess.TimeoutExpired:
         return None

--- a/generator/src/tend/cli.py
+++ b/generator/src/tend/cli.py
@@ -31,6 +31,7 @@ def _detect_default_branch_local() -> str:
             capture_output=True,
             text=True,
             timeout=5,
+            check=False,
         )
         if result.returncode == 0:
             # Returns "origin/main" or "origin/master" — strip the remote prefix

--- a/generator/tests/test_bot_review_state.py
+++ b/generator/tests/test_bot_review_state.py
@@ -14,6 +14,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+
 from tests import BASH, GH_PREAMBLE, fake_bin, tool_path
 
 BOT_REVIEW_STATE = (
@@ -80,7 +81,11 @@ def env(tmp_path: Path) -> dict[str, str]:
 
 def _state(env: dict[str, str]) -> dict:
     result = subprocess.run(
-        [BASH, str(BOT_REVIEW_STATE), "7"], env=env, capture_output=True, text=True
+        [BASH, str(BOT_REVIEW_STATE), "7"],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
     )
     assert result.returncode == 0, result.stderr
     return json.loads(result.stdout)

--- a/generator/tests/test_checks.py
+++ b/generator/tests/test_checks.py
@@ -10,25 +10,24 @@ from urllib.parse import quote
 
 import pytest
 from click.testing import CliRunner
-
 from tend.checks import (
-    admitted_refs,
-    check_credential_environments,
-    check_environment,
-    check_environment_deployments,
-    fix_environment,
     ROLE_ID_ADMIN,
     ROLE_ID_MAINTAIN,
     ROLE_ID_WRITE,
     CheckResult,
     _has_restrict_updates_ruleset,
     _restrict_updates_ruleset,
+    admitted_refs,
     check_bot_permission,
     check_branch_protection,
+    check_credential_environments,
+    check_environment,
+    check_environment_deployments,
     check_repo_secret_allowlist,
     check_secrets,
     detect_canonical_owner,
     detect_repo,
+    fix_environment,
     run_all_checks,
 )
 from tend.cli import main
@@ -1488,9 +1487,7 @@ def _url(args: tuple[str, ...]) -> str:
 
     A `graphql` call carries no path, so it answers with its subcommand.
     """
-    return next(
-        (a for a in args if a.startswith("repos/") or a.startswith("orgs/")), args[1]
-    )
+    return next((a for a in args if a.startswith(("repos/", "orgs/"))), args[1])
 
 
 def _env_gh(env_body: str | None, policies: str = "main"):

--- a/generator/tests/test_config_edge_cases.py
+++ b/generator/tests/test_config_edge_cases.py
@@ -6,11 +6,11 @@ from pathlib import Path
 from textwrap import dedent
 
 import pytest
-from tests import _yaml as yaml
 from click import ClickException
-
 from tend.config import BOT_TOKEN_SECRET, Config
 from tend.workflows import generate_all
+
+from tests import _yaml as yaml
 
 
 def _write_config(tmp_path: Path, content: str) -> Path:

--- a/generator/tests/test_cross_file_contracts.py
+++ b/generator/tests/test_cross_file_contracts.py
@@ -6,7 +6,6 @@ together, so each reads correct on its own while the pair stops agreeing.
 
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 

--- a/generator/tests/test_generate.py
+++ b/generator/tests/test_generate.py
@@ -7,12 +7,9 @@ import re
 from pathlib import Path
 from textwrap import dedent
 
-import pytest
-from tests import ACTION_VERSION
-from tests import _yaml as yaml
 import click
+import pytest
 from click.testing import CliRunner
-
 from tend.cli import main
 from tend.config import (
     ANTHROPIC_API_KEY_SECRET,
@@ -22,13 +19,16 @@ from tend.config import (
     Config,
 )
 from tend.workflows import (
-    _deep_merge,
     GENERATORS,
     GeneratedWorkflow,
+    _deep_merge,
     generate_all,
     generate_install_test,
     generate_mention,
 )
+
+from tests import ACTION_VERSION
+from tests import _yaml as yaml
 
 
 def _minimal_config(tmp_path: Path, extra: str = "") -> Path:
@@ -110,8 +110,10 @@ def _restore_step_index(steps: list[dict[str, object]]) -> int | None:
         (
             "review",
             "review",
-            lambda s: s.get("uses", "").startswith("actions/checkout")
-            and "ref" in s.get("with", {}),
+            lambda s: (
+                s.get("uses", "").startswith("actions/checkout")
+                and "ref" in s.get("with", {})
+            ),
         ),
         (
             "mention",
@@ -1314,7 +1316,7 @@ def test_no_extras_output_unchanged(tmp_path: Path) -> None:
     """Without extras, generate_all() output matches direct generator output."""
     cfg = Config.load(_minimal_config(tmp_path))
     via_all = {wf.filename: wf.content for wf in generate_all(cfg)}
-    for name, gen_fn in GENERATORS.items():
+    for gen_fn in GENERATORS.values():
         try:
             wf = gen_fn(cfg)
         except click.ClickException:

--- a/generator/tests/test_integration.py
+++ b/generator/tests/test_integration.py
@@ -15,12 +15,12 @@ from unittest.mock import patch
 
 import click.testing
 import pytest
-from tests import ACTION_VERSION, BASH, tool_path
-from tests import _yaml as yaml
 from click.testing import CliRunner
-
 from tend.checks import CheckResult
 from tend.cli import main
+
+from tests import ACTION_VERSION, BASH, tool_path
+from tests import _yaml as yaml
 
 
 def _write_config(tmp_path: Path, content: str) -> None:
@@ -310,7 +310,7 @@ def _fake_gh_all_pass(*args: str, **kwargs: str) -> subprocess.CompletedProcess[
         return _make_completed(
             json.dumps({"data": {"repository": {"object": {"entries": []}}}})
         )
-    url = next(a for a in args if a.startswith("repos/") or a.startswith("orgs/"))
+    url = next(a for a in args if a.startswith(("repos/", "orgs/")))
     # Only the ref-gated environment exists, holding the operational secrets.
     if url.endswith("/environments"):
         return _make_completed("tend\n")
@@ -580,10 +580,7 @@ def test_notifications_precheck_tolerates_transient_non_json(
         "GITHUB_REPOSITORY": "owner/repo",
     }
     result = subprocess.run(
-        [BASH, "-e", "-c", script],
-        env=env,
-        capture_output=True,
-        text=True,
+        [BASH, "-e", "-c", script], env=env, capture_output=True, text=True, check=False
     )
 
     assert result.returncode == 0, (

--- a/generator/tests/test_list_recent_runs.py
+++ b/generator/tests/test_list_recent_runs.py
@@ -13,9 +13,11 @@ from __future__ import annotations
 
 import json
 import subprocess
+from datetime import UTC
 from pathlib import Path
 
 import pytest
+
 from tests import BASH, GH_PREAMBLE, fake_bin, tool_path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -26,9 +28,9 @@ NOW = 1700000000
 
 
 def _iso(epoch: int) -> str:
-    from datetime import datetime, timezone
+    from datetime import datetime
 
-    return datetime.fromtimestamp(epoch, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return datetime.fromtimestamp(epoch, tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 FAKE_GH = (
@@ -135,7 +137,7 @@ def _runs(env: dict[str, str], *entries: dict) -> None:
 
 def _run(env: dict[str, str], *args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        [BASH, str(SCRIPT), *args], env=env, capture_output=True, text=True
+        [BASH, str(SCRIPT), *args], env=env, capture_output=True, text=True, check=False
     )
 
 

--- a/generator/tests/test_mention_verify.py
+++ b/generator/tests/test_mention_verify.py
@@ -14,6 +14,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+
 from tests import BASH, GH_PREAMBLE, fake_bin, tool_path
 
 MENTION_VERIFY = (
@@ -133,7 +134,11 @@ def env(tmp_path: Path) -> dict[str, str]:
 def _run(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
     # `bash -e` mirrors the shell GitHub Actions gives a `run:` block.
     return subprocess.run(
-        [BASH, "-e", str(MENTION_VERIFY)], env=env, capture_output=True, text=True
+        [BASH, "-e", str(MENTION_VERIFY)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
     )
 
 

--- a/generator/tests/test_migrate.py
+++ b/generator/tests/test_migrate.py
@@ -8,7 +8,6 @@ from textwrap import dedent
 import pytest
 from click import ClickException
 from click.testing import CliRunner
-
 from tend.cli import main
 from tend.config import Config
 from tend.migrate import migrate_toml_to_yaml

--- a/generator/tests/test_poll_scripts.py
+++ b/generator/tests/test_poll_scripts.py
@@ -16,6 +16,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+
 from tests import BASH, GH_PREAMBLE, fake_bin, tool_path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -186,6 +187,7 @@ def _poll(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
         env=env,
         capture_output=True,
         text=True,
+        check=False,
     )
 
 
@@ -467,6 +469,7 @@ def test_abbreviated_sha_is_rejected_at_entry(env: dict[str, str]) -> None:
         env=env,
         capture_output=True,
         text=True,
+        check=False,
     )
     out = result.stdout + result.stderr
 
@@ -489,6 +492,7 @@ def test_uppercase_sha_is_rejected_at_entry(env: dict[str, str]) -> None:
         env=env,
         capture_output=True,
         text=True,
+        check=False,
     )
     out = result.stdout + result.stderr
 
@@ -510,6 +514,7 @@ def test_omitted_sha_is_rejected_not_reported_red(env: dict[str, str]) -> None:
         env=env,
         capture_output=True,
         text=True,
+        check=False,
     )
     out = result.stdout + result.stderr
 
@@ -544,6 +549,7 @@ def _rerun(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
         env=env,
         capture_output=True,
         text=True,
+        check=False,
     )
 
 

--- a/generator/tests/test_repo_pins.py
+++ b/generator/tests/test_repo_pins.py
@@ -124,6 +124,7 @@ def test_inline_run_bodies_pass_shellcheck(action: str) -> None:
             input=GHA_EXPR.sub("${_GHA_EXPR}", body),
             capture_output=True,
             text=True,
+            check=False,
         )
         if result.returncode != 0:
             findings.append(f"--- {action} :: {name}\n{result.stdout}")

--- a/generator/tests/test_review_runs_corrections.py
+++ b/generator/tests/test_review_runs_corrections.py
@@ -18,6 +18,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+
 from tests import BASH, GH_PREAMBLE, fake_bin, tool_path
 
 SCRIPT = (
@@ -80,7 +81,7 @@ def env(tmp_path: Path) -> dict[str, str]:
 
 def _run(env: dict[str, str], *args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        [BASH, str(SCRIPT), *args], env=env, capture_output=True, text=True
+        [BASH, str(SCRIPT), *args], env=env, capture_output=True, text=True, check=False
     )
 
 

--- a/generator/tests/test_shared_steps.py
+++ b/generator/tests/test_shared_steps.py
@@ -19,6 +19,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 import pytest
+
 from tests import BASH, GH_PREAMBLE, fake_bin, tool_path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -187,6 +188,7 @@ def _pin(script: Path, repo: Path, event: Path) -> subprocess.CompletedProcess[s
         },
         capture_output=True,
         text=True,
+        check=False,
     )
 
 
@@ -392,6 +394,7 @@ def _run_check(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
         env=env,
         capture_output=True,
         text=True,
+        check=False,
     )
 
 
@@ -506,7 +509,7 @@ def test_sensitive_paths_are_documented_where_adopters_read_them() -> None:
     the surface for the only audience that reads the README.
     """
     script = RESTORE_SENSITIVE_CONFIG.read_text()
-    sensitive = re.search(r"^SENSITIVE=\((.*?)\)$", script, re.M)
+    sensitive = re.search(r"^SENSITIVE=\((.*?)\)$", script, re.MULTILINE)
     assert sensitive, "SENSITIVE array not found — did the script's shape change?"
     paths = sensitive.group(1).split()
     assert paths, "SENSITIVE is empty"
@@ -514,7 +517,9 @@ def test_sensitive_paths_are_documented_where_adopters_read_them() -> None:
     # Scope to the paragraph making the claim; a stray mention elsewhere in the
     # file (README's own repo layout, say) must not satisfy it.
     readme = REPO_ROOT / "README.md"
-    claim = re.search(r"\*\*Config pinning\*\*.*?(?=\n\n)", readme.read_text(), re.S)
+    claim = re.search(
+        r"\*\*Config pinning\*\*.*?(?=\n\n)", readme.read_text(), re.DOTALL
+    )
     assert claim, "README's config-pinning paragraph not found"
 
     threat_model = (REPO_ROOT / "docs" / "security-model.md").read_text()

--- a/generator/tests/test_token_report.py
+++ b/generator/tests/test_token_report.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+
 from tests import BASH, GH_PREAMBLE, fake_bin, tool_path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -102,9 +103,7 @@ class Report:
             "USAGE_DIR": str(self._usage_dir),
         }
 
-    def add(
-        self, run_id: int, *, workflow: str = "tend-review", **over: Any
-    ) -> "Report":
+    def add(self, run_id: int, *, workflow: str = "tend-review", **over: Any) -> Report:
         """A completed run and the artifact it uploaded."""
         self._runs.append(
             {
@@ -119,13 +118,13 @@ class Report:
         )
         return self
 
-    def add_raw(self, run_id: int, body: str) -> "Report":
+    def add_raw(self, run_id: int, body: str) -> Report:
         """A run whose artifact holds *body* verbatim, valid JSON or not."""
         self.add_run_without_artifact(run_id)
         (self._usage_dir / f"{run_id}.json").write_text(body)
         return self
 
-    def add_run_without_artifact(self, run_id: int) -> "Report":
+    def add_run_without_artifact(self, run_id: int) -> Report:
         self._runs.append(
             {
                 "databaseId": run_id,
@@ -153,6 +152,7 @@ class Report:
             env=self._env,
             capture_output=True,
             text=True,
+            check=False,
         )
         assert result.returncode == 0, result.stderr
         self.stderr = result.stderr
@@ -204,7 +204,7 @@ def test_repeat_runs_on_one_subject_collapse_into_one_row(report: Report) -> Non
     for run_id in (1, 2, 3):
         report.add(run_id, cost_usd=2.0)
     report.add(4, number=852, cost_usd=1.0)
-    _, rows = report.run()
+    _, _rows = report.run()
 
     assert _table(report, "SUBJECT") == [
         ["#851", "3", "$6.00", "tend-review", "30K"],
@@ -221,7 +221,7 @@ def test_tables_are_ranked_by_cost_not_by_token_count(report: Report) -> None:
     """
     report.add(1, workflow="tend-nightly", cost_usd=0.5, cache_read_input_tokens=999999)
     report.add(2, workflow="tend-review", cost_usd=9.0, cache_read_input_tokens=1000)
-    _, rows = report.run()
+    _, _rows = report.run()
 
     workflows = [row[0] for row in _table(report, "WORKFLOW")]
     assert workflows == ["tend-review", "tend-nightly"], (
@@ -254,7 +254,7 @@ def test_a_run_whose_record_predates_the_subject_fields(report: Report) -> None:
     of the totals.
     """
     report.add(1, number=None, head_sha=None, repo=None, event=None)
-    output, rows = report.run()
+    output, _rows = report.run()
 
     assert output["runs"][0]["subject"] == "?"
     assert output["totals"]["cost_usd"] == 1.0
@@ -331,7 +331,7 @@ def test_cost_unknown_runs_get_their_own_ranked_table(report: Report) -> None:
             partial=True,
             cache_read_input_tokens=5_000_000,
         )
-    _, rows = report.run()
+    _, _rows = report.run()
 
     assert "#2222" not in [row[0] for row in _table(report, "SUBJECT")], (
         "a $0 floor cannot outrank priced work, which is why it needs its own table"
@@ -354,7 +354,7 @@ def test_a_matrix_runs_row_agrees_with_its_rollup_to_the_cent(report: Report) ->
             + "\n"
             + json.dumps(_record(run_id=1, cost_usd=cost))
         )
-    output, rows = report.run()
+    output, _rows = report.run()
 
     assert output["totals"]["cost_usd"] == 28.17
     assert _table(report, "RUN")[0][3] == "$28.17"

--- a/generator/tests/test_token_report.py
+++ b/generator/tests/test_token_report.py
@@ -204,7 +204,7 @@ def test_repeat_runs_on_one_subject_collapse_into_one_row(report: Report) -> Non
     for run_id in (1, 2, 3):
         report.add(run_id, cost_usd=2.0)
     report.add(4, number=852, cost_usd=1.0)
-    _, _rows = report.run()
+    report.run()
 
     assert _table(report, "SUBJECT") == [
         ["#851", "3", "$6.00", "tend-review", "30K"],
@@ -221,7 +221,7 @@ def test_tables_are_ranked_by_cost_not_by_token_count(report: Report) -> None:
     """
     report.add(1, workflow="tend-nightly", cost_usd=0.5, cache_read_input_tokens=999999)
     report.add(2, workflow="tend-review", cost_usd=9.0, cache_read_input_tokens=1000)
-    _, _rows = report.run()
+    report.run()
 
     workflows = [row[0] for row in _table(report, "WORKFLOW")]
     assert workflows == ["tend-review", "tend-nightly"], (
@@ -254,7 +254,7 @@ def test_a_run_whose_record_predates_the_subject_fields(report: Report) -> None:
     of the totals.
     """
     report.add(1, number=None, head_sha=None, repo=None, event=None)
-    output, _rows = report.run()
+    output, _ = report.run()
 
     assert output["runs"][0]["subject"] == "?"
     assert output["totals"]["cost_usd"] == 1.0
@@ -331,7 +331,7 @@ def test_cost_unknown_runs_get_their_own_ranked_table(report: Report) -> None:
             partial=True,
             cache_read_input_tokens=5_000_000,
         )
-    _, _rows = report.run()
+    report.run()
 
     assert "#2222" not in [row[0] for row in _table(report, "SUBJECT")], (
         "a $0 floor cannot outrank priced work, which is why it needs its own table"
@@ -354,7 +354,7 @@ def test_a_matrix_runs_row_agrees_with_its_rollup_to_the_cent(report: Report) ->
             + "\n"
             + json.dumps(_record(run_id=1, cost_usd=cost))
         )
-    output, _rows = report.run()
+    output, _ = report.run()
 
     assert output["totals"]["cost_usd"] == 28.17
     assert _table(report, "RUN")[0][3] == "$28.17"

--- a/plugins/install-tend/skills/install-tend/scripts/oauth_token.py
+++ b/plugins/install-tend/skills/install-tend/scripts/oauth_token.py
@@ -196,7 +196,9 @@ def main():
             stdout=slave,
             stderr=slave,
             close_fds=True,
-            preexec_fn=take_controlling_tty,
+            # The hazard is threads; this is a single-threaded CLI helper, and the
+            # child needs the pty as its controlling terminal to run interactively.
+            preexec_fn=take_controlling_tty,  # noqa: PLW1509
         )
     except FileNotFoundError:
         sys.exit("Error: claude CLI not found. Install Claude Code first.")

--- a/plugins/install-tend/skills/install-tend/scripts/test_oauth_token.py
+++ b/plugins/install-tend/skills/install-tend/scripts/test_oauth_token.py
@@ -19,15 +19,17 @@ import time
 from pathlib import Path
 
 import pytest
-
 from oauth_token import (
     ANSI_CSI,
     AUTHORIZE_URL,
     MAX_TOKEN_LENGTH,
     TIMEOUT_SECONDS,
     TOKEN,
+    complete_match,
+    failure_message,
+    first_url,
+    stop_and_reap,
 )
-from oauth_token import complete_match, failure_message, first_url, stop_and_reap
 
 URL = (
     b"https://claude.com/cai/oauth/authorize?code=true&client_id=9d1"

--- a/proxy/inject_credentials.py
+++ b/proxy/inject_credentials.py
@@ -124,7 +124,11 @@ class CredentialInjector:
             # Not an allowlisted host — never attach a credential. Leave the
             # request exactly as the agent sent it.
             return
-        logging.info("injected credential for %s %s", flow.request.method, host)
+        # mitmproxy's documented addon pattern logs through the root logger, which
+        # its own handler captures; a named logger would change where this lands.
+        logging.info(  # noqa: LOG015
+            "injected credential for %s %s", flow.request.method, host
+        )
 
     def responseheaders(self, flow: http.HTTPFlow) -> None:
         # Stream every intercepted response straight through — intentionally

--- a/proxy/test_inject_credentials.py
+++ b/proxy/test_inject_credentials.py
@@ -14,15 +14,14 @@ from importlib.metadata import version
 from pathlib import Path
 
 import pytest
-from mitmproxy.test import tflow, tutils
-from ruamel.yaml import YAML
-
 from inject_credentials import (
     ANTHROPIC_HOSTS,
     BASIC_HOSTS,
     TOKEN_HOSTS,
     CredentialInjector,
 )
+from mitmproxy.test import tflow, tutils
+from ruamel.yaml import YAML
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -71,6 +70,7 @@ def test_proxy_starts_and_finishes_its_empty_replay(tmp_path: Path) -> None:
         capture_output=True,
         text=True,
         timeout=10,
+        check=False,
     )
 
     assert result.returncode == 0, result.stdout + result.stderr

--- a/shared/steps/_common.py
+++ b/shared/steps/_common.py
@@ -221,7 +221,9 @@ def utcnow() -> datetime.datetime:
     baseline range — is UTC, and a local-time reading would silently shift a
     day boundary the limits are scoped to.
     """
-    return datetime.datetime.now(datetime.UTC)
+    # These modules stay 3.10-compatible (see this module's docstring);
+    # `datetime.UTC` is 3.11+.
+    return datetime.datetime.now(datetime.timezone.utc)  # noqa: UP017
 
 
 def read_ndjson(path: Path) -> Iterator[dict[str, Any]]:

--- a/shared/steps/_common.py
+++ b/shared/steps/_common.py
@@ -221,7 +221,7 @@ def utcnow() -> datetime.datetime:
     baseline range — is UTC, and a local-time reading would silently shift a
     day boundary the limits are scoped to.
     """
-    return datetime.datetime.now(datetime.timezone.utc)
+    return datetime.datetime.now(datetime.UTC)
 
 
 def read_ndjson(path: Path) -> Iterator[dict[str, Any]]:

--- a/shared/steps/conftest.py
+++ b/shared/steps/conftest.py
@@ -13,9 +13,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
 import _common
+import pytest
 from _fakes import FakeGh, GithubFiles
 
 

--- a/shared/steps/rate_limit_preflight.py
+++ b/shared/steps/rate_limit_preflight.py
@@ -276,8 +276,7 @@ def count_approvals(
         labelled = event.get("event") == "labeled"
         if labelled and (event.get("label") or {}).get("name") == label:
             at = event.get("created_at") or ""
-            if at > since:
-                since = at
+            since = max(since, at)
     return sum(1 for event in events if _is_approval(event, bot_id=bot_id, since=since))
 
 

--- a/shared/steps/sandbox_setup.py
+++ b/shared/steps/sandbox_setup.py
@@ -107,7 +107,7 @@ def _lines(argv: list[str]) -> list[str]:
     filename on either PATH need not be UTF-8, and a strict decode would raise
     out of a report that is best-effort by design.
     """
-    result = subprocess.run(argv, stdout=subprocess.PIPE)
+    result = subprocess.run(argv, stdout=subprocess.PIPE, check=False)
     if result.returncode != 0:
         return []
     return result.stdout.decode("utf-8", errors="replace").splitlines()
@@ -199,7 +199,7 @@ def main() -> int:
         argv = setup_argv(
             commands, sandbox=sandbox, agent_env_file=env["AGENT_ENV_FILE"]
         )
-        code = subprocess.run(argv).returncode
+        code = subprocess.run(argv, check=False).returncode
         if code != 0:
             return code
         _common.log(STEP, f"ran adopter sandbox_setup commands as {sandbox}")

--- a/shared/steps/test_common.py
+++ b/shared/steps/test_common.py
@@ -4,9 +4,8 @@ import json
 import subprocess
 from pathlib import Path
 
-import pytest
-
 import _common
+import pytest
 from _fakes import FakeGh, GithubFiles
 
 

--- a/shared/steps/test_issue.py
+++ b/shared/steps/test_issue.py
@@ -5,10 +5,9 @@ import subprocess
 from datetime import UTC, datetime
 from pathlib import Path
 
-import pytest
-
 import _common
 import _issue
+import pytest
 from _fakes import FakeGh
 
 RUN_LINK = "[workflow run](https://github.com/owner/repo/actions/runs/12345)"

--- a/shared/steps/test_mark_notification_read.py
+++ b/shared/steps/test_mark_notification_read.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
 import mark_notification_read
+import pytest
 from _fakes import FakeGh
 
 REPO = "owner/repo"

--- a/shared/steps/test_rate_limit_preflight.py
+++ b/shared/steps/test_rate_limit_preflight.py
@@ -7,9 +7,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-import pytest
-
 import _common
+import pytest
 import rate_limit_preflight as preflight
 from _fakes import FakeGh, GithubFiles
 

--- a/shared/steps/test_report_failure.py
+++ b/shared/steps/test_report_failure.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-
 import report_failure
 from _fakes import FakeGh
 

--- a/shared/steps/test_run_claude.py
+++ b/shared/steps/test_run_claude.py
@@ -21,9 +21,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-import pytest
-
 import _sandbox
+import pytest
 import run_claude
 from _fakes import GithubFiles
 

--- a/shared/steps/test_sandbox.py
+++ b/shared/steps/test_sandbox.py
@@ -16,9 +16,8 @@ import sys
 from collections.abc import Callable
 from pathlib import Path
 
-import pytest
-
 import _sandbox
+import pytest
 import run_claude
 import sandbox_setup
 

--- a/shared/steps/test_sandbox_setup.py
+++ b/shared/steps/test_sandbox_setup.py
@@ -17,7 +17,6 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-
 import sandbox_setup
 
 

--- a/shared/steps/test_security_preflight.py
+++ b/shared/steps/test_security_preflight.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import subprocess
 
 import pytest
-
 import security_preflight
 from _fakes import FakeGh
 

--- a/shared/steps/test_token_usage.py
+++ b/shared/steps/test_token_usage.py
@@ -14,7 +14,6 @@ import sys
 from pathlib import Path
 
 import pytest
-
 import token_usage
 from _fakes import GithubFiles
 


### PR DESCRIPTION
Moves `ruff-pre-commit` from v0.14.11 to v0.16.5, held out of #1099 because it isn't an ordinary rev bump: ruff 0.16.0 expanded the default rule set from 59 rules to 413, and 0.15.0 moved the formatter to the 2026 style guide. The repo carries no ruff configuration, so it takes those defaults directly — 64 findings appear on a codebase that reports `All checks passed!` under the old pin. Every change here is behaviour-preserving; the point is to move the pin without smuggling in a semantic change.

Three findings are suppressed rather than fixed, each with the reason inline. Each is in code where satisfying the rule would be a real change: the mitmproxy addon's root-logger call (`LOG015`) sits in the credential-injection path and follows mitmproxy's documented addon pattern, `preexec_fn` in the OAuth helper (`PLW1509`) is what gives the child its controlling terminal, and `UP017` in `shared/steps/_common.py` would rewrite `datetime.timezone.utc` to the 3.11+ `datetime.UTC` in a directory documented as 3.10-compatible (those step bodies run on the runner's system `python3`, which is 3.10 on an `ubuntu-22.04` `runs-on` override). Say the word and either can become a named logger / restructured spawn instead.

<details><summary>What the 64 findings were, and how each was handled</summary>

| Rule | n | Handling |
|---|---|---|
| `I001` unsorted-imports | 27 | ruff's own safe fix |
| `PLW1510` subprocess-run-without-check | 19 | explicit `check=False` at every site — this is the current behaviour spelled out, not a change to it |
| `RUF059` unused-unpacked-variable | 5 | ruff's fix (`rows` → `_rows`) |
| `UP037` quoted-annotation | 3 | ruff's fix; the file carries `from __future__ import annotations`, so unquoting is safe |
| `UP017` datetime-timezone-utc | 2 | one ruff's fix (a test); one suppressed in `shared/steps/`, reason inline |
| `PIE810` multiple-starts-ends-with | 2 | ruff's fix (tuple argument) |
| `FURB167` regex-flag-alias | 2 | ruff's fix |
| `PLR1730` if-stmt-min-max | 1 | ruff's fix |
| `PERF102` incorrect-dict-iterator | 1 | ruff's fix; the discarded key was genuinely unused |
| `LOG015` root-logger-call | 1 | suppressed, reason inline |
| `PLW1509` subprocess-popen-preexec-fn | 1 | suppressed, reason inline |

`PLW1510` has no autofix in ruff, so `check=False` was inserted at each call's closing paren via an AST pass that refused to write any file it couldn't re-parse, then normalised by `ruff format`.

**Formatting.** 14 files are reformatted. One is the 2026 style guide's own doing — it is the only file `ruff format --check` rewrites against `main` at v0.16.5. The other 13 are the `check=False` insertions being wrapped back onto their lines.

**Verification.** `pre-commit run --all-files` passes at the new rev, and `uv run pytest` passes (763), including the regtest snapshots — so no generated workflow output moved. `worker/` and `site/` are untouched.

**The alternative, not taken.** Pinning `select = ["E4", "E7", "E9", "F"]` would reproduce the pre-0.16 default exactly and drop the diff to one line. That trades a config-free repo for a frozen rule set, which reads like the wrong direction for a repo that has deliberately carried no ruff config — but it is a one-line change if you'd rather have it.

</details>

