### PR TITLE
fix(generator): silence GraphQL shellcheck false positive

### DIFF
--- a/generator/src/tend/templates/notifications-check.sh
+++ b/generator/src/tend/templates/notifications-check.sh
@@ -39,6 +39,7 @@ echo "count=$COUNT" >> "$GITHUB_OUTPUT"
 # boot gate; the agent test-merges every candidate before changing a branch.
 # Read the newest comments: a deferral is normally the PR's latest activity.
 # An older marker can waste boots, but the resolver paginates before acting.
+# shellcheck disable=SC2016  # $q is a GraphQL variable, not a shell variable.
 if BOT_LOGIN=$(gh api user --jq .login 2>/dev/null) \
   && PRS=$(gh api graphql -f query='
     query($q: String!) {

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
@@ -74,6 +74,7 @@ jobs:
           # boot gate; the agent test-merges every candidate before changing a branch.
           # Read the newest comments: a deferral is normally the PR's latest activity.
           # An older marker can waste boots, but the resolver paginates before acting.
+          # shellcheck disable=SC2016  # $q is a GraphQL variable, not a shell variable.
           if BOT_LOGIN=$(gh api user --jq .login 2>/dev/null) \
             && PRS=$(gh api graphql -f query='
               query($q: String!) {

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[notifications].out
@@ -73,6 +73,7 @@ jobs:
           # boot gate; the agent test-merges every candidate before changing a branch.
           # Read the newest comments: a deferral is normally the PR's latest activity.
           # An older marker can waste boots, but the resolver paginates before acting.
+          # shellcheck disable=SC2016  # $q is a GraphQL variable, not a shell variable.
           if BOT_LOGIN=$(gh api user --jq .login 2>/dev/null) \
             && PRS=$(gh api graphql -f query='
               query($q: String!) {

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
@@ -73,6 +73,7 @@ jobs:
           # boot gate; the agent test-merges every candidate before changing a branch.
           # Read the newest comments: a deferral is normally the PR's latest activity.
           # An older marker can waste boots, but the resolver paginates before acting.
+          # shellcheck disable=SC2016  # $q is a GraphQL variable, not a shell variable.
           if BOT_LOGIN=$(gh api user --jq .login 2>/dev/null) \
             && PRS=$(gh api graphql -f query='
               query($q: String!) {

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
@@ -73,6 +73,7 @@ jobs:
           # boot gate; the agent test-merges every candidate before changing a branch.
           # Read the newest comments: a deferral is normally the PR's latest activity.
           # An older marker can waste boots, but the resolver paginates before acting.
+          # shellcheck disable=SC2016  # $q is a GraphQL variable, not a shell variable.
           if BOT_LOGIN=$(gh api user --jq .login 2>/dev/null) \
             && PRS=$(gh api graphql -f query='
               query($q: String!) {


### PR DESCRIPTION
The notifications pre-check intentionally passes a single-quoted GraphQL query containing `$q`; GitHub's GraphQL API expands that variable, not the shell. Actionlint's embedded ShellCheck therefore reported SC2016 on workflows generated by 0.1.23.

Add a command-scoped ShellCheck directive to the source template and update all affected render snapshots. This keeps the query semantics unchanged while making freshly generated workflows pass actionlint.

Validation:

- `wt test` (880 Python tests, 32 worker tests, TypeScript typecheck)
- `pre-commit run --all-files`
- freshly rendered `tend-notifications.yaml` piped through `actionlint`

> _This was written by Codex on behalf of max-sixty_
