### PR TITLE
test(nightly): pin Step 7's staging pathspecs to what init writes

### DIFF
--- a/generator/tests/test_cross_file_contracts.py
+++ b/generator/tests/test_cross_file_contracts.py
@@ -272,8 +272,11 @@ def test_nightly_regen_stages_every_path_init_writes(
     # The stamp-only skip and the `git status` inspection both read the staged
     # set: a file `init` newly created is invisible to a plain `git diff`, so a
     # release whose only change is a new output path would skip the PR as a
-    # no-op.
-    assert "git diff --cached" in skill
+    # no-op. They must name the same paths the `git add -A` lines stage —
+    # widening only the staging leaves the no-op check blind to the new path.
+    specs = " ".join(staged)
+    assert f"git status --porcelain {specs}" in skill
+    assert f"git diff --cached --no-color {specs}" in skill
 
     config = tmp_path / ".config" / "tend.yaml"
     config.parent.mkdir(parents=True)

--- a/generator/tests/test_cross_file_contracts.py
+++ b/generator/tests/test_cross_file_contracts.py
@@ -5,7 +5,12 @@ together, so each reads correct on its own while the pair stops agreeing.
 """
 
 import json
+import re
 from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+from tend.cli import main
 
 from tests import _yaml as yaml
 
@@ -244,3 +249,51 @@ def test_review_reviewers_matrix_covers_consumers() -> None:
 
     missing = sorted(set(consumers) - set(matrix))
     assert not missing, f"add consumers to review-reviewers.yaml matrix: {missing}"
+
+
+def test_nightly_regen_stages_every_path_init_writes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Step 7's `git add -A` pathspecs must cover everything `tend init` writes.
+
+    The recipe names a fixed pathspec while the generator's output set grows —
+    `.github/actionlint.yaml` arrived after the recipe was written, and while
+    the pathspec read `.github/workflows .config` the regeneration PR shipped
+    without it, leaving adopters who lint workflows red and re-creating the
+    file untracked every night.
+    """
+    skill = _read("plugins", "tend-ci-runner", "skills", "nightly", "SKILL.md")
+
+    pathspecs = re.findall(r"^git add -A (.+)$", skill, re.MULTILINE)
+    assert pathspecs, "Step 7 no longer stages the regenerated files"
+    assert len(set(pathspecs)) == 1, f"Step 7 stages inconsistent sets: {pathspecs}"
+    staged = pathspecs[0].split()
+
+    # The stamp-only skip and the `git status` inspection both read the staged
+    # set: a file `init` newly created is invisible to a plain `git diff`, so a
+    # release whose only change is a new output path would skip the PR as a
+    # no-op.
+    assert "git diff --cached" in skill
+
+    config = tmp_path / ".config" / "tend.yaml"
+    config.parent.mkdir(parents=True)
+    config.write_text("bot_name: test-bot\n")
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(main, ["init"])
+    assert result.exit_code == 0, result.output
+
+    written = {
+        p.relative_to(tmp_path).as_posix() for p in tmp_path.rglob("*") if p.is_file()
+    }
+    assert ".github/actionlint.yaml" in written, "review no longer writes the ignore"
+
+    uncovered = sorted(
+        path
+        for path in written
+        if not any(path == spec or path.startswith(f"{spec}/") for spec in staged)
+    )
+    assert not uncovered, (
+        f"`tend init` writes paths the nightly regeneration never stages: {uncovered}. "
+        "Widen Step 7's `git add -A` pathspecs so the regeneration PR carries them."
+    )


### PR DESCRIPTION
The nightly Step 7 gap max-sixty/tend#1116 reports was already closed on `main` — #1095 widened the recipe's pathspecs to `.github .config` and moved the stamp-only check to `git diff --cached` in the same commit that taught the generator to write `.github/actionlint.yaml`. What #1095 did not add is anything that keeps the pair in sync, so this adds the missing contract test.

The adopter still saw the bug because the two halves ship on different clocks: the nightly skill comes from the action ref pinned in the adopter's workflow files (the *previous* release), while `uv tool run tend@latest init` is always the newest generator. A release that adds an output path is therefore run by the prior release's recipe for exactly one night. That skew is structural and this PR does not change it; what it does prevent is the recipe and the generator disagreeing *within* a release, which is what turns a one-night gap into a permanent one.

`test_nightly_regen_stages_every_path_init_writes` runs `tend init` into a temp repo and asserts every file it writes is covered by the `git add -A` pathspecs parsed out of the nightly skill, that both `git add -A` lines in Step 7 name the same set, and that the stamp-only skip reads `git diff --cached` rather than the worktree.

<details><summary>Verification that the guard catches the reported bug</summary>

Run against the recipe as it stood at `0.1.22`, the version the reporter's adopter was on:

```
0.1.22 pathspecs: ['.github/workflows .config']
has --cached: False
uncovered under 0.1.22 recipe: ['.github/actionlint.yaml']
```

Both assertions fail there and pass on `main`. Local run: `uv run pytest generator/tests/test_cross_file_contracts.py` — 14 passed; `pre-commit run --files generator/tests/test_cross_file_contracts.py` clean.

</details>

---
Closes #1116 — automated triage
