### PR TITLE
Extract review posting checks into a preflight script

### DIFF
--- a/generator/tests/test_bot_review_state.py
+++ b/generator/tests/test_bot_review_state.py
@@ -409,17 +409,32 @@ def test_the_repo_is_named_explicitly_on_every_call(env: dict[str, str]) -> None
 
 
 def test_review_skill_preserves_the_status_free_queue_contract() -> None:
-    """The skill deduplicates outward reviews while the workflow keeps events."""
+    """The skill deduplicates outward reviews while the workflow keeps events.
+
+    Step 1's checks stay in the skill; the pre-post copies of them are
+    `review-preflight.sh`, which this pins alongside so the pair cannot drift
+    into disagreeing about what already counts as reviewed.
+    """
     skill = REVIEW_SKILL.read_text()
+    preflight = BOT_REVIEW_STATE.parent / "review-preflight.sh"
+    preflight_src = preflight.read_text()
 
     assert "repos/$REPO/statuses/$HEAD_SHA" not in skill
     assert "tend-review/<number>" not in skill
     assert "--json headRefOid,state" in skill
     assert '[ "$PR_STATE" != "OPEN" ]' in skill
-    assert '[ "$CURRENT_HEAD" != "$HEAD_SHA" ]' in skill
-    assert "ALREADY_POSTED=" in skill
-    assert ".at_head.draft_mode" in skill
-    assert '--argjson force "${FORCE_FULL_REVIEW:-false}"' in skill
+    assert "scripts/review-preflight.sh <number>" in skill
+
+    assert '[ "$PR_STATE" != "OPEN" ]' in preflight_src
+    assert '[ "$CURRENT_HEAD" != "$REVIEWED" ]' in preflight_src
+    assert ".at_head.draft_mode" in preflight_src
+    assert '--argjson force "$FORCE"' in preflight_src
+    # Derived from the event rather than read from the environment: the value
+    # step 1 exported is gone by the time a review is posted, so an inherited
+    # `FORCE_FULL_REVIEW` would always read false and a ready-for-review pass
+    # would stop on the draft COMMENT it exists to replace.
+    assert "${FORCE_FULL_REVIEW" not in preflight_src
+    assert 'if [ "$EVENT_ACTION" = "ready_for_review" ]; then' in preflight_src
     assert 'if [ "$EVENT_ACTION" = "ready_for_review" ]; then' in skill
     assert (
         "If `FORCE_FULL_REVIEW` is false and the incremental changes are trivial"

--- a/generator/tests/test_bot_review_state.py
+++ b/generator/tests/test_bot_review_state.py
@@ -409,32 +409,14 @@ def test_the_repo_is_named_explicitly_on_every_call(env: dict[str, str]) -> None
 
 
 def test_review_skill_preserves_the_status_free_queue_contract() -> None:
-    """The skill deduplicates outward reviews while the workflow keeps events.
-
-    Step 1's checks stay in the skill; the pre-post copies of them are
-    `review-preflight.sh`, which this pins alongside so the pair cannot drift
-    into disagreeing about what already counts as reviewed.
-    """
+    """Reading and posting use the same review-state definition."""
     skill = REVIEW_SKILL.read_text()
-    preflight = BOT_REVIEW_STATE.parent / "review-preflight.sh"
-    preflight_src = preflight.read_text()
 
     assert "repos/$REPO/statuses/$HEAD_SHA" not in skill
     assert "tend-review/<number>" not in skill
     assert "--json headRefOid,state" in skill
     assert '[ "$PR_STATE" != "OPEN" ]' in skill
     assert "scripts/review-preflight.sh <number>" in skill
-
-    assert '[ "$PR_STATE" != "OPEN" ]' in preflight_src
-    assert '[ "$CURRENT_HEAD" != "$REVIEWED" ]' in preflight_src
-    assert ".at_head.draft_mode" in preflight_src
-    assert '--argjson force "$FORCE"' in preflight_src
-    # Derived from the event rather than read from the environment: the value
-    # step 1 exported is gone by the time a review is posted, so an inherited
-    # `FORCE_FULL_REVIEW` would always read false and a ready-for-review pass
-    # would stop on the draft COMMENT it exists to replace.
-    assert "${FORCE_FULL_REVIEW" not in preflight_src
-    assert 'if [ "$EVENT_ACTION" = "ready_for_review" ]; then' in preflight_src
     assert 'if [ "$EVENT_ACTION" = "ready_for_review" ]; then' in skill
     assert (
         "If `FORCE_FULL_REVIEW` is false and the incremental changes are trivial"

--- a/generator/tests/test_cross_file_contracts.py
+++ b/generator/tests/test_cross_file_contracts.py
@@ -95,6 +95,8 @@ def test_installation_and_each_poll_enable_repository_watching() -> None:
 def test_review_skill_retargets_a_moved_head_rather_than_discarding_it() -> None:
     """A push mid-review re-targets the review rather than throwing it away.
 
+    The mechanics live in `review-preflight.sh`; the skill keeps the pin file
+    contract on either side of it and the instructions for reading the delta.
     Re-targeting requires the live head to build on the reviewed one, and every
     review pins the commit it read: unpinned, GitHub anchors it at whatever is
     live when the POST lands, so the review claims code the session never saw.
@@ -104,13 +106,15 @@ def test_review_skill_retargets_a_moved_head_rather_than_discarding_it() -> None
     posting, and shell state does not survive a tool call.
     """
     skill = _read("plugins", "tend-ci-runner", "skills", "review", "SKILL.md")
+    preflight = _read("plugins", "tend-ci-runner", "scripts", "review-preflight.sh")
 
-    assert 'git merge-base --is-ancestor "$HEAD_SHA" "$CURRENT_HEAD"' in skill
+    assert 'git merge-base --is-ancestor "$REVIEWED" "$CURRENT_HEAD"' in preflight
     assert "HEAD moved — leaving" not in skill
 
     # Written where the head is read, and rewritten where it moves.
     assert 'echo "$HEAD_SHA" > /tmp/reviewed-head' in skill
-    assert 'echo "$CURRENT_HEAD" > /tmp/reviewed-head' in skill
+    assert 'echo "$CURRENT_HEAD" > "$PIN_FILE"' in preflight
+    assert 'PIN_FILE="${REVIEWED_HEAD_FILE:-/tmp/reviewed-head}"' in preflight
     # Read back by both posting recipes, and read *before* the POST: inlined as
     # `$(cat ...)` a missing file substitutes the empty string and the request
     # still goes out, which is the unpinned review the pin exists to prevent.
@@ -123,12 +127,15 @@ def test_review_skill_retargets_a_moved_head_rather_than_discarding_it() -> None
     #
     # The scoped log is the author's own new code: a plain two-dot diff between
     # the heads would hand the session everything a base merge dragged in.
-    assert "git log -p --no-merges" in skill
-    assert '--not "$BASE_SHA"' in skill
+    assert "git log -p --no-merges" in preflight
+    assert '--not "$BASE_SHA"' in preflight
     # The merges log is the only place a base merge appears, and it carries a
     # label or it reads as one more commit in the scoped log's stream.
-    assert '--merges "$HEAD_SHA..$CURRENT_HEAD"' in skill
-    assert "base merge: %h %s" in skill
+    assert '--merges "$REVIEWED..$CURRENT_HEAD"' in preflight
+    assert "base merge: %h %s" in preflight
+    # Both logs reach the session through one field, so the skill has to say
+    # they are two — an unlabelled `base merge:` line reads as one more commit.
+    assert "**Read both halves of `delta` as a pair.**" in skill
     # `--cc` is the only place a conflicted merge's resolution appears: the
     # author commits it inside the merge, where neither log reaches it. It is
     # not a substitute for re-verifying, though — a resolution taking the base

--- a/generator/tests/test_cross_file_contracts.py
+++ b/generator/tests/test_cross_file_contracts.py
@@ -95,8 +95,6 @@ def test_installation_and_each_poll_enable_repository_watching() -> None:
 def test_review_skill_retargets_a_moved_head_rather_than_discarding_it() -> None:
     """A push mid-review re-targets the review rather than throwing it away.
 
-    The mechanics live in `review-preflight.sh`; the skill keeps the pin file
-    contract on either side of it and the instructions for reading the delta.
     Re-targeting requires the live head to build on the reviewed one, and every
     review pins the commit it read: unpinned, GitHub anchors it at whatever is
     live when the POST lands, so the review claims code the session never saw.
@@ -108,12 +106,10 @@ def test_review_skill_retargets_a_moved_head_rather_than_discarding_it() -> None
     skill = _read("plugins", "tend-ci-runner", "skills", "review", "SKILL.md")
     preflight = _read("plugins", "tend-ci-runner", "scripts", "review-preflight.sh")
 
-    assert 'git merge-base --is-ancestor "$REVIEWED" "$CURRENT_HEAD"' in preflight
     assert "HEAD moved — leaving" not in skill
 
     # Written where the head is read, and rewritten where it moves.
     assert 'echo "$HEAD_SHA" > /tmp/reviewed-head' in skill
-    assert 'echo "$CURRENT_HEAD" > "$PIN_FILE"' in preflight
     assert 'PIN_FILE="${REVIEWED_HEAD_FILE:-/tmp/reviewed-head}"' in preflight
     # Read back by both posting recipes, and read *before* the POST: inlined as
     # `$(cat ...)` a missing file substitutes the empty string and the request
@@ -122,20 +118,8 @@ def test_review_skill_retargets_a_moved_head_rather_than_discarding_it() -> None
     assert '-f commit_id="$REVIEWED"' in skill
     assert '--arg sha "$REVIEWED"' in skill
 
-    # Three commands read the delta, and dropping any one of them silently
-    # narrows what the session sees rather than failing.
-    #
-    # The scoped log is the author's own new code: a plain two-dot diff between
-    # the heads would hand the session everything a base merge dragged in.
-    assert "git log -p --no-merges" in preflight
-    assert '--not "$BASE_SHA"' in preflight
-    # The merges log is the only place a base merge appears, and it carries a
-    # label or it reads as one more commit in the scoped log's stream.
-    assert '--merges "$REVIEWED..$CURRENT_HEAD"' in preflight
-    assert "base merge: %h %s" in preflight
-    # Both logs reach the session through one field, so the skill has to say
-    # they are two — an unlabelled `base merge:` line reads as one more commit.
-    assert "**Read both halves of `delta` as a pair.**" in skill
+    # Both logs reach the session in one stream, so the skill names both halves.
+    assert "**Read both halves of the delta file as a pair.**" in skill
     # `--cc` is the only place a conflicted merge's resolution appears: the
     # author commits it inside the merge, where neither log reaches it. It is
     # not a substitute for re-verifying, though — a resolution taking the base

--- a/generator/tests/test_review_preflight.py
+++ b/generator/tests/test_review_preflight.py
@@ -1,13 +1,4 @@
-"""Tests for review-preflight.sh — the three checks that gate a posted review.
-
-The recipe used to be forty lines of shell inside the review skill, retyped
-from prose every session. Each check decides an outward action and none of
-them fails loudly when it is skipped: an approval lands on a closed PR, a
-review claims code the session never read, or a second review duplicates one
-already on the commit. These pin the extracted script against a real git
-repository, because two of the three answers come from git rather than the
-API — what a base merge dragged in, and whether the push was a rewrite.
-"""
+"""Behavior tests for review-preflight.sh."""
 
 from __future__ import annotations
 
@@ -30,8 +21,6 @@ DRAFT_REVIEW_LINE = (
     "Mark ready for a full review."
 )
 
-# One fixture serves every `pr view`: the script's own `--jq` selects the
-# fields, so a filter naming the wrong one reads as empty rather than passing.
 FAKE_GH = (
     GH_PREAMBLE
     + r"""
@@ -76,93 +65,74 @@ def _commit(repo: Path, name: str, content: str, message: str) -> str:
 
 
 class Fixture:
-    """A PR at `reviewed`, plus the pushes a mid-review head move can be."""
-
     def __init__(self, tmp_path: Path) -> None:
         self.tmp_path = tmp_path
         self.origin = tmp_path / "origin"
         self.work = tmp_path / "work"
         self.pin = tmp_path / "reviewed-head"
 
-        # Built once: `fake_bin` creates its directory, so a second call from a
-        # test that runs the script twice would fail on the existing one.
         git = shutil.which("git")
         assert git, "git is required for these tests"
-        self.git_dir = Path(git).parent
         self.bindir = fake_bin(tmp_path, gh=FAKE_GH)
+        self.git = Path(git)
+        self.git_dir = Path(git).parent
 
         self.origin.mkdir()
         _git(self.origin, "init", "-b", "main", "-q")
-        # Real GitHub serves a reachable object by sha; a bare local remote
-        # refuses unless asked to, and the base-tip fetch is one of those.
         _git(self.origin, "config", "uploadpack.allowReachableSHA1InWant", "true")
         _commit(self.origin, "base.txt", "1\n", "base-1")
         _git(self.origin, "checkout", "-q", "-b", "pr")
         self.reviewed = _commit(self.origin, "feature.txt", "a\n", "pr-1")
         self.base = _git(self.origin, "rev-parse", "main")
 
-        # The session's checkout: it has the reviewed commit and nothing since.
         _git(tmp_path, "clone", "-q", str(self.origin), str(self.work))
         self.pin.write_text(self.reviewed + "\n")
         self.set_head(self.reviewed)
 
-    def _publish(self, sha: str) -> None:
+    def publish(self, sha: str) -> None:
         _git(self.origin, "update-ref", f"refs/pull/{PR}/head", sha)
+        self.set_head(sha)
 
-    def push_over_a_base_merge(self) -> str:
-        """An "Update branch" click, then a commit of the author's own."""
+    def push_over_base_merge(self) -> str:
         _git(self.origin, "checkout", "-q", "main")
         self.base = _commit(self.origin, "base.txt", "2\n", "base-2")
         _git(self.origin, "checkout", "-q", "pr")
         _git(self.origin, "merge", "--no-ff", "-q", "-m", "Merge main into pr", "main")
         head = _commit(self.origin, "feature.txt", "a\nb\n", "pr-2")
-        self._publish(head)
-        self.set_head(head)
+        self.publish(head)
         return head
 
-    def base_absorbs_the_branch(self) -> str:
-        """The base fast-forwards over the reviewed commit and moves on, and
-        the PR head follows it: the head moved, but every commit it gained
-        belongs to the base."""
+    def move_head_to_base(self) -> str:
         _git(self.origin, "checkout", "-q", "main")
         _git(self.origin, "merge", "--ff-only", "-q", "pr")
         self.base = _commit(self.origin, "base.txt", "2\n", "base-2")
         _git(self.origin, "checkout", "-q", "-B", "pr", "main")
-        self._publish(self.base)
-        self.set_head(self.base)
+        self.publish(self.base)
         return self.base
 
     def force_push(self) -> str:
-        """A rewrite: the reviewed commit is no longer an ancestor."""
         _git(self.origin, "checkout", "-q", "-B", "pr", "main")
         head = _commit(self.origin, "feature.txt", "rewritten\n", "pr-1'")
-        self._publish(head)
-        self.set_head(head)
+        self.publish(head)
         return head
-
-    # -- API fixtures --------------------------------------------------------
 
     def set_head(self, sha: str, state: str = "OPEN") -> None:
         self.head = sha
-        self._write(
+        self.write(
             "PR_JSON", {"headRefOid": sha, "state": state, "baseRefOid": self.base}
         )
 
-    def close(self, state: str = "CLOSED") -> None:
-        self.set_head(self.head, state)
-
     def reviews(self, *reviews: dict) -> None:
-        self._write("REVIEWS_JSON", list(reviews))
+        self.write("REVIEWS_JSON", list(reviews))
 
-    def _write(self, key: str, value: object) -> None:
+    def write(self, key: str, value: object) -> None:
         (self.tmp_path / f"{key.lower()}.json").write_text(json.dumps(value))
-
-    # -- running -------------------------------------------------------------
 
     def env(self, **extra: str) -> dict[str, str]:
         return {
             "PATH": tool_path(self.bindir, self.git_dir),
             "HOME": str(self.tmp_path),
+            "TMPDIR": str(self.tmp_path),
             "GH_CALLS": str(self.tmp_path / "gh-calls.log"),
             "GITHUB_REPOSITORY": "owner/repo",
             "BOT_LOGIN": BOT,
@@ -185,10 +155,10 @@ class Fixture:
             check=False,
         )
 
-    def verdict(self, **extra: str) -> dict:
+    def output(self, **extra: str) -> str:
         result = self.run(**extra)
         assert result.returncode == 0, result.stderr
-        return json.loads(result.stdout)
+        return result.stdout
 
     def pinned(self) -> str:
         return self.pin.read_text().strip()
@@ -197,28 +167,20 @@ class Fixture:
 @pytest.fixture
 def pr(tmp_path: Path) -> Fixture:
     fixture = Fixture(tmp_path)
-    fixture._write("INLINE_JSON", [])
-    fixture._write("TIMELINE_JSON", [])
+    fixture.write("INLINE_JSON", [])
+    fixture.write("TIMELINE_JSON", [])
     fixture.reviews()
     return fixture
 
 
-def _review(
-    rid: int,
-    *,
-    sha: str,
-    body: str = "",
-    state: str = "COMMENTED",
-    at: str = "2026-01-01T00:00:00Z",
-    author: str = BOT,
-) -> dict:
+def _review(sha: str, body: str, state: str = "COMMENTED") -> dict:
     return {
-        "id": rid,
-        "user": {"login": author},
+        "id": 1,
+        "user": {"login": BOT},
         "body": body,
         "state": state,
         "commit_id": sha,
-        "submitted_at": at,
+        "submitted_at": "2026-01-01T00:00:00Z",
     }
 
 
@@ -227,118 +189,60 @@ def _event(path: Path, action: str) -> str:
     return str(path)
 
 
-# ---------------------------------------------------------------------------
-# The plain path
-# ---------------------------------------------------------------------------
+def _delta(output: str) -> str:
+    paths = [
+        line.removeprefix("delta: ")
+        for line in output.splitlines()
+        if line.startswith("delta: ")
+    ]
+    assert len(paths) == 1, output
+    return Path(paths[0]).read_text()
 
 
-def test_an_unreviewed_head_that_has_not_moved_posts(pr: Fixture) -> None:
-    verdict = pr.verdict()
-
-    assert verdict["verdict"] == "post"
-    assert verdict["head"] == pr.reviewed
-    assert verdict["retargeted"] is False
-    assert verdict["delta"] == ""
+def test_an_unreviewed_unchanged_head_posts(pr: Fixture) -> None:
+    assert pr.output() == f"post: {pr.reviewed} is still the head you reviewed\n"
     assert pr.pinned() == pr.reviewed
 
 
-def test_the_head_it_reports_is_the_head_the_pin_file_holds(pr: Fixture) -> None:
-    """The two travel to the POST separately — `head` is what the session
-    reads, the file is what the posting recipe substitutes — so a disagreement
-    would pin a review to a commit the session never decided on."""
-    moved = pr.push_over_a_base_merge()
-
-    assert pr.verdict()["head"] == pr.pinned() == moved
-
-
-# ---------------------------------------------------------------------------
-# The PR closed under the session
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.parametrize("state", ["CLOSED", "MERGED"])
-def test_a_pr_that_closed_mid_review_takes_no_review(pr: Fixture, state: str) -> None:
-    """HEAD does not move when a PR closes, so nothing else notices: the
-    approval lands timestamped after the close."""
-    pr.close(state)
+def test_a_closed_pr_is_skipped(pr: Fixture, state: str) -> None:
+    pr.set_head(pr.head, state)
 
-    verdict = pr.verdict()
-
-    assert verdict["verdict"] == "skip"
-    assert state in verdict["reason"]
+    assert pr.output() == f"skip: PR is {state}\n"
 
 
-# ---------------------------------------------------------------------------
-# A push mid-review
-# ---------------------------------------------------------------------------
+def test_a_moved_head_is_retargeted_with_a_scoped_delta(pr: Fixture) -> None:
+    moved = pr.push_over_base_merge()
 
+    output = pr.output()
+    status = output.splitlines()[0]
+    delta = _delta(output)
 
-def test_a_moved_head_is_retargeted_and_the_pin_file_follows(pr: Fixture) -> None:
-    moved = pr.push_over_a_base_merge()
-
-    verdict = pr.verdict()
-
-    assert verdict["verdict"] == "post"
-    assert verdict["retargeted"] is True
-    assert verdict["head"] == moved
+    assert status == f"post: re-targeted onto {moved} — read the delta before posting"
     assert pr.pinned() == moved
-
-
-def test_the_delta_is_the_authored_push_and_not_the_base_churn(pr: Fixture) -> None:
-    """`--not "$BASE_SHA"` is what separates them. Without it the base branch's
-    own commits sit in the range and read as the author's, and the session
-    reviews main's history as if it were the push."""
-    pr.push_over_a_base_merge()
-
-    delta = pr.verdict()["delta"]
-
     assert "pr-2" in delta
-    assert "base-2" not in delta, delta
-
-
-def test_a_base_merge_appears_only_as_a_labelled_merges_line(pr: Fixture) -> None:
-    """The scoped log drops the merge commit and everything it brought in, so
-    an "Update branch" click is invisible there while it re-scopes every
-    file's hunks. The label is what stops it reading as one more commit."""
-    pr.push_over_a_base_merge()
-
-    delta = pr.verdict()["delta"]
-
+    assert "base-2" not in delta
     assert "base merge: " in delta
     assert "Merge main into pr" in delta
 
 
-def test_a_delta_larger_than_one_argv_string_still_reaches_the_session(
-    pr: Fixture,
-) -> None:
-    """Linux caps a single argv string at 131072 bytes, so a patch passed to
-    `jq --arg` kills the preflight outright — after the pin file has been
-    advanced, which leaves the head this session never reviewed looking like
-    the one it did. macOS has no per-argument cap, so this catches the
-    regression on CI (ubuntu) rather than on a developer's box."""
-    pr.push_over_a_base_merge()
+def test_a_large_delta_is_preserved_for_chunked_reads(pr: Fixture) -> None:
+    pr.push_over_base_merge()
     big = "\n".join(f"line {i} of a regenerated file" for i in range(8000))
-    _commit(pr.origin, "generated.txt", big, "pr-3")
-    head = _git(pr.origin, "rev-parse", "HEAD")
-    _git(pr.origin, "update-ref", f"refs/pull/{PR}/head", head)
-    pr.set_head(head)
+    head = _commit(pr.origin, "generated.txt", big, "pr-3")
+    pr.publish(head)
 
-    verdict = pr.verdict()
+    output = pr.output()
+    delta = _delta(output)
 
-    assert len(verdict["delta"]) > 200_000, len(verdict["delta"])
-    assert verdict["verdict"] == "post"
+    assert len(delta) > 200_000
+    assert output.startswith(f"post: re-targeted onto {head}")
     assert pr.pinned() == head
 
 
-def test_a_failing_scoped_log_aborts_rather_than_reporting_a_base_merge(
-    pr: Fixture,
-) -> None:
-    """`set -e` does not reach inside `$( … )`, so the two logs have to run
-    somewhere it does. Swallowed, the scoped log's failure leaves a delta of
-    base merges alone — the author's push reading as an "Update branch" click,
-    which the bullets treat as nothing new to review."""
-    pr.push_over_a_base_merge()
-    pr.base = "0" * 40  # a base tip that will not fetch or resolve
+def test_a_failing_scoped_log_aborts(pr: Fixture) -> None:
+    pr.push_over_base_merge()
+    pr.base = "0" * 40
     pr.set_head(pr.head)
 
     result = pr.run()
@@ -347,121 +251,81 @@ def test_a_failing_scoped_log_aborts_rather_than_reporting_a_base_merge(
     assert result.stdout == ""
 
 
-def test_a_moved_head_can_carry_an_empty_delta(pr: Fixture) -> None:
-    """`retargeted` is a separate field because an empty delta does not mean
-    the head stayed put: `--not "$BASE_SHA"` legitimately empties it when
-    everything the head gained is the base's. Read off `delta` alone, the
-    session would post against a commit it never noticed it had moved to."""
-    moved = pr.base_absorbs_the_branch()
+def test_a_moved_head_can_have_an_empty_delta(pr: Fixture) -> None:
+    moved = pr.move_head_to_base()
 
-    verdict = pr.verdict()
+    output = pr.output()
 
-    assert verdict["retargeted"] is True
-    assert verdict["delta"] == ""
-    assert verdict["head"] == moved
-
-
-def test_a_rewritten_head_is_left_to_the_queued_review(pr: Fixture) -> None:
-    """Re-targeting needs the live head to build on the reviewed one. After a
-    rewrite the findings describe code that is gone, and posting them against
-    the new head would attach them to lines nobody wrote."""
-    rewritten = pr.force_push()
-
-    verdict = pr.verdict()
-
-    assert verdict["verdict"] == "skip"
-    assert "no longer an ancestor" in verdict["reason"]
-    assert pr.pinned() == pr.reviewed, "the pin must not follow a rewrite"
-    assert rewritten not in pr.pinned()
-
-
-# ---------------------------------------------------------------------------
-# A review already anchoring the head
-# ---------------------------------------------------------------------------
-
-
-def test_a_review_already_on_the_head_stops_a_duplicate(pr: Fixture) -> None:
-    pr.reviews(_review(1, sha=pr.reviewed, body="findings"))
-
-    verdict = pr.verdict()
-
-    assert verdict["verdict"] == "skip"
-    assert "already carries" in verdict["reason"]
-
-
-def test_the_dedup_reads_the_head_the_review_was_retargeted_onto(
-    pr: Fixture,
-) -> None:
-    """A racing run can post at the new head while this one is composing, so
-    the check has to run against the head this review would now pin — not the
-    one the session started from."""
-    moved = pr.push_over_a_base_merge()
-    pr.reviews(_review(1, sha=moved, body="findings from the queued run"))
-
-    assert pr.verdict()["verdict"] == "skip"
-    # The re-target already happened, so the pin follows the head even though
-    # nothing is posted. Harmless only because a skip ends the session — worth
-    # stating, since a later path that posted after a skip would post unpinned.
+    assert output.startswith(
+        f"post: re-targeted onto {moved} — read the delta before posting\n"
+    )
+    assert _delta(output) == ""
     assert pr.pinned() == moved
 
 
-def test_a_reply_container_on_the_head_does_not_stop_the_post(pr: Fixture) -> None:
-    """Deferred to `bot-review-state.sh`: replying to a thread makes GitHub
-    wrap the reply in a zero-body COMMENTED review anchored at the head. Read
-    as a review it would discard this session's real one."""
-    pr.reviews(_review(1, sha=pr.reviewed))
+def test_a_force_push_is_left_to_the_queued_review(pr: Fixture) -> None:
+    rewritten = pr.force_push()
 
-    assert pr.verdict()["verdict"] == "post"
+    output = pr.output()
+
+    assert output.startswith(f"skip: cannot re-target onto {rewritten}")
+    assert pr.pinned() == pr.reviewed
 
 
-def test_a_ready_for_review_event_replaces_the_draft_comment(
-    pr: Fixture, tmp_path: Path
-) -> None:
-    """Becoming ready asks for the full review the draft pass withheld."""
-    pr.reviews(_review(1, sha=pr.reviewed, body=DRAFT_REVIEW_LINE))
-
-    verdict = pr.verdict(
-        GITHUB_EVENT_PATH=_event(tmp_path / "event.json", "ready_for_review")
+def test_a_merge_base_error_aborts(pr: Fixture) -> None:
+    pr.push_over_base_merge()
+    fake_git = pr.bindir / "git"
+    fake_git.write_text(
+        f'''#!/usr/bin/env bash
+if [ "$1" = "merge-base" ]; then exit 128; fi
+exec "{pr.git}" "$@"
+'''
     )
+    fake_git.chmod(0o755)
 
-    assert verdict["verdict"] == "post"
+    result = pr.run()
+
+    assert result.returncode == 128
+    assert "git merge-base failed with status 128" in result.stderr
+    assert result.stdout == ""
+    assert pr.pinned() == pr.reviewed
 
 
-def test_a_ready_for_review_event_still_stops_on_a_full_review(
-    pr: Fixture, tmp_path: Path
+def test_an_existing_review_stops_a_duplicate(pr: Fixture) -> None:
+    pr.reviews(_review(pr.reviewed, "findings"))
+
+    assert "already carries" in pr.output()
+
+
+def test_dedup_uses_the_retargeted_head(pr: Fixture) -> None:
+    moved = pr.push_over_base_merge()
+    pr.reviews(_review(moved, "findings from the queued run"))
+
+    output = pr.output()
+
+    assert f"{moved} already carries" in output
+    assert pr.pinned() == pr.reviewed
+
+
+@pytest.mark.parametrize(
+    ("action", "body", "expected"),
+    [
+        ("ready_for_review", DRAFT_REVIEW_LINE, "post:"),
+        ("ready_for_review", "A landing concern.", "skip:"),
+        ("synchronize", DRAFT_REVIEW_LINE, "skip:"),
+    ],
+)
+def test_only_ready_for_review_replaces_a_draft_review(
+    pr: Fixture, tmp_path: Path, action: str, body: str, expected: str
 ) -> None:
-    """The override reaches Tend's own draft COMMENT and nothing else — a full
-    pass that raced this one still stands."""
-    pr.reviews(_review(1, sha=pr.reviewed, body="A landing concern."))
+    pr.reviews(_review(pr.reviewed, body))
 
-    verdict = pr.verdict(
-        GITHUB_EVENT_PATH=_event(tmp_path / "event.json", "ready_for_review")
-    )
+    output = pr.output(GITHUB_EVENT_PATH=_event(tmp_path / "event.json", action))
 
-    assert verdict["verdict"] == "skip"
+    assert output.startswith(expected)
 
 
-def test_a_synchronize_event_does_not_replace_the_draft_comment(
-    pr: Fixture, tmp_path: Path
-) -> None:
-    pr.reviews(_review(1, sha=pr.reviewed, body=DRAFT_REVIEW_LINE))
-
-    verdict = pr.verdict(
-        GITHUB_EVENT_PATH=_event(tmp_path / "event.json", "synchronize")
-    )
-
-    assert verdict["verdict"] == "skip"
-
-
-# ---------------------------------------------------------------------------
-# The pin file
-# ---------------------------------------------------------------------------
-
-
-def test_an_unreadable_pr_fails_rather_than_reading_as_closed(pr: Fixture) -> None:
-    """`gh` failing must not come back as a verdict. An empty state is not
-    "OPEN", so a blip that went unnoticed would look like a considered
-    decision to post nothing, and the review would be lost."""
+def test_an_unreadable_pr_fails(pr: Fixture) -> None:
     Path(pr.env()["PR_JSON"]).write_text("")
 
     result = pr.run()
@@ -471,15 +335,50 @@ def test_an_unreadable_pr_fails_rather_than_reading_as_closed(pr: Fixture) -> No
     assert result.stdout == ""
 
 
-@pytest.mark.parametrize("content", ["", "\n", "head", None])
-def test_a_pin_file_that_holds_no_sha_fails_rather_than_posting(
-    pr: Fixture, content: str | None
+def test_a_failing_review_state_check_preserves_the_delta_for_retry(
+    pr: Fixture,
 ) -> None:
-    """Every posting recipe substitutes this file as the review's `commit_id`.
-    Empty, GitHub anchors the review at whatever is live when the POST lands —
-    the unpinned review the file exists to prevent — so an absent one is a bug
-    in step 1, not a verdict. A lone newline survives a size test, and the
-    empty sha it yields then reads downstream as a force-push."""
+    moved = pr.push_over_base_merge()
+    Path(pr.env()["REVIEWS_JSON"]).write_text("")
+
+    result = pr.run()
+
+    assert result.returncode != 0
+    assert result.stdout == ""
+    assert pr.pinned() == pr.reviewed
+
+    pr.reviews()
+    output = pr.output()
+
+    assert output.startswith(f"post: re-targeted onto {moved}")
+    assert "pr-2" in _delta(output)
+    assert pr.pinned() == moved
+
+
+def test_a_failed_status_write_preserves_the_delta_for_retry(pr: Fixture) -> None:
+    moved = pr.push_over_base_merge()
+
+    result = subprocess.run(
+        [BASH, "-c", 'exec 1>&-; exec "$@"', "_", BASH, str(PREFLIGHT), PR],
+        cwd=pr.work,
+        env=pr.env(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert pr.pinned() == pr.reviewed
+
+    output = pr.output()
+
+    assert output.startswith(f"post: re-targeted onto {moved}")
+    assert "pr-2" in _delta(output)
+    assert pr.pinned() == moved
+
+
+@pytest.mark.parametrize("content", ["", "\n", "head", None])
+def test_an_invalid_pin_file_fails(pr: Fixture, content: str | None) -> None:
     if content is None:
         pr.pin.unlink()
     else:

--- a/generator/tests/test_review_preflight.py
+++ b/generator/tests/test_review_preflight.py
@@ -1,0 +1,492 @@
+"""Tests for review-preflight.sh — the three checks that gate a posted review.
+
+The recipe used to be forty lines of shell inside the review skill, retyped
+from prose every session. Each check decides an outward action and none of
+them fails loudly when it is skipped: an approval lands on a closed PR, a
+review claims code the session never read, or a second review duplicates one
+already on the commit. These pin the extracted script against a real git
+repository, because two of the three answers come from git rather than the
+API — what a base merge dragged in, and whether the push was a rewrite.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests import BASH, GH_PREAMBLE, fake_bin, tool_path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PREFLIGHT = REPO_ROOT / "plugins" / "tend-ci-runner" / "scripts" / "review-preflight.sh"
+
+BOT = "tend-bot"
+PR = "7"
+DRAFT_REVIEW_LINE = (
+    "Reviewing as a draft — flagging anything that looks worth a quick fix. "
+    "Mark ready for a full review."
+)
+
+# One fixture serves every `pr view`: the script's own `--jq` selects the
+# fields, so a filter naming the wrong one reads as empty rather than passing.
+FAKE_GH = (
+    GH_PREAMBLE
+    + r"""
+case "$*" in
+  "api user"*)              emit '{"login":"'"$BOT_LOGIN"'"}' ;;
+  "pr view "*)              emit "$(cat "$PR_JSON")" ;;
+  *"/pulls/"*"/comments"*)  emit "$(cat "$INLINE_JSON")" ;;
+  *"/issues/"*"/timeline"*) emit "$(cat "$TIMELINE_JSON")" ;;
+  *"/pulls/"*"/reviews"*)   emit "$(cat "$REVIEWS_JSON")" ;;
+  *) exit 1 ;;
+esac
+"""
+)
+
+GIT_ENV = {
+    "GIT_AUTHOR_NAME": "T",
+    "GIT_AUTHOR_EMAIL": "t@example.com",
+    "GIT_COMMITTER_NAME": "T",
+    "GIT_COMMITTER_EMAIL": "t@example.com",
+    "GIT_CONFIG_GLOBAL": "/dev/null",
+    "GIT_CONFIG_SYSTEM": "/dev/null",
+}
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        env={"PATH": "/usr/bin:/bin", "HOME": str(cwd), **GIT_ENV},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _commit(repo: Path, name: str, content: str, message: str) -> str:
+    (repo / name).write_text(content)
+    _git(repo, "add", name)
+    _git(repo, "commit", "-m", message)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+class Fixture:
+    """A PR at `reviewed`, plus the pushes a mid-review head move can be."""
+
+    def __init__(self, tmp_path: Path) -> None:
+        self.tmp_path = tmp_path
+        self.origin = tmp_path / "origin"
+        self.work = tmp_path / "work"
+        self.pin = tmp_path / "reviewed-head"
+
+        # Built once: `fake_bin` creates its directory, so a second call from a
+        # test that runs the script twice would fail on the existing one.
+        git = shutil.which("git")
+        assert git, "git is required for these tests"
+        self.git_dir = Path(git).parent
+        self.bindir = fake_bin(tmp_path, gh=FAKE_GH)
+
+        self.origin.mkdir()
+        _git(self.origin, "init", "-b", "main", "-q")
+        # Real GitHub serves a reachable object by sha; a bare local remote
+        # refuses unless asked to, and the base-tip fetch is one of those.
+        _git(self.origin, "config", "uploadpack.allowReachableSHA1InWant", "true")
+        _commit(self.origin, "base.txt", "1\n", "base-1")
+        _git(self.origin, "checkout", "-q", "-b", "pr")
+        self.reviewed = _commit(self.origin, "feature.txt", "a\n", "pr-1")
+        self.base = _git(self.origin, "rev-parse", "main")
+
+        # The session's checkout: it has the reviewed commit and nothing since.
+        _git(tmp_path, "clone", "-q", str(self.origin), str(self.work))
+        self.pin.write_text(self.reviewed + "\n")
+        self.set_head(self.reviewed)
+
+    def _publish(self, sha: str) -> None:
+        _git(self.origin, "update-ref", f"refs/pull/{PR}/head", sha)
+
+    def push_over_a_base_merge(self) -> str:
+        """An "Update branch" click, then a commit of the author's own."""
+        _git(self.origin, "checkout", "-q", "main")
+        self.base = _commit(self.origin, "base.txt", "2\n", "base-2")
+        _git(self.origin, "checkout", "-q", "pr")
+        _git(self.origin, "merge", "--no-ff", "-q", "-m", "Merge main into pr", "main")
+        head = _commit(self.origin, "feature.txt", "a\nb\n", "pr-2")
+        self._publish(head)
+        self.set_head(head)
+        return head
+
+    def base_absorbs_the_branch(self) -> str:
+        """The base fast-forwards over the reviewed commit and moves on, and
+        the PR head follows it: the head moved, but every commit it gained
+        belongs to the base."""
+        _git(self.origin, "checkout", "-q", "main")
+        _git(self.origin, "merge", "--ff-only", "-q", "pr")
+        self.base = _commit(self.origin, "base.txt", "2\n", "base-2")
+        _git(self.origin, "checkout", "-q", "-B", "pr", "main")
+        self._publish(self.base)
+        self.set_head(self.base)
+        return self.base
+
+    def force_push(self) -> str:
+        """A rewrite: the reviewed commit is no longer an ancestor."""
+        _git(self.origin, "checkout", "-q", "-B", "pr", "main")
+        head = _commit(self.origin, "feature.txt", "rewritten\n", "pr-1'")
+        self._publish(head)
+        self.set_head(head)
+        return head
+
+    # -- API fixtures --------------------------------------------------------
+
+    def set_head(self, sha: str, state: str = "OPEN") -> None:
+        self.head = sha
+        self._write(
+            "PR_JSON", {"headRefOid": sha, "state": state, "baseRefOid": self.base}
+        )
+
+    def close(self, state: str = "CLOSED") -> None:
+        self.set_head(self.head, state)
+
+    def reviews(self, *reviews: dict) -> None:
+        self._write("REVIEWS_JSON", list(reviews))
+
+    def _write(self, key: str, value: object) -> None:
+        (self.tmp_path / f"{key.lower()}.json").write_text(json.dumps(value))
+
+    # -- running -------------------------------------------------------------
+
+    def env(self, **extra: str) -> dict[str, str]:
+        return {
+            "PATH": tool_path(self.bindir, self.git_dir),
+            "HOME": str(self.tmp_path),
+            "GH_CALLS": str(self.tmp_path / "gh-calls.log"),
+            "GITHUB_REPOSITORY": "owner/repo",
+            "BOT_LOGIN": BOT,
+            "REVIEWED_HEAD_FILE": str(self.pin),
+            "PR_JSON": str(self.tmp_path / "pr_json.json"),
+            "INLINE_JSON": str(self.tmp_path / "inline_json.json"),
+            "TIMELINE_JSON": str(self.tmp_path / "timeline_json.json"),
+            "REVIEWS_JSON": str(self.tmp_path / "reviews_json.json"),
+            **GIT_ENV,
+            **extra,
+        }
+
+    def run(self, **extra: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [BASH, str(PREFLIGHT), PR],
+            cwd=self.work,
+            env=self.env(**extra),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def verdict(self, **extra: str) -> dict:
+        result = self.run(**extra)
+        assert result.returncode == 0, result.stderr
+        return json.loads(result.stdout)
+
+    def pinned(self) -> str:
+        return self.pin.read_text().strip()
+
+
+@pytest.fixture
+def pr(tmp_path: Path) -> Fixture:
+    fixture = Fixture(tmp_path)
+    fixture._write("INLINE_JSON", [])
+    fixture._write("TIMELINE_JSON", [])
+    fixture.reviews()
+    return fixture
+
+
+def _review(
+    rid: int,
+    *,
+    sha: str,
+    body: str = "",
+    state: str = "COMMENTED",
+    at: str = "2026-01-01T00:00:00Z",
+    author: str = BOT,
+) -> dict:
+    return {
+        "id": rid,
+        "user": {"login": author},
+        "body": body,
+        "state": state,
+        "commit_id": sha,
+        "submitted_at": at,
+    }
+
+
+def _event(path: Path, action: str) -> str:
+    path.write_text(json.dumps({"action": action}))
+    return str(path)
+
+
+# ---------------------------------------------------------------------------
+# The plain path
+# ---------------------------------------------------------------------------
+
+
+def test_an_unreviewed_head_that_has_not_moved_posts(pr: Fixture) -> None:
+    verdict = pr.verdict()
+
+    assert verdict["verdict"] == "post"
+    assert verdict["head"] == pr.reviewed
+    assert verdict["retargeted"] is False
+    assert verdict["delta"] == ""
+    assert pr.pinned() == pr.reviewed
+
+
+def test_the_head_it_reports_is_the_head_the_pin_file_holds(pr: Fixture) -> None:
+    """The two travel to the POST separately — `head` is what the session
+    reads, the file is what the posting recipe substitutes — so a disagreement
+    would pin a review to a commit the session never decided on."""
+    moved = pr.push_over_a_base_merge()
+
+    assert pr.verdict()["head"] == pr.pinned() == moved
+
+
+# ---------------------------------------------------------------------------
+# The PR closed under the session
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("state", ["CLOSED", "MERGED"])
+def test_a_pr_that_closed_mid_review_takes_no_review(pr: Fixture, state: str) -> None:
+    """HEAD does not move when a PR closes, so nothing else notices: the
+    approval lands timestamped after the close."""
+    pr.close(state)
+
+    verdict = pr.verdict()
+
+    assert verdict["verdict"] == "skip"
+    assert state in verdict["reason"]
+
+
+# ---------------------------------------------------------------------------
+# A push mid-review
+# ---------------------------------------------------------------------------
+
+
+def test_a_moved_head_is_retargeted_and_the_pin_file_follows(pr: Fixture) -> None:
+    moved = pr.push_over_a_base_merge()
+
+    verdict = pr.verdict()
+
+    assert verdict["verdict"] == "post"
+    assert verdict["retargeted"] is True
+    assert verdict["head"] == moved
+    assert pr.pinned() == moved
+
+
+def test_the_delta_is_the_authored_push_and_not_the_base_churn(pr: Fixture) -> None:
+    """`--not "$BASE_SHA"` is what separates them. Without it the base branch's
+    own commits sit in the range and read as the author's, and the session
+    reviews main's history as if it were the push."""
+    pr.push_over_a_base_merge()
+
+    delta = pr.verdict()["delta"]
+
+    assert "pr-2" in delta
+    assert "base-2" not in delta, delta
+
+
+def test_a_base_merge_appears_only_as_a_labelled_merges_line(pr: Fixture) -> None:
+    """The scoped log drops the merge commit and everything it brought in, so
+    an "Update branch" click is invisible there while it re-scopes every
+    file's hunks. The label is what stops it reading as one more commit."""
+    pr.push_over_a_base_merge()
+
+    delta = pr.verdict()["delta"]
+
+    assert "base merge: " in delta
+    assert "Merge main into pr" in delta
+
+
+def test_a_delta_larger_than_one_argv_string_still_reaches_the_session(
+    pr: Fixture,
+) -> None:
+    """Linux caps a single argv string at 131072 bytes, so a patch passed to
+    `jq --arg` kills the preflight outright — after the pin file has been
+    advanced, which leaves the head this session never reviewed looking like
+    the one it did. macOS has no per-argument cap, so this catches the
+    regression on CI (ubuntu) rather than on a developer's box."""
+    pr.push_over_a_base_merge()
+    big = "\n".join(f"line {i} of a regenerated file" for i in range(8000))
+    _commit(pr.origin, "generated.txt", big, "pr-3")
+    head = _git(pr.origin, "rev-parse", "HEAD")
+    _git(pr.origin, "update-ref", f"refs/pull/{PR}/head", head)
+    pr.set_head(head)
+
+    verdict = pr.verdict()
+
+    assert len(verdict["delta"]) > 200_000, len(verdict["delta"])
+    assert verdict["verdict"] == "post"
+    assert pr.pinned() == head
+
+
+def test_a_failing_scoped_log_aborts_rather_than_reporting_a_base_merge(
+    pr: Fixture,
+) -> None:
+    """`set -e` does not reach inside `$( … )`, so the two logs have to run
+    somewhere it does. Swallowed, the scoped log's failure leaves a delta of
+    base merges alone — the author's push reading as an "Update branch" click,
+    which the bullets treat as nothing new to review."""
+    pr.push_over_a_base_merge()
+    pr.base = "0" * 40  # a base tip that will not fetch or resolve
+    pr.set_head(pr.head)
+
+    result = pr.run()
+
+    assert result.returncode != 0
+    assert result.stdout == ""
+
+
+def test_a_moved_head_can_carry_an_empty_delta(pr: Fixture) -> None:
+    """`retargeted` is a separate field because an empty delta does not mean
+    the head stayed put: `--not "$BASE_SHA"` legitimately empties it when
+    everything the head gained is the base's. Read off `delta` alone, the
+    session would post against a commit it never noticed it had moved to."""
+    moved = pr.base_absorbs_the_branch()
+
+    verdict = pr.verdict()
+
+    assert verdict["retargeted"] is True
+    assert verdict["delta"] == ""
+    assert verdict["head"] == moved
+
+
+def test_a_rewritten_head_is_left_to_the_queued_review(pr: Fixture) -> None:
+    """Re-targeting needs the live head to build on the reviewed one. After a
+    rewrite the findings describe code that is gone, and posting them against
+    the new head would attach them to lines nobody wrote."""
+    rewritten = pr.force_push()
+
+    verdict = pr.verdict()
+
+    assert verdict["verdict"] == "skip"
+    assert "no longer an ancestor" in verdict["reason"]
+    assert pr.pinned() == pr.reviewed, "the pin must not follow a rewrite"
+    assert rewritten not in pr.pinned()
+
+
+# ---------------------------------------------------------------------------
+# A review already anchoring the head
+# ---------------------------------------------------------------------------
+
+
+def test_a_review_already_on_the_head_stops_a_duplicate(pr: Fixture) -> None:
+    pr.reviews(_review(1, sha=pr.reviewed, body="findings"))
+
+    verdict = pr.verdict()
+
+    assert verdict["verdict"] == "skip"
+    assert "already carries" in verdict["reason"]
+
+
+def test_the_dedup_reads_the_head_the_review_was_retargeted_onto(
+    pr: Fixture,
+) -> None:
+    """A racing run can post at the new head while this one is composing, so
+    the check has to run against the head this review would now pin — not the
+    one the session started from."""
+    moved = pr.push_over_a_base_merge()
+    pr.reviews(_review(1, sha=moved, body="findings from the queued run"))
+
+    assert pr.verdict()["verdict"] == "skip"
+    # The re-target already happened, so the pin follows the head even though
+    # nothing is posted. Harmless only because a skip ends the session — worth
+    # stating, since a later path that posted after a skip would post unpinned.
+    assert pr.pinned() == moved
+
+
+def test_a_reply_container_on_the_head_does_not_stop_the_post(pr: Fixture) -> None:
+    """Deferred to `bot-review-state.sh`: replying to a thread makes GitHub
+    wrap the reply in a zero-body COMMENTED review anchored at the head. Read
+    as a review it would discard this session's real one."""
+    pr.reviews(_review(1, sha=pr.reviewed))
+
+    assert pr.verdict()["verdict"] == "post"
+
+
+def test_a_ready_for_review_event_replaces_the_draft_comment(
+    pr: Fixture, tmp_path: Path
+) -> None:
+    """Becoming ready asks for the full review the draft pass withheld."""
+    pr.reviews(_review(1, sha=pr.reviewed, body=DRAFT_REVIEW_LINE))
+
+    verdict = pr.verdict(
+        GITHUB_EVENT_PATH=_event(tmp_path / "event.json", "ready_for_review")
+    )
+
+    assert verdict["verdict"] == "post"
+
+
+def test_a_ready_for_review_event_still_stops_on_a_full_review(
+    pr: Fixture, tmp_path: Path
+) -> None:
+    """The override reaches Tend's own draft COMMENT and nothing else — a full
+    pass that raced this one still stands."""
+    pr.reviews(_review(1, sha=pr.reviewed, body="A landing concern."))
+
+    verdict = pr.verdict(
+        GITHUB_EVENT_PATH=_event(tmp_path / "event.json", "ready_for_review")
+    )
+
+    assert verdict["verdict"] == "skip"
+
+
+def test_a_synchronize_event_does_not_replace_the_draft_comment(
+    pr: Fixture, tmp_path: Path
+) -> None:
+    pr.reviews(_review(1, sha=pr.reviewed, body=DRAFT_REVIEW_LINE))
+
+    verdict = pr.verdict(
+        GITHUB_EVENT_PATH=_event(tmp_path / "event.json", "synchronize")
+    )
+
+    assert verdict["verdict"] == "skip"
+
+
+# ---------------------------------------------------------------------------
+# The pin file
+# ---------------------------------------------------------------------------
+
+
+def test_an_unreadable_pr_fails_rather_than_reading_as_closed(pr: Fixture) -> None:
+    """`gh` failing must not come back as a verdict. An empty state is not
+    "OPEN", so a blip that went unnoticed would look like a considered
+    decision to post nothing, and the review would be lost."""
+    Path(pr.env()["PR_JSON"]).write_text("")
+
+    result = pr.run()
+
+    assert result.returncode != 0
+    assert "could not read PR" in result.stderr
+    assert result.stdout == ""
+
+
+@pytest.mark.parametrize("content", ["", "\n", "head", None])
+def test_a_pin_file_that_holds_no_sha_fails_rather_than_posting(
+    pr: Fixture, content: str | None
+) -> None:
+    """Every posting recipe substitutes this file as the review's `commit_id`.
+    Empty, GitHub anchors the review at whatever is live when the POST lands —
+    the unpinned review the file exists to prevent — so an absent one is a bug
+    in step 1, not a verdict. A lone newline survives a size test, and the
+    empty sha it yields then reads downstream as a force-push."""
+    if content is None:
+        pr.pin.unlink()
+    else:
+        pr.pin.write_text(content)
+
+    result = pr.run()
+
+    assert result.returncode != 0
+    assert "does not hold a commit sha" in result.stderr
+    assert result.stdout == ""

--- a/plugins/tend-ci-runner/scripts/review-preflight.sh
+++ b/plugins/tend-ci-runner/scripts/review-preflight.sh
@@ -10,6 +10,7 @@
 #
 # env: GITHUB_REPOSITORY (optional; defaults to the checkout's remote)
 #      GITHUB_EVENT_PATH (optional; ready_for_review replaces a draft review)
+#      REVIEWED_HEAD_FILE (test-only override of /tmp/reviewed-head)
 
 set -euo pipefail
 
@@ -60,7 +61,7 @@ if [ "$CURRENT_HEAD" != "$REVIEWED" ]; then
   git fetch --no-tags --quiet origin "refs/pull/$PR/head" || true
   git fetch --no-tags --quiet origin "$BASE_SHA" || true
 
-  if git merge-base --is-ancestor "$REVIEWED" "$CURRENT_HEAD" 2>/dev/null; then
+  if git merge-base --is-ancestor "$REVIEWED" "$CURRENT_HEAD"; then
     :
   else
     STATUS=$?

--- a/plugins/tend-ci-runner/scripts/review-preflight.sh
+++ b/plugins/tend-ci-runner/scripts/review-preflight.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Decides whether this session may post its review, and re-targets the review
+# when the PR's head moved while it was being composed.
+#
+# Usage: review-preflight.sh <pr-number>
+#
+# A `pull_request_target` review routinely runs 5–10 minutes between reading
+# the head and posting the verdict, so three things can have changed underneath
+# it. Each is checked here rather than in the skill, because each is a
+# deterministic read the session would otherwise re-derive from prose:
+#
+#   The PR closed. HEAD does not move when a PR closes or merges, so nothing
+#   else notices. An APPROVE that lands afterwards is timestamped after the
+#   close and reads as the bot approving a closed PR.
+#
+#   The head moved. The review is re-targeted onto the live head — but only
+#   when the reviewed commit is still an ancestor of it. A rewrite leaves
+#   nothing to build on, and the queued run reviews the new head in full.
+#   `delta` is then the session's only record of what was pushed.
+#
+#   A review already anchors the head. The queued run and this one can both
+#   reach the same commit; `bot-review-state.sh` decides which of the bot's
+#   reviews genuinely anchors it (see its header for why `.commit_id` alone
+#   cannot be read directly).
+#
+# The pin file is the contract with the rest of the skill: step 1 writes the
+# commit it read there, every posting recipe reads it back as the review's
+# `commit_id`, and this script rewrites it on a re-target. `FORCE_FULL_REVIEW`
+# is derived here rather than passed in — shell state does not survive a tool
+# call, so a value step 1 exported is gone by the time a review is posted.
+#
+# Output (one object, all fields always present):
+#   verdict     "post" — go ahead, pinning `head`; "skip" — post nothing
+#   reason      one human-readable line; on a skip, why
+#   head        the commit to pin, and what the pin file now holds
+#   retargeted  true when the head moved and the review was re-pointed at it
+#   delta       what was pushed since the reviewed commit: the authored log
+#               (scoped off base churn), then the base merges. "" when the
+#               head did not move — and legitimately empty on a fast-forward
+#               onto the base, which is why `retargeted` is separate
+#
+# A non-zero exit is a third outcome, not a verdict: nothing was decided and
+# stderr says why. It is the loud direction on purpose — every quiet failure
+# here ends with a review that was never posted, or one posted unpinned.
+#
+# env: GITHUB_REPOSITORY (optional; falls back to the checkout's remote)
+#      GITHUB_EVENT_PATH (optional; a `ready_for_review` action lets a full
+#                         pass replace Tend's earlier draft COMMENT)
+#      REVIEWED_HEAD_FILE (the pin file; defaults to the path the skill names)
+
+set -euo pipefail
+
+PR="$1"
+REPO="${GITHUB_REPOSITORY:-$(gh repo view --json nameWithOwner --jq '.nameWithOwner')}"
+PIN_FILE="${REVIEWED_HEAD_FILE:-/tmp/reviewed-head}"
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+# The delta reaches jq as a file, never an argument: Linux caps one argv
+# string at 131072 bytes, and a mid-review push that regenerates a large file
+# blows past that — killing the preflight after the pin file has already been
+# advanced, which is the one failure that leaves an unreviewed head looking
+# reviewed.
+DELTA_FILE=$(mktemp)
+trap 'rm -f "$DELTA_FILE"' EXIT
+
+emit() {
+  jq -n --arg verdict "$1" --arg reason "$2" --arg head "$3" \
+    --argjson retargeted "$4" --rawfile delta "$DELTA_FILE" \
+    '{verdict: $verdict, reason: $reason, head: $head,
+      retargeted: $retargeted, delta: $delta}'
+}
+
+# Fail rather than substitute an empty sha: unpinned, GitHub anchors the review
+# at whatever is live when the POST lands, and the review then claims code this
+# session never saw.
+REVIEWED=$(cat "$PIN_FILE" 2>/dev/null || true)
+if [[ ! "$REVIEWED" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "review-preflight: $PIN_FILE does not hold a commit sha — step 1 records the reviewed commit there" >&2
+  exit 1
+fi
+
+# Assigned before `read` so a failing `gh` aborts here: read off a process
+# substitution succeeds with empty fields, and an empty state is not "OPEN",
+# so an API blip would come back as a considered decision to post nothing.
+PR_VIEW=$(gh pr view "$PR" --repo "$REPO" \
+  --json headRefOid,state --jq '"\(.headRefOid) \(.state)"')
+read -r CURRENT_HEAD PR_STATE <<<"$PR_VIEW"
+if [ -z "$CURRENT_HEAD" ] || [ -z "$PR_STATE" ]; then
+  echo "review-preflight: could not read PR #$PR — got '$PR_VIEW'" >&2
+  exit 1
+fi
+
+if [ "$PR_STATE" != "OPEN" ]; then
+  emit skip "PR is $PR_STATE" "$REVIEWED" false
+  exit 0
+fi
+
+PINNED="$REVIEWED"
+RETARGETED=false
+
+if [ "$CURRENT_HEAD" != "$REVIEWED" ]; then
+  # Re-targeting needs the live head to build on the reviewed one; a rewrite
+  # (or a head that won't fetch) leaves nothing to re-target onto.
+  BASE_SHA=$(gh pr view "$PR" --repo "$REPO" --json baseRefOid --jq '.baseRefOid')
+  git fetch --no-tags --quiet origin "refs/pull/$PR/head" || true
+  git fetch --no-tags --quiet origin "$BASE_SHA" || true
+  if ! git merge-base --is-ancestor "$REVIEWED" "$CURRENT_HEAD" 2>/dev/null; then
+    emit skip \
+      "cannot re-target onto $CURRENT_HEAD — $REVIEWED is no longer an ancestor of it, so the push rewrote what was reviewed; leaving it to the queued review" \
+      "$REVIEWED" false
+    exit 0
+  fi
+  # A brace group, not `$( … )`: `set -e` does not reach inside a command
+  # substitution, so a scoped log that failed would vanish and leave a delta
+  # showing only the base merges — a push of the author's own code reading as
+  # an "Update branch" click.
+  {
+    # The author's own new code, scoped off base churn as in step 1:
+    # `--not "$BASE_SHA"` drops everything a base merge dragged in, which a
+    # plain `git diff` between the two heads would present as the author's.
+    git log -p --no-merges --format='%h %s' "$REVIEWED..$CURRENT_HEAD" --not "$BASE_SHA"
+    # Base merges, which the scoped log above cannot show — it drops the merge
+    # commit and every commit the merge brought in. An "Update branch" click
+    # prints nothing there while re-scoping every file's hunks.
+    git log --format='base merge: %h %s' --merges "$REVIEWED..$CURRENT_HEAD"
+  } > "$DELTA_FILE"
+  echo "$CURRENT_HEAD" > "$PIN_FILE"
+  PINNED="$CURRENT_HEAD"
+  RETARGETED=true
+fi
+
+# A forced ready-for-review pass may replace Tend's earlier draft COMMENT, but
+# no other substantive review — including a full pass that raced this one.
+FORCE=false
+EVENT_ACTION=""
+if [ -r "${GITHUB_EVENT_PATH:-}" ]; then
+  EVENT_ACTION=$(jq -r '.action // ""' "$GITHUB_EVENT_PATH" 2>/dev/null || true)
+fi
+if [ "$EVENT_ACTION" = "ready_for_review" ]; then
+  FORCE=true
+fi
+
+STATE_JSON=$(GITHUB_REPOSITORY="$REPO" "$HERE/bot-review-state.sh" "$PR")
+ALREADY=$(jq -r --argjson force "$FORCE" '
+  if .at_head == null or ($force and .at_head.draft_mode) then ""
+  else "\(.at_head.state) review \(.at_head.id)" end' \
+  <<<"$STATE_JSON")
+
+if [ -n "$ALREADY" ]; then
+  emit skip "$PINNED already carries a $ALREADY" "$PINNED" "$RETARGETED"
+  exit 0
+fi
+
+if [ "$RETARGETED" = true ]; then
+  emit post "re-targeted onto $PINNED — read the delta before posting" "$PINNED" true
+else
+  emit post "$PINNED is still the head you reviewed" "$PINNED" false
+fi

--- a/plugins/tend-ci-runner/scripts/review-preflight.sh
+++ b/plugins/tend-ci-runner/scripts/review-preflight.sh
@@ -1,52 +1,15 @@
 #!/usr/bin/env bash
-# Decides whether this session may post its review, and re-targets the review
-# when the PR's head moved while it was being composed.
+# Check the live PR before posting a review.
 #
 # Usage: review-preflight.sh <pr-number>
 #
-# A `pull_request_target` review routinely runs 5–10 minutes between reading
-# the head and posting the verdict, so three things can have changed underneath
-# it. Each is checked here rather than in the skill, because each is a
-# deterministic read the session would otherwise re-derive from prose:
+# Prints `post: <reason>` when the review may proceed or `skip: <reason>` when
+# it must stop. A re-targeted post also prints `delta: <path>`; that file holds
+# the commits pushed since the review began, excluding base-branch churn. A
+# non-zero exit means no decision was made.
 #
-#   The PR closed. HEAD does not move when a PR closes or merges, so nothing
-#   else notices. An APPROVE that lands afterwards is timestamped after the
-#   close and reads as the bot approving a closed PR.
-#
-#   The head moved. The review is re-targeted onto the live head — but only
-#   when the reviewed commit is still an ancestor of it. A rewrite leaves
-#   nothing to build on, and the queued run reviews the new head in full.
-#   `delta` is then the session's only record of what was pushed.
-#
-#   A review already anchors the head. The queued run and this one can both
-#   reach the same commit; `bot-review-state.sh` decides which of the bot's
-#   reviews genuinely anchors it (see its header for why `.commit_id` alone
-#   cannot be read directly).
-#
-# The pin file is the contract with the rest of the skill: step 1 writes the
-# commit it read there, every posting recipe reads it back as the review's
-# `commit_id`, and this script rewrites it on a re-target. `FORCE_FULL_REVIEW`
-# is derived here rather than passed in — shell state does not survive a tool
-# call, so a value step 1 exported is gone by the time a review is posted.
-#
-# Output (one object, all fields always present):
-#   verdict     "post" — go ahead, pinning `head`; "skip" — post nothing
-#   reason      one human-readable line; on a skip, why
-#   head        the commit to pin, and what the pin file now holds
-#   retargeted  true when the head moved and the review was re-pointed at it
-#   delta       what was pushed since the reviewed commit: the authored log
-#               (scoped off base churn), then the base merges. "" when the
-#               head did not move — and legitimately empty on a fast-forward
-#               onto the base, which is why `retargeted` is separate
-#
-# A non-zero exit is a third outcome, not a verdict: nothing was decided and
-# stderr says why. It is the loud direction on purpose — every quiet failure
-# here ends with a review that was never posted, or one posted unpinned.
-#
-# env: GITHUB_REPOSITORY (optional; falls back to the checkout's remote)
-#      GITHUB_EVENT_PATH (optional; a `ready_for_review` action lets a full
-#                         pass replace Tend's earlier draft COMMENT)
-#      REVIEWED_HEAD_FILE (the pin file; defaults to the path the skill names)
+# env: GITHUB_REPOSITORY (optional; defaults to the checkout's remote)
+#      GITHUB_EVENT_PATH (optional; ready_for_review replaces a draft review)
 
 set -euo pipefail
 
@@ -54,105 +17,90 @@ PR="$1"
 REPO="${GITHUB_REPOSITORY:-$(gh repo view --json nameWithOwner --jq '.nameWithOwner')}"
 PIN_FILE="${REVIEWED_HEAD_FILE:-/tmp/reviewed-head}"
 HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+DELTA_FILE=""
 
-# The delta reaches jq as a file, never an argument: Linux caps one argv
-# string at 131072 bytes, and a mid-review push that regenerates a large file
-# blows past that — killing the preflight after the pin file has already been
-# advanced, which is the one failure that leaves an unreviewed head looking
-# reviewed.
-DELTA_FILE=$(mktemp)
-trap 'rm -f "$DELTA_FILE"' EXIT
-
-emit() {
-  jq -n --arg verdict "$1" --arg reason "$2" --arg head "$3" \
-    --argjson retargeted "$4" --rawfile delta "$DELTA_FILE" \
-    '{verdict: $verdict, reason: $reason, head: $head,
-      retargeted: $retargeted, delta: $delta}'
+skip() {
+  printf 'skip: %s\n' "$1"
+  exit 0
 }
 
-# Fail rather than substitute an empty sha: unpinned, GitHub anchors the review
-# at whatever is live when the POST lands, and the review then claims code this
-# session never saw.
+post() {
+  printf 'post: %s\n' "$1"
+  if [ -n "$DELTA_FILE" ]; then
+    printf 'delta: %s\n' "$DELTA_FILE"
+  fi
+  if [ "$RETARGETED" = true ]; then
+    echo "$REVIEWED" > "$PIN_FILE"
+  fi
+}
+
+# Every posting recipe uses this value as commit_id. An empty value would let
+# GitHub anchor the review at code this session did not read.
 REVIEWED=$(cat "$PIN_FILE" 2>/dev/null || true)
 if [[ ! "$REVIEWED" =~ ^[0-9a-f]{40}$ ]]; then
-  echo "review-preflight: $PIN_FILE does not hold a commit sha — step 1 records the reviewed commit there" >&2
+  echo "review-preflight: $PIN_FILE does not hold a commit sha" >&2
   exit 1
 fi
 
-# Assigned before `read` so a failing `gh` aborts here: read off a process
-# substitution succeeds with empty fields, and an empty state is not "OPEN",
-# so an API blip would come back as a considered decision to post nothing.
 PR_VIEW=$(gh pr view "$PR" --repo "$REPO" \
   --json headRefOid,state --jq '"\(.headRefOid) \(.state)"')
 read -r CURRENT_HEAD PR_STATE <<<"$PR_VIEW"
 if [ -z "$CURRENT_HEAD" ] || [ -z "$PR_STATE" ]; then
-  echo "review-preflight: could not read PR #$PR — got '$PR_VIEW'" >&2
+  echo "review-preflight: could not read PR #$PR" >&2
   exit 1
 fi
 
 if [ "$PR_STATE" != "OPEN" ]; then
-  emit skip "PR is $PR_STATE" "$REVIEWED" false
-  exit 0
+  skip "PR is $PR_STATE"
 fi
 
-PINNED="$REVIEWED"
 RETARGETED=false
-
 if [ "$CURRENT_HEAD" != "$REVIEWED" ]; then
-  # Re-targeting needs the live head to build on the reviewed one; a rewrite
-  # (or a head that won't fetch) leaves nothing to re-target onto.
   BASE_SHA=$(gh pr view "$PR" --repo "$REPO" --json baseRefOid --jq '.baseRefOid')
   git fetch --no-tags --quiet origin "refs/pull/$PR/head" || true
   git fetch --no-tags --quiet origin "$BASE_SHA" || true
-  if ! git merge-base --is-ancestor "$REVIEWED" "$CURRENT_HEAD" 2>/dev/null; then
-    emit skip \
-      "cannot re-target onto $CURRENT_HEAD — $REVIEWED is no longer an ancestor of it, so the push rewrote what was reviewed; leaving it to the queued review" \
-      "$REVIEWED" false
-    exit 0
+
+  if git merge-base --is-ancestor "$REVIEWED" "$CURRENT_HEAD" 2>/dev/null; then
+    :
+  else
+    STATUS=$?
+    if [ "$STATUS" -eq 1 ]; then
+      skip "cannot re-target onto $CURRENT_HEAD — $REVIEWED is no longer an ancestor; leaving it to the queued review"
+    fi
+    echo "review-preflight: git merge-base failed with status $STATUS" >&2
+    exit "$STATUS"
   fi
-  # A brace group, not `$( … )`: `set -e` does not reach inside a command
-  # substitution, so a scoped log that failed would vanish and leave a delta
-  # showing only the base merges — a push of the author's own code reading as
-  # an "Update branch" click.
+
+  DELTA_FILE=$(mktemp)
+  # Run outside a command substitution so `set -e` catches either log failing.
+  # The first log excludes base churn; the second identifies base merges whose
+  # conflict resolutions still need inspection with `git show --cc`.
   {
-    # The author's own new code, scoped off base churn as in step 1:
-    # `--not "$BASE_SHA"` drops everything a base merge dragged in, which a
-    # plain `git diff` between the two heads would present as the author's.
     git log -p --no-merges --format='%h %s' "$REVIEWED..$CURRENT_HEAD" --not "$BASE_SHA"
-    # Base merges, which the scoped log above cannot show — it drops the merge
-    # commit and every commit the merge brought in. An "Update branch" click
-    # prints nothing there while re-scoping every file's hunks.
     git log --format='base merge: %h %s' --merges "$REVIEWED..$CURRENT_HEAD"
   } > "$DELTA_FILE"
-  echo "$CURRENT_HEAD" > "$PIN_FILE"
-  PINNED="$CURRENT_HEAD"
+
+  REVIEWED="$CURRENT_HEAD"
   RETARGETED=true
 fi
 
-# A forced ready-for-review pass may replace Tend's earlier draft COMMENT, but
-# no other substantive review — including a full pass that raced this one.
 FORCE=false
-EVENT_ACTION=""
-if [ -r "${GITHUB_EVENT_PATH:-}" ]; then
-  EVENT_ACTION=$(jq -r '.action // ""' "$GITHUB_EVENT_PATH" 2>/dev/null || true)
-fi
-if [ "$EVENT_ACTION" = "ready_for_review" ]; then
+if [ -r "${GITHUB_EVENT_PATH:-}" ] \
+  && jq -e '.action == "ready_for_review"' "$GITHUB_EVENT_PATH" >/dev/null 2>&1; then
   FORCE=true
 fi
 
-STATE_JSON=$(GITHUB_REPOSITORY="$REPO" "$HERE/bot-review-state.sh" "$PR")
-ALREADY=$(jq -r --argjson force "$FORCE" '
-  if .at_head == null or ($force and .at_head.draft_mode) then ""
-  else "\(.at_head.state) review \(.at_head.id)" end' \
-  <<<"$STATE_JSON")
+ALREADY=$(GITHUB_REPOSITORY="$REPO" "$HERE/bot-review-state.sh" "$PR" \
+  | jq -r --argjson force "$FORCE" '
+      if .at_head == null or ($force and .at_head.draft_mode) then ""
+      else "\(.at_head.state) review \(.at_head.id)" end')
 
 if [ -n "$ALREADY" ]; then
-  emit skip "$PINNED already carries a $ALREADY" "$PINNED" "$RETARGETED"
-  exit 0
+  skip "$REVIEWED already carries a $ALREADY"
 fi
 
 if [ "$RETARGETED" = true ]; then
-  emit post "re-targeted onto $PINNED — read the delta before posting" "$PINNED" true
+  post "re-targeted onto $REVIEWED — read the delta before posting"
 else
-  emit post "$PINNED is still the head you reviewed" "$PINNED" false
+  post "$REVIEWED is still the head you reviewed"
 fi

--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -234,48 +234,18 @@ gh api "repos/$REPO/issues/<number>/reactions" -f content="+1"
 
 #### Posting mechanics
 
-Before posting, check the PR is still open, re-target the review if HEAD moved, and check no review was already posted for this commit:
+Before posting, run the preflight. It checks the PR is still open, re-targets the review onto the live head if HEAD moved, and stops a second review of a commit that already carries one:
 
 ```bash
-REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
-read -r CURRENT_HEAD PR_STATE < <(gh pr view <number> --json headRefOid,state \
-  --jq '"\(.headRefOid) \(.state)"')
-[ "$PR_STATE" != "OPEN" ] && echo "PR is $PR_STATE — skipping" && exit 0
-
-HEAD_SHA=$(cat /tmp/reviewed-head)
-if [ "$CURRENT_HEAD" != "$HEAD_SHA" ]; then
-  # Re-targeting needs the live head to build on the reviewed one; a rewrite
-  # (or a head that won't fetch) leaves nothing to re-target onto.
-  BASE_SHA=$(gh pr view <number> --json baseRefOid --jq '.baseRefOid')
-  git fetch --no-tags --quiet origin "refs/pull/<number>/head" || true
-  git fetch --no-tags --quiet origin "$BASE_SHA" || true
-  git merge-base --is-ancestor "$HEAD_SHA" "$CURRENT_HEAD" 2>/dev/null \
-    || { echo "cannot re-target onto $CURRENT_HEAD — leaving it to the queued review"; exit 0; }
-  # The author's own new code, scoped off base churn as in step 1:
-  # `--not "$BASE_SHA"` drops everything a base merge dragged in, which a plain
-  # `git diff` between the two heads would present as the author's.
-  git log -p --no-merges --format='%h %s' "$HEAD_SHA..$CURRENT_HEAD" --not "$BASE_SHA"
-  # Base merges, which the scoped log above cannot show — it drops the merge
-  # commit and every commit the merge brought in. An "Update branch" click
-  # prints nothing there while re-scoping every file's hunks.
-  git log --format='base merge: %h %s' --merges "$HEAD_SHA..$CURRENT_HEAD"
-  # The workspace still holds the tree that was reviewed, so read any file you
-  # need in full from git: `git show "$CURRENT_HEAD":<path>`.
-  echo "$CURRENT_HEAD" > /tmp/reviewed-head
-fi
-
-# `at_head` is non-null only for a review that genuinely anchors this commit: a
-# synthetic reply container and a review re-anchored by a rewrite are excluded.
-# A forced ready-for-review pass may replace Tend's earlier draft COMMENT, but
-# no other substantive review — including a full pass that raced this one.
-POST_STATE=$(${CLAUDE_PLUGIN_ROOT}/scripts/bot-review-state.sh <number>)
-ALREADY_POSTED=$(jq -r --argjson force "${FORCE_FULL_REVIEW:-false}" '
-  if .at_head == null or ($force and .at_head.draft_mode)
-  then "" else .at_head.at end' <<<"$POST_STATE")
-[ -n "$ALREADY_POSTED" ] && echo "Already reviewed — skipping" && exit 0
+PREFLIGHT=$(${CLAUDE_PLUGIN_ROOT}/scripts/review-preflight.sh <number>) || exit 1
+jq -r '"\(.verdict): \(.reason)", .delta' <<<"$PREFLIGHT"
 ```
 
-The state check matters because the maintainer may close (or another path may merge) the PR while a review is in flight — `pull_request_target` reviews routinely run for 5–10 minutes between fetching `HEAD_SHA` and posting the verdict, and HEAD doesn't move when the PR is closed. Approving a CLOSED or MERGED PR creates a confusing artifact (an approval timestamped after the close).
+On `skip`, post nothing and finish; the reason says which check stopped you. On `post`, the commit to anchor at is in `/tmp/reviewed-head` — the preflight rewrote it if HEAD moved, and every posting recipe reads it back. A non-empty `delta` is the push that landed mid-review, and the only record of it; read it per the bullets below.
+
+A non-zero exit is neither: nothing was decided and the error says why. Fix it and re-run — posting on a preflight that never answered is posting unpinned. Don't drop the `|| exit 1`; piped into `jq` a failure prints nothing and reads exactly like a clean run.
+
+The state check matters because the maintainer may close (or another path may merge) the PR while a review is in flight — `pull_request_target` reviews routinely run for 5–10 minutes between reading the head and posting the verdict, and HEAD doesn't move when the PR is closed. Approving a CLOSED or MERGED PR creates a confusing artifact (an approval timestamped after the close).
 
 **A push mid-review re-targets the review.** Everything read so far still holds for the code it was read against, and the delta is the only new information — however many pushes it spans. Read it, then post against the new head:
 
@@ -284,9 +254,9 @@ The state check matters because the maintainer may close (or another path may me
 - Findings the delta fixed drop out. If that empties the review and the delta itself reads clean, approve the new head: an empty-body approval is a verdict here, not the absence of one.
 - Finish without posting only when you can't judge the delta — it rewrites what you just reviewed, or it is a review's worth of new code in its own right. The queued run then reviews the new head in full.
 - Inline comments resolve against the commit the review pins, so re-verify each one against the current `gh pr diff`, which now returns the new head's. On a file the delta didn't touch, the line is unchanged and the comment stands. On one it did, move the comment to the line the code sits on now; where the line no longer falls inside a hunk, put the finding in the review body as a fenced quote with its path, as under **Recovering from inline comment 422 errors**.
-- **Read the two `git log` outputs as a pair.** The scoped one is the author's new code; the `base merge:` lines are base merges, and are the only place they appear. The two together distinguish an empty delta from an "Update branch" click. When a `base merge:` line appears, re-verify every inline comment against the new `gh pr diff` even if the scoped log printed nothing — the merge re-scopes hunks in files the scoped delta cannot show, so the "file the delta didn't touch" shortcut above does not hold.
+- **Read both halves of `delta` as a pair.** It is two logs in sequence: the scoped one is the author's new code; the `base merge:` lines are base merges, and are the only place they appear. The two together distinguish an empty delta from an "Update branch" click. When a `base merge:` line appears, re-verify every inline comment against the new `gh pr diff` even if the scoped log printed nothing — the merge re-scopes hunks in files the scoped delta cannot show, so the "file the delta didn't touch" shortcut above does not hold.
 - **Also read `git show --cc <merge sha>` on a base merge**, for what the merge itself changed. Where it conflicted, the author's resolution is committed *inside* the merge, and both logs miss it: the scoped log excludes merge commits, and the merges line says a merge happened, not what it changed. A finding the resolution already fixed must drop out. `--cc` prints only hunks differing from every parent, so a resolution that took the base side prints nothing at all — it tells you what a merge changed, never that a merge changed nothing, which is why re-verification above is unconditional.
-- Re-compose every `suggestion` block on a file the delta touched, reading the new content with `git show "$CURRENT_HEAD":<path>` — the workspace still holds the tree you reviewed, so disk gives you the old lines. A suggestion carried over unchanged reverts the author's newest edit on one click, and a multi-line one deletes every in-range line it doesn't reproduce.
+- Re-compose every `suggestion` block on a file the delta touched, reading the new content with `git show "$(cat /tmp/reviewed-head)":<path>` — the workspace still holds the tree you reviewed, so disk gives you the old lines. A suggestion carried over unchanged reverts the author's newest edit on one click, and a multi-line one deletes every in-range line it doesn't reproduce.
 
 **Pin every review to the commit you read** — `commit_id` in every posting recipe, read back from `/tmp/reviewed-head`. Two things depend on the pin. GitHub otherwise anchors the review at whatever is live when the POST lands, so the review claims code this session never saw. And the anchor is what `bot-review-state.sh` reports as `LAST_REVIEW_SHA`: pinned to the head you re-targeted onto, the queued run's step 1 finds that head already reviewed and finishes without posting a second review of the same code.
 

--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -234,18 +234,15 @@ gh api "repos/$REPO/issues/<number>/reactions" -f content="+1"
 
 #### Posting mechanics
 
-Before posting, run the preflight. It checks the PR is still open, re-targets the review onto the live head if HEAD moved, and stops a second review of a commit that already carries one:
+Before posting, run the preflight. It checks the PR is open, re-targets onto a newer descendant head, and stops duplicate reviews:
 
 ```bash
-PREFLIGHT=$(${CLAUDE_PLUGIN_ROOT}/scripts/review-preflight.sh <number>) || exit 1
-jq -r '"\(.verdict): \(.reason)", .delta' <<<"$PREFLIGHT"
+${CLAUDE_PLUGIN_ROOT}/scripts/review-preflight.sh <number>
 ```
 
-On `skip`, post nothing and finish; the reason says which check stopped you. On `post`, the commit to anchor at is in `/tmp/reviewed-head` — the preflight rewrote it if HEAD moved, and every posting recipe reads it back. A non-empty `delta` is the push that landed mid-review, and the only record of it; read it per the bullets below.
+On `skip`, post nothing and finish. On `post`, anchor the review at `/tmp/reviewed-head`; the preflight updates the file when HEAD moves. A re-targeted post also prints `delta: <path>`. Read that entire file in chunks as needed before posting; it is the push that landed mid-review.
 
-A non-zero exit is neither: nothing was decided and the error says why. Fix it and re-run — posting on a preflight that never answered is posting unpinned. Don't drop the `|| exit 1`; piped into `jq` a failure prints nothing and reads exactly like a clean run.
-
-The state check matters because the maintainer may close (or another path may merge) the PR while a review is in flight — `pull_request_target` reviews routinely run for 5–10 minutes between reading the head and posting the verdict, and HEAD doesn't move when the PR is closed. Approving a CLOSED or MERGED PR creates a confusing artifact (an approval timestamped after the close).
+A non-zero exit means nothing was decided. Fix the error and re-run the preflight.
 
 **A push mid-review re-targets the review.** Everything read so far still holds for the code it was read against, and the delta is the only new information — however many pushes it spans. Read it, then post against the new head:
 
@@ -254,7 +251,7 @@ The state check matters because the maintainer may close (or another path may me
 - Findings the delta fixed drop out. If that empties the review and the delta itself reads clean, approve the new head: an empty-body approval is a verdict here, not the absence of one.
 - Finish without posting only when you can't judge the delta — it rewrites what you just reviewed, or it is a review's worth of new code in its own right. The queued run then reviews the new head in full.
 - Inline comments resolve against the commit the review pins, so re-verify each one against the current `gh pr diff`, which now returns the new head's. On a file the delta didn't touch, the line is unchanged and the comment stands. On one it did, move the comment to the line the code sits on now; where the line no longer falls inside a hunk, put the finding in the review body as a fenced quote with its path, as under **Recovering from inline comment 422 errors**.
-- **Read both halves of `delta` as a pair.** It is two logs in sequence: the scoped one is the author's new code; the `base merge:` lines are base merges, and are the only place they appear. The two together distinguish an empty delta from an "Update branch" click. When a `base merge:` line appears, re-verify every inline comment against the new `gh pr diff` even if the scoped log printed nothing — the merge re-scopes hunks in files the scoped delta cannot show, so the "file the delta didn't touch" shortcut above does not hold.
+- **Read both halves of the delta file as a pair.** It contains two logs in sequence: the scoped one is the author's new code; the `base merge:` lines are base merges, and are the only place they appear. The two together distinguish an empty delta from an "Update branch" click. When a `base merge:` line appears, re-verify every inline comment against the new `gh pr diff` even if the scoped log printed nothing — the merge re-scopes hunks in files the scoped delta cannot show, so the "file the delta didn't touch" shortcut above does not hold.
 - **Also read `git show --cc <merge sha>` on a base merge**, for what the merge itself changed. Where it conflicted, the author's resolution is committed *inside* the merge, and both logs miss it: the scoped log excludes merge commits, and the merges line says a merge happened, not what it changed. A finding the resolution already fixed must drop out. `--cc` prints only hunks differing from every parent, so a resolution that took the base side prints nothing at all — it tells you what a merge changed, never that a merge changed nothing, which is why re-verification above is unconditional.
 - Re-compose every `suggestion` block on a file the delta touched, reading the new content with `git show "$(cat /tmp/reviewed-head)":<path>` — the workspace still holds the tree you reviewed, so disk gives you the old lines. A suggestion carried over unchanged reverts the author's newest edit on one click, and a multi-line one deletes every in-range line it doesn't reproduce.
 


### PR DESCRIPTION
Moves the deterministic checks immediately before a review post into `review-preflight.sh`, so every review run uses the same tested path. The preflight rechecks PR state, safely retargets descendant heads, preserves large deltas for chunked reading, and stops duplicate reviews. It advances the reviewed-head pin only after every fallible check and status write succeeds, so a retry cannot lose unread changes.

> _This was written by Codex on behalf of @max-sixty_
