### PR TITLE
fix(install-tend): surface the OAuth TUI's own error instead of waiting it out

### DIFF
--- a/plugins/install-tend/skills/install-tend/SKILL.md
+++ b/plugins/install-tend/skills/install-tend/SKILL.md
@@ -680,18 +680,23 @@ as 1-year), two mint paths, routed by environment rather than asked:
   ```
 
   Read the task's output as it runs and hand the user the authorize URL
-  it prints. Approving it either returns to the CLI, which finishes the
-  run on its own, or lands on a page showing a `code#state` string. For
-  the second, have them paste that string back and write it to the
-  watched path while the task runs — the wrapper types it into the
-  prompt:
+  it prints. Approving it normally ends the run on its own — the CLI holds
+  a localhost listener that takes the redirect, so the approval is the
+  whole of the user's job. Only when the browser lands on a page showing a
+  `code#state` string is a paste needed; have them send that string back
+  and write it to the watched path while the task runs, and the wrapper
+  types it into the prompt:
 
   ```bash
   printf '%s' '<code#state>' > /tmp/tend-oauth-code
   ```
 
-  Each run generates a fresh PKCE challenge, so a code from an earlier
-  run is dead; a restart needs a fresh approval.
+  Each run generates a fresh PKCE challenge and each code is good once, so
+  a code from an earlier run — or one the localhost listener already
+  redeemed — is dead, and a restart needs a fresh approval. Keep reading
+  the task's output either way: the wrapper reports whatever
+  `claude setup-token` says and exits on it, so a rejected code names its
+  own cause within seconds instead of going quiet until the window ends.
 
   The window needs the user at the browser throughout it. The authorize
   URL logs the browser out on the way in

--- a/plugins/install-tend/skills/install-tend/scripts/oauth_token.py
+++ b/plugins/install-tend/skills/install-tend/scripts/oauth_token.py
@@ -65,15 +65,12 @@ TOKEN = re.compile(rb"sk-ant-oat01-[A-Za-z0-9_-]{80,}")
 # The TUI's own failure line. `claude setup-token` reports a rejected code and
 # then waits at "Press Enter to retry", which produces no further output — so
 # without this the run is silent to its deadline and reads as an approval the
-# user never gave.
-TUI_ERROR = re.compile(rb"OAuth\s*error:\s*([^\r\n]*)")
-# Drives the progress line and nothing else. Gating the paste on it would tie
-# the fallback path to TUI wording that is free to change, and buy nothing: the
-# prompt renders alongside the authorize URL, so a code can't arrive first.
-# Ink lays adjacent text nodes out with cursor moves rather than spaces, so
-# stripping CSI closes the gaps between words: both patterns above read against
-# the stripped view and have to tolerate their absence.
-PASTE_PROMPT = re.compile(rb"Paste\s*code\s*here")
+# user never gave. Ink lays adjacent text nodes out with cursor moves rather
+# than spaces, and stripping CSI closes those gaps, so the gaps here are
+# optional — but horizontal only: `\s*` after the colon would step over the
+# line break and report the following line ("Press Enter to retry.") as the
+# detail whenever the CLI's own message is empty.
+TUI_ERROR = re.compile(rb"OAuth[^\S\r\n]*error:[^\S\r\n]*([^\r\n]*)")
 
 
 def complete_match(pattern, buf):
@@ -120,9 +117,13 @@ def failure_message(code_file, typed_at, announced, tui_error=None):
     whose own output this wrapper swallows, and is the one case where the fix
     is to go look at that command rather than at the browser.
     """
-    if tui_error:
+    # `is not None`, not truthiness: the CLI prints the label with nothing after
+    # it when it has no detail to give, and an empty capture is still an error
+    # seen — falling through from here would report that no error was reported.
+    if tui_error is not None:
+        detail = f": {tui_error}" if tui_error else ", with no detail on the line"
         return (
-            f"Error: `claude setup-token` reported: {tui_error}\n"
+            f"Error: `claude setup-token` reported an OAuth error{detail}\n"
             "A code belongs to the run whose challenge issued it, is good once, "
             "and dies with that run — so a code from an earlier run, or one the "
             "CLI's own localhost callback already redeemed, fails here. Rerun "
@@ -230,9 +231,21 @@ def main():
         sys.exit("Error: claude CLI not found. Install Claude Code first.")
     os.close(slave)
 
+    # Goes out with the URL rather than waiting on the paste prompt to render:
+    # timing it against TUI wording would tie it to text free to change, and the
+    # user wants it at the moment they get the link anyway.
+    hint = (
+        "The CLI takes the redirect on its own localhost callback, so approving "
+        "is usually the whole job. If the browser shows a `code#state` string "
+        + (
+            f"instead, write that to {args.code_file}."
+            if args.code_file
+            else "instead, this run has no --code-file to read it from."
+        )
+    )
+
     buf = bytearray()
     announced = False
-    prompted = False
     typed_at = None
     enters = 0
     token = None
@@ -257,24 +270,11 @@ def main():
             if not announced:
                 url = first_url(visible)
                 if url:
-                    print(f"Approve in the browser:\n{url.decode()}", file=sys.stderr)
+                    print(
+                        f"Approve in the browser:\n{url.decode()}\n{hint}",
+                        file=sys.stderr,
+                    )
                     announced = True
-
-            if not prompted and PASTE_PROMPT.search(visible):
-                prompted = True
-                fallback = (
-                    f"If it shows a `code#state` string instead, write that to "
-                    f"{args.code_file}."
-                    if args.code_file
-                    else "If it shows a `code#state` string instead, this run has "
-                    "no --code-file to read it from."
-                )
-                print(
-                    "Waiting for the approval. The CLI takes the redirect on its "
-                    "own localhost callback, so approving in the browser is "
-                    f"usually the whole job. {fallback}",
-                    file=sys.stderr,
-                )
 
             if typed_at is None and args.code_file and os.path.exists(args.code_file):
                 with open(args.code_file, encoding="utf-8") as fh:
@@ -301,8 +301,11 @@ def main():
                 break
 
             # After the token check, so a token already on screen wins over an
-            # error earlier in the same buffer. The message itself is read off
-            # the final buffer below, where the line has finished arriving.
+            # error earlier in the same buffer. Nothing reads the pty between
+            # here and the final scan below, so the detail reported is whatever
+            # had arrived by this read and may be cut at a chunk boundary —
+            # naming the error at all is what turns a silent window into a
+            # failure, and a clipped message still does that.
             if TUI_ERROR.search(visible):
                 break
 

--- a/plugins/install-tend/skills/install-tend/scripts/oauth_token.py
+++ b/plugins/install-tend/skills/install-tend/scripts/oauth_token.py
@@ -5,24 +5,30 @@ Prints the token to stdout and everything else to stderr, so stdout pipes
 straight into a consumer without the rest of the run coming with it.
 
 `claude setup-token` renders its TUI with Ink, which draws only when stdout
-is a TTY, so the child needs a pty. It then completes one of two ways: the
-browser redirects to the CLI's own localhost callback, or it lands on a page
-showing a `code#state` string and the TUI waits at a paste prompt. Both paths
-have to stay open, which is why this drives the pty itself rather than through
-script(1) — script(1) reads terminal attributes from its own stdin and aborts
-with "tcgetattr: Operation not supported on socket" when that is anything but a
-tty or /dev/null, and a /dev/null stdin leaves the paste prompt unanswerable.
+is a TTY, so the child needs a pty. It then completes one of two ways. Normally
+the CLI's own localhost listener takes the redirect and the run finishes with
+no input at all — approving in the browser is the whole of the user's job.
+Failing that, the browser lands on a page showing a `code#state` string and the
+TUI waits at its paste prompt. Both paths have to stay open, which is why this
+drives the pty itself rather than through script(1) — script(1) reads terminal
+attributes from its own stdin and aborts with "tcgetattr: Operation not
+supported on socket" when that is anything but a tty or /dev/null, and a
+/dev/null stdin leaves the paste prompt unanswerable.
 
 The authorize URL goes to stderr as soon as the TUI offers it, so a caller
-running this in the background can hand it to the user. Nothing else from the
-TUI is echoed: its output carries the token.
+running this in the background can hand it to the user. So does the TUI's own
+error line, which is the difference between a run that is waiting for a person
+and one that has already failed — indistinguishable from outside otherwise,
+since a rejected code leaves the TUI sitting at "Press Enter to retry" for the
+rest of the window. Nothing else from the TUI is echoed: its output carries the
+token.
 
 Usage:
     oauth_token.py [--code-file PATH]
 
 `--code-file` names a path to watch. Write the `code#state` string there and it
 is typed into the TUI, for the runs where the browser shows a code instead of
-returning to the CLI.
+returning to the CLI. Most runs never need it.
 """
 
 import argparse
@@ -56,6 +62,18 @@ AUTHORIZE_URL = re.compile(
 # bytes, and `complete_match` would then see a following byte and call the
 # truncation final. Length is checked after extraction so it fails loudly.
 TOKEN = re.compile(rb"sk-ant-oat01-[A-Za-z0-9_-]{80,}")
+# The TUI's own failure line. `claude setup-token` reports a rejected code and
+# then waits at "Press Enter to retry", which produces no further output — so
+# without this the run is silent to its deadline and reads as an approval the
+# user never gave.
+TUI_ERROR = re.compile(rb"OAuth\s*error:\s*([^\r\n]*)")
+# Drives the progress line and nothing else. Gating the paste on it would tie
+# the fallback path to TUI wording that is free to change, and buy nothing: the
+# prompt renders alongside the authorize URL, so a code can't arrive first.
+# Ink lays adjacent text nodes out with cursor moves rather than spaces, so
+# stripping CSI closes the gaps between words: both patterns above read against
+# the stripped view and have to tolerate their absence.
+PASTE_PROMPT = re.compile(rb"Paste\s*code\s*here")
 
 
 def complete_match(pattern, buf):
@@ -90,23 +108,31 @@ def take_controlling_tty():
     fcntl.ioctl(0, termios.TIOCSCTTY, 0)
 
 
-def failure_message(code_file, typed_at, announced):
+def failure_message(code_file, typed_at, announced, tui_error=None):
     """Why no token came back, in terms of what this run actually saw.
 
-    A caller that already passed `--code-file` is told to pass it, and reads
-    that as the diagnosis, so the causes it can act on are named apart. The
-    loop ends three ways — the deadline, a pty the child closed, and a child
-    already exited — so a message may not assume the window passed either. A
-    run that never announced a URL ended inside `claude setup-token`, whose own
-    output this wrapper swallows, and is the one case where the fix is to go
-    look at that command rather than at the browser.
+    The TUI's own error line beats every inference below it, so it comes
+    first. A caller that already passed `--code-file` is told to pass it, and
+    reads that as the diagnosis, so the causes it can act on are named apart.
+    The loop ends three ways — the deadline, a pty the child closed, and a
+    child already exited — so a message may not assume the window passed
+    either. A run that never announced a URL ended inside `claude setup-token`,
+    whose own output this wrapper swallows, and is the one case where the fix
+    is to go look at that command rather than at the browser.
     """
+    if tui_error:
+        return (
+            f"Error: `claude setup-token` reported: {tui_error}\n"
+            "A code belongs to the run whose challenge issued it, is good once, "
+            "and dies with that run — so a code from an earlier run, or one the "
+            "CLI's own localhost callback already redeemed, fails here. Rerun "
+            "and approve the fresh URL."
+        )
     if typed_at is not None:
         return (
             f"Error: the code from {code_file} was typed into the prompt and no "
-            "token came back, so the authorize page rejected it. A code belongs "
-            "to the run whose challenge issued it and dies with that run; "
-            "approve the URL this run printed."
+            "token came back, and the TUI reported no error either. Rerun and "
+            "approve the fresh URL."
         )
     if not announced:
         return (
@@ -206,6 +232,7 @@ def main():
 
     buf = bytearray()
     announced = False
+    prompted = False
     typed_at = None
     enters = 0
     token = None
@@ -233,6 +260,22 @@ def main():
                     print(f"Approve in the browser:\n{url.decode()}", file=sys.stderr)
                     announced = True
 
+            if not prompted and PASTE_PROMPT.search(visible):
+                prompted = True
+                fallback = (
+                    f"If it shows a `code#state` string instead, write that to "
+                    f"{args.code_file}."
+                    if args.code_file
+                    else "If it shows a `code#state` string instead, this run has "
+                    "no --code-file to read it from."
+                )
+                print(
+                    "Waiting for the approval. The CLI takes the redirect on its "
+                    "own localhost callback, so approving in the browser is "
+                    f"usually the whole job. {fallback}",
+                    file=sys.stderr,
+                )
+
             if typed_at is None and args.code_file and os.path.exists(args.code_file):
                 with open(args.code_file, encoding="utf-8") as fh:
                     code = fh.read().strip()
@@ -257,6 +300,12 @@ def main():
                 token = match.decode()
                 break
 
+            # After the token check, so a token already on screen wins over an
+            # error earlier in the same buffer. The message itself is read off
+            # the final buffer below, where the line has finished arriving.
+            if TUI_ERROR.search(visible):
+                break
+
             if child.poll() is not None and not readable:
                 break
     finally:
@@ -265,15 +314,21 @@ def main():
         finally:
             os.close(master)
 
+    final_visible = ANSI_CSI.sub(b"", buf)
     if token is None:
         # Nothing more can arrive, so a match here cannot be a partial read —
         # which is the case where the token is the last thing the TUI writes.
-        final = TOKEN.search(ANSI_CSI.sub(b"", buf))
+        final = TOKEN.search(final_visible)
         if final:
             token = final.group(0).decode()
 
     if not token:
-        sys.exit(failure_message(args.code_file, typed_at, announced))
+        # Read unconditionally rather than off a flag the loop set: the loop
+        # also ends on a closed pty and on an exited child, either of which can
+        # carry the error line in the same read that ends it.
+        error = TUI_ERROR.search(final_visible)
+        detail = error.group(1).decode("utf-8", "replace").strip() if error else None
+        sys.exit(failure_message(args.code_file, typed_at, announced, detail))
     if len(token) > MAX_TOKEN_LENGTH:
         sys.exit(f"Error: extracted token has implausible length ({len(token)} chars)")
     print(token)

--- a/plugins/install-tend/skills/install-tend/scripts/test_oauth_token.py
+++ b/plugins/install-tend/skills/install-tend/scripts/test_oauth_token.py
@@ -23,7 +23,6 @@ from oauth_token import (
     ANSI_CSI,
     AUTHORIZE_URL,
     MAX_TOKEN_LENGTH,
-    PASTE_PROMPT,
     TIMEOUT_SECONDS,
     TOKEN,
     TUI_ERROR,
@@ -136,9 +135,21 @@ def test_tui_error_captures_only_its_own_line() -> None:
     assert match.group(1).strip() == b"status code 400"
 
 
-def test_paste_prompt_matches_the_stripped_render() -> None:
-    assert PASTE_PROMPT.search(b"Pastecodehereifprompted>")
-    assert PASTE_PROMPT.search(b"Paste code here if prompted >")
+def test_a_detail_free_error_does_not_borrow_the_next_line() -> None:
+    # The CLI prints the label with nothing after it when it has no detail. A
+    # gap pattern that steps over the line break reports the TUI's *next* line
+    # as the cause, which sends the reader after "Press Enter to retry."
+    match = TUI_ERROR.search(b"OAuth error:\r\nPress Enter to retry.")
+    assert match.group(1) == b""
+
+
+def test_a_detail_free_error_is_still_reported_as_an_error() -> None:
+    # An empty capture is falsy, so a truthiness check here falls through to a
+    # message saying the TUI reported no error — about a run that ended because
+    # it did. The empty string and "no error seen" have to stay distinct.
+    message = failure_message("/tmp/tend-oauth-code", 1.0, True, "")
+    assert "reported an OAuth error" in message
+    assert "no error" not in message
 
 
 def test_a_run_with_nowhere_to_receive_a_code_is_told_to_pass_one() -> None:

--- a/plugins/install-tend/skills/install-tend/scripts/test_oauth_token.py
+++ b/plugins/install-tend/skills/install-tend/scripts/test_oauth_token.py
@@ -23,8 +23,10 @@ from oauth_token import (
     ANSI_CSI,
     AUTHORIZE_URL,
     MAX_TOKEN_LENGTH,
+    PASTE_PROMPT,
     TIMEOUT_SECONDS,
     TOKEN,
+    TUI_ERROR,
     complete_match,
     failure_message,
     first_url,
@@ -109,7 +111,34 @@ def test_unapproved_run_is_not_blamed_on_the_flag_it_was_given() -> None:
 
 
 def test_a_refused_code_reads_differently_from_no_code_at_all() -> None:
-    assert "rejected it" in failure_message("/tmp/tend-oauth-code", 1.0, True)
+    message = failure_message("/tmp/tend-oauth-code", 1.0, True)
+    assert "no token came back" in message
+    assert "went unapproved" not in message
+
+
+def test_the_tuis_own_error_outranks_every_inference() -> None:
+    # The wrapper used to guess at why a code failed; the CLI says so outright,
+    # and the guess it replaced ("the authorize page rejected it") sent the
+    # caller to re-approve a URL when the real cause was a code already spent.
+    message = failure_message("/tmp/tend-oauth-code", 1.0, True, "status code 400")
+    assert "status code 400" in message
+
+
+def test_tui_error_matches_the_line_as_ink_renders_it() -> None:
+    # Ink lays adjacent text nodes out with cursor moves, so stripping CSI
+    # closes the gaps: a pattern written against the pretty version misses.
+    assert TUI_ERROR.search(b"OAuth error: Request failed with status code 400")
+    assert TUI_ERROR.search(b"OAutherror:Request failed with status code 400")
+
+
+def test_tui_error_captures_only_its_own_line() -> None:
+    match = TUI_ERROR.search(b"OAuth error: status code 400\r\nPress Enter to retry.")
+    assert match.group(1).strip() == b"status code 400"
+
+
+def test_paste_prompt_matches_the_stripped_render() -> None:
+    assert PASTE_PROMPT.search(b"Pastecodehereifprompted>")
+    assert PASTE_PROMPT.search(b"Paste code here if prompted >")
 
 
 def test_a_run_with_nowhere_to_receive_a_code_is_told_to_pass_one() -> None:
@@ -247,3 +276,98 @@ time.sleep(5)
                 os.kill(child_pid, signal.SIGTERM)
             except ProcessLookupError:
                 pass
+
+
+TUI_URL = (
+    "https://claude.com/cai/oauth/authorize?code=true&client_id=9d1"
+    "&code_challenge=AAA&code_challenge_method=S256&state=BBB"
+)
+FAKE_TOKEN = "sk-ant-oat01-" + "A" * 95
+
+
+def run_wrapper(
+    tmp_path: Path, script: str, *args: str
+) -> subprocess.CompletedProcess[str]:
+    """The wrapper against a fake `claude` that renders a scripted TUI."""
+    fake_claude = tmp_path / "claude"
+    fake_claude.write_text(f"#!{sys.executable}\n{script}")
+    fake_claude.chmod(0o755)
+    return subprocess.run(
+        [sys.executable, str(Path(__file__).with_name("oauth_token.py")), *args],
+        env=os.environ | {"PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}"},
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+
+def test_a_rejected_code_fails_now_rather_than_at_the_deadline(
+    tmp_path: Path,
+) -> None:
+    # The failure this guard exists for. `claude setup-token` reports a rejected
+    # code and then waits at "Press Enter to retry", emitting nothing further —
+    # so a wrapper watching only for a token sits out the rest of its window,
+    # and the caller cannot tell that from an approval still pending. It has to
+    # end at the error, carrying the CLI's own words.
+    # The fake writes the code itself, after the prompt is up: the wrapper
+    # unlinks any code file it finds at startup, since a code that predates the
+    # run belongs to an earlier challenge and is already dead.
+    code_file = tmp_path / "code"
+    result = run_wrapper(
+        tmp_path,
+        f"""
+import pathlib, sys, time
+print({TUI_URL!r}, flush=True)
+print("Paste code here if prompted >", flush=True)
+pathlib.Path({str(code_file)!r}).write_text("SPENTcode#BBB")
+sys.stdin.readline()
+print("OAuth error: Request failed with status code 400", flush=True)
+print("Press Enter to retry.", flush=True)
+time.sleep(60)
+""",
+        "--code-file",
+        str(code_file),
+    )
+    assert result.returncode != 0
+    assert "status code 400" in result.stderr
+    assert result.stdout == ""
+
+
+def test_a_code_is_typed_even_when_the_prompt_never_renders(tmp_path: Path) -> None:
+    # The paste path must not depend on matching the TUI's prompt wording, which
+    # is free to change under us: the fallback would go quiet exactly when the
+    # localhost callback has already failed.
+    code_file = tmp_path / "code"
+    result = run_wrapper(
+        tmp_path,
+        f"""
+import pathlib, sys
+print({TUI_URL!r}, flush=True)
+pathlib.Path({str(code_file)!r}).write_text("GOODcode#BBB")
+line = sys.stdin.readline()
+assert "GOODcode#BBB" in line, line
+print("Your OAuth token (valid for 1 year):" + {FAKE_TOKEN!r}, flush=True)
+print("Store this token securely.", flush=True)
+""",
+        "--code-file",
+        str(code_file),
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == FAKE_TOKEN
+
+
+def test_the_localhost_callback_path_needs_no_code_at_all(tmp_path: Path) -> None:
+    # The common run: the CLI takes the redirect on its own listener and prints
+    # the token with nothing typed. Nothing may block that on a paste.
+    result = run_wrapper(
+        tmp_path,
+        f"""
+print({TUI_URL!r}, flush=True)
+print("Paste code here if prompted >", flush=True)
+print("Your OAuth token (valid for 1 year):" + {FAKE_TOKEN!r}, flush=True)
+print("Store this token securely.", flush=True)
+""",
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == FAKE_TOKEN


### PR DESCRIPTION
Rotating a consumer's `CLAUDE_CODE_OAUTH_TOKEN` today meant watching `oauth_token.py` sit silent for its full 900s window with no idea whether it was waiting on a person or had already failed. It had already failed: `claude setup-token` reports a rejected code as `OAuth error: Request failed with status code 400` and then parks at "Press Enter to retry", emitting nothing further. The wrapper watched only for a token, so that state was indistinguishable from an approval still pending.

Watch for the TUI's error line, end the run on it, and report what the CLI actually said. A rejected code now fails in seconds and names its own cause instead of timing out under a guess.

The same investigation corrected a factual error in the skill. `claude setup-token` holds a localhost listener (observed at `127.0.0.1:56305`) that takes the browser redirect, so approving is normally the whole of the user's job and the run completes with nothing typed. SKILL.md presented the `code#state` paste as a co-equal path; it's the fallback for when the browser shows a code page instead. A code is also good exactly once, so one the listener already redeemed fails at the prompt — which is the likely shape of today's failure.

Two integration tests against a fake `claude`: a rejected code must fail fast (this hung for the harness's full 60s timeout before the fix), and the localhost path must produce a token with nothing typed.

<details>
<summary>Review rounds folded in</summary>

Before the PR opened:

- A comment claimed the error check's placement preserved a retry that the `break` right under it makes unreachable.
- The `failed` flag it set was redundant and slightly wrong: the loop also ends on a closed pty and on an exited child, either of which can carry the error line in the read that ends it, leaving the flag false with the error sitting in the buffer. Reading the buffer unconditionally is both shorter and more correct.

From tend's review of the first commit — two real bugs, both reproduced before fixing:

- `\s*` after the colon crossed the line break, so an error the CLI prints with no detail captured the *next* line and reported "Press Enter to retry." as the cause. Horizontal whitespace only.
- An empty capture is falsy, so that same detail-free error fell through to a message saying the TUI reported no error — about a run that ended because it did. "No error seen" and "an error with nothing after the label" are now distinct.
- The comment at the break claimed the error line "has finished arriving"; nothing establishes that, since no read happens between it and the final scan. Rewritten to say the detail may be clipped and that naming the error is what matters.
- `PASTE_PROMPT` and the flag timing the stderr hint against it are gone. The hint goes out with the authorize URL, where it's more use, and scheduling it by matching TUI wording was the coupling this change argues against elsewhere.

</details>

> _This was written by Claude Code on behalf of max-sixty_
