### PR TITLE
fix(nightly): capture the regen commit's OID before removing the worktree

### DIFF
--- a/generator/tests/test_cross_file_contracts.py
+++ b/generator/tests/test_cross_file_contracts.py
@@ -244,3 +244,53 @@ def test_review_reviewers_matrix_covers_consumers() -> None:
 
     missing = sorted(set(consumers) - set(matrix))
     assert not missing, f"add consumers to review-reviewers.yaml matrix: {missing}"
+
+
+def _bash_blocks(markdown: str) -> list[str]:
+    return [block.split("```", 1)[0] for block in markdown.split("```bash\n")[1:]]
+
+
+def test_nightly_regen_pins_its_poll_to_the_commit_it_pushed() -> None:
+    """Step 7 must stash the pushed OID before it removes the regen worktree.
+
+    The commit is made on `tend/update-workflows` inside `/tmp`, and the block
+    destroys that worktree on the way out. Afterwards the main checkout's
+    `git rev-parse HEAD` — the derivation **CI Monitoring** prescribes "after
+    your own push" — resolves to the default branch, a different commit on a
+    different branch, so the session is steered to the two sources tend has
+    ruled out: the PR head (which a sibling push retargets mid-poll) or the
+    abbreviated OID retyped out of `git commit`'s output.
+    """
+    skill = _read("plugins", "tend-ci-runner", "skills", "nightly", "SKILL.md")
+
+    ship = [
+        block
+        for block in _bash_blocks(skill)
+        if "gh pr create" in block and "git worktree remove" in block
+    ]
+    assert len(ship) == 1, "Step 7 no longer ships the regen PR from one block"
+    block = ship[0]
+
+    capture = [
+        line
+        for line in block.splitlines()
+        if line.startswith("git rev-parse HEAD > ") and "/tmp/" in line
+    ]
+    assert capture, (
+        "Step 7 pushes from the /tmp worktree and then removes it without "
+        "recording the pushed OID; the poll that follows has no correct local "
+        "source for it."
+    )
+    assert block.index(capture[0]) < block.index("git worktree remove"), (
+        "the OID must be captured while the worktree still exists"
+    )
+
+    stash = capture[0].split(">", 1)[1].strip().strip('"')
+    poll = [
+        line
+        for line in skill.splitlines()
+        if "poll-pr-checks.sh" in line and f"cat {stash}" in line
+    ]
+    assert poll, (
+        f"Step 7 stashes the pushed OID at {stash} but never points the poll at it"
+    )

--- a/generator/tests/test_cross_file_contracts.py
+++ b/generator/tests/test_cross_file_contracts.py
@@ -281,6 +281,9 @@ def test_nightly_regen_pins_its_poll_to_the_commit_it_pushed() -> None:
         "recording the pushed OID; the poll that follows has no correct local "
         "source for it."
     )
+    assert block.index("git commit") < block.index(capture[0]), (
+        "the OID must be captured after the commit it names"
+    )
     assert block.index(capture[0]) < block.index("git worktree remove"), (
         "the OID must be captured while the worktree still exists"
     )

--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -255,8 +255,20 @@ git config --global user.email "${BOT_ID}+${BOT_LOGIN}@users.noreply.github.com"
 git commit -m "$TITLE"
 git push -u origin tend/update-workflows
 gh pr create --title "$TITLE" --body-file "/tmp/tend-update-body.md"
+# Stash the pushed OID before the worktree goes. The poll below pins to the
+# commit this run pushed, and once the worktree is removed the main checkout's
+# `git rev-parse HEAD` resolves to the default branch — a different commit on a
+# different branch — leaving the PR head (which a sibling push retargets
+# mid-poll) or a retyped abbreviated OID as the only sources.
+git rev-parse HEAD > "/tmp/tend-update-sha"
 cd -
 git worktree remove "/tmp/tend-update-workflows" --force
+```
+
+Then poll that commit's checks per **CI Monitoring** in `/tend-ci-runner:running-in-ci` — foreground, `timeout: 600000`:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/scripts/poll-pr-checks.sh <pr-number> "$(cat /tmp/tend-update-sha)"
 ```
 
 ## Step 8: Fix findings

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -276,6 +276,9 @@ PINNED_SHA=$(git rev-parse HEAD)
 # In a review session, HEAD is the ephemeral refs/pull/N/merge commit, which
 # carries no rollup at all; pin the PR head instead:
 #   PINNED_SHA=$(gh pr view <number> --json headRefOid --jq '.headRefOid')
+# When the push happened in a /tmp worktree the recipe then removes, capture
+# the OID there — `git rev-parse HEAD > /tmp/<name>-sha` — before the removal.
+# Back in the main checkout HEAD is the default branch, not what you pushed.
 ${CLAUDE_PLUGIN_ROOT}/scripts/poll-pr-checks.sh <number> "$PINNED_SHA"
 ```
 


### PR DESCRIPTION
## Problem

Step 7 of the nightly skill commits and pushes the workflow regeneration inside `/tmp/tend-update-workflows`, opens the PR, then destroys that worktree. The poll that must follow — **CI Monitoring** in `running-in-ci` prescribes `PINNED_SHA=$(git rev-parse HEAD)` "after your own push" — has nowhere left to read the OID from: back in the main checkout `HEAD` is the default branch, a different commit on a different branch, so the prescribed derivation doesn't just fail, it returns a plausible wrong SHA. That leaves the PR head (which a sibling `tend-mention` push retargets mid-poll — the head-following source max-sixty/tend#965 removed from the poll itself) or the abbreviated OID retyped out of `git commit`'s output. Reported in #1118 with one observed occurrence of each route on a consumer repo.

## Solution

Stash the OID inside the worktree, before the removal, using the `/tmp` idiom the block already uses for `/tmp/tend-old-ver`, and point Step 7's poll at it so the next step has nothing to re-derive. Also names the worktree case in **CI Monitoring**'s `PINNED_SHA` block, which until now only spelled out the plain-checkout and review-merge-ref shapes.

## Testing

`test_nightly_regen_pins_its_poll_to_the_commit_it_pushed` in `generator/tests/test_cross_file_contracts.py` parses Step 7's ship block, requires a `git rev-parse HEAD > /tmp/...` capture ordered before `git worktree remove`, and requires the stashed path to reach a `poll-pr-checks.sh` invocation. It fails on `main` with "Step 7 pushes from the /tmp worktree and then removes it without recording the pushed OID" and passes here. Full `uv run pytest`: 881 passed. `pre-commit` clean on the changed files.

---
Closes #1118 — automated triage
