### PR TITLE
fix(checks): paginate the secret listings, so page 2 can't pass as clean

### DIFF
--- a/generator/src/tend/checks.py
+++ b/generator/src/tend/checks.py
@@ -486,6 +486,20 @@ def check_bot_permission(repo: str, bot_name: str) -> CheckResult:
     )
 
 
+def _lines(stdout: str) -> set[str]:
+    """The non-empty lines of a `gh --jq` stream, which emits one result per line.
+
+    Every secret listing below is read this way, and every one of them passes
+    `--paginate`. Both halves are load-bearing: an Actions secrets endpoint
+    serves 30 per page, and `gh api --paginate` applies `--jq` per page — so an
+    array-building filter emits one array *per page* and their concatenation is
+    not JSON. Reading a single page instead reports the tail as absent, which
+    in `check_repo_secret_allowlist` reads as "no unexpected secret": the
+    direction that hides exposure rather than announcing it.
+    """
+    return {line.strip() for line in stdout.splitlines() if line.strip()}
+
+
 # The operational secrets live in a deployment-gated environment rather than at
 # repo level, so every "is the secret set?" check reads them from there. A copy
 # left at repo level defeats the gate entirely — any workflow can read it
@@ -495,9 +509,10 @@ def _env_secret_names(repo: str) -> tuple[set[str] | None, str]:
     """Secret names in the tend environment. Returns (names, error message)."""
     result = _gh(
         "api",
+        "--paginate",
         f"repos/{repo}/environments/{TEND_ENVIRONMENT}/secrets",
         "--jq",
-        "[.secrets[].name]",
+        ".secrets[].name",
     )
     if result is None:
         return None, "gh CLI not found"
@@ -507,10 +522,7 @@ def _env_secret_names(repo: str) -> tuple[set[str] | None, str]:
             "(missing environment, or requires admin access). "
             "See the environment check above for how to create it."
         )
-    try:
-        return set(json.loads(result.stdout)), ""
-    except json.JSONDecodeError:
-        return None, "Could not parse environment secrets response"
+    return _lines(result.stdout), ""
 
 
 def _env_path(env_name: str) -> str:
@@ -1389,7 +1401,7 @@ def _org_secret_repos(org: str, name: str) -> set[str] | None:
     )
     if result is None or result.returncode != 0:
         return None
-    return {line.strip() for line in result.stdout.splitlines() if line.strip()}
+    return _lines(result.stdout)
 
 
 def _org_plan_is_free(org: str) -> bool:
@@ -1417,9 +1429,10 @@ def _list_org_secrets(org: str, repo: str) -> tuple[set[str] | None, bool]:
     """
     result = _gh(
         "api",
+        "--paginate",
         f"orgs/{org}/actions/secrets",
         "--jq",
-        "[.secrets[] | {name, visibility}]",
+        ".secrets[] | {name, visibility}",
     )
     if result is None:
         return None, False
@@ -1427,7 +1440,10 @@ def _list_org_secrets(org: str, repo: str) -> tuple[set[str] | None, bool]:
         forbidden = "HTTP 403" in result.stderr
         return None, forbidden
     try:
-        listed = [(s["name"], s.get("visibility")) for s in json.loads(result.stdout)]
+        listed = [
+            (s["name"], s.get("visibility"))
+            for s in (json.loads(line) for line in _lines(result.stdout))
+        ]
     except (json.JSONDecodeError, TypeError, KeyError):
         return None, False
 
@@ -1457,7 +1473,9 @@ def check_repo_secret_allowlist(repo: str, allowed: set[str]) -> CheckResult:
     (registry tokens, signing keys) that should be in a protected GitHub
     Environment instead.
     """
-    result = _gh("api", f"repos/{repo}/actions/secrets", "--jq", "[.secrets[].name]")
+    result = _gh(
+        "api", "--paginate", f"repos/{repo}/actions/secrets", "--jq", ".secrets[].name"
+    )
     if result is None:
         return CheckResult("repo-secret-allowlist", None, "gh CLI not found")
     if result.returncode != 0:
@@ -1467,12 +1485,7 @@ def check_repo_secret_allowlist(repo: str, allowed: set[str]) -> CheckResult:
             "Could not list secrets (may require admin access)",
         )
 
-    try:
-        repo_secrets = set(json.loads(result.stdout))
-    except json.JSONDecodeError:
-        return CheckResult(
-            "repo-secret-allowlist", None, "Could not parse secrets response"
-        )
+    repo_secrets = _lines(result.stdout)
 
     # Best-effort: include the org-level secrets this repo can read (also
     # available to its workflows). Ones scoped away from it are not.

--- a/generator/tests/test_checks.py
+++ b/generator/tests/test_checks.py
@@ -16,6 +16,7 @@ from tend.checks import (
     ROLE_ID_WRITE,
     CheckResult,
     _has_restrict_updates_ruleset,
+    _list_org_secrets,
     _restrict_updates_ruleset,
     admitted_refs,
     check_bot_permission,
@@ -78,10 +79,12 @@ def _make_completed(
 
 
 def _secret_names(args: tuple, *names: str) -> str:
-    """A secrets listing in whichever shape the caller asked for: objects for
-    `gh secret list --json name`, bare names for the `--jq` reads."""
-    listed = [{"name": n} for n in names] if "--json" in args else list(names)
-    return json.dumps(listed) + "\n"
+    """A secrets listing in whichever shape the caller asked for: JSON objects
+    for `gh secret list --json name`, one name per line for the `--jq` reads,
+    which every caller makes under `--paginate`."""
+    if "--json" in args:
+        return json.dumps([{"name": n} for n in names]) + "\n"
+    return "".join(f"{n}\n" for n in names)
 
 
 def _write_config(tmp_path: Path, content: str = "bot_name: test-bot") -> Path:
@@ -151,12 +154,12 @@ def _org_secret_gh(
             return _make_completed("\n".join(shared.get(url.split("/")[-2], [])) + "\n")
         if url == "orgs/acme/actions/secrets":
             listed = [{"name": n, "visibility": v} for n, v in org_secrets]
-            return _make_completed(json.dumps(listed) + "\n")
+            return _make_completed("".join(json.dumps(e) + "\n" for e in listed))
         if url == "orgs/acme":
             return _make_completed(f"{plan}\n")
         if url == "repos/acme/widget":
             return _make_completed(f"{str(repo_private).lower()}\n")
-        return _make_completed("[]\n")
+        return _make_completed("")
 
     return fake
 
@@ -308,7 +311,7 @@ def test_branch_protected() -> None:
     ruleset = json.dumps({"bypass_actors": [_role_actor(ROLE_ID_ADMIN)]})
 
     def fake_gh(*args, **kwargs):
-        url = args[1]
+        url = _url(args)
         if "rules/branches" in url:
             return _make_completed(branch_rules)
         if "/rulesets/" in url:
@@ -351,7 +354,7 @@ def test_branch_protected_ruleset_inconclusive_skips() -> None:
     )
 
     def fake_gh(*args, **kwargs):
-        url = args[1]
+        url = _url(args)
         if url == "repos/owner/repo/branches/main" and ".protected" in args:
             return _make_completed("true\n")
         if "rules/branches" in url:
@@ -720,7 +723,7 @@ def test_bot_permission_404_wrong_username() -> None:
 def test_secrets_present() -> None:
     with patch(
         "tend.checks._gh",
-        return_value=_make_completed('["TEND_BOT_TOKEN","CLAUDE_CODE_OAUTH_TOKEN"]\n'),
+        return_value=_make_completed("TEND_BOT_TOKEN\nCLAUDE_CODE_OAUTH_TOKEN\n"),
     ):
         result = check_secrets(
             "owner/repo", ["TEND_BOT_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"]
@@ -729,7 +732,7 @@ def test_secrets_present() -> None:
 
 
 def test_secrets_missing() -> None:
-    with patch("tend.checks._gh", return_value=_make_completed('["TEND_BOT_TOKEN"]\n')):
+    with patch("tend.checks._gh", return_value=_make_completed("TEND_BOT_TOKEN\n")):
         result = check_secrets(
             "owner/repo", ["TEND_BOT_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"]
         )
@@ -741,7 +744,7 @@ def test_secrets_missing() -> None:
 def test_secrets_missing_with_org_403_hint() -> None:
     """When org secrets return 403 and secrets are missing, include the hint."""
     with (
-        patch("tend.checks._gh", return_value=_make_completed('["TEND_BOT_TOKEN"]\n')),
+        patch("tend.checks._gh", return_value=_make_completed("TEND_BOT_TOKEN\n")),
         patch("tend.checks._list_org_secrets", return_value=(None, True)),
     ):
         result = check_secrets(
@@ -776,10 +779,50 @@ def test_secrets_api_error() -> None:
     assert result.passed is None
 
 
-def test_secrets_bad_json() -> None:
-    with patch("tend.checks._gh", return_value=_make_completed("not json")):
-        result = check_secrets("owner/repo", ["TEND_BOT_TOKEN"])
-    assert result.passed is None
+def test_secrets_reads_every_page_of_the_environment() -> None:
+    """An Actions secrets endpoint serves 30 per page. Reading only the first
+    reports a secret that is present as missing, failing a correctly set up
+    repo."""
+    calls: list[tuple[str, ...]] = []
+
+    def fake(*args: str, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        # What `gh api --paginate --jq '.secrets[].name'` emits across two
+        # pages: one name per line, the pages simply concatenated.
+        return _make_completed(f"{BOT_TOKEN_SECRET}\n{CLAUDE_TOKEN_SECRET}\n")
+
+    with patch("tend.checks._gh", side_effect=fake):
+        result = check_secrets("owner/repo", [BOT_TOKEN_SECRET, CLAUDE_TOKEN_SECRET])
+    assert result.passed is True, result.message
+    assert any("--paginate" in c for c in calls), (
+        "the listing must be paginated, or page 2 is invisible whatever the parse does"
+    )
+
+
+def test_org_secrets_read_every_page() -> None:
+    """`_list_org_secrets` feeds both the allowlist and the org-copy hint, and
+    an org past 30 secrets is the ordinary case rather than the exotic one."""
+    calls: list[tuple[str, ...]] = []
+
+    def fake(*args: str, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        url = next(a for a in args if a.startswith(("repos/", "orgs/")))
+        if url == "orgs/acme/actions/secrets":
+            return _make_completed(
+                '{"name":"FIRST_PAGE","visibility":"all"}\n'
+                '{"name":"SECOND_PAGE","visibility":"all"}\n'
+            )
+        if url == "orgs/acme":
+            return _make_completed("team\n")
+        if url == "repos/acme/widget":
+            return _make_completed("false\n")
+        return _make_completed("")
+
+    with patch("tend.checks._gh", side_effect=fake):
+        secrets, forbidden = _list_org_secrets("acme", "acme/widget")
+    assert forbidden is False
+    assert secrets == {"FIRST_PAGE", "SECOND_PAGE"}
+    assert any("--paginate" in c and "orgs/acme/actions/secrets" in c for c in calls)
 
 
 # ---------------------------------------------------------------------------
@@ -792,9 +835,7 @@ def test_repo_secret_allowlist_pass() -> None:
     with (
         patch(
             "tend.checks._gh",
-            return_value=_make_completed(
-                '["TEND_BOT_TOKEN","CLAUDE_CODE_OAUTH_TOKEN"]\n'
-            ),
+            return_value=_make_completed("TEND_BOT_TOKEN\nCLAUDE_CODE_OAUTH_TOKEN\n"),
         ),
         patch("tend.checks._list_org_secrets", return_value=(set(), False)),
     ):
@@ -811,7 +852,7 @@ def test_repo_secret_allowlist_unexpected_repo() -> None:
         patch(
             "tend.checks._gh",
             return_value=_make_completed(
-                '["TEND_BOT_TOKEN","CLAUDE_CODE_OAUTH_TOKEN","PYPI_TOKEN"]\n'
+                "TEND_BOT_TOKEN\nCLAUDE_CODE_OAUTH_TOKEN\nPYPI_TOKEN\n"
             ),
         ),
         patch("tend.checks._list_org_secrets", return_value=(set(), False)),
@@ -829,7 +870,7 @@ def test_repo_secret_allowlist_unexpected_org() -> None:
     with (
         patch(
             "tend.checks._gh",
-            return_value=_make_completed('["TEND_BOT_TOKEN"]\n'),
+            return_value=_make_completed("TEND_BOT_TOKEN\n"),
         ),
         patch(
             "tend.checks._list_org_secrets",
@@ -847,7 +888,7 @@ def test_repo_secret_allowlist_unexpected_both() -> None:
     with (
         patch(
             "tend.checks._gh",
-            return_value=_make_completed('["TEND_BOT_TOKEN","PYPI_TOKEN"]\n'),
+            return_value=_make_completed("TEND_BOT_TOKEN\nPYPI_TOKEN\n"),
         ),
         patch(
             "tend.checks._list_org_secrets",
@@ -867,7 +908,7 @@ def test_repo_secret_allowlist_org_allowed() -> None:
     with (
         patch(
             "tend.checks._gh",
-            return_value=_make_completed('["TEND_BOT_TOKEN"]\n'),
+            return_value=_make_completed("TEND_BOT_TOKEN\n"),
         ),
         patch(
             "tend.checks._list_org_secrets",
@@ -885,7 +926,7 @@ def test_repo_secret_allowlist_org_forbidden() -> None:
     with (
         patch(
             "tend.checks._gh",
-            return_value=_make_completed('["TEND_BOT_TOKEN"]\n'),
+            return_value=_make_completed("TEND_BOT_TOKEN\n"),
         ),
         patch("tend.checks._list_org_secrets", return_value=(None, True)),
     ):
@@ -900,7 +941,7 @@ def test_repo_secret_allowlist_with_extra_allowed() -> None:
         patch(
             "tend.checks._gh",
             return_value=_make_completed(
-                '["TEND_BOT_TOKEN","CLAUDE_CODE_OAUTH_TOKEN","CODECOV_TOKEN"]\n'
+                "TEND_BOT_TOKEN\nCLAUDE_CODE_OAUTH_TOKEN\nCODECOV_TOKEN\n"
             ),
         ),
         patch("tend.checks._list_org_secrets", return_value=(set(), False)),
@@ -914,7 +955,7 @@ def test_repo_secret_allowlist_with_extra_allowed() -> None:
 def test_repo_secret_allowlist_empty_repo() -> None:
     """No secrets at all — passes."""
     with (
-        patch("tend.checks._gh", return_value=_make_completed("[]\n")),
+        patch("tend.checks._gh", return_value=_make_completed("")),
         patch("tend.checks._list_org_secrets", return_value=(set(), False)),
     ):
         result = check_repo_secret_allowlist("owner/repo", {"TEND_BOT_TOKEN"})
@@ -1064,10 +1105,24 @@ def test_repo_secret_allowlist_no_gh() -> None:
     assert result.passed is None
 
 
-def test_repo_secret_allowlist_bad_json() -> None:
-    with patch("tend.checks._gh", return_value=_make_completed("not json")):
-        result = check_repo_secret_allowlist("owner/repo", {"TEND_BOT_TOKEN"})
-    assert result.passed is None
+def test_repo_secret_allowlist_reads_every_page() -> None:
+    """The failure mode a missed page produces here is a silent pass: an
+    ungated release secret sitting on page 2 reads as "no unexpected secret",
+    so the check reports the repo clean while the exposure stands."""
+    calls: list[tuple[str, ...]] = []
+
+    def fake(*args: str, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        return _make_completed(f"{BOT_TOKEN_SECRET}\nPYPI_TOKEN\n")
+
+    with (
+        patch("tend.checks._gh", side_effect=fake),
+        patch("tend.checks._list_org_secrets", return_value=(set(), False)),
+    ):
+        result = check_repo_secret_allowlist("owner/repo", {BOT_TOKEN_SECRET})
+    assert result.passed is False, result.message
+    assert "PYPI_TOKEN" in result.message
+    assert any("--paginate" in c for c in calls)
 
 
 # ---------------------------------------------------------------------------
@@ -1111,9 +1166,6 @@ def _gh_all_pass(*admitted: str, environment_secrets: tuple[str, ...] | None = N
         if url.endswith("/environments"):
             return _make_completed(f"{TEND_ENVIRONMENT}\n")
         if url.endswith("/secrets") and "/environments/" in url:
-            # Two callers read this path with different `--jq` shapes: the
-            # membership check wants a JSON array, the environment sweep one
-            # name per line. The fake answers whichever was asked for.
             names = (
                 list(
                     (BOT_TOKEN_SECRET, CLAUDE_TOKEN_SECRET)
@@ -1123,9 +1175,7 @@ def _gh_all_pass(*admitted: str, environment_secrets: tuple[str, ...] | None = N
                 if url.endswith(f"{TEND_ENVIRONMENT}/secrets")
                 else []
             )
-            if any(a.startswith("[.secrets") for a in args):
-                return _make_completed(json.dumps(names))
-            return _make_completed("\n".join(names) + "\n")
+            return _make_completed("".join(f"{n}\n" for n in names))
         if url == "repos/owner/repo" and "--jq" in args and ".default_branch" in args:
             return _make_completed("main\n")
         if "rules/branches" in url:
@@ -1160,7 +1210,7 @@ def _gh_all_pass(*admitted: str, environment_secrets: tuple[str, ...] | None = N
         # is deliberately the only place the operational names appear, so a
         # check reading the wrong level cannot pass by accident.
         if "secrets" in url:
-            return _make_completed("[]\n")
+            return _make_completed("")
         return _make_completed(returncode=1)
 
     return fake
@@ -1269,9 +1319,9 @@ def test_run_all_checks_flags_operational_secrets_left_at_repo_level() -> None:
     """
 
     def gh_with_repo_level_copy(*args, **kwargs) -> subprocess.CompletedProcess[str]:
-        url = args[1]
+        url = _url(args)
         if "environments/tend/secrets" not in url and url.endswith("actions/secrets"):
-            return _make_completed(json.dumps([BOT_TOKEN_SECRET]) + "\n")
+            return _make_completed(f"{BOT_TOKEN_SECRET}\n")
         return _gh_all_pass()(*args, **kwargs)
 
     with (
@@ -1292,7 +1342,7 @@ def test_run_all_checks_allowlist_catches_unexpected() -> None:
     """Unexpected repo-level secret is flagged."""
 
     def fake_gh_with_extra_secret(*args, **kwargs) -> subprocess.CompletedProcess[str]:
-        url = args[1]
+        url = _url(args)
         if url == "repos/owner/repo" and "--jq" in args and ".default_branch" in args:
             return _make_completed("main\n")
         if "rules/branches" in url:
@@ -1306,7 +1356,7 @@ def test_run_all_checks_allowlist_catches_unexpected() -> None:
         if "collaborators" in url:
             return _make_completed(_permission_response("write"))
         if "secrets" in url:
-            return _make_completed('["T1","T2","PYPI_TOKEN"]\n')
+            return _make_completed("T1\nT2\nPYPI_TOKEN\n")
         return _make_completed(returncode=1)
 
     with (
@@ -1347,7 +1397,7 @@ def test_codex_engine_passes_with_openai_key() -> None:
     """Engine=codex with OPENAI_API_KEY set passes the codex-auth check."""
 
     def fake_gh(*args, **kwargs):
-        url = args[1]
+        url = _url(args)
         if url == "repos/owner/repo" and "--jq" in args and ".default_branch" in args:
             return _make_completed("main\n")
         if "rules/branches" in url:
@@ -1377,7 +1427,7 @@ def test_codex_engine_fails_when_no_auth() -> None:
     """Engine=codex with OPENAI_API_KEY unset is a hard failure."""
 
     def fake_gh(*args, **kwargs):
-        url = args[1]
+        url = _url(args)
         if url == "repos/owner/repo" and "--jq" in args and ".default_branch" in args:
             return _make_completed("main\n")
         if "rules/branches" in url:
@@ -1427,7 +1477,7 @@ def test_claude_engine_passes_with_api_key() -> None:
     """Engine=claude with only ANTHROPIC_API_KEY set passes claude-auth."""
 
     def fake_gh(*args, **kwargs):
-        url = args[1]
+        url = _url(args)
         if url == "repos/owner/repo" and "--jq" in args and ".default_branch" in args:
             return _make_completed("main\n")
         if "rules/branches" in url:
@@ -1456,7 +1506,7 @@ def test_claude_engine_fails_when_no_auth() -> None:
     """Engine=claude with neither secret set is a hard failure."""
 
     def fake_gh(*args, **kwargs):
-        url = args[1]
+        url = _url(args)
         if url == "repos/owner/repo" and "--jq" in args and ".default_branch" in args:
             return _make_completed("main\n")
         if "rules/branches" in url:

--- a/generator/tests/test_checks.py
+++ b/generator/tests/test_checks.py
@@ -78,12 +78,17 @@ def _make_completed(
     )
 
 
-def _secret_names(args: tuple, *names: str) -> str:
-    """A secrets listing in whichever shape the caller asked for: JSON objects
-    for `gh secret list --json name`, one name per line for the `--jq` reads,
-    which every caller makes under `--paginate`."""
-    if "--json" in args:
-        return json.dumps([{"name": n} for n in names]) + "\n"
+def _url(args: tuple[str, ...]) -> str:
+    """The API path in a `_gh` call, wherever flags put it.
+
+    A `graphql` call carries no path, so it answers with its subcommand.
+    """
+    return next((a for a in args if a.startswith(("repos/", "orgs/"))), args[1])
+
+
+def _secret_names(*names: str) -> str:
+    """A secrets listing in the shape every caller reads: one name per line,
+    which is what `--jq` under `--paginate` emits."""
     return "".join(f"{n}\n" for n in names)
 
 
@@ -806,7 +811,7 @@ def test_org_secrets_read_every_page() -> None:
 
     def fake(*args: str, **kwargs: object) -> subprocess.CompletedProcess[str]:
         calls.append(args)
-        url = next(a for a in args if a.startswith(("repos/", "orgs/")))
+        url = _url(args)
         if url == "orgs/acme/actions/secrets":
             return _make_completed(
                 '{"name":"FIRST_PAGE","visibility":"all"}\n'
@@ -1407,9 +1412,7 @@ def test_codex_engine_passes_with_openai_key() -> None:
         if "collaborators" in url:
             return _make_completed("write\n")
         if "secrets" in url:
-            return _make_completed(
-                _secret_names(args, BOT_TOKEN_SECRET, OPENAI_KEY_SECRET)
-            )
+            return _make_completed(_secret_names(BOT_TOKEN_SECRET, OPENAI_KEY_SECRET))
         return _make_completed(returncode=1)
 
     with (
@@ -1437,7 +1440,7 @@ def test_codex_engine_fails_when_no_auth() -> None:
         if "collaborators" in url:
             return _make_completed("write\n")
         if "secrets" in url:
-            return _make_completed(_secret_names(args, BOT_TOKEN_SECRET))
+            return _make_completed(_secret_names(BOT_TOKEN_SECRET))
         return _make_completed(returncode=1)
 
     with (
@@ -1488,7 +1491,7 @@ def test_claude_engine_passes_with_api_key() -> None:
             return _make_completed("write\n")
         if "secrets" in url:
             return _make_completed(
-                _secret_names(args, BOT_TOKEN_SECRET, ANTHROPIC_API_KEY_SECRET)
+                _secret_names(BOT_TOKEN_SECRET, ANTHROPIC_API_KEY_SECRET)
             )
         return _make_completed(returncode=1)
 
@@ -1516,7 +1519,7 @@ def test_claude_engine_fails_when_no_auth() -> None:
         if "collaborators" in url:
             return _make_completed("write\n")
         if "secrets" in url:
-            return _make_completed(_secret_names(args, BOT_TOKEN_SECRET))
+            return _make_completed(_secret_names(BOT_TOKEN_SECRET))
         return _make_completed(returncode=1)
 
     with (
@@ -1638,14 +1641,6 @@ def test_init_prints_check_reminder(
 # pushed to a feature branch before its first step. Each way the policy can be
 # too generous is a way the secrets come back.
 # ---------------------------------------------------------------------------
-
-
-def _url(args: tuple[str, ...]) -> str:
-    """The API path in a `_gh` call, wherever flags put it.
-
-    A `graphql` call carries no path, so it answers with its subcommand.
-    """
-    return next((a for a in args if a.startswith(("repos/", "orgs/"))), args[1])
 
 
 def _env_gh(env_body: str | None, policies: str = "main"):

--- a/generator/tests/test_integration.py
+++ b/generator/tests/test_integration.py
@@ -520,6 +520,14 @@ def _make_completed(
     )
 
 
+def _url(args: tuple[str, ...]) -> str:
+    """The API path in a `_gh` call, wherever flags put it.
+
+    A `graphql` call carries no path, so it answers with its subcommand.
+    """
+    return next((a for a in args if a.startswith(("repos/", "orgs/"))), args[1])
+
+
 def _fake_gh_all_pass(*args: str, **kwargs: str) -> subprocess.CompletedProcess[str]:
     """Simulate a gh CLI where all checks pass for owner/repo."""
     if "graphql" in args:
@@ -528,7 +536,7 @@ def _fake_gh_all_pass(*args: str, **kwargs: str) -> subprocess.CompletedProcess[
         return _make_completed(
             json.dumps({"data": {"repository": {"object": {"entries": []}}}})
         )
-    url = next(a for a in args if a.startswith(("repos/", "orgs/")))
+    url = _url(args)
     # Only the ref-gated environment exists, holding the operational secrets.
     if url.endswith("/environments"):
         return _make_completed("tend\n")
@@ -635,7 +643,7 @@ def test_check_full_pipeline_branch_not_protected(
     def fake_gh_unprotected(
         *args: str, **kwargs: str
     ) -> subprocess.CompletedProcess[str]:
-        url = next((a for a in args if a.startswith(("repos/", "orgs/"))), args[1])
+        url = _url(args)
         if url == "repos/owner/repo" and ".default_branch" in args:
             return _make_completed("main\n")
         if "rules/branches" in url:

--- a/generator/tests/test_integration.py
+++ b/generator/tests/test_integration.py
@@ -538,9 +538,7 @@ def _fake_gh_all_pass(*args: str, **kwargs: str) -> subprocess.CompletedProcess[
             if url.endswith("tend/secrets")
             else []
         )
-        if any(a.startswith("[.secrets") for a in args):
-            return _make_completed(json.dumps(names))
-        return _make_completed("\n".join(names) + "\n")
+        return _make_completed("".join(f"{n}\n" for n in names))
     if url == "repos/owner/repo" and ".default_branch" in args:
         return _make_completed("main\n")
     if "rules/branches" in url:
@@ -602,7 +600,7 @@ def _fake_gh_all_pass(*args: str, **kwargs: str) -> subprocess.CompletedProcess[
     # deliberately the only place the operational names appear, so a check
     # reading the wrong level cannot pass by accident.
     if "secrets" in url:
-        return _make_completed("[]\n")
+        return _make_completed("")
     return _make_completed(returncode=1)
 
 
@@ -637,7 +635,7 @@ def test_check_full_pipeline_branch_not_protected(
     def fake_gh_unprotected(
         *args: str, **kwargs: str
     ) -> subprocess.CompletedProcess[str]:
-        url = args[1]
+        url = next((a for a in args if a.startswith(("repos/", "orgs/"))), args[1])
         if url == "repos/owner/repo" and ".default_branch" in args:
             return _make_completed("main\n")
         if "rules/branches" in url:
@@ -647,7 +645,7 @@ def test_check_full_pipeline_branch_not_protected(
         if "collaborators" in url:
             return _make_completed("write\n")
         if "secrets" in url:
-            return _make_completed('["TEND_BOT_TOKEN","CLAUDE_CODE_OAUTH_TOKEN"]\n')
+            return _make_completed("TEND_BOT_TOKEN\nCLAUDE_CODE_OAUTH_TOKEN\n")
         return _make_completed(returncode=1)
 
     with (


### PR DESCRIPTION
`tend check`'s secret listings read only the first page. GitHub's Actions secrets endpoints serve 30 per page, so on a repo or org past that count the tail is invisible — and in `check_repo_secret_allowlist` an unread tail reads as "no unexpected secret", so the check reports the repo clean while an ungated release token sits on page 2. This adds `--paginate` to the three listings that lacked it and reads them one name per line.

The parse has to change alongside the flag: `gh api --paginate` applies `--jq` per page, so the array-building filters these call sites used (`[.secrets[].name]`) would emit one array *per page* and their concatenation is not JSON. The two paginated listings already in this file (`_org_secret_repos`, and the per-environment sweep in `check_credential_environments`) already read line-oriented for exactly this reason; the new `_lines` helper is the idiom the first of those had open-coded.

Three call sites, in severity order:

- `check_repo_secret_allowlist` — a missed repo-level secret is a silent PASS on a security boundary. This is the one that hides exposure rather than announcing it.
- `_list_org_secrets` — feeds both the allowlist and the org-copy hint in `check_secrets`. An org past 30 secrets is the ordinary case, not the exotic one.
- `_env_secret_names` — under-reporting here fails in the safe direction (a present secret reads as missing), but it is still a wrong verdict on a correctly configured repo.

Verification: each of the three regression tests fails on `main` (`Could not parse secrets response` / `assert None == {'FIRST_PAGE', 'SECOND_PAGE'}`) and passes here. Full suite 915 passed; every pre-commit hook passes.

<details><summary>Test-fixture churn</summary>

Most of the diff is fixtures. The fakes returned JSON arrays where real `gh --jq` emits one result per line, so they had to move to the real shape — `_secret_names` and `_gh_all_pass` each carried a branch answering *both* shapes depending on the requested `--jq`, and with one shape left those branches are gone.

Several fakes also read the API path as `args[1]`, which `--paginate` displaces. They now use the existing `_url(args)` helper (and its positional fallback in `test_integration.py`), which finds the path wherever flags put it.

Two tests are removed rather than updated: `test_secrets_bad_json` and `test_repo_secret_allowlist_bad_json` covered `json.JSONDecodeError` branches that no longer exist, since a line-oriented read has nothing to decode.

</details>
