### PR TITLE
chore: release 0.1.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ published verbatim as that version's GitHub Release notes
 0.1.1 predate this changelog; see the compare views at
 https://github.com/max-sixty/tend/compare for their history.
 
+## 0.1.24
+
+### Fixed
+
+- **Generated notifications workflows pass actionlint.** The literal GraphQL `$q` variable now carries a scoped ShellCheck directive, avoiding SC2016 without allowing the shell to expand it. ([#1112](https://github.com/max-sixty/tend/pull/1112))
+
 ## 0.1.23
 
 ### Improved

--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "tend"
-version = "0.1.23"
+version = "0.1.24"
 description = "An autonomous junior maintainer for GitHub repos, powered by Claude or OpenAI Codex — reviews PRs, triages issues, fixes CI"
 license = "MIT"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -955,7 +955,7 @@ wheels = [
 
 [[package]]
 name = "tend"
-version = "0.1.23"
+version = "0.1.24"
 source = { editable = "generator" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Patch release for the scoped notifications-workflow lint fix merged in #1112.

The release updates the package version and lockfile to 0.1.24 and adds the matching changelog section. Once published, Tend's repo-owned workflows can be regenerated with the corrected template before enabling the experimental Gist-memory trial.

Validation:

- `wt test` (880 Python tests, 32 worker tests, TypeScript typecheck)
- `pre-commit run --all-files`

> _This was written by Codex on behalf of max-sixty_
