### PR TITLE
docs(CLAUDE.md): name memory_gist as the second use of the gist PAT scope

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,11 +219,13 @@ stored as secrets in the repo's `tend` GitHub Environment, whose deployment
 branch policy admits only the branches `tend check` confirmed the bot
 cannot write — the default branch and any `protected_branches` that exist
 and are protected. A workflow the bot pushes to any other ref is refused
-them before its first step. The `gist` scope supports bot-owned secret gists
-used by `review-reviewers` as a per-month structured evidence store
-(avoids the 65 KB comment-body limit). The `user` scope lets `install-tend`
-set the bot's profile bio (`PATCH /user`) so the account's authorization
-stance is discoverable on the bot's user page.
+them before its first step. The `gist` scope supports bot-owned secret
+gists, of which there are two: `review-reviewers` keeps a per-month
+structured evidence store (avoids the 65 KB comment-body limit), and the
+experimental `memory_gist` setting persists Claude Code's auto memory
+across runs. The `user` scope lets `install-tend` set the bot's profile
+bio (`PATCH /user`) so the account's authorization stance is discoverable
+on the bot's user page.
 
 Classic PATs are all-or-nothing — `public_repo` grants full write to every
 public repo the user can access. Fine-grained PATs allow per-category

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,8 +219,8 @@ stored as secrets in the repo's `tend` GitHub Environment, whose deployment
 branch policy admits only the branches `tend check` confirmed the bot
 cannot write — the default branch and any `protected_branches` that exist
 and are protected. A workflow the bot pushes to any other ref is refused
-them before its first step. The `gist` scope supports bot-owned secret
-gists, of which there are two: `review-reviewers` keeps a per-month
+them before its first step. Two things use the `gist` scope, both
+through bot-owned secret gists: `review-reviewers` keeps a per-month
 structured evidence store (avoids the 65 KB comment-body limit), and the
 experimental `memory_gist` setting persists Claude Code's auto memory
 across runs. The `user` scope lets `install-tend` set the bot's profile

--- a/docs/tend.example.yaml
+++ b/docs/tend.example.yaml
@@ -72,9 +72,11 @@ bot_name: my-project-bot
 #
 # Classic PAT scopes: `repo`, `workflow`, `notifications`, `write:discussion`,
 # `gist`, `user`. `workflow` is required to push commits that modify
-# `.github/workflows/` files. `gist` lets internal skills store structured
-# evidence in secret gists owned by the bot. `user` lets `install-tend` set
-# the bot's profile bio so contributors can see the authorization stance.
+# `.github/workflows/` files. `gist` covers two uses of secret gists owned by
+# the bot: internal skills store structured evidence in them, and the
+# experimental `memory_gist` setting persists Claude Code's auto memory across
+# runs. `user` lets `install-tend` set the bot's profile bio so contributors
+# can see the authorization stance.
 #
 # Fine-grained PAT permissions: `contents:write`, `pull-requests:write`,
 # `issues:write`, `actions:write`, `workflows:write`, `discussions:write`,

--- a/plugins/install-tend/skills/install-tend/references/tend.example.yaml
+++ b/plugins/install-tend/skills/install-tend/references/tend.example.yaml
@@ -72,9 +72,11 @@ bot_name: my-project-bot
 #
 # Classic PAT scopes: `repo`, `workflow`, `notifications`, `write:discussion`,
 # `gist`, `user`. `workflow` is required to push commits that modify
-# `.github/workflows/` files. `gist` lets internal skills store structured
-# evidence in secret gists owned by the bot. `user` lets `install-tend` set
-# the bot's profile bio so contributors can see the authorization stance.
+# `.github/workflows/` files. `gist` covers two uses of secret gists owned by
+# the bot: internal skills store structured evidence in them, and the
+# experimental `memory_gist` setting persists Claude Code's auto memory across
+# runs. `user` lets `install-tend` set the bot's profile bio so contributors
+# can see the authorization stance.
 #
 # Fine-grained PAT permissions: `contents:write`, `pull-requests:write`,
 # `issues:write`, `actions:write`, `workflows:write`, `discussions:write`,


### PR DESCRIPTION
`memory_gist` landed in #1110 and was enabled on this repo in #1114, but two places that justify the `gist` PAT scope still describe it as existing for `review-reviewers`' evidence store alone. That scope now has a second, more load-bearing consumer: every Claude workflow run restores and saves auto memory through it.

- `CLAUDE.md`'s Auth section — adds the second use to the sentence that enumerates them.
- `docs/tend.example.yaml` and its synced copy under `plugins/install-tend/` — the file an adopter reads when minting the PAT. Its "internal skills store structured evidence" wording covers `review-reviewers` but not the memory sync, which runs from a step in [`claude/action.yaml`](https://github.com/max-sixty/tend/blob/75d7f1f064564e93bffaf3d6752e77ffee0326cb/claude/action.yaml#L314-L337) rather than a skill.

Doc-only, so no regression test — the claim it fixes isn't executable. Verified against the feature's own docs: [`docs/tend.example.yaml`](https://github.com/max-sixty/tend/blob/6057b75/docs/tend.example.yaml#L243-L264) and [`docs/security-model.md`](https://github.com/max-sixty/tend/blob/6057b75/docs/security-model.md#L429-L437). `uv run pytest` (880 passed) and `pre-commit` on the changed files both pass; the sync hook confirms the two example-yaml copies stay identical.
