### PR TITLE
fix(running-in-ci): resolve the SHAs in a body before posting it

### DIFF
--- a/generator/tests/test_check_body_links.py
+++ b/generator/tests/test_check_body_links.py
@@ -1,0 +1,156 @@
+"""Tests for check-body-links.sh.
+
+The script exists because shape and existence are different questions: a
+hand-typed 40-hex string is a well-formed permalink whether or not the commit
+is real, so the pre-post scan it replaces passed a fabricated OID straight
+through to a public PR body. The fake `gh` therefore resolves exactly one
+(repo, SHA) pair and refuses everything else, which is what an invented OID
+and a wrong owner both look like from the API.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests import BASH, GH_PREAMBLE, fake_bin, tool_path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "plugins" / "tend-ci-runner" / "scripts" / "check-body-links.sh"
+
+NWO = "max-sixty/tend"
+REAL = "0123456789abcdef0123456789abcdef01234567"
+FAKE = "0123456789abcdefdeadbeefdeadbeefdeadbeef"
+
+# Only the one commit in the one repo resolves; every other path 404s, the way
+# an extended-abbreviation OID and a hand-typed owner both do.
+FAKE_GH = (
+    GH_PREAMBLE
+    + r"""
+case "$*" in
+  "api repos/"""
+    + NWO
+    + "/commits/"
+    + REAL
+    + r""" "*) emit '{"sha": "'"""
+    + REAL
+    + r"""'"}' ;;
+  *) echo "gh: Not Found (HTTP 404)" >&2; exit 1 ;;
+esac
+"""
+)
+
+
+class Fixture:
+    def __init__(self, tmp_path: Path) -> None:
+        self.tmp_path = tmp_path
+        self.calls = tmp_path / "gh-calls"
+        self.bindir = fake_bin(tmp_path, gh=FAKE_GH)
+
+    def run(self, body: str) -> subprocess.CompletedProcess[str]:
+        path = self.tmp_path / "body.md"
+        path.write_text(body)
+        return self.run_path(str(path))
+
+    def run_path(self, arg: str, *extra: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [BASH, str(SCRIPT), arg, *extra],
+            capture_output=True,
+            text=True,
+            env={
+                "PATH": tool_path(self.bindir),
+                "HOME": str(self.tmp_path),
+                "GH_CALLS": str(self.calls),
+            },
+        )
+
+    def gh_calls(self) -> list[str]:
+        if not self.calls.exists():
+            return []
+        return [ln for ln in self.calls.read_text().splitlines() if ln]
+
+
+@pytest.fixture
+def fx(tmp_path: Path) -> Fixture:
+    return Fixture(tmp_path)
+
+
+def test_resolvable_permalink_and_file_level_branch_link_pass(fx: Fixture) -> None:
+    """A pinned line link that resolves, and a branch link with no line anchor."""
+    result = fx.run(
+        f"See [decorators.py#L305-L331](https://github.com/{NWO}/blob/{REAL}/a.py#L305-L331) "
+        f"and https://github.com/{NWO}/blob/main/CLAUDE.md for context.\n"
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout == ""
+
+
+def test_fabricated_sha_is_reported(fx: Fixture) -> None:
+    """The shape is valid; only resolving the OID tells the two apart."""
+    result = fx.run(f"[a.py#L10](https://github.com/{NWO}/blob/{FAKE}/a.py#L10)\n")
+    assert result.returncode == 1
+    assert FAKE in result.stdout
+    assert "unresolvable SHA" in result.stdout
+
+
+def test_wrong_owner_is_reported_by_the_same_check(fx: Fixture) -> None:
+    result = fx.run(f"https://github.com/anthropics/tend/blob/{REAL}/a.py#L10\n")
+    assert result.returncode == 1
+    assert "anthropics/tend" in result.stdout
+
+
+def test_branch_pinned_line_anchor_is_reported(fx: Fixture) -> None:
+    result = fx.run(f"https://github.com/{NWO}/blob/main/CLAUDE.md#L10\n")
+    assert result.returncode == 1
+    assert "un-pinned line link" in result.stdout
+    assert fx.gh_calls() == []
+
+
+def test_abbreviated_sha_with_a_line_anchor_is_reported(fx: Fixture) -> None:
+    """An abbreviation is what the model extends; it cannot pin a line either."""
+    result = fx.run(f"https://github.com/{NWO}/blob/{REAL[:7]}/a.py#L10\n")
+    assert result.returncode == 1
+    assert "un-pinned line link" in result.stdout
+
+
+def test_each_distinct_sha_costs_one_api_call(fx: Fixture) -> None:
+    """Bodies repeat the same permalink; the check must not repeat the call."""
+    body = "\n".join(
+        [
+            f"https://github.com/{NWO}/blob/{REAL}/a.py#L1",
+            f"https://github.com/{NWO}/blob/{REAL}/b.py#L2",
+            f"https://github.com/{NWO}/commit/{FAKE}",
+        ]
+    )
+    result = fx.run(body + "\n")
+    assert result.returncode == 1
+    assert len(fx.gh_calls()) == 2
+
+
+def test_markdown_delimiters_do_not_leak_into_the_ref(fx: Fixture) -> None:
+    """A URL closed by `)` or wrapped in backticks still parses to the bare ref."""
+    result = fx.run(
+        f"([a](https://github.com/{NWO}/blob/{FAKE}/a.py#L10)) "
+        f"`https://github.com/{NWO}/blob/{FAKE}/b.py`\n"
+    )
+    assert result.returncode == 1
+    assert f"unresolvable SHA {FAKE} in {NWO}" in result.stdout
+    assert ")" not in result.stdout.split(" in ")[0]
+
+
+def test_body_without_github_links_passes_without_calling_the_api(fx: Fixture) -> None:
+    result = fx.run("Thanks for reporting this — I could not reproduce it.\n")
+    assert result.returncode == 0
+    assert fx.gh_calls() == []
+
+
+def test_missing_file_and_bad_arity_exit_two(fx: Fixture) -> None:
+    missing = fx.run_path(str(fx.tmp_path / "nope.md"))
+    assert missing.returncode == 2
+    assert "no such file" in missing.stderr
+
+    extra = fx.run_path(str(fx.tmp_path), "second")
+    assert extra.returncode == 2
+    assert "usage:" in extra.stderr

--- a/generator/tests/test_check_body_links.py
+++ b/generator/tests/test_check_body_links.py
@@ -20,7 +20,7 @@ from tests import BASH, GH_PREAMBLE, fake_bin, tool_path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "plugins" / "tend-ci-runner" / "scripts" / "check-body-links.sh"
 
-NWO = "max-sixty/tend"
+SLUG = "max-sixty/tend"
 REAL = "0123456789abcdef0123456789abcdef01234567"
 FAKE = "0123456789abcdefdeadbeefdeadbeefdeadbeef"
 
@@ -31,7 +31,7 @@ FAKE_GH = (
     + r"""
 case "$*" in
   "api repos/"""
-    + NWO
+    + SLUG
     + "/commits/"
     + REAL
     + r""" "*) emit '{"sha": "'"""
@@ -59,6 +59,7 @@ class Fixture:
             [BASH, str(SCRIPT), arg, *extra],
             capture_output=True,
             text=True,
+            check=False,
             env={
                 "PATH": tool_path(self.bindir),
                 "HOME": str(self.tmp_path),
@@ -80,8 +81,8 @@ def fx(tmp_path: Path) -> Fixture:
 def test_resolvable_permalink_and_file_level_branch_link_pass(fx: Fixture) -> None:
     """A pinned line link that resolves, and a branch link with no line anchor."""
     result = fx.run(
-        f"See [decorators.py#L305-L331](https://github.com/{NWO}/blob/{REAL}/a.py#L305-L331) "
-        f"and https://github.com/{NWO}/blob/main/CLAUDE.md for context.\n"
+        f"See [decorators.py#L305-L331](https://github.com/{SLUG}/blob/{REAL}/a.py#L305-L331) "
+        f"and https://github.com/{SLUG}/blob/main/CLAUDE.md for context.\n"
     )
     assert result.returncode == 0, result.stdout + result.stderr
     assert result.stdout == ""
@@ -89,7 +90,7 @@ def test_resolvable_permalink_and_file_level_branch_link_pass(fx: Fixture) -> No
 
 def test_fabricated_sha_is_reported(fx: Fixture) -> None:
     """The shape is valid; only resolving the OID tells the two apart."""
-    result = fx.run(f"[a.py#L10](https://github.com/{NWO}/blob/{FAKE}/a.py#L10)\n")
+    result = fx.run(f"[a.py#L10](https://github.com/{SLUG}/blob/{FAKE}/a.py#L10)\n")
     assert result.returncode == 1
     assert FAKE in result.stdout
     assert "unresolvable SHA" in result.stdout
@@ -102,7 +103,7 @@ def test_wrong_owner_is_reported_by_the_same_check(fx: Fixture) -> None:
 
 
 def test_branch_pinned_line_anchor_is_reported(fx: Fixture) -> None:
-    result = fx.run(f"https://github.com/{NWO}/blob/main/CLAUDE.md#L10\n")
+    result = fx.run(f"https://github.com/{SLUG}/blob/main/CLAUDE.md#L10\n")
     assert result.returncode == 1
     assert "un-pinned line link" in result.stdout
     assert fx.gh_calls() == []
@@ -110,7 +111,7 @@ def test_branch_pinned_line_anchor_is_reported(fx: Fixture) -> None:
 
 def test_abbreviated_sha_with_a_line_anchor_is_reported(fx: Fixture) -> None:
     """An abbreviation is what the model extends; it cannot pin a line either."""
-    result = fx.run(f"https://github.com/{NWO}/blob/{REAL[:7]}/a.py#L10\n")
+    result = fx.run(f"https://github.com/{SLUG}/blob/{REAL[:7]}/a.py#L10\n")
     assert result.returncode == 1
     assert "un-pinned line link" in result.stdout
 
@@ -119,9 +120,9 @@ def test_each_distinct_sha_costs_one_api_call(fx: Fixture) -> None:
     """Bodies repeat the same permalink; the check must not repeat the call."""
     body = "\n".join(
         [
-            f"https://github.com/{NWO}/blob/{REAL}/a.py#L1",
-            f"https://github.com/{NWO}/blob/{REAL}/b.py#L2",
-            f"https://github.com/{NWO}/commit/{FAKE}",
+            f"https://github.com/{SLUG}/blob/{REAL}/a.py#L1",
+            f"https://github.com/{SLUG}/blob/{REAL}/b.py#L2",
+            f"https://github.com/{SLUG}/commit/{FAKE}",
         ]
     )
     result = fx.run(body + "\n")
@@ -132,11 +133,11 @@ def test_each_distinct_sha_costs_one_api_call(fx: Fixture) -> None:
 def test_markdown_delimiters_do_not_leak_into_the_ref(fx: Fixture) -> None:
     """A URL closed by `)` or wrapped in backticks still parses to the bare ref."""
     result = fx.run(
-        f"([a](https://github.com/{NWO}/blob/{FAKE}/a.py#L10)) "
-        f"`https://github.com/{NWO}/blob/{FAKE}/b.py`\n"
+        f"([a](https://github.com/{SLUG}/blob/{FAKE}/a.py#L10)) "
+        f"`https://github.com/{SLUG}/blob/{FAKE}/b.py`\n"
     )
     assert result.returncode == 1
-    assert f"unresolvable SHA {FAKE} in {NWO}" in result.stdout
+    assert f"unresolvable SHA {FAKE} in {SLUG}" in result.stdout
     assert ")" not in result.stdout.split(" in ")[0]
 
 

--- a/generator/tests/test_check_body_links.py
+++ b/generator/tests/test_check_body_links.py
@@ -141,6 +141,17 @@ def test_markdown_delimiters_do_not_leak_into_the_ref(fx: Fixture) -> None:
     assert ")" not in result.stdout.split(" in ")[0]
 
 
+def test_sentence_punctuation_does_not_skip_the_resolve(fx: Fixture) -> None:
+    """A bare `commit/<sha>` URL in prose ends at the period, which is part of the ref."""
+    result = fx.run(
+        f"Pushed as https://github.com/{SLUG}/commit/{FAKE}.\n"
+        f"See https://github.com/{SLUG}/commit/{REAL}, which is real.\n"
+    )
+    assert result.returncode == 1
+    assert f"unresolvable SHA {FAKE} in {SLUG}" in result.stdout
+    assert REAL not in result.stdout
+
+
 def test_body_without_github_links_passes_without_calling_the_api(fx: Fixture) -> None:
     result = fx.run("Thanks for reporting this — I could not reproduce it.\n")
     assert result.returncode == 0

--- a/plugins/tend-ci-runner/scripts/check-body-links.sh
+++ b/plugins/tend-ci-runner/scripts/check-body-links.sh
@@ -58,6 +58,9 @@ while IFS= read -r url; do
   # https://github.com/OWNER/REPO/blob/REF/path -> fields 4, 5, 7
   read -r slug ref <<<"$(printf '%s\n' "$url" | awk -F/ '{print $4 "/" $5, $7}')"
   ref=${ref%%#*}
+  # A bare URL in prose ends at the sentence, so trailing punctuation lands in
+  # the ref of a `commit/<sha>` link and would skip the resolve entirely.
+  ref=${ref%[.,;:!?]}
   if [[ "$ref" =~ ^[0-9a-f]{40}$ ]]; then
     printf '%s %s\n' "$slug" "$ref" >>"$shas"
   elif [[ "$url" == *"#L"* ]]; then

--- a/plugins/tend-ci-runner/scripts/check-body-links.sh
+++ b/plugins/tend-ci-runner/scripts/check-body-links.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Checks the GitHub links in a composed body before it is posted.
+#
+# Usage: check-body-links.sh <body-file>
+#
+# Two failure shapes, both of which ship a citation that resolves to nothing or
+# to different code than the text describes, in the artifact a maintainer reads
+# to decide whether to merge:
+#
+#   Fabricated SHA. The model sees an abbreviated OID in `git log` output and
+#   extends it to 40 characters instead of running `git rev-parse HEAD`. The
+#   result is well-formed, so any check that tests the *shape* of a permalink
+#   passes it, and the link 404s from the moment it is posted. Only resolving
+#   the OID separates a real commit from an invented one.
+#
+#   Un-pinned line anchor. `blob/main/...#L42` stays valid while the lines
+#   underneath it move, so the link silently comes to point at other code. A
+#   ref that is not a full 40-hex OID cannot pin a line.
+#
+# One API call per distinct (repo, SHA) pair, and bodies carry one or two. A
+# hand-typed owner falls out of the same call: `repos/<wrong-owner>/<repo>/
+# commits/<sha>` does not resolve either.
+#
+# A repo the token cannot read reports the same way a dead SHA does, so the
+# message names both readings rather than asserting the link is dead. A commit
+# this session made but has not pushed yet reports the same way too, and there
+# it is right: the link would 404 for a reader. Run the check after the push.
+#
+# Exit codes:
+#   0  every GitHub link in the body checks out
+#   1  problems found, one per line on stdout
+#   2  usage error
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: check-body-links.sh <body-file>" >&2
+  exit 2
+fi
+
+body="$1"
+if [ ! -f "$body" ]; then
+  echo "check-body-links.sh: no such file: $body" >&2
+  exit 2
+fi
+
+# A URL ends at the delimiters that surround it in markdown: `)` closes a link,
+# `]`, quotes, backticks, angle brackets and whitespace end a bare one. The
+# leading `]` inside the negated class is literal.
+url_re='https?://github\.com/[A-Za-z0-9._-]+/[A-Za-z0-9._-]+/(blob|blame|tree|commit|commits|raw)/[^][)("<>`'"'"'[:space:]]+'
+
+problems=$(mktemp)
+shas=$(mktemp)
+trap 'rm -f "$problems" "$shas"' EXIT
+
+while IFS= read -r url; do
+  [ -n "$url" ] || continue
+  # https://github.com/OWNER/REPO/blob/REF/path -> fields 4, 5, 7
+  read -r nwo ref <<<"$(printf '%s\n' "$url" | awk -F/ '{print $4 "/" $5, $7}')"
+  ref=${ref%%#*}
+  if [[ "$ref" =~ ^[0-9a-f]{40}$ ]]; then
+    printf '%s %s\n' "$nwo" "$ref" >>"$shas"
+  elif [[ "$url" == *"#L"* ]]; then
+    printf 'un-pinned line link: ref `%s` is not a full commit SHA, so the lines it points at can move — %s\n' \
+      "$ref" "$url" >>"$problems"
+  fi
+done < <(grep -oE "$url_re" "$body" || true)
+
+while read -r nwo sha; do
+  [ -n "$sha" ] || continue
+  gh api "repos/$nwo/commits/$sha" --jq '.sha' >/dev/null 2>&1 && continue
+  printf 'unresolvable SHA %s in %s — the commit does not exist (a hand-typed OID or a wrong owner), or the token cannot read that repo\n' \
+    "$sha" "$nwo" >>"$problems"
+done < <(sort -u "$shas")
+
+if [ -s "$problems" ]; then
+  cat "$problems"
+  exit 1
+fi

--- a/plugins/tend-ci-runner/scripts/check-body-links.sh
+++ b/plugins/tend-ci-runner/scripts/check-body-links.sh
@@ -56,21 +56,21 @@ trap 'rm -f "$problems" "$shas"' EXIT
 while IFS= read -r url; do
   [ -n "$url" ] || continue
   # https://github.com/OWNER/REPO/blob/REF/path -> fields 4, 5, 7
-  read -r nwo ref <<<"$(printf '%s\n' "$url" | awk -F/ '{print $4 "/" $5, $7}')"
+  read -r slug ref <<<"$(printf '%s\n' "$url" | awk -F/ '{print $4 "/" $5, $7}')"
   ref=${ref%%#*}
   if [[ "$ref" =~ ^[0-9a-f]{40}$ ]]; then
-    printf '%s %s\n' "$nwo" "$ref" >>"$shas"
+    printf '%s %s\n' "$slug" "$ref" >>"$shas"
   elif [[ "$url" == *"#L"* ]]; then
     printf 'un-pinned line link: ref `%s` is not a full commit SHA, so the lines it points at can move — %s\n' \
       "$ref" "$url" >>"$problems"
   fi
 done < <(grep -oE "$url_re" "$body" || true)
 
-while read -r nwo sha; do
+while read -r slug sha; do
   [ -n "$sha" ] || continue
-  gh api "repos/$nwo/commits/$sha" --jq '.sha' >/dev/null 2>&1 && continue
+  gh api "repos/$slug/commits/$sha" --jq '.sha' >/dev/null 2>&1 && continue
   printf 'unresolvable SHA %s in %s — the commit does not exist (a hand-typed OID or a wrong owner), or the token cannot read that repo\n' \
-    "$sha" "$nwo" >>"$problems"
+    "$sha" "$slug" >>"$problems"
 done < <(sort -u "$shas")
 
 if [ -s "$problems" ]; then

--- a/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
+++ b/plugins/tend-ci-runner/skills/running-in-ci/SKILL.md
@@ -436,7 +436,15 @@ When an answer rests on deeper research — citations across several files, a re
 
 Always use markdown links for files, issues, PRs, and docs. **Any link containing `#L` must use a commit SHA, never `blob/main/...#L42`** — line numbers shift silently, so the link stays valid but starts pointing at different code than the comment describes. Get the SHA with `git rev-parse HEAD` before composing the link.
 
-**GitHub URLs — read `$GITHUB_REPOSITORY` from the environment, don't hand-type the owner.** The model reliably guesses wrong — past comments have shipped with the wrong owner (e.g. `anthropics/<repo>` on a repo not owned by Anthropic). Before posting, scan the composed body for `github.com/`: confirm every owner matches `$GITHUB_REPOSITORY`, **and** every URL with a `#L<n>` anchor is SHA-pinned. A `blob/main/...#L<n>` hit is the link-rot shape — replace `main` with `$(git rev-parse HEAD)` for that link and re-scan. This catches both the wrong-owner typo and the un-pinned line-link slip in one pre-post pass.
+**Check the body's links before posting it.** Run this over every composed body — comment, PR body, issue body — as part of the pre-post pass, and fix what it names:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/scripts/check-body-links.sh /tmp/comment-body.md
+```
+
+It resolves every 40-hex SHA in the body against the API and reports any `#L` anchor pinned to a branch or an abbreviation. Resolving is the part a scan by eye cannot do: a hand-typed OID is well-formed whether or not the commit exists, so a fabricated SHA — the model extending an abbreviation it saw in `git log` instead of running `git rev-parse HEAD` — reads as correctly pinned and ships a permalink that 404s. Run it after the push when the body cites a commit from this session; before the push that commit is unreachable and reports as dead, correctly.
+
+**Owners it cannot check — read `$GITHUB_REPOSITORY` from the environment, don't hand-type the owner.** The model reliably guesses wrong — past comments have shipped with the wrong owner (e.g. `anthropics/<repo>` on a repo not owned by Anthropic). The script catches a wrong owner on a SHA-pinned link, because that URL does not resolve either; on every other link, scan the body's `github.com/` hits and confirm each owner is either `$GITHUB_REPOSITORY` or a repo the text genuinely means.
 
 **Authoring fenced bodies with backticks.** When a body contains a fenced code block, the model often defensively escapes the inner fence (`` \`\`\`bash ``) "to prevent it from closing the outer fence early"; the same instinct can produce `` \`foo\` `` for inline spans. Those backslashes survive into the rendered body as literal `\` characters. Author with bare backticks. For nested fenced blocks, use a **longer outer fence** — four or five backticks outside, three inside — so the inner three-backtick fence renders intact without escaping. The Write tool preserves data verbatim, so the same authoring rule applies whether you compose with the Write tool or inline; Write just removes shell-quoting from the equation.
 


### PR DESCRIPTION
## Problem

`running-in-ci`'s pre-post scan checked that a `#L` link was *SHA-pinned*, not that the SHA *existed*. A hand-typed 40-hex string satisfies the shape either way, so a fabricated OID — the model extending an abbreviation it saw in `git log` output rather than running `git rev-parse HEAD` — passed the scan and shipped a permalink that 404s from the moment it was posted. #1142 documents two occurrences that reached a public PR body, the second with nothing in the session to catch it: the poll-side sentinel that accidentally backstopped the first now resolves a good SHA on the first iteration, so it never sends the session to `git rev-parse HEAD` any more.

## Solution

`plugins/tend-ci-runner/scripts/check-body-links.sh <body-file>` resolves every 40-hex SHA in a composed body against the API — one call per distinct (repo, SHA) pair, and bodies carry one or two — and reports any `#L` anchor pinned to a branch or an abbreviation. A hand-typed owner falls out of the same call, since `repos/<wrong-owner>/<repo>/commits/<sha>` does not resolve either. Exit 1 with one problem per line, exit 0 clean.

The Comment Formatting section now invokes it in place of the by-eye scan. The owner rule stays as prose for the links the script cannot check (issue/PR links carry no SHA to resolve).

Deliberately reported rather than swallowed: a repo the token cannot read, and a commit this session has made but not yet pushed, both read as unresolvable. The second is correct — the link would 404 for a reader — so the skill says to run the check after the push.

## Testing

`generator/tests/test_check_body_links.py` (10 tests) drives the script against a fake `gh` that resolves exactly one (repo, SHA) pair: a fabricated OID and a wrong owner are reported, a resolvable permalink and a file-level branch link pass, a branch- or abbreviation-pinned `#L` anchor is reported without an API call, a repeated permalink costs one call, and neither markdown delimiters (`)`, backticks) nor sentence punctuation after a bare URL leak into the parsed ref.

Full `uv run pytest` is green (925 passed), as is `pre-commit run --all-files` — shellcheck at warning severity covers `plugins/**/*.sh`.

---
Closes #1142 — automated triage

