### PR TITLE
fix(notifications): acknowledge each resolved thread instead of the whole repository

### DIFF
--- a/generator/src/tend/templates/notifications-check.sh
+++ b/generator/src/tend/templates/notifications-check.sh
@@ -6,9 +6,9 @@
 # env: GITHUB_REPOSITORY, GITHUB_OUTPUT, GITHUB_TOKEN
 
 # Activity newer than this belongs to an event workflow that may still be
-# running. The same cutoff is passed to the agent and, once every older item has
-# a semantic outcome, to GitHub's repository-level mark-read endpoint. Newer
-# activity therefore cannot be acknowledged by this run.
+# running. The cutoff is passed to the agent, which acknowledges each thread it
+# resolves individually. Newer activity never enters the snapshot, so this run
+# cannot acknowledge it.
 CUTOFF=$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
 echo "cutoff=$CUTOFF" >> "$GITHUB_OUTPUT"
 

--- a/generator/src/tend/templates/notifications-check.sh
+++ b/generator/src/tend/templates/notifications-check.sh
@@ -6,9 +6,9 @@
 # env: GITHUB_REPOSITORY, GITHUB_OUTPUT, GITHUB_TOKEN
 
 # Activity newer than this belongs to an event workflow that may still be
-# running. The cutoff is passed to the agent, which acknowledges each thread it
-# resolves individually. Newer activity never enters the snapshot, so this run
-# cannot acknowledge it.
+# running. The cutoff bounds the snapshot below, which is passed to the agent;
+# the agent acknowledges each thread it resolves individually, so this run can
+# only acknowledge threads the snapshot returned.
 CUTOFF=$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
 echo "cutoff=$CUTOFF" >> "$GITHUB_OUTPUT"
 

--- a/generator/src/tend/templates/notifications-check.sh
+++ b/generator/src/tend/templates/notifications-check.sh
@@ -6,9 +6,9 @@
 # env: GITHUB_REPOSITORY, GITHUB_OUTPUT, GITHUB_TOKEN
 
 # Activity newer than this belongs to an event workflow that may still be
-# running. The cutoff bounds the snapshot below, which is passed to the agent;
-# the agent acknowledges each thread it resolves individually, so this run can
-# only acknowledge threads the snapshot returned.
+# running. The cutoff bounds the snapshot below and is the value passed to the
+# agent, which takes its own snapshot with it and acknowledges each thread it
+# resolves individually — so this run acknowledges only threads it examined.
 CUTOFF=$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
 echo "cutoff=$CUTOFF" >> "$GITHUB_OUTPUT"
 

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
@@ -41,9 +41,9 @@ jobs:
           # env: GITHUB_REPOSITORY, GITHUB_OUTPUT, GITHUB_TOKEN
 
           # Activity newer than this belongs to an event workflow that may still be
-          # running. The cutoff bounds the snapshot below, which is passed to the agent;
-          # the agent acknowledges each thread it resolves individually, so this run can
-          # only acknowledge threads the snapshot returned.
+          # running. The cutoff bounds the snapshot below and is the value passed to the
+          # agent, which takes its own snapshot with it and acknowledges each thread it
+          # resolves individually ? so this run acknowledges only threads it examined.
           CUTOFF=$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
           echo "cutoff=$CUTOFF" >> "$GITHUB_OUTPUT"
 

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
@@ -41,9 +41,9 @@ jobs:
           # env: GITHUB_REPOSITORY, GITHUB_OUTPUT, GITHUB_TOKEN
 
           # Activity newer than this belongs to an event workflow that may still be
-          # running. The same cutoff is passed to the agent and, once every older item has
-          # a semantic outcome, to GitHub's repository-level mark-read endpoint. Newer
-          # activity therefore cannot be acknowledged by this run.
+          # running. The cutoff is passed to the agent, which acknowledges each thread it
+          # resolves individually. Newer activity never enters the snapshot, so this run
+          # cannot acknowledge it.
           CUTOFF=$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
           echo "cutoff=$CUTOFF" >> "$GITHUB_OUTPUT"
 

--- a/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_fork_guard_rendered_shape_regtest[tend-notifications.yaml].out
@@ -41,9 +41,9 @@ jobs:
           # env: GITHUB_REPOSITORY, GITHUB_OUTPUT, GITHUB_TOKEN
 
           # Activity newer than this belongs to an event workflow that may still be
-          # running. The cutoff is passed to the agent, which acknowledges each thread it
-          # resolves individually. Newer activity never enters the snapshot, so this run
-          # cannot acknowledge it.
+          # running. The cutoff bounds the snapshot below, which is passed to the agent;
+          # the agent acknowledges each thread it resolves individually, so this run can
+          # only acknowledge threads the snapshot returned.
           CUTOFF=$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
           echo "cutoff=$CUTOFF" >> "$GITHUB_OUTPUT"
 

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[notifications].out
@@ -40,9 +40,9 @@ jobs:
           # env: GITHUB_REPOSITORY, GITHUB_OUTPUT, GITHUB_TOKEN
 
           # Activity newer than this belongs to an event workflow that may still be
-          # running. The same cutoff is passed to the agent and, once every older item has
-          # a semantic outcome, to GitHub's repository-level mark-read endpoint. Newer
-          # activity therefore cannot be acknowledged by this run.
+          # running. The cutoff is passed to the agent, which acknowledges each thread it
+          # resolves individually. Newer activity never enters the snapshot, so this run
+          # cannot acknowledge it.
           CUTOFF=$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
           echo "cutoff=$CUTOFF" >> "$GITHUB_OUTPUT"
 

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[notifications].out
@@ -40,9 +40,9 @@ jobs:
           # env: GITHUB_REPOSITORY, GITHUB_OUTPUT, GITHUB_TOKEN
 
           # Activity newer than this belongs to an event workflow that may still be
-          # running. The cutoff is passed to the agent, which acknowledges each thread it
-          # resolves individually. Newer activity never enters the snapshot, so this run
-          # cannot acknowledge it.
+          # running. The cutoff bounds the snapshot below, which is passed to the agent;
+          # the agent acknowledges each thread it resolves individually, so this run can
+          # only acknowledge threads the snapshot returned.
           CUTOFF=$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
           echo "cutoff=$CUTOFF" >> "$GITHUB_OUTPUT"
 

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_codex_regtest[notifications].out
@@ -40,9 +40,9 @@ jobs:
           # env: GITHUB_REPOSITORY, GITHUB_OUTPUT, GITHUB_TOKEN
 
           # Activity newer than this belongs to an event workflow that may still be
-          # running. The cutoff bounds the snapshot below, which is passed to the agent;
-          # the agent acknowledges each thread it resolves individually, so this run can
-          # only acknowledge threads the snapshot returned.
+          # running. The cutoff bounds the snapshot below and is the value passed to the
+          # agent, which takes its own snapshot with it and acknowledges each thread it
+          # resolves individually ? so this run acknowledges only threads it examined.
           CUTOFF=$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
           echo "cutoff=$CUTOFF" >> "$GITHUB_OUTPUT"
 

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
@@ -40,9 +40,9 @@ jobs:
           # env: GITHUB_REPOSITORY, GITHUB_OUTPUT, GITHUB_TOKEN
 
           # Activity newer than this belongs to an event workflow that may still be
-          # running. The same cutoff is passed to the agent and, once every older item has
-          # a semantic outcome, to GitHub's repository-level mark-read endpoint. Newer
-          # activity therefore cannot be acknowledged by this run.
+          # running. The cutoff is passed to the agent, which acknowledges each thread it
+          # resolves individually. Newer activity never enters the snapshot, so this run
+          # cannot acknowledge it.
           CUTOFF=$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
           echo "cutoff=$CUTOFF" >> "$GITHUB_OUTPUT"
 

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
@@ -40,9 +40,9 @@ jobs:
           # env: GITHUB_REPOSITORY, GITHUB_OUTPUT, GITHUB_TOKEN
 
           # Activity newer than this belongs to an event workflow that may still be
-          # running. The cutoff is passed to the agent, which acknowledges each thread it
-          # resolves individually. Newer activity never enters the snapshot, so this run
-          # cannot acknowledge it.
+          # running. The cutoff bounds the snapshot below, which is passed to the agent;
+          # the agent acknowledges each thread it resolves individually, so this run can
+          # only acknowledge threads the snapshot returned.
           CUTOFF=$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
           echo "cutoff=$CUTOFF" >> "$GITHUB_OUTPUT"
 

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_minimal_regtest[notifications].out
@@ -40,9 +40,9 @@ jobs:
           # env: GITHUB_REPOSITORY, GITHUB_OUTPUT, GITHUB_TOKEN
 
           # Activity newer than this belongs to an event workflow that may still be
-          # running. The cutoff bounds the snapshot below, which is passed to the agent;
-          # the agent acknowledges each thread it resolves individually, so this run can
-          # only acknowledge threads the snapshot returned.
+          # running. The cutoff bounds the snapshot below and is the value passed to the
+          # agent, which takes its own snapshot with it and acknowledges each thread it
+          # resolves individually ? so this run acknowledges only threads it examined.
           CUTOFF=$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
           echo "cutoff=$CUTOFF" >> "$GITHUB_OUTPUT"
 

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
@@ -40,9 +40,9 @@ jobs:
           # env: GITHUB_REPOSITORY, GITHUB_OUTPUT, GITHUB_TOKEN
 
           # Activity newer than this belongs to an event workflow that may still be
-          # running. The same cutoff is passed to the agent and, once every older item has
-          # a semantic outcome, to GitHub's repository-level mark-read endpoint. Newer
-          # activity therefore cannot be acknowledged by this run.
+          # running. The cutoff is passed to the agent, which acknowledges each thread it
+          # resolves individually. Newer activity never enters the snapshot, so this run
+          # cannot acknowledge it.
           CUTOFF=$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
           echo "cutoff=$CUTOFF" >> "$GITHUB_OUTPUT"
 

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
@@ -40,9 +40,9 @@ jobs:
           # env: GITHUB_REPOSITORY, GITHUB_OUTPUT, GITHUB_TOKEN
 
           # Activity newer than this belongs to an event workflow that may still be
-          # running. The cutoff is passed to the agent, which acknowledges each thread it
-          # resolves individually. Newer activity never enters the snapshot, so this run
-          # cannot acknowledge it.
+          # running. The cutoff bounds the snapshot below, which is passed to the agent;
+          # the agent acknowledges each thread it resolves individually, so this run can
+          # only acknowledge threads the snapshot returned.
           CUTOFF=$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
           echo "cutoff=$CUTOFF" >> "$GITHUB_OUTPUT"
 

--- a/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
+++ b/generator/tests/_regtest_outputs/test_generate.test_workflow_with_setup_regtest[notifications].out
@@ -40,9 +40,9 @@ jobs:
           # env: GITHUB_REPOSITORY, GITHUB_OUTPUT, GITHUB_TOKEN
 
           # Activity newer than this belongs to an event workflow that may still be
-          # running. The cutoff bounds the snapshot below, which is passed to the agent;
-          # the agent acknowledges each thread it resolves individually, so this run can
-          # only acknowledge threads the snapshot returned.
+          # running. The cutoff bounds the snapshot below and is the value passed to the
+          # agent, which takes its own snapshot with it and acknowledges each thread it
+          # resolves individually ? so this run acknowledges only threads it examined.
           CUTOFF=$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
           echo "cutoff=$CUTOFF" >> "$GITHUB_OUTPUT"
 

--- a/generator/tests/test_cross_file_contracts.py
+++ b/generator/tests/test_cross_file_contracts.py
@@ -27,12 +27,11 @@ def test_notification_skill_uses_one_paginated_cutoff_snapshot() -> None:
 def test_notification_skill_acknowledges_only_the_threads_it_resolved() -> None:
     """The acknowledgement is per thread, never repository-wide.
 
-    `PUT /repos/{owner}/{repo}/notifications` bounds itself on GitHub's own
-    notification timestamp, not the `updated_at` the list endpoint returns.
-    The bot's own activity bumps `updated_at` without re-notifying, so a
-    deferred thread whose in-flight workflow has since posted looks newer than
-    any cutoff derived from it and is marked read anyway. REST has no
-    "mark unread", so that overshoot is unrecoverable.
+    `PUT /repos/{owner}/{repo}/notifications` marks by timestamp rather than by
+    outcome, so it acts on threads the run never examined — including a thread
+    deferred because its dedicated workflow is still in flight. REST has no
+    "mark unread", so that overshoot is unrecoverable. Acknowledging exactly the
+    threads that reached an outcome needs no timestamp reasoning at all.
     """
     skill = _read("plugins", "tend-ci-runner", "skills", "notifications", "SKILL.md")
 

--- a/generator/tests/test_cross_file_contracts.py
+++ b/generator/tests/test_cross_file_contracts.py
@@ -24,16 +24,23 @@ def test_notification_skill_uses_one_paginated_cutoff_snapshot() -> None:
     assert "sort_by(.updated_at)" in skill
 
 
-def test_notification_skill_uses_a_bounded_repository_acknowledgement() -> None:
+def test_notification_skill_acknowledges_only_the_threads_it_resolved() -> None:
+    """The acknowledgement is per thread, never repository-wide.
+
+    `PUT /repos/{owner}/{repo}/notifications` bounds itself on GitHub's own
+    notification timestamp, not the `updated_at` the list endpoint returns.
+    The bot's own activity bumps `updated_at` without re-notifying, so a
+    deferred thread whose in-flight workflow has since posted looks newer than
+    any cutoff derived from it and is marked read anyway. REST has no
+    "mark unread", so that overshoot is unrecoverable.
+    """
     skill = _read("plugins", "tend-ci-runner", "skills", "notifications", "SKILL.md")
 
-    assert "repos/$GITHUB_REPOSITORY/notifications" in skill
-    assert 'last_read_at="$ACK_CUTOFF"' in skill
-    assert '"$UNRESOLVED_AT -1 second"' in skill
-    assert 'if [ -n "$UNRESOLVED_AT" ]; then' in skill
-    assert "else\n  ACK_CUTOFF=$CUTOFF" in skill
-    assert "Never acknowledge a same-repository thread individually." in skill
-    assert "notifications/threads/<thread-id>" in skill
+    assert 'gh api "notifications/threads/$THREAD_ID" -X PATCH' in skill
+    assert "repos/$GITHUB_REPOSITORY/notifications" not in skill
+    assert "-f last_read_at=" not in skill
+    assert "ACK_CUTOFF" not in skill
+    assert "Never acknowledge a thread before it has an outcome" in skill
 
 
 def test_notification_skill_pins_the_fragile_dedup_queries() -> None:

--- a/plugins/tend-ci-runner/skills/notifications/SKILL.md
+++ b/plugins/tend-ci-runner/skills/notifications/SKILL.md
@@ -9,7 +9,7 @@ metadata:
 
 Unread notifications are the recovery queue. Event workflows are the fast path; after a successful run they mark the notification that triggered them read. This poll handles whatever remains and repairs conflicts on the configured bot's PRs.
 
-The workflow prompt supplies the **notification snapshot cutoff**. This run owns unread activity before that time; activity at or after it stays unread.
+The workflow prompt supplies the **notification snapshot cutoff**. This run owns activity that became unread before that time; activity at or after it belongs to the next poll.
 
 ## 1. Snapshot the queue
 
@@ -23,6 +23,8 @@ jq '.[] | {id, reason, repo: .repository.full_name, updated_at,
   subject_type: .subject.type, subject_title: .subject.title,
   subject_url: .subject.url}' /tmp/tend-notifications.json
 ```
+
+A thread's `updated_at` can be later than the cutoff. `before` filters on when the thread became unread, while `updated_at` tracks the latest activity of any kind — including the bot's own, which bumps the thread without re-notifying. Those threads are the run's to handle; do not filter them back out.
 
 If the snapshot is empty and the prompt reports no possible conflicted PRs, exit.
 Otherwise continue; notification work still comes before conflict repair.
@@ -44,7 +46,7 @@ For each notification, identify the activity that made the thread unread and app
 
 Process the snapshot oldest first. Read the live issue or PR and decide what it needs now:
 
-- If a dedicated tend workflow is still running for the subject, defer it. Its `updated_at` limits the repository acknowledgement in Step 4.
+- If a dedicated tend workflow is still running for the subject, defer it. Step 4 leaves it unread for the next poll.
 - If the bot already handled the latest activity, record it as handled without posting again.
 - Otherwise use the normal live workflow: `/tend-ci-runner:triage` for an issue, `/tend-ci-runner:review` for an unreviewed PR head, or answer a comment or review thread that asks the bot for something.
 - A closed thread or a human conversation that needs nothing from the bot has the semantic outcome “no action”.
@@ -80,29 +82,17 @@ gh api "repos/$GITHUB_REPOSITORY/issues/$NUMBER/timeline?per_page=100" \
           and .created_at > $cutoff)] | length'
 ```
 
-After a cross-repository notification has an outcome, acknowledge that thread individually:
+## 4. Acknowledge each resolved thread
+
+Acknowledge a thread as soon as it has an outcome, one call per thread, same repository or not:
 
 ```bash
-gh api "notifications/threads/<thread-id>" -X PATCH
+gh api "notifications/threads/$THREAD_ID" -X PATCH --silent
 ```
 
-## 4. Acknowledge the cutoff
+Never acknowledge a thread before it has an outcome. A deferred or unresolved thread is left alone and the next poll picks it up.
 
-Set the acknowledgement cutoff from the oldest unresolved same-repository item. If every same-repository item has an outcome, use the snapshot cutoff. Otherwise set it to one second before the unresolved item's `updated_at`:
-
-```bash
-# $UNRESOLVED_AT is the first unresolved same-repository item's `updated_at`,
-# empty when every same-repository item has an outcome.
-if [ -n "$UNRESOLVED_AT" ]; then
-  ACK_CUTOFF=$(date -u -d "$UNRESOLVED_AT -1 second" +%Y-%m-%dT%H:%M:%SZ)
-else
-  ACK_CUTOFF=$CUTOFF
-fi
-gh api "repos/$GITHUB_REPOSITORY/notifications" -X PUT \
-  -f last_read_at="$ACK_CUTOFF" --silent
-```
-
-Skip the call when the unresolved item is the first same-repository item in the snapshot, or when the snapshot contains no same-repository items. The next poll starts with the unresolved item instead of repeating completed work. Never acknowledge a same-repository thread individually.
+Never acknowledge repository-wide (`PUT /repos/{owner}/{repo}/notifications`). Its `last_read_at` bounds on when each thread became unread, which is not the `updated_at` the snapshot shows, so no cutoff computed from a deferred thread's `updated_at` can spare it — and REST has no "mark unread" to walk the overshoot back.
 
 ## 5. Resolve possible conflicts
 
@@ -111,5 +101,5 @@ If the prompt reports possible conflicted PRs, load
 only. The count is a boot signal; the conflict skill re-reads and test-merges the
 current PR heads before changing a branch.
 
-Report the notifications handled, responses posted, items deferred, repository
-cutoff, and conflict outcomes.
+Report the notifications handled, responses posted, items deferred, threads
+acknowledged, and conflict outcomes.

--- a/plugins/tend-ci-runner/skills/notifications/SKILL.md
+++ b/plugins/tend-ci-runner/skills/notifications/SKILL.md
@@ -9,7 +9,7 @@ metadata:
 
 Unread notifications are the recovery queue. Event workflows are the fast path; after a successful run they mark the notification that triggered them read. This poll handles whatever remains and repairs conflicts on the configured bot's PRs.
 
-The workflow prompt supplies the **notification snapshot cutoff**. This run owns activity that became unread before that time; activity at or after it belongs to the next poll.
+The workflow prompt supplies the **notification snapshot cutoff**. This run owns whatever the snapshot returned; anything the snapshot did not return belongs to the next poll.
 
 ## 1. Snapshot the queue
 
@@ -24,7 +24,7 @@ jq '.[] | {id, reason, repo: .repository.full_name, updated_at,
   subject_url: .subject.url}' /tmp/tend-notifications.json
 ```
 
-A thread's `updated_at` can be later than the cutoff. `before` filters on when the thread became unread, while `updated_at` tracks the latest activity of any kind — including the bot's own, which bumps the thread without re-notifying. Those threads are the run's to handle; do not filter them back out.
+A thread's `updated_at` can be later than the cutoff. `before` is documented as filtering on `updated_at`, but threads bumped after they became unread — including by the bot's own activity, which bumps a thread without re-notifying — have been observed in snapshots taken minutes after the bump. Take the snapshot's membership as the run's scope rather than re-deriving it: whatever came back is this run's to handle, so do not filter it back out on `updated_at`.
 
 If the snapshot is empty and the prompt reports no possible conflicted PRs, exit.
 Otherwise continue; notification work still comes before conflict repair.
@@ -51,7 +51,7 @@ Process the snapshot oldest first. Read the live issue or PR and decide what it 
 - Otherwise use the normal live workflow: `/tend-ci-runner:triage` for an issue, `/tend-ci-runner:review` for an unreviewed PR head, or answer a comment or review thread that asks the bot for something.
 - A closed thread or a human conversation that needs nothing from the bot has the semantic outcome “no action”.
 - A non-conversational subject, such as a release or check suite, also has the outcome “no action”. Default-branch CI recovery belongs to the daily current-state scan.
-- A subject with no readable target — a `Discussion`, whose `subject.url` is null, or a deleted issue or PR, whose `subject.url` 404s — also has the outcome “no action”. Nothing makes it readable on a later poll, so leaving it unresolved would pin the Step 4 cutoff permanently. A read that fails for any other reason — a 5xx, a rate limit — leaves the item unresolved.
+- A subject with no readable target — a `Discussion`, whose `subject.url` is null, or a deleted issue or PR, whose `subject.url` 404s — also has the outcome “no action”. Nothing makes it readable on a later poll, so leaving it unresolved would hand it to every later poll to re-examine. A read that fails for any other reason — a 5xx, a rate limit — leaves the item unresolved.
 
 Judge deduplication from current state, including bot reviews and bot-authored PRs that cross-reference an issue. The notification timestamp alone does not prove whether a response covered the activity.
 
@@ -92,7 +92,7 @@ gh api "notifications/threads/$THREAD_ID" -X PATCH --silent
 
 Never acknowledge a thread before it has an outcome. A deferred or unresolved thread is left alone and the next poll picks it up.
 
-Never acknowledge repository-wide (`PUT /repos/{owner}/{repo}/notifications`). Its `last_read_at` bounds on when each thread became unread, which is not the `updated_at` the snapshot shows, so no cutoff computed from a deferred thread's `updated_at` can spare it — and REST has no "mark unread" to walk the overshoot back.
+Never acknowledge repository-wide (`PUT /repos/{owner}/{repo}/notifications`). It marks threads by timestamp rather than by outcome, so it acts on threads this run never examined — and REST has no "mark unread" to walk an overshoot back.
 
 ## 5. Resolve possible conflicts
 


### PR DESCRIPTION
`tend-notifications` Step 4 acknowledged the whole repository with `PUT /repos/{owner}/{repo}/notifications`, bounding the call one second below a deferred thread's `updated_at`. That makes the deferral a timestamp comparison GitHub controls rather than a decision the run makes: a repository-wide ack marks by timestamp, not by outcome, so it acts on threads the run never examined — and REST has no "mark unread" to walk an overshoot back. The thread it can drop is exactly the one the cutoff exists to spare: a subject whose dedicated workflow is still in flight, and which that workflow has since bumped.

Step 4 now PATCHes each thread that reached an outcome, one call per thread, same-repository or not, and leaves deferred and unresolved threads untouched. That deletes the cutoff arithmetic and the `Never acknowledge a same-repository thread individually` rule, whose real invariant — never acknowledge before an outcome — is now stated directly. Nothing in the rewritten skill rests on a claim about which timestamp either endpoint bounds on.

<details><summary>Evidence</summary>

The report (#1120) attributed this to two GitHub bugs. The divergences it saw are real but narrower than "the endpoints are broken", and one of its suggested changes would make things worse.

**What the reported run shows.** The snapshot was taken by the check step at `17:50:01Z` with `before=2026-08-31T17:40:00Z`, and returned six threads — including two whose `updated_at` had already reached their final values nine minutes earlier, so the divergence is not the snapshot being read back later:

| thread | PR | unread since | `prql-bot` review | thread `updated_at` |
|---|---|---|---|---|
| 25394372529 | PRQL/prql#6262 | 17:21:47 | 17:40:21 | 17:40:43 |
| 25394267616 | PRQL/prql#6259 | 17:15:10 | 17:44:11 | 17:44:34 |

Both became unread before the cutoff and were bumped past it by the bot's own reviews, which do not re-notify. [List notifications](https://docs.github.com/en/rest/activity/notifications) documents `before` as "Only show notifications updated before the given time", and the repository-wide PUT documents `last_read_at` as "Anything updated since this time will not be marked as read" — under those semantics neither thread should have been returned by the snapshot, and neither should have been marked read by the PUT. Both were.

**The boundary behaves as documented when nothing was bumped.** Neither probe reproduces the divergence in isolation:

```
$ gh api "notifications?all=true&before=2026-08-31T06:00:00Z&per_page=5" --paginate --slurp \
    | jq '[add // [] | .[] | .updated_at] | sort | {n: length, newest: .[-1]}'
{ "n": 494, "newest": "2026-08-31T05:53:40Z" }
```

`PUT /repos/max-sixty/tend/notifications` with `last_read_at=2026-08-31T17:00:00Z` returned `205 Reset Content`, and the one thread updated after it stayed unread across a minute of rechecks:

```
{"id":"25394889617","last_read_at":null,"unread":true,"updated_at":"2026-08-31T17:55:10Z"}
```

Neither probe covers the case that diverged — a thread bumped after it became unread and before the call — so the underlying semantics stay unsettled, and this PR does not try to settle them. Acknowledging exactly the threads that reached an outcome needs no timestamp reasoning at all, which is why it is the right shape under either reading.

**Why the report's other suggestion is not taken.** Filtering the snapshot client-side on `updated_at < $CUTOFF` would have dropped both threads above, which the run did own and did handle. Step 1 now records the observation — a returned thread's `updated_at` can be past the cutoff — and says to take the snapshot's membership as the run's scope rather than re-deriving it.

</details>

---
Closes #1120 — automated triage
