### PR TITLE
fix(review-runs): inherit errexit so a failed gh call can't shrink the corrections window

### DIFF
--- a/generator/tests/test_review_runs_corrections.py
+++ b/generator/tests/test_review_runs_corrections.py
@@ -45,9 +45,17 @@ case "$*" in
     [ -n "${SEARCH_FAILS:-}" ] && { echo "API rate limit exceeded" >&2; exit 1; }
     emit "$(cat "$CANDIDATES_JSON")" ;;
   "pr list"*)              emit "$(cat "$BOT_PRS_JSON")" ;;
-  *"/issues/comments"*)    emit "$(cat "$ISSUE_COMMENTS_JSON")" ;;
+  *"/issues/comments"*)
+    [ -n "${ISSUE_COMMENTS_FAILS:-}" ] && { echo "502 Bad Gateway" >&2; exit 1; }
+    emit "$(cat "$ISSUE_COMMENTS_JSON")" ;;
   *"/pulls/comments"*)     emit "$(cat "$PR_COMMENTS_JSON")" ;;
-  *"/pulls/"*"/reviews"*)  emit "$(cat "$REVIEWS_JSON")" ;;
+  # Unset, the placeholder matches no numeric PR path.
+  *"/pulls/"*"/reviews"*)
+    case "$*" in
+      *"/pulls/${REVIEWS_FAIL_FOR:-none}/reviews"*)
+        echo "502 Bad Gateway" >&2; exit 1 ;;
+    esac
+    emit "$(cat "$REVIEWS_JSON")" ;;
   *) exit 1 ;;
 esac
 """
@@ -150,6 +158,39 @@ def test_a_failed_candidate_search_aborts_rather_than_reporting_no_reviews(
     the call most likely to fail — and inline in the `for` list its failure is
     invisible to `set -e`, leaving `reviews: []` to read as an all-clear."""
     env["SEARCH_FAILS"] = "1"
+
+    result = _run(env, SINCE)
+
+    assert result.returncode != 0
+    assert result.stdout == ""
+
+
+def test_a_failed_comment_endpoint_aborts_rather_than_reporting_the_other_half(
+    env: dict[str, str],
+) -> None:
+    """Both comment endpoints are read in one loop inside a command substitution.
+
+    Bash applies `-e` there only under `inherit_errexit`, and `pipefail` sees
+    just the loop's final iteration — so a dropped `issues` page would leave
+    every conversation comment out of a report that still exits 0.
+    """
+    _write(env, "PR_COMMENTS_JSON", [_comment(IN_WINDOW)])
+    env["ISSUE_COMMENTS_FAILS"] = "1"
+
+    result = _run(env, SINCE)
+
+    assert result.returncode != 0
+    assert result.stdout == ""
+
+
+def test_a_failed_review_fetch_aborts_rather_than_dropping_that_prs_reviews(
+    env: dict[str, str],
+) -> None:
+    """One `gh` call per candidate PR, in that same loop: a failure on any but
+    the last would drop that PR's reviews and report the rest as the window."""
+    _write(env, "CANDIDATES_JSON", [{"number": 1}, {"number": 2}])
+    _write(env, "REVIEWS_JSON", [_review(IN_WINDOW)])
+    env["REVIEWS_FAIL_FOR"] = "1"
 
     result = _run(env, SINCE)
 

--- a/plugins/tend-ci-runner/scripts/review-runs-corrections.sh
+++ b/plugins/tend-ci-runner/scripts/review-runs-corrections.sh
@@ -23,6 +23,11 @@
 # env: GITHUB_REPOSITORY (optional; falls back to the checkout's remote)
 
 set -euo pipefail
+# Bash does not apply `-e` inside a command substitution unless this is on,
+# and every collection below is one. Without it a `gh` call that fails in any
+# but the last iteration of a loop is dropped from the JSON and the run
+# reports the remainder as the whole window.
+shopt -s inherit_errexit
 
 SINCE="${1:-}"
 if [ -z "$SINCE" ]; then
@@ -65,11 +70,10 @@ COMMENTS=$(
 # wraps around a standalone inline reply, which would otherwise report a
 # correction on every thread where anyone replied inline.
 #
-# The candidate list is its own assignment because `set -e` checks an
-# assignment's command substitution but not a `for` word list's: inline, a
-# failed `--search` — the search API's 30 req/min, not the 5000/h core budget —
-# would yield an empty list, skip the loop, and report `reviews: []` as an
-# all-clear.
+# The candidate list is its own assignment because a `for` word list is the one
+# place `inherit_errexit` does not reach: inline, a failed `--search` — the
+# search API's 30 req/min, not the 5000/h core budget — would yield an empty
+# list, skip the loop, and report `reviews: []` as an all-clear.
 CANDIDATES=$(gh pr list --repo "$REPO" --state all --limit 200 \
   --search "updated:>=$SINCE" --json number --jq '.[].number')
 REVIEWS=$(


### PR DESCRIPTION
`review-runs-corrections.sh` collects the maintainer-correction signals that Step 4 of `review-runs` turns into "no maintainer corrections" in the tracking issue — which later runs read as ground truth under Gate 1. Two of its three collections loop `gh` calls inside a command substitution, and bash does not apply `set -e` inside one unless `inherit_errexit` is set. A `gh` failure in any but the final iteration was therefore dropped from the JSON while the script still exited 0, reporting the surviving iterations as the whole window.

The fix is `shopt -s inherit_errexit` next to the existing `set -euo pipefail`, so every command substitution in the script aborts on a failed call rather than each collection needing its own guard.

Two regression tests, both failing before the change and passing after:

- a 502 on the `issues/comments` endpoint (the first of the two the loop reads) — previously exited 0 with only the `pulls/comments` half present
- a 502 on the first of two candidate PRs' `reviews` — previously exited 0 with only the second PR's reviews present

<details><summary>Why the existing guard didn't cover this</summary>

The script already reasons about `set -e` and this loop. Its comment above `CANDIDATES` explains that the candidate list is pulled into its own assignment because a failed `--search` inline in the `for` *word list* is invisible to `set -e`, and `test_a_failed_candidate_search_aborts_rather_than_reporting_no_reviews` pins that. That guard is correct and unchanged — but it covers the word list, not the loop *bodies*, which are the calls this PR fixes.

The distinction is `inherit_errexit`, not `pipefail`. `pipefail` does propagate the loop's status out of the pipeline, so a failure on the **last** iteration was already caught; only earlier iterations were silently dropped. The observed asymmetry:

```
$ bash -c 'set -euo pipefail; O=$(for i in 1 2 3; do
    if [ "$i" = 2 ]; then cat /nope 2>/dev/null; else echo "$i"; fi
  done | tr "\n" ","); echo "REACHED [$O]"'
REACHED [1,3,]        # exit 0

$ bash -c 'set -euo pipefail; shopt -s inherit_errexit; ...same...'
                      # exit 1
```

The pre-fix test output shows the real shape — the script emitted a complete-looking payload (`"reviews": []`, comments missing one endpoint) on stdout with `502 Bad Gateway` on stderr and status 0.

`review-runs-corrections.sh` is the only script in the repo with this shape; the other nine under `plugins/tend-ci-runner/scripts/` have no multi-command substitution, so the change is scoped to this file.

</details>

Verified with `uv run pytest` (884 passed).
