### PR TITLE
skills: gate sweep-found fixes on reachability, and stop tests pinning undefined behavior

### DIFF
--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -141,7 +141,7 @@ Used by both Step 4 (applied to recent diffs) and Step 6 (applied to full files)
 - Stale or incorrect documentation (comments, docstrings that no longer match behavior)
 - Missing test coverage for non-trivial logic
 
-A bug finding earns a PR only where a caller can reach it. For a defect found by reading rather than from an observed failure, name the in-repo call path that triggers it. If no caller can, the finding is a note in the Step 9 summary, not a PR — `pub` visibility doesn't clear the bar on its own, since an item exported incidentally (a utility module under a default-on feature) promises nothing to anyone. Where it *is* part of a published library's documented surface, the fix stands: say so in the PR body, naming the contract rather than the visibility keyword.
+A bug finding earns a PR only where a caller can reach it. For a defect found by reading rather than from an observed failure, name the in-repo call path that triggers it. If no caller can, the finding is a note in the Step 9 summary, not a PR — public visibility doesn't clear the bar on its own, since an item exported incidentally (a utility module under a default-on feature) promises nothing to anyone. Where it *is* part of a published library's documented surface, the fix stands: say so in the PR body, naming the contract rather than the visibility keyword.
 
 **Convention compliance (from CLAUDE.md and project skills):**
 - Code patterns that violate conventions stated in the project's CLAUDE.md

--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -141,6 +141,8 @@ Used by both Step 4 (applied to recent diffs) and Step 6 (applied to full files)
 - Stale or incorrect documentation (comments, docstrings that no longer match behavior)
 - Missing test coverage for non-trivial logic
 
+A bug finding earns a PR only where a caller can reach it. For a defect found by reading rather than from an observed failure, name the in-repo call path that triggers it. If no caller can, the finding is a note in the Step 9 summary, not a PR — `pub` visibility doesn't clear the bar on its own, since an item exported incidentally (a utility module under a default-on feature) promises nothing to anyone. Where it *is* part of a published library's documented surface, the fix stands: say so in the PR body, naming the contract rather than the visibility keyword.
+
 **Convention compliance (from CLAUDE.md and project skills):**
 - Code patterns that violate conventions stated in the project's CLAUDE.md
 - Stale CLAUDE.md entries — conventions that reference renamed files, deleted functions, or outdated patterns

--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -164,6 +164,7 @@ Check the project's CLAUDE.md for language-specific review criteria and conventi
 **Testing:**
 
 - Are the changes adequately tested?
+- Where a doc comment and the code disagree, the finding is which one is wrong — don't suggest a test that pins the current output, which freezes behavior nobody has called intended.
 
 **Same pattern elsewhere:**
 

--- a/plugins/tend-ci-runner/skills/triage/SKILL.md
+++ b/plugins/tend-ci-runner/skills/triage/SKILL.md
@@ -98,6 +98,10 @@ When the bug is about bot behavior (e.g., "bot didn't use links", "bot posted wr
 
 If the proposed change removes coverage for the failing scenario instead of restoring the assertion, stop. Smell patterns: a newly-added early-return at the top of the test (`let Ok(_) = X else { return };`, `if !path.exists() { return; }`), a fresh `#[ignore]`, a newly-inserted `skipIf` / `pytest.skip` keyed on the failing condition. The fix belongs in production code or test setup, not in a guard that makes the test bail when the bug fires.
 
+### Don't pin undefined behavior in a test
+
+When a doc claim and the code disagree and which of the two is wrong is still an open question, the finding *is* that question. A test asserting the current output settles it without the authority to — it turns unspecified behavior into a pinned contract, so the eventual fix arrives looking like a regression. Report the discrepancy and let a maintainer say which side moves; write the test after that.
+
 ### Defer to in-flight same-root-cause PRs
 
 Step 3's duplicate check catches identical fixes. It misses the *same root cause class, different surface* pattern: several failing tests share one underlying cause, and an outstanding PR fixes some of them but not the one being triaged. When the triage analysis itself names an existing PR as same-root-cause, that's the signal to wait for it to merge and re-run, or to mirror its approach for the remaining sites — not to open a parallel narrow workaround.


### PR DESCRIPTION
A nightly sweep on PRQL opened [PRQL/prql#6250](https://github.com/PRQL/prql/pull/6250) for a real vector-sizing mismatch that no in-repo caller can trigger, and the collaborator rejected it: "While the change might fix theoretical future problems, it's not fixing a current problem." Nothing in the bundled skills asked the sweep to check that. `nightly`'s review checklist leads with "Bugs, logic errors, unhandled edge cases" and carries no reachability test; `running-in-ci`'s **Weighing a Fix** raises the bar only for compute-saving changes, and `triage`'s reproduction gate never applies because a sweep has no report to reproduce. Reported by the PRQL bot in #1133.

Three lines of guidance, no new machinery:

- **`nightly`** — a gate on the checklist's bug line. Before a sweep-found defect becomes a PR, name the in-repo call path that reaches it. If none does, the finding is a note in the Step 9 summary. public visibility doesn't clear the bar on its own; a documented public surface on a published library does, and the PR body should name the contract rather than the keyword.
- **`triage`** — a fix-quality gate beside the existing "Don't 'fix' tests by adding skip guards". When a doc claim and the code disagree and which is wrong is still open, the finding *is* that question; a test pinning the current output turns unspecified behavior into a contract, so the eventual fix arrives looking like a regression. This is the second finding on the same PR: the bot answered a doc/code mismatch by asserting current output in a test, and the reviewer flagged it.
- **`review`** — the reviewer-side counterpart under **Testing**, one line: don't *suggest* that test either. Distinct action from the `triage` gate (what to suggest vs. what to write), and a wrong inline suggestion is an outward action, so it's worth the line rather than relying on the author-side gate alone.

Verification is `pre-commit` on the three files (all hooks pass, including the bang-backtick and install-tend mirror guards) plus `generator/tests/test_cross_file_contracts.py` (15 passed). No regression test: nothing in the suite asserts skill prose, and these are prompt-text changes whose effect shows up in adopter run outcomes, not in CI.

---
Closes #1133 — automated triage

