### PR TITLE
Correct the stale claude_version claim in the code-review TODO entry

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -225,9 +225,9 @@ with "PLAUSIBLE by default", the same sweep — so the copy buys nothing on
 method and costs the usual: it drifts silently, and nothing re-checks it
 against the binary.
 
-That drift is no longer hypothetical. `claude/action.yaml` now pins 2.1.226,
-which restructured the built-in without touching those texts, so the copy is
-already a version behind the binary CI runs — and the thing that changed is
+That drift is no longer hypothetical. 2.1.226 restructured the built-in without
+touching those texts, and `claude/action.yaml` has been pinned past it ever
+since, so the copy is behind the binary CI runs — and the thing that changed is
 exactly what decides this question.
 
 Reaching the built-in is possible. It carries `disable-model-invocation`,

--- a/TODO.md
+++ b/TODO.md
@@ -226,9 +226,9 @@ method and costs the usual: it drifts silently, and nothing re-checks it
 against the binary.
 
 That drift is no longer hypothetical. 2.1.226 restructured the built-in without
-touching those texts, and `claude/action.yaml` has been pinned past it ever
-since, so the copy is behind the binary CI runs — and the thing that changed is
-exactly what decides this question.
+touching those texts, and `claude/action.yaml` has been pinned at or beyond
+2.1.226 ever since, so the copy is behind the binary CI runs — and the thing
+that changed is exactly what decides this question.
 
 Reaching the built-in is possible. It carries `disable-model-invocation`,
 which the `Skill` tool waives for a turn whose own user message names the


### PR DESCRIPTION
The `/code-review` decision record in `TODO.md` asserts that `claude/action.yaml` "now pins 2.1.226". The pin is `2.1.251` — so the paragraph that exists to tell a future reader how stale the vendored port is reads as current when its own evidence is 25 releases old.

Restated as a historical fact (2.1.226 restructured the built-in) plus a monotone one (the pin has been at or beyond 2.1.226 ever since). That form matches the recorded pin history — `6619c545` set it to exactly 2.1.226 and `333c89fb` moved it to 2.1.233 — and stays true as the weekly `claude_version` sweep advances the pin, so the claim stops re-staling every time that sweep runs. The `2.1.226 binary` anchor further down is left alone — it correctly names the version the analysis was read from, which is what dates the evidence.

No regression test: the change is prose in a decision record, with no code path to exercise. The stale claim was verified against `claude/action.yaml:57` and `pre-commit run --files TODO.md` passes.
