### PR TITLE
docs(CLAUDE.md): name the lint command that works in the CI sandbox

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -9,7 +9,7 @@ metadata:
 
 ## Steps
 
-1. **Sync the release branch, then run tests and lints**: The `release` branch is long-lived and may sit behind `main` (or carry leftover state) when a cycle starts. Basing the changelog on a stale branch silently drops any commit merged to `main` after the branch was last realigned — `git log <last-version>..HEAD` won't show it. Bring it current first: `git fetch origin && git merge origin/main` (resolve any conflicts; if `release` has no commits of its own, `git reset --hard origin/main` instead). Then `wt test` and `pre-commit run --all-files`.
+1. **Sync the release branch, then run tests and lints**: The `release` branch is long-lived and may sit behind `main` (or carry leftover state) when a cycle starts. Basing the changelog on a stale branch silently drops any commit merged to `main` after the branch was last realigned — `git log <last-version>..HEAD` won't show it. Bring it current first: `git fetch origin && git merge origin/main` (resolve any conflicts; if `release` has no commits of its own, `git reset --hard origin/main` instead). Then `wt test` and `uv tool run pre-commit run --all-files`.
 2. **Check current version**: Read `version` in `generator/pyproject.toml`
 3. **Review commits**: `git log <last-version>..origin/main --oneline` to understand scope — against `origin/main` (not `HEAD`), so the range is the full set of commits this release ships even if step 1 was skipped
 4. **Confirm version with user**: Present changes summary and proposed version

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,10 @@ typecheck. Its arguments narrow pytest and nothing else, so a filtered run
 still pays for worker/; `uv run pytest -k render`
 is the Python half on its own.
 
+`pre-commit` is not on the CI sandbox's PATH. A tend session runs the lint gate
+as `uv tool run pre-commit run --all-files`; a narrower substitute (ruff alone,
+shellcheck alone) skips typos, actionlint and uv-lock.
+
 ## Architecture
 
 Four pieces:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,12 +21,12 @@ over refining it.
 ## Commands
 
 ```bash
-wt test                            # everything: uv run pytest, then worker/'s vitest
-uv run pytest                      # the Python half alone, from the repo root
-uvx tend@latest init               # regenerate workflows from .config/tend.yaml
-uvx tend@latest init --dry-run     # preview without writing
-uvx tend@latest check              # verify branch protection, secrets, bot access
-pre-commit run --all-files         # lint: ruff, typos, actionlint, shellcheck, uv-lock
+wt test                                # everything: uv run pytest, then worker/'s vitest
+uv run pytest                          # the Python half alone, from the repo root
+uvx tend@latest init                   # regenerate workflows from .config/tend.yaml
+uvx tend@latest init --dry-run         # preview without writing
+uvx tend@latest check                  # verify branch protection, secrets, bot access
+uv tool run pre-commit run --all-files # lint: every hook in .pre-commit-config.yaml
 ```
 
 The repo root is a uv workspace, and pytest run from it collects every Python
@@ -37,9 +37,11 @@ typecheck. Its arguments narrow pytest and nothing else, so a filtered run
 still pays for worker/; `uv run pytest -k render`
 is the Python half on its own.
 
-`pre-commit` is not on the CI sandbox's PATH. A tend session runs the lint gate
-as `uv tool run pre-commit run --all-files`; a narrower substitute (ruff alone,
-shellcheck alone) skips typos, actionlint and uv-lock.
+`pre-commit` is not on the CI sandbox's PATH, which is why the lint command
+above carries the `uv tool run` prefix; a narrower substitute (ruff alone,
+shellcheck alone) skips ten of the thirteen hooks, including the three
+`repo: local` guards — the bang-backtick check, the install-tend mirror sync,
+and the `sandbox_env` reserved-set parity check.
 
 ## Architecture
 


### PR DESCRIPTION
`pre-commit` is not on the CI sandbox's PATH, but CLAUDE.md's Commands block names bare `pre-commit run --all-files` as the lint gate — so a tend session that follows it gets `command not found`. Three sessions hit that in the last 24 h; two recovered with `uv tool run pre-commit`, one substituted ruff plus shellcheck and ran a narrower gate than the repo's. The Commands block now carries `uv tool run pre-commit run --all-files` — the one form that works in both a human checkout and the sandbox — and the paragraph below it says why the prefix is there and what a narrower substitute costs: ten of the thirteen hooks, including the three `repo: local` guards. `.claude/skills/release/SKILL.md`'s lint step takes the same prefix.

<details><summary>Evidence, verification, and the alternative I didn't take</summary>

**Verified live from inside the sandbox** (this run, as `tend-sandbox`): `command -v pre-commit` is empty; `command -v uv` is `/opt/hostedtoolcache/uv/0.12.8/x86_64/uv`; `uv tool run pre-commit --version` prints `pre-commit 4.6.2`.

**Occurrences in the window** `2026-08-31T07:50:43Z → 2026-09-01T07:49Z`, from the session JSONL of each run:

| Run | Workflow | What happened |
|---|---|---|
| [33423814339](https://github.com/max-sixty/tend/actions/runs/33423814339) | `tend-mention` (#1121) | `pre-commit run --all-files` → `/usr/bin/bash: line 1: pre-commit: command not found`, then retried as `uv tool run pre-commit` |
| [33425029498](https://github.com/max-sixty/tend/actions/runs/33425029498) | `tend-mention` (#1121) | same `command not found`, same recovery; its summary notes "via `uv tool run` — `pre-commit` isn't on PATH in this sandbox" |
| [33479300709](https://github.com/max-sixty/tend/actions/runs/33479300709) | `tend-review` (#1124) | same `command not found`, **no retry** — substituted `uv run ruff check` + `ruff format --check` and a standalone shellcheck, so `typos`, `actionlint` and `uv-lock` went unrun |

Three further sessions ([33424356768](https://github.com/max-sixty/tend/actions/runs/33424356768), [33440961515](https://github.com/max-sixty/tend/actions/runs/33440961515), [33442043938](https://github.com/max-sixty/tend/actions/runs/33442043938)) plus `tend-nightly` [33478582882](https://github.com/max-sixty/tend/actions/runs/33478582882) went straight to `uv tool run pre-commit` without trying the bare form — the workaround is already in circulation, just not written down. The overlay's own weekly recipe already uses `uv tool run pre-commit autoupdate` at `.claude/skills/running-tend/SKILL.md:196`.

**Classification.** Structural — the same conditions produce the same failure every session. Cost class: **waste** this window; no wrong outward action occurred. Run 33479300709 did not claim `pre-commit` passed (its review said "shellcheck clean on the script", which is accurate), so nothing false was posted. The remedy is one paragraph in a file that already exists, which is why it clears Gate 3 despite the waste class.

**The alternative, and why not.** `sandbox_setup: ["uv tool install pre-commit"]` in `.config/tend.yaml` would put the binary on the sandbox PATH, which is the shape [#691](https://github.com/max-sixty/tend/pull/691) was steered toward ("should we install into our environment in the workflow, rather than having the agent do it?"). It's repo-level, so it would run on every agent boot — including the ~11 `tend-notifications` sessions a day that never lint — to spare a four-word prefix on the few that do. That trade reads the wrong way against "Simplicity outranks efficiency", so I've left the knob to you rather than taking it.

**Verification of this change:** `uv tool run pre-commit run --files CLAUDE.md` passes (`typos`, `ruff format`, the plugin-skill and install-tend sync hooks all green); `uv run pytest` is 882 passed.

</details>

