### PR TITLE
fix(codex): pass the OpenAI key through env, not into the run body

### DIFF
--- a/codex/action.yaml
+++ b/codex/action.yaml
@@ -144,8 +144,10 @@ runs:
     # prerelease only for a fix that hasn't been released yet.
     - name: Install Codex CLI
       shell: bash
+      env:
+        CODEX_VERSION: ${{ inputs.codex_version }}
       run: |
-        npm install -g "@openai/codex@${{ inputs.codex_version }}"
+        npm install -g "@openai/codex@$CODEX_VERSION"
         codex --version
 
     # Install the tend-ci-runner plugin from the action's own checkout.

--- a/codex/action.yaml
+++ b/codex/action.yaml
@@ -111,10 +111,18 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
 
+    # The key arrives through `env:`, not `${{ }}` in the body. GitHub
+    # substitutes an expression into the script *text* before bash parses it,
+    # so a secret carrying a quote or a `$(…)` — a mistyped value is the
+    # realistic path — is executed as script rather than compared as a string,
+    # under the runner user that holds the real PAT. The Claude harness already
+    # passes all three of its credentials this way.
     - name: Validate auth configured
       shell: bash
+      env:
+        OPENAI_API_KEY: ${{ inputs.openai_api_key }}
       run: |
-        if [ -z "${{ inputs.openai_api_key }}" ]; then
+        if [ -z "$OPENAI_API_KEY" ]; then
           echo "::error::OPENAI_API_KEY is unset. Set the OPENAI_API_KEY repo secret."
           exit 1
         fi

--- a/generator/tests/test_repo_pins.py
+++ b/generator/tests/test_repo_pins.py
@@ -179,3 +179,41 @@ def test_inline_run_bodies_pass_shellcheck(action: str) -> None:
             findings.append(f"--- {action} :: {name}\n{result.stdout}")
 
     assert not findings, "\n".join(findings)
+
+
+# Inputs whose value is a credential. Matched by name so an input added later
+# is covered without anyone remembering this test exists — every credential
+# either action takes is named for what it is (`github_token`,
+# `anthropic_api_key`, `claude_code_oauth_token`, `openai_api_key`).
+CREDENTIAL_INPUT = re.compile(r"(_token|_key|secret|password)$")
+INPUT_REF = re.compile(r"\$\{\{\s*inputs\.([A-Za-z0-9_]+)\s*\}\}")
+
+
+@pytest.mark.parametrize("action", ACTIONS)
+def test_credential_inputs_reach_run_bodies_through_env(action: str) -> None:
+    """A credential must not be interpolated into an inline `run:` body.
+
+    GitHub substitutes `${{ … }}` into the script *text* before bash parses it,
+    so a secret carrying a quote or `$(…)` stops being a string being compared
+    and becomes script executing as the runner user — which holds the real PAT
+    and, under codex, the model key. Through `env:` the value is passed to the
+    process, never to the parser. Nothing else catches this: shellcheck sees
+    the placeholder the sibling test substitutes in, and actionlint does not
+    read action.yaml at all.
+    """
+    doc = YAML(typ="safe", pure=True).load((REPO_ROOT / action).read_text())
+
+    credentials = {n for n in doc["inputs"] if CREDENTIAL_INPUT.search(n)}
+    assert credentials, f"{action}: no credential-shaped inputs — did they rename?"
+
+    inlined = [
+        f"{step.get('name', '<unnamed>')} inlines inputs.{name}"
+        for step in doc["runs"]["steps"]
+        if "run" in step
+        for name in sorted(set(INPUT_REF.findall(step["run"])))
+        if name in credentials
+    ]
+    assert not inlined, (
+        f"{action}: pass these through the step's `env:` instead of `${{{{ }}}}` "
+        f"in the body: {inlined}"
+    )

--- a/generator/tests/test_repo_pins.py
+++ b/generator/tests/test_repo_pins.py
@@ -181,12 +181,20 @@ def test_inline_run_bodies_pass_shellcheck(action: str) -> None:
     assert not findings, "\n".join(findings)
 
 
-# Inputs whose value is a credential. Matched by name so an input added later
-# is covered without anyone remembering this test exists — every credential
-# either action takes is named for what it is (`github_token`,
-# `anthropic_api_key`, `claude_code_oauth_token`, `openai_api_key`).
-CREDENTIAL_INPUT = re.compile(r"(_token|_key|secret|password)$")
-INPUT_REF = re.compile(r"\$\{\{\s*inputs\.([A-Za-z0-9_]+)\s*\}\}")
+# Inputs whose value is secret. Matched by name suffix so an input added later
+# is covered without anyone remembering this test exists, which holds while
+# credentials keep being named for what they are (`github_token`,
+# `anthropic_api_key`, `claude_code_oauth_token`, `openai_api_key`). The one
+# input that needed the convention widened for it is `memory_gist_id`: it comes
+# from a repo secret and grants read/write to the bot's memory gist, so
+# `gist_id` joins the suffixes rather than the test skipping it.
+CREDENTIAL_INPUT = re.compile(r"(_token|_key|secret|password|gist_id)$")
+# Anchoring on `${{ … }}` would match the bare reference alone, letting
+# `${{ inputs.x || '' }}` and `${{ format('{0}', inputs.x) }}` through. Any
+# `inputs.<name>` in a `run:` body is necessarily a GHA expression — bash has no
+# such syntax — so the unanchored match is both simpler and strictly broader.
+# (`inputs['x']` index syntax is missed either way.)
+INPUT_REF = re.compile(r"inputs\.([A-Za-z0-9_]+)")
 
 
 @pytest.mark.parametrize("action", ACTIONS)

--- a/generator/tests/test_repo_pins.py
+++ b/generator/tests/test_repo_pins.py
@@ -181,14 +181,6 @@ def test_inline_run_bodies_pass_shellcheck(action: str) -> None:
     assert not findings, "\n".join(findings)
 
 
-# Inputs whose value is secret. Matched by name suffix so an input added later
-# is covered without anyone remembering this test exists, which holds while
-# credentials keep being named for what they are (`github_token`,
-# `anthropic_api_key`, `claude_code_oauth_token`, `openai_api_key`). The one
-# input that needed the convention widened for it is `memory_gist_id`: it comes
-# from a repo secret and grants read/write to the bot's memory gist, so
-# `gist_id` joins the suffixes rather than the test skipping it.
-CREDENTIAL_INPUT = re.compile(r"(_token|_key|secret|password|gist_id)$")
 # Anchoring on `${{ … }}` would match the bare reference alone, letting
 # `${{ inputs.x || '' }}` and `${{ format('{0}', inputs.x) }}` through. Any
 # `inputs.<name>` in a `run:` body is necessarily a GHA expression — bash has no
@@ -198,28 +190,27 @@ INPUT_REF = re.compile(r"inputs\.([A-Za-z0-9_]+)")
 
 
 @pytest.mark.parametrize("action", ACTIONS)
-def test_credential_inputs_reach_run_bodies_through_env(action: str) -> None:
-    """A credential must not be interpolated into an inline `run:` body.
+def test_inputs_reach_run_bodies_through_env(action: str) -> None:
+    """An input must not be interpolated into an inline `run:` body.
 
     GitHub substitutes `${{ … }}` into the script *text* before bash parses it,
-    so a secret carrying a quote or `$(…)` stops being a string being compared
-    and becomes script executing as the runner user — which holds the real PAT
-    and, under codex, the model key. Through `env:` the value is passed to the
-    process, never to the parser. Nothing else catches this: shellcheck sees
-    the placeholder the sibling test substitutes in, and actionlint does not
-    read action.yaml at all.
+    so a value carrying a quote or `$(…)` stops being a string and becomes
+    script executing as the runner user — which holds the real PAT and, under
+    codex, the model key. Through `env:` the value is passed to the process,
+    never to the parser. Nothing else catches this: shellcheck sees the
+    placeholder the sibling test substitutes in, and actionlint does not read
+    action.yaml at all.
+
+    Every input in both actions already arrives this way, so the rule is a flat
+    ban rather than a list of which values are secret enough to deserve it.
     """
     doc = YAML(typ="safe", pure=True).load((REPO_ROOT / action).read_text())
-
-    credentials = {n for n in doc["inputs"] if CREDENTIAL_INPUT.search(n)}
-    assert credentials, f"{action}: no credential-shaped inputs — did they rename?"
 
     inlined = [
         f"{step.get('name', '<unnamed>')} inlines inputs.{name}"
         for step in doc["runs"]["steps"]
         if "run" in step
         for name in sorted(set(INPUT_REF.findall(step["run"])))
-        if name in credentials
     ]
     assert not inlined, (
         f"{action}: pass these through the step's `env:` instead of `${{{{ }}}}` "


### PR DESCRIPTION
The Codex harness's `Validate auth configured` step interpolated the OpenAI key straight into the shell script body — `if [ -z "${{ inputs.openai_api_key }}" ]`. GitHub substitutes an expression into the script *text* before bash ever parses it, so the value isn't a string being compared; it's script. This passes the key through the step's `env:` instead, which is how the Claude harness already handles all three of its credentials, and adds a test that fails on any `inputs.<name>` interpolated into an inline `run:` body in either action.

Found during the nightly rolling survey of `codex/action.yaml` — not from an observed failure.

<details><summary>Why it matters, and why nothing caught it</summary>

**The failure.** A key whose value contains a quote or a `$(…)` stops being compared and starts executing, as the `runner` user — which under `codex` holds the real PAT and the model key in its own environment. The realistic path is a mistyped or mis-pasted secret rather than a hostile one, since the value comes from the adopter's own repo secret; the consequence is the same either way, and the step runs before any other codex step.

**The scope.** `openai_api_key` was the only credential inlined across both actions — an outlier, not a pattern. Everything else already goes through `env:`:

| action | credential inputs | reached a `run:` body inline |
| --- | --- | --- |
| `claude/action.yaml` | `github_token`, `anthropic_api_key`, `claude_code_oauth_token` | none |
| `codex/action.yaml` | `github_token`, `openai_api_key` | `openai_api_key` |

**Why no existing check saw it.** actionlint doesn't read `action.yaml` at all (it parses one as a malformed workflow), and the sibling `test_inline_run_bodies_pass_shellcheck` substitutes every `${{ … }}` for an opaque `${_GHA_EXPR}` before handing the body to shellcheck — deliberately, so shellcheck reports on the code rather than the placeholder, but it means the interpolation itself is invisible there.

**The test.** [`test_inputs_reach_run_bodies_through_env`](https://github.com/max-sixty/tend/blob/6086574f1dded3e0349c24910b86f896c0439881/generator/tests/test_repo_pins.py#L193) in `generator/tests/test_repo_pins.py`, parametrized over both actions. It bans *any* `inputs.<name>` from an inline `run:` body rather than matching credential-shaped names, so nothing depends on a future input being named for what it holds. That flat rule is only possible because the one input still reaching a body — `codex_version`, in `Install Codex CLI` — moves to `env:` here too; with it gone the earlier suffix convention and its comment delete outright.

**Verification.** `uv run pytest` — 887 passed. `uv tool run pre-commit run --all-files` — all 13 hooks pass. The guard fails on either pre-fix body: on the original `openai_api_key` inline, and (checked by stashing the action) on `Install Codex CLI inlines inputs.codex_version`. No live codex session exercised it: no `OPENAI_API_KEY` reaches this repo's runs, so the auth step's behavior on a *set* key is unverified here; the empty-key branch is unchanged in shape and the `env:` form is what `claude/action.yaml` already ships. The `npm install -g "@openai/codex@$CODEX_VERSION"` rewrite is likewise unexercised here — CI's `test-codex-surface` job installs the pin through its own path, not through this step.

</details>
