### PR TITLE
skills(running-tend): fix the usage-analysis recipe's unexpanded script paths

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -46,13 +46,17 @@ default. `uvx tend@latest init` doesn't rewrite them either, so their
 ### Usage analysis
 
 Pass extra prefixes when running token reports or listing runs so these
-workflows are included. Take each script's path from the bundled skill that
-invokes it — `${CLAUDE_PLUGIN_ROOT}` is substituted into bundled plugin skills
-but not into this repo-local one, where it expands to nothing:
+workflows are included. Both scripts live in the bundled `scripts/` directory —
+take its path from any absolute `.../scripts/...` path a loaded bundled skill
+renders. Under the Claude harness `${CLAUDE_PLUGIN_ROOT}` is text-substituted
+into bundled plugin skill markdown but is not set in the shell, so writing the
+literal in this repo-local skill would expand to nothing (under Codex the
+action exports it as a real variable, so there it would work).
 
 ```bash
-token-report.sh "${HOURS:-24}" "review-"
-TARGET_REPO=max-sixty/tend list-recent-runs.sh "tend-" "review-"
+SCRIPTS=<bundled scripts/ dir>
+"$SCRIPTS/token-report.sh" "${HOURS:-24}" "review-"
+TARGET_REPO=max-sixty/tend "$SCRIPTS/list-recent-runs.sh" "tend-" "review-"
 ```
 
 Under `review-runs`, `$HOURS` is the lookback derived from its Step 1 anchor —

--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -46,11 +46,13 @@ default. `uvx tend@latest init` doesn't rewrite them either, so their
 ### Usage analysis
 
 Pass extra prefixes when running token reports or listing runs so these
-workflows are included:
+workflows are included. Take each script's path from the bundled skill that
+invokes it — `${CLAUDE_PLUGIN_ROOT}` is substituted into bundled plugin skills
+but not into this repo-local one, where it expands to nothing:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" "${HOURS:-24}" "review-"
-TARGET_REPO=max-sixty/tend "${CLAUDE_PLUGIN_ROOT}/scripts/list-recent-runs.sh" "tend-" "review-"
+token-report.sh "${HOURS:-24}" "review-"
+TARGET_REPO=max-sixty/tend list-recent-runs.sh "tend-" "review-"
 ```
 
 Under `review-runs`, `$HOURS` is the lookback derived from its Step 1 anchor —

--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -46,15 +46,11 @@ default. `uvx tend@latest init` doesn't rewrite them either, so their
 ### Usage analysis
 
 Pass extra prefixes when running token reports or listing runs so these
-workflows are included. Both scripts live in the bundled `scripts/` directory —
-take its path from any absolute `.../scripts/...` path a loaded bundled skill
-renders. Under the Claude harness `${CLAUDE_PLUGIN_ROOT}` is text-substituted
-into bundled plugin skill markdown but is not set in the shell, so writing the
-literal in this repo-local skill would expand to nothing (under Codex the
-action exports it as a real variable, so there it would work).
+workflows are included:
 
 ```bash
-SCRIPTS=<bundled scripts/ dir>
+# Claude leaves this unset in the shell; Codex exports it.
+SCRIPTS="${CLAUDE_PLUGIN_ROOT:-/home/tend-sandbox/tend-marketplace/plugins/tend-ci-runner}/scripts"
 "$SCRIPTS/token-report.sh" "${HOURS:-24}" "review-"
 TARGET_REPO=max-sixty/tend "$SCRIPTS/list-recent-runs.sh" "tend-" "review-"
 ```

--- a/codex/action.yaml
+++ b/codex/action.yaml
@@ -158,9 +158,11 @@ runs:
     # become discoverable by `codex exec`.
     #
     # We export `CLAUDE_PLUGIN_ROOT` to the install location so skills can
-    # resolve `${CLAUDE_PLUGIN_ROOT}/scripts/...` paths the same way they do
-    # under Claude Code (which sets this variable natively). One variable
-    # name across harnesses — skills stay harness-agnostic.
+    # resolve `${CLAUDE_PLUGIN_ROOT}/scripts/...` paths. Claude Code reaches the
+    # same place by a different route — it text-substitutes the variable into
+    # bundled plugin skill markdown at load time rather than setting it in the
+    # shell, so under Claude the literal resolves only inside a bundled skill.
+    # One variable name across harnesses — skills stay harness-agnostic.
     - name: Install tend-ci-runner plugin
       shell: bash
       run: |


### PR DESCRIPTION
The `Usage analysis` recipe in `.claude/skills/running-tend/SKILL.md` was not runnable as written: it invoked `"${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh"`, but under the Claude harness `CLAUDE_PLUGIN_ROOT` is text-substituted into *bundled plugin* skill markdown at load time and is never set in the shell — so the literal in this repo-local skill expands to the empty string and the command exits 127. The recipe now resolves the directory once with `SCRIPTS="${CLAUDE_PLUGIN_ROOT:-<claude sandbox path>}/scripts"`, which is copy-paste runnable on both harnesses with nothing to substitute: Codex sets the variable to the install root it parsed, Claude leaves it unset and the fallback fires.

Also corrects the comment in [`codex/action.yaml`](https://github.com/max-sixty/tend/blob/b2195db38aece9ad20bd280f459ea1d142ff60b5/codex/action.yaml#L160) that asserted the same parity from the other direction ("Claude Code ... sets this variable natively") — same single factual claim, stated wrongly in two places.

<details><summary>Evidence, verification, and gate assessment</summary>

## What was observed

Run [33953576688](https://github.com/max-sixty/tend/actions/runs/33953576688), reviewing the window `2026-09-04T07:48:42Z → 2026-09-05T07:49Z`.

The two forms, run back to back:

```
$ "${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" 1 "review-"
bash: line 1: /scripts/token-report.sh: No such file or directory
exit=127

$ "/home/tend-sandbox/tend-marketplace/plugins/tend-ci-runner/scripts/token-report.sh" 1 "review-"
exit=0
```

The mechanism is visible in the skill text each session receives. The bundled `review-runs` skill renders an absolute path; the repo-local `running-tend` skill renders the variable verbatim. `CLAUDE_PLUGIN_ROOT` is unset in the Bash tool environment in both cases — the substitution happens when the plugin skill's markdown is rendered, and a repo-local skill is not a plugin skill.

A related slip landed in the window: `tend-triage` [33851553517](https://github.com/max-sixty/tend/actions/runs/33851553517) ran `${CLAUDE_PLUGIN_ROOT}/scripts/poll-pr-checks.sh 1139 "$PINNED_SHA"` and got the same `No such file or directory`, then re-ran with the absolute path. That one is the model typing the source form it had just been editing in-tree, not this file — but it is the same expansion failing the same way.

## Why a `:-` fallback rather than a substitution instruction

Two earlier revisions asked the reader to substitute a path — first "take it from the bundled skill that invokes it", then `SCRIPTS=<bundled scripts/ dir>`. Both fail the PR's own premise, which is that a session copies the block verbatim: the placeholder form is a bash syntax error (`syntax error near unexpected token 'newline'`), and the derivation instruction has no source under Codex, where nothing renders an absolute path — `codex/action.yaml` exports `CLAUDE_PLUGIN_ROOT` precisely *because* Codex does not substitute it into skill markdown.

The `:-` form needs no substitution on either harness, so the mechanism prose that explained what to substitute goes away with it — CLAUDE.md's "Authoring skills" section asks for a code block plus one sentence of framing, and this file loads into every tend session on this repo.

The hardcoded `/home/tend-sandbox/tend-marketplace/...` is the fallback branch only, so it never fires under Codex. It does still rot if the Claude sandbox home changes — that path is `$AGENT_HOME/tend-marketplace` from [`shared/steps/install-tend-plugins.sh`](https://github.com/max-sixty/tend/blob/b2195db38aece9ad20bd280f459ea1d142ff60b5/shared/steps/install-tend-plugins.sh#L19) — but it rots to the same 127 as today, and to a literal that is greppable in-repo rather than to a syntax error on every copy.

## Gates

- **Gate 1 (confidence).** Structural and deterministic — not a sampled behavior. The broken expansion is demonstrable on demand (exit 127 above) and provable from the two rendered skill texts. One related runtime failure of the same expansion was observed this window.
- **Gate 2 (magnitude).** Documentation correction plus a comment correction; no code paths change.
- **Gate 3 (cost).** Waste class: the observed failure cost one round-trip and was recovered immediately; nothing wrong was posted. The remedy adds no mechanism.

## Verification

The block was extracted from the file and run verbatim at `b2195db`: `bash -n` clean, and `HOURS=1 bash /tmp/recipe.sh` exits 0 with both scripts producing their reports. `uv tool run pre-commit run --files .claude/skills/running-tend/SKILL.md codex/action.yaml` — all applicable hooks pass. No behavior changed, so no test is exercised by this diff.

</details>
