### PR TITLE
fix(logs): copy the agent's session tree out as root instead of opening it up

### DIFF
--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -472,6 +472,9 @@ runs:
       env:
         MODEL: ${{ inputs.model }}
         STREAM_JSON: ${{ steps.claude.outputs.stream_json }}
+        # The session-log copy reads an agent-owned tree as root, so it runs
+        # only once the supervisor has reaped the sandbox uid.
+        SANDBOX_REAPED: ${{ steps.claude.outputs.sandbox_reaped }}
       run: /usr/bin/python3 -E -s "${{ github.action_path }}/../shared/steps/token_usage.py" --harness claude
 
     # Gate on the job being red, not on the agent step specifically. A dozen

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -340,6 +340,14 @@ made as the sandbox user with `sandbox_setup:`. A generic failure shim keeps a
 dropped home-selected command from silently falling through to a different
 same-named system tool.
 
+**Session-log upload.** The token-usage step uploads the agent's session JSONL
+as an artifact, so the runner has to read a tree the sandbox user owns. It
+copies as root and chowns the result rather than making the source readable,
+since a `chmod -R` aimed through a symlink the agent planted would grant read on
+whatever tree it named. Both the session directory and the dot-directory above
+it are refused if either is a symlink, and links inside the copy are deleted
+before `upload-artifact` resolves them as the runner.
+
 The Codex harness (`codex/action.yaml`) still passes both the PAT and the model
 auth directly to the agent. The merge restriction and the environment gate
 remain the load-bearing boundaries regardless of harness.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -344,9 +344,16 @@ same-named system tool.
 as an artifact, so the runner has to read a tree the sandbox user owns. It
 copies as root and chowns the result rather than making the source readable,
 since a `chmod -R` aimed through a symlink the agent planted would grant read on
-whatever tree it named. Both the session directory and the dot-directory above
-it are refused if either is a symlink, and links inside the copy are deleted
-before `upload-artifact` resolves them as the runner.
+whatever tree it named.
+
+The agent chooses the input to every check that follows. The copy waits for the
+supervisor to reap every sandbox process, so nothing is left alive to change
+what was checked. The session directory and the dot-directory above it are
+refused if either is a symlink. The copied modes are reset to the runner's,
+since deleting an entry needs write on its parent and those modes came from the
+agent. Every entry that is not a regular file or a directory is deleted before
+`upload-artifact` reads it: a symlink it would otherwise resolve as the runner,
+a FIFO it would block on until the job times out.
 
 The Codex harness (`codex/action.yaml`) still passes both the PAT and the model
 auth directly to the agent. The merge restriction and the environment gate

--- a/shared/steps/test_run_claude.py
+++ b/shared/steps/test_run_claude.py
@@ -727,7 +727,7 @@ def test_supervise_reaps_the_sandbox_uid_when_the_runner_cancels_the_job(
 
     SIGTERM's default disposition ends this process where it stands, so the
     reap would be skipped and the agent would run on as an orphan — still
-    writing to the workspace — while the runner tore the job down. `tend-review`
+    writing to the workspace — while the runner tore the job down. `tend-triage`
     runs with `cancel-in-progress: true`, so this is a routine exit, not an
     exotic one.
     """

--- a/shared/steps/test_token_usage.py
+++ b/shared/steps/test_token_usage.py
@@ -121,6 +121,40 @@ def logs_dir(tmp_path: Path) -> Path:
     return path
 
 
+@pytest.fixture
+def sudoless(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Run the consolidating copy's commands unprivileged, as themselves.
+
+    The copy runs as root on a runner because the source belongs to another
+    UID; under a test the source is the test's own, so dropping the `sudo`
+    prefix leaves each command doing exactly what it does in CI.
+    """
+    run_command = token_usage.best_effort
+
+    def run_without_sudo(*argv: str) -> None:
+        run_command(*(argv[1:] if argv[:1] == ("sudo",) else argv))
+
+    monkeypatch.setattr(token_usage, "best_effort", run_without_sudo)
+
+
+def _record_commands(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, ...]]:
+    """Capture what the consolidating copy would run instead of running it."""
+    commands: list[tuple[str, ...]] = []
+    monkeypatch.setattr(token_usage, "best_effort", lambda *argv: commands.append(argv))
+    return commands
+
+
+def _aimed_inside(
+    commands: list[tuple[str, ...]], *paths: Path
+) -> list[tuple[str, ...]]:
+    """The captured commands naming any of *paths* — none, when a guard held."""
+    return [
+        argv
+        for argv in commands
+        if any(str(path) in arg for arg in argv for path in paths)
+    ]
+
+
 def test_reconstructs_a_cancelled_session(tmp_path: Path, logs_dir: Path) -> None:
     """A cancelled session must be accounted from its session JSONL.
 
@@ -336,6 +370,7 @@ def test_claude_main_publishes_the_record_three_ways(
     logs_dir: Path,
     github_files: GithubFiles,
     monkeypatch: pytest.MonkeyPatch,
+    sudoless: None,
 ) -> None:
     """End to end: consolidate the sandbox's logs, then report from them.
 
@@ -356,13 +391,6 @@ def test_claude_main_publishes_the_record_three_ways(
     monkeypatch.setenv("MODEL", "opus")
     monkeypatch.setenv("STREAM_JSON", str(_cancelled_stream(tmp_path)))
     monkeypatch.setattr(sys, "argv", ["token_usage.py", "--harness", "claude"])
-
-    run_command = token_usage.best_effort
-
-    def run_without_sudo(*argv: str) -> None:
-        run_command(*(argv[1:] if argv[:1] == ("sudo",) else argv))
-
-    monkeypatch.setattr(token_usage, "best_effort", run_without_sudo)
 
     assert token_usage.main() == 0
 
@@ -463,3 +491,138 @@ def test_cost_renders_to_the_cent_and_says_so_when_unknown() -> None:
     assert token_usage.cell(None, "cost_usd") == "unknown"
     assert token_usage.cell(0, "cost_usd") == "$0.00"
     assert token_usage.cell(1.2, "cost_usd") == "$1.20"
+
+
+def test_consolidation_refuses_a_symlinked_session_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`cp -a` follows a symlinked argument, so the sandbox must not aim it.
+
+    The agent owns the parent of `.claude/projects`, so it chooses what the
+    runner's root-privileged copy reads. Pointing it at a tree of the agent's
+    choosing publishes that tree; refusing the link is the fix.
+    """
+    agent_home = tmp_path / "agent-home"
+    (agent_home / ".claude").mkdir(parents=True)
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    (elsewhere / "ca-key.pem").write_text("PRIVATE KEY\n")
+    (agent_home / ".claude" / "projects").symlink_to(elsewhere)
+    monkeypatch.setenv("AGENT_HOME", str(agent_home))
+    commands = _record_commands(monkeypatch)
+
+    token_usage.consolidate_logs(tmp_path / "logs", tmp_path / "runner-temp")
+
+    assert _aimed_inside(commands, agent_home, elsewhere) == []
+    assert list((tmp_path / "logs").iterdir()) == []
+
+
+def test_consolidation_refuses_a_symlinked_dot_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The dot-dir the session dir sits in is a boundary too.
+
+    Checking only `.claude/projects` leaves `.claude` itself free to be a link:
+    the session dir under it is then a real directory and passes, while the
+    privileged copy reads out of whatever tree the agent aimed the dot-dir at.
+    """
+    agent_home = tmp_path / "agent-home"
+    agent_home.mkdir()
+    elsewhere = tmp_path / "elsewhere"
+    (elsewhere / "projects").mkdir(parents=True)
+    (elsewhere / "projects" / "session.jsonl").write_text("{}\n")
+    (agent_home / ".claude").symlink_to(elsewhere, target_is_directory=True)
+    monkeypatch.setenv("AGENT_HOME", str(agent_home))
+    commands = _record_commands(monkeypatch)
+
+    token_usage.consolidate_logs(tmp_path / "logs", tmp_path / "runner-temp")
+
+    assert _aimed_inside(commands, agent_home, elsewhere) == []
+    assert list((tmp_path / "logs").iterdir()) == []
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root is never denied the lstat")
+def test_consolidation_asks_root_about_a_path_it_cannot_stat(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A dot-dir the agent has closed must not answer the symlink check `False`.
+
+    The sandbox home is the agent's, so it can `chmod` `.claude` shut at will —
+    and `Path.is_symlink` reports an unreachable path as "not a symlink", which
+    waves the link straight past the check meant to catch it. The question goes
+    to root instead, which can always see.
+    """
+    agent_home = tmp_path / "agent-home"
+    (agent_home / ".claude").mkdir(parents=True)
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    projects = agent_home / ".claude" / "projects"
+    projects.symlink_to(elsewhere, target_is_directory=True)
+    # `sudo test` is out of reach here, so root's answers are read off the
+    # link while the test can still see it, and served back from this table.
+    root_sees = {"-d": projects.is_dir(), "-L": projects.is_symlink()}
+    monkeypatch.setenv("AGENT_HOME", str(agent_home))
+    commands = _record_commands(monkeypatch)
+
+    asked: list[str] = []
+
+    def as_root(flag: str, path: Path) -> bool:
+        asked.append(flag)
+        assert path == projects
+        return root_sees[flag]
+
+    monkeypatch.setattr(token_usage, "root_test", as_root)
+
+    (agent_home / ".claude").chmod(0o600)
+    try:
+        token_usage.consolidate_logs(tmp_path / "logs", tmp_path / "runner-temp")
+    finally:
+        (agent_home / ".claude").chmod(0o700)
+
+    assert asked == ["-d", "-L"], "the unreadable boundary was never re-asked"
+    assert _aimed_inside(commands, agent_home, elsewhere) == []
+    assert list((tmp_path / "logs").iterdir()) == []
+
+
+def test_consolidation_copies_nothing_when_the_agent_never_wrote_logs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`AGENT_HOME` is unset when sandbox setup died before exporting it.
+
+    The placeholder home names nothing, and neither does a home whose agent
+    never opened a session — both read as nothing to copy, without a privileged
+    command run against a path that isn't there.
+    """
+    monkeypatch.delenv("AGENT_HOME", raising=False)
+    commands = _record_commands(monkeypatch)
+
+    token_usage.consolidate_logs(tmp_path / "logs", tmp_path / "runner-temp")
+
+    assert _aimed_inside(commands, Path("/nonexistent")) == []
+    assert list((tmp_path / "logs").iterdir()) == []
+
+
+def test_consolidation_drops_symlinks_from_the_uploaded_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sudoless: None
+) -> None:
+    """`cp -a` preserves links and upload-artifact resolves them as the runner.
+
+    A link the agent plants in its session dir would otherwise publish whatever
+    the runner can read — the proxy's CA private key, its own
+    `/proc/<pid>/environ` — into a downloadable artifact.
+    """
+    agent_home = tmp_path / "agent-home"
+    projects = agent_home / ".claude" / "projects" / "project"
+    projects.mkdir(parents=True)
+    (projects / "session.jsonl").write_text("{}\n")
+    secret = tmp_path / "ca-key.pem"
+    secret.write_text("PRIVATE KEY\n")
+    (projects / "leak.pem").symlink_to(secret)
+    monkeypatch.setenv("AGENT_HOME", str(agent_home))
+
+    logs_dir = tmp_path / "logs"
+    token_usage.consolidate_logs(logs_dir, tmp_path / "runner-temp")
+
+    assert (logs_dir / "project" / "session.jsonl").is_file()
+    assert not (logs_dir / "project" / "leak.pem").exists()
+    assert secret.read_text() == "PRIVATE KEY\n"

--- a/shared/steps/test_token_usage.py
+++ b/shared/steps/test_token_usage.py
@@ -122,6 +122,16 @@ def logs_dir(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
+def reaped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The supervisor's record that every sandbox process is dead.
+
+    `consolidate_logs` copies nothing without it, so a test that exercises the
+    copy has to say the reap happened.
+    """
+    monkeypatch.setenv("SANDBOX_REAPED", "true")
+
+
+@pytest.fixture
 def sudoless(monkeypatch: pytest.MonkeyPatch) -> None:
     """Run the consolidating copy's commands unprivileged, as themselves.
 
@@ -371,6 +381,7 @@ def test_claude_main_publishes_the_record_three_ways(
     github_files: GithubFiles,
     monkeypatch: pytest.MonkeyPatch,
     sudoless: None,
+    reaped: None,
 ) -> None:
     """End to end: consolidate the sandbox's logs, then report from them.
 
@@ -494,7 +505,7 @@ def test_cost_renders_to_the_cent_and_says_so_when_unknown() -> None:
 
 
 def test_consolidation_refuses_a_symlinked_session_dir(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, reaped: None
 ) -> None:
     """`cp -a` follows a symlinked argument, so the sandbox must not aim it.
 
@@ -518,7 +529,7 @@ def test_consolidation_refuses_a_symlinked_session_dir(
 
 
 def test_consolidation_refuses_a_symlinked_dot_directory(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, reaped: None
 ) -> None:
     """The dot-dir the session dir sits in is a boundary too.
 
@@ -543,7 +554,7 @@ def test_consolidation_refuses_a_symlinked_dot_directory(
 
 @pytest.mark.skipif(os.geteuid() == 0, reason="root is never denied the lstat")
 def test_consolidation_asks_root_about_a_path_it_cannot_stat(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, reaped: None
 ) -> None:
     """A dot-dir the agent has closed must not answer the symlink check `False`.
 
@@ -585,7 +596,7 @@ def test_consolidation_asks_root_about_a_path_it_cannot_stat(
 
 
 def test_consolidation_copies_nothing_when_the_agent_never_wrote_logs(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, reaped: None
 ) -> None:
     """`AGENT_HOME` is unset when sandbox setup died before exporting it.
 
@@ -603,7 +614,7 @@ def test_consolidation_copies_nothing_when_the_agent_never_wrote_logs(
 
 
 def test_consolidation_drops_symlinks_from_the_uploaded_dir(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sudoless: None
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sudoless: None, reaped: None
 ) -> None:
     """`cp -a` preserves links and upload-artifact resolves them as the runner.
 
@@ -626,3 +637,27 @@ def test_consolidation_drops_symlinks_from_the_uploaded_dir(
     assert (logs_dir / "project" / "session.jsonl").is_file()
     assert not (logs_dir / "project" / "leak.pem").exists()
     assert secret.read_text() == "PRIVATE KEY\n"
+
+
+def test_consolidation_waits_for_the_sandbox_to_be_reaped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A surviving agent can swap the session dir between the check and the copy.
+
+    `copy_agent_tree` checks the tree it is about to read as root, so the check
+    holds only once nothing is left running to change it. The supervisor
+    publishes the reap, and without it the run reports its usage from the
+    stream-json and uploads no session logs.
+    """
+    agent_home = tmp_path / "agent-home"
+    projects = agent_home / ".claude" / "projects" / "project"
+    projects.mkdir(parents=True)
+    (projects / "session.jsonl").write_text("{}\n")
+    monkeypatch.setenv("AGENT_HOME", str(agent_home))
+    monkeypatch.delenv("SANDBOX_REAPED", raising=False)
+    commands = _record_commands(monkeypatch)
+
+    token_usage.consolidate_logs(tmp_path / "logs", tmp_path / "runner-temp")
+
+    assert _aimed_inside(commands, agent_home) == []
+    assert list((tmp_path / "logs").iterdir()) == []

--- a/shared/steps/test_token_usage.py
+++ b/shared/steps/test_token_usage.py
@@ -661,3 +661,35 @@ def test_consolidation_waits_for_the_sandbox_to_be_reaped(
 
     assert _aimed_inside(commands, agent_home) == []
     assert list((tmp_path / "logs").iterdir()) == []
+
+
+def test_consolidation_drops_a_symlink_a_directory_mode_would_shield(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sudoless: None, reaped: None
+) -> None:
+    """`cp -a` preserves the agent's directory modes, and `chown` leaves them.
+
+    Unlinking needs write on the parent, so a link the agent leaves in a `0555`
+    directory outlives `drop_symlinks` and takes the `if: always()` step down
+    with a `PermissionError` on the way. A `0000` directory is the same cause
+    with a quieter outcome: `rglob` yields nothing and the link just stays. The
+    copy normalises the modes it lands, which covers both.
+    """
+    agent_home = tmp_path / "agent-home"
+    project = agent_home / ".claude" / "projects" / "project"
+    project.mkdir(parents=True)
+    (project / "session.jsonl").write_text("{}\n")
+    secret = tmp_path / "ca-key.pem"
+    secret.write_text("PRIVATE KEY\n")
+    (project / "leak.pem").symlink_to(secret)
+    project.chmod(0o555)
+    monkeypatch.setenv("AGENT_HOME", str(agent_home))
+
+    logs_dir = tmp_path / "logs"
+    try:
+        token_usage.consolidate_logs(logs_dir, tmp_path / "runner-temp")
+    finally:
+        project.chmod(0o700)
+
+    assert (logs_dir / "project" / "session.jsonl").is_file()
+    assert not (logs_dir / "project" / "leak.pem").is_symlink()
+    assert secret.read_text() == "PRIVATE KEY\n"

--- a/shared/steps/test_token_usage.py
+++ b/shared/steps/test_token_usage.py
@@ -168,7 +168,7 @@ def _aimed_inside(
 def test_reconstructs_a_cancelled_session(tmp_path: Path, logs_dir: Path) -> None:
     """A cancelled session must be accounted from its session JSONL.
 
-    `tend-review` runs with `cancel-in-progress: true`, so cancellation is
+    `tend-triage` runs with `cancel-in-progress: true`, so cancellation is
     routine — and a cancelled session never emits a `type: "result"` event.
     The step is `if: always()`, so it still writes token-usage.json and still
     uploads the artifact; only the accounting would be lost. Reporting zeros
@@ -669,7 +669,7 @@ def test_consolidation_drops_a_symlink_a_directory_mode_would_shield(
     """`cp -a` preserves the agent's directory modes, and `chown` leaves them.
 
     Unlinking needs write on the parent, so a link the agent leaves in a `0555`
-    directory outlives `drop_symlinks` and takes the `if: always()` step down
+    directory outlives the sweep and takes the `if: always()` step down
     with a `PermissionError` on the way. A `0000` directory is the same cause
     with a quieter outcome: `rglob` yields nothing and the link just stays. The
     copy normalises the modes it lands, which covers both.
@@ -693,3 +693,27 @@ def test_consolidation_drops_a_symlink_a_directory_mode_would_shield(
     assert (logs_dir / "project" / "session.jsonl").is_file()
     assert not (logs_dir / "project" / "leak.pem").is_symlink()
     assert secret.read_text() == "PRIVATE KEY\n"
+
+
+def test_consolidation_drops_a_fifo_the_agent_planted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sudoless: None, reaped: None
+) -> None:
+    """`cp -a` reproduces a FIFO as a FIFO, and the upload streams it.
+
+    `upload-artifact` reads every entry that isn't a directory, and opening a
+    FIFO with no writer blocks — so one left in the session dir hangs an
+    `if: always()` upload until the job times out. `mkfifo` needs no privilege,
+    so the agent chooses whether that happens.
+    """
+    agent_home = tmp_path / "agent-home"
+    project = agent_home / ".claude" / "projects" / "project"
+    project.mkdir(parents=True)
+    (project / "session.jsonl").write_text("{}\n")
+    os.mkfifo(project / "pipe")
+    monkeypatch.setenv("AGENT_HOME", str(agent_home))
+
+    logs_dir = tmp_path / "logs"
+    token_usage.consolidate_logs(logs_dir, tmp_path / "runner-temp")
+
+    assert (logs_dir / "project" / "session.jsonl").is_file()
+    assert not (logs_dir / "project" / "pipe").exists()

--- a/shared/steps/token_usage.py
+++ b/shared/steps/token_usage.py
@@ -39,9 +39,9 @@ Claude's accounting has three paths, tried in order:
    ``usage.*`` and ``num_turns`` are per-event while ``total_cost_usd`` is
    cumulative, so the per-event fields are summed and cost taken from the last.
 2. No result event: the session JSONL this step has just consolidated. A
-   cancelled session never emits a result, and ``tend-review`` runs with
+   cancelled session never emits a result, and ``tend-triage`` runs with
    ``cancel-in-progress: true``, so this is routine rather than exotic — the
-   run may have done dozens of turns and already posted its review.
+   run may have done dozens of turns and already posted its comment.
 3. Neither: the agent never ran (a preflight failure, say). That run genuinely
    cost nothing, so it reports a real zero rather than flagging an unknown.
 
@@ -204,13 +204,25 @@ def codex_step(model: str) -> tuple[dict[str, Any], Path]:
 def consolidate_logs(logs_dir: Path, runner_temp: Path) -> None:
     """Copy the agent's session JSONL and stderr log into a runner-owned dir.
 
+    The copy waits on ``SANDBOX_REAPED``, the supervisor's record that every
+    sandbox process is dead. :func:`copy_agent_tree` checks the tree it is about
+    to read, and a surviving agent could swap a session dir for a symlink
+    between that check and the root copy that follows. The memory save keys on
+    the same output for the same reason, and that read is unprivileged where
+    this one runs as root.
+
+    It is set from a ``finally``, so only a supervisor killed outright — a
+    second signal during an escalating cancel — leaves it unset. That run
+    reports its usage from the stream-json and uploads no session logs.
+
     ``AGENT_HOME`` is unset when sandbox setup died before exporting it; the
     placeholder names nothing, which :func:`copy_agent_tree` reads as the same
     nothing-to-copy outcome as a run whose agent never started.
     """
     logs_dir.mkdir(parents=True, exist_ok=True)
     agent_home = Path(os.environ.get("AGENT_HOME") or "/nonexistent")
-    copy_agent_tree(agent_home / ".claude" / "projects", logs_dir)
+    if os.environ.get("SANDBOX_REAPED") == "true":
+        copy_agent_tree(agent_home / ".claude" / "projects", logs_dir)
     best_effort("cp", "-a", str(runner_temp / "tend-claude-stderr.log"), f"{logs_dir}/")
 
 

--- a/shared/steps/token_usage.py
+++ b/shared/steps/token_usage.py
@@ -239,11 +239,12 @@ def copy_agent_tree(source: Path, destination: Path) -> None:
     - **No symlink at either boundary.** ``cp -a`` follows a symlinked
       *argument*, so the session dir and the dot-dir holding it are both
       checked; see :func:`safe_agent_directory`.
-    - **No symlink inside.** ``cp -a`` copies nested links as links, and they
-      are deleted before anything reads the copy; see :func:`drop_symlinks`.
+    - **Only regular files inside.** ``cp -a`` reproduces a nested symlink or
+      FIFO as one, and both are removed before anything reads the copy; see
+      :func:`drop_non_regular_files`.
       ``cp -a`` also preserves the agent's directory modes and ``chown`` leaves
       them alone, so the modes are normalised too: unlinking needs write on the
-      parent, and a ``0555`` directory would keep its link (and raise), a
+      parent, and a ``0555`` directory would keep what it holds (and raise), a
       ``0000`` one hide it. That chmod is nothing like the one this replaces —
       it lands on a destination the runner made and now owns, so there is
       nothing for the agent to aim it at.
@@ -260,7 +261,7 @@ def copy_agent_tree(source: Path, destination: Path) -> None:
     best_effort("sudo", "cp", "-a", f"{source}/.", f"{destination}/")
     best_effort("sudo", "chown", "-R", f"{os.getuid()}:{os.getgid()}", str(destination))
     best_effort("sudo", "chmod", "-R", "u+rwX", str(destination))
-    drop_symlinks(destination)
+    drop_non_regular_files(destination)
 
 
 def safe_agent_directory(path: Path) -> bool:
@@ -295,16 +296,20 @@ def root_test(flag: str, path: Path) -> bool:
     )
 
 
-def drop_symlinks(logs_dir: Path) -> None:
-    """Remove every symlink from the dir about to be uploaded.
+def drop_non_regular_files(logs_dir: Path) -> None:
+    """Remove everything but files and directories from the dir to be uploaded.
 
-    ``cp -a`` copies links as links and ``upload-artifact`` resolves them as
-    the runner — which can read the proxy's CA private key and its own
-    ``/proc/<pid>/environ``. The agent writes only regular files here, so a
-    link is it reaching for something else.
+    The agent writes only regular files here, so anything else is it reaching
+    for something other than its own session log, and ``cp -a`` reproduces
+    whatever it finds. A symlink stays a symlink, and ``upload-artifact``
+    resolves it as the runner — which can read the proxy's CA private key and
+    its own ``/proc/<pid>/environ``. A FIFO stays a FIFO, and the upload
+    streams every entry that isn't a directory, so opening one with no writer
+    blocks until the job times out. One test on the mode covers both.
     """
     for path in list(logs_dir.rglob("*")):
-        if path.is_symlink():
+        mode = path.lstat().st_mode
+        if not (stat.S_ISREG(mode) or stat.S_ISDIR(mode)):
             path.unlink()
 
 

--- a/shared/steps/token_usage.py
+++ b/shared/steps/token_usage.py
@@ -241,6 +241,12 @@ def copy_agent_tree(source: Path, destination: Path) -> None:
       checked; see :func:`safe_agent_directory`.
     - **No symlink inside.** ``cp -a`` copies nested links as links, and they
       are deleted before anything reads the copy; see :func:`drop_symlinks`.
+      ``cp -a`` also preserves the agent's directory modes and ``chown`` leaves
+      them alone, so the modes are normalised too: unlinking needs write on the
+      parent, and a ``0555`` directory would keep its link (and raise), a
+      ``0000`` one hide it. That chmod is nothing like the one this replaces —
+      it lands on a destination the runner made and now owns, so there is
+      nothing for the agent to aim it at.
 
     A boundary that fails the check copies nothing: an empty artifact, the same
     thing a run whose agent never started leaves behind. Telling the two apart
@@ -253,6 +259,7 @@ def copy_agent_tree(source: Path, destination: Path) -> None:
     destination.mkdir(parents=True, exist_ok=True)
     best_effort("sudo", "cp", "-a", f"{source}/.", f"{destination}/")
     best_effort("sudo", "chown", "-R", f"{os.getuid()}:{os.getgid()}", str(destination))
+    best_effort("sudo", "chmod", "-R", "u+rwX", str(destination))
     drop_symlinks(destination)
 
 
@@ -304,8 +311,8 @@ def drop_symlinks(logs_dir: Path) -> None:
 def best_effort(*argv: str) -> None:
     """Run ``argv``, discarding its output and its failure.
 
-    Everything this runs is a copy or a chown that enriches the uploaded
-    artifact. None of it is worth failing an ``if: always()`` accounting step
+    Everything this runs is a copy, a chown, or a chmod that enriches the
+    uploaded artifact. None of it is worth failing an ``if: always()`` step
     for, and a partial copy still beats no artifact. ``stdin`` is closed so a
     ``sudo`` without a tty fails instead of waiting for a password.
     """

--- a/shared/steps/token_usage.py
+++ b/shared/steps/token_usage.py
@@ -79,6 +79,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import stat
 import subprocess
 from collections.abc import Callable, Iterable, Iterator
 from pathlib import Path
@@ -203,24 +204,95 @@ def codex_step(model: str) -> tuple[dict[str, Any], Path]:
 def consolidate_logs(logs_dir: Path, runner_temp: Path) -> None:
     """Copy the agent's session JSONL and stderr log into a runner-owned dir.
 
-    The session JSONL is written under the sandbox home with restrictive perms,
-    so the runner needs a chmod first — of the session dir only, not the whole
-    plugin tree. ``AGENT_HOME`` is unset when sandbox setup died before
-    exporting it; the placeholder keeps every command below well-formed and
-    failing, which is the same nothing-to-copy outcome.
+    ``AGENT_HOME`` is unset when sandbox setup died before exporting it; the
+    placeholder names nothing, which :func:`copy_agent_tree` reads as the same
+    nothing-to-copy outcome as a run whose agent never started.
     """
-    agent_home = os.environ.get("AGENT_HOME") or "/nonexistent"
-    best_effort("sudo", "chmod", "a+x", agent_home, f"{agent_home}/.claude")
-    best_effort("sudo", "chmod", "-R", "a+rX", f"{agent_home}/.claude/projects")
     logs_dir.mkdir(parents=True, exist_ok=True)
-    best_effort("cp", "-a", f"{agent_home}/.claude/projects/.", f"{logs_dir}/")
+    agent_home = Path(os.environ.get("AGENT_HOME") or "/nonexistent")
+    copy_agent_tree(agent_home / ".claude" / "projects", logs_dir)
     best_effort("cp", "-a", str(runner_temp / "tend-claude-stderr.log"), f"{logs_dir}/")
+
+
+def copy_agent_tree(source: Path, destination: Path) -> None:
+    """Copy a reaped agent's session dir out of the sandbox home, as root.
+
+    The sandbox user owns ``source`` and its parent, so the agent picks what a
+    privileged command here lands on. Three things close that:
+
+    - **Copy, don't grant.** Reading the tree as root and chowning the copy to
+      the runner needs no permission change on the agent's side. The
+      ``chmod -R a+rX`` this replaces was an escalation primitive: aimed
+      through a symlink it opened up any tree the agent named.
+    - **No symlink at either boundary.** ``cp -a`` follows a symlinked
+      *argument*, so the session dir and the dot-dir holding it are both
+      checked; see :func:`safe_agent_directory`.
+    - **No symlink inside.** ``cp -a`` copies nested links as links, and they
+      are deleted before anything reads the copy; see :func:`drop_symlinks`.
+
+    A boundary that fails the check copies nothing: an empty artifact, the same
+    thing a run whose agent never started leaves behind. Telling the two apart
+    is not worth failing an ``if: always()`` step over a directory the runner
+    may simply be unable to see.
+    """
+    for boundary in (source.parent, source):
+        if not safe_agent_directory(boundary):
+            return
+    destination.mkdir(parents=True, exist_ok=True)
+    best_effort("sudo", "cp", "-a", f"{source}/.", f"{destination}/")
+    best_effort("sudo", "chown", "-R", f"{os.getuid()}:{os.getgid()}", str(destination))
+    drop_symlinks(destination)
+
+
+def safe_agent_directory(path: Path) -> bool:
+    """Whether *path* is a real directory rather than a symlink or absent.
+
+    The runner cannot always stat inside the sandbox home — the agent may
+    ``chmod`` its own dot-dir shut — and ``Path.is_symlink`` answers ``False``
+    for a path it cannot reach, which waves a symlink through the check meant
+    to catch it. So the ``lstat`` is raw, and the one question the runner
+    cannot answer is re-asked as root, which can always see. An unreachable
+    answer, root included, reads as unsafe.
+    """
+    try:
+        return stat.S_ISDIR(os.lstat(path).st_mode)
+    except FileNotFoundError:
+        return False
+    except OSError:
+        return root_test("-d", path) and not root_test("-L", path)
+
+
+def root_test(flag: str, path: Path) -> bool:
+    """``test <flag> <path>`` as root, for a path the runner cannot stat."""
+    return (
+        subprocess.run(
+            ["sudo", "test", flag, str(path)],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+def drop_symlinks(logs_dir: Path) -> None:
+    """Remove every symlink from the dir about to be uploaded.
+
+    ``cp -a`` copies links as links and ``upload-artifact`` resolves them as
+    the runner — which can read the proxy's CA private key and its own
+    ``/proc/<pid>/environ``. The agent writes only regular files here, so a
+    link is it reaching for something else.
+    """
+    for path in list(logs_dir.rglob("*")):
+        if path.is_symlink():
+            path.unlink()
 
 
 def best_effort(*argv: str) -> None:
     """Run ``argv``, discarding its output and its failure.
 
-    Everything this runs is a chmod or a copy that enriches the uploaded
+    Everything this runs is a copy or a chown that enriches the uploaded
     artifact. None of it is worth failing an ``if: always()`` accounting step
     for, and a partial copy still beats no artifact. ``stdin`` is closed so a
     ``sudo`` without a tty fails instead of waiting for a password.


### PR DESCRIPTION
The token-usage step consolidates the agent's session JSONL so it can be uploaded as an artifact. To read it, the step granted itself access to the source, as root, in a tree the sandbox user owns:

```
sudo chmod a+x     $AGENT_HOME $AGENT_HOME/.claude
sudo chmod -R a+rX $AGENT_HOME/.claude/projects
```

`chmod` follows a symlinked argument, and the agent owns both `.claude` and `projects`, so replacing either with a link points an `a+rX` at whatever tree the agent names. Nothing checked for one. The `cp -a` that follows has the same shape from the other side: it reproduces whatever it finds, and `upload-artifact` then reads the result as the runner, which can read the proxy's CA private key and its own `/proc/<pid>/environ`.

This copies as root and chowns the result to the runner instead. That needs no permission change on the agent's side, so the escalation primitive is gone rather than guarded.

Four things then have to hold for the copy that replaces it, and the agent chooses the input to each:

- **Neither boundary is a symlink.** `cp -a` follows a symlinked argument, so the session directory and the dot-directory above it are both checked. The check asks root when it cannot answer itself: `Path.is_symlink` reports an unreachable path as "not a symlink", and the sandbox home is the agent's to `chmod` shut, so trusting the runner's own `lstat` would wave through exactly the link the check exists to catch. It falls back to `sudo test`, and an answer neither can give reads as unsafe.
- **Nothing is alive to change what was checked.** A check holds only while nothing can act after it, so the copy waits on `sandbox_reaped` — the output the memory save already keys on, for the same reason and against a read that isn't even privileged.
- **The copied modes are the runner's.** `cp -a` preserves the agent's directory modes and `chown` leaves them alone, and deleting an entry needs write on its parent. Without normalising them, a `0555` directory keeps what it holds (and raises out of an `if: always()` step) and a `0000` one hides it.
- **Only regular files and directories reach the upload.** The sweep tested for a symlink while its docstring named the invariant that matters — the agent writes only regular files there. A `mkfifo` rode the copy out, and since `upload-artifact` streams every entry that isn't a directory, opening a FIFO with no writer hangs the upload to the job timeout. Testing the mode covers links, FIFOs and sockets at once.

Only the Claude harness is affected: `codex_step` reads the runner's own `$HOME/.codex`, with no privileged copy.

`docs/security-model.md` gains a paragraph on this boundary — it enumerates the others and had nothing on the session-log copy.

Three docstrings said `tend-review` runs with `cancel-in-progress: true`. It runs with `false`; `tend-triage` is the one that cancels in progress, so it's the one that makes a result-less session routine.

<details>
<summary>Test coverage</summary>

Eight tests, each failing against the current `main` and passing with the change:

- a symlinked `.claude/projects` copies nothing
- a symlinked `.claude` copies nothing (the boundary the old code had no notion of)
- a `.claude` the runner cannot stat is re-asked as root rather than answered `False`
- an absent `AGENT_HOME` runs no privileged command at all
- an unreaped sandbox copies nothing
- a link planted inside the session dir never reaches the uploaded artifact
- nor does one inside a `0555` directory, which without the mode fix both survives and raises
- nor does a FIFO

</details>

> _This was written by Claude Code on behalf of max-sixty_
