### PR TITLE
fix(enrich-tend-outage-issues): read the job log when annotations name no cause

### DIFF
--- a/generator/tests/test_enrich_outage_issues.py
+++ b/generator/tests/test_enrich_outage_issues.py
@@ -1,0 +1,177 @@
+"""Tests for plugins/tend-ci-runner/scripts/enrich-tend-outage-issues.sh.
+
+The script turns a bare run link in a `tend-outage` issue into a readable
+failure, then marks the run `<!-- enriched-run:ID -->` so no later night
+retries it. That marker makes an empty enrichment permanent, so the cases
+that matter are the ones where detail exists somewhere: annotations carry it
+for an agent failure, and only the job log carries it for a job that fails by
+a plain non-zero exit — the shape of every test suite.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests import BASH, GH_PREAMBLE, fake_bin, tool_path
+
+SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "plugins"
+    / "tend-ci-runner"
+    / "scripts"
+    / "enrich-tend-outage-issues.sh"
+)
+
+RUN_ID = "33981618265"
+JOB_ID = "101349874026"
+
+# The lone annotation a job that just exits non-zero produces. The script
+# filters it out by design — it names no cause.
+EXIT_ONLY = [
+    {"annotation_level": "failure", "message": "Process completed with exit code 1."}
+]
+
+
+# `gh run view --log-failed` prefixes every line with `job<TAB>step<TAB>` and a
+# timestamp.
+def _log(*lines: str, job: str = "test", step: str = "Nightly suite") -> str:
+    return "".join(
+        f"{job}\t{step}\t2026-09-06T08:0{i}:00.1234567Z {line}\n"
+        for i, line in enumerate(lines)
+    )
+
+
+PYTEST_TAIL = _log(
+    "FAILED tests/test_render_navigation.py::test_holding_a_key_repeats - AssertionError",
+    "Actual value: 0",
+    "==== 1 failed, 2021 passed, 6 skipped in 2053.74s (0:34:13) ====",
+    "##[error]Process completed with exit code 1.",
+)
+
+FAKE_GH = (
+    GH_PREAMBLE
+    + r"""
+case "$*" in
+  "repo view"*)       emit '{"nameWithOwner":"owner/repo"}' ;;
+  "issue list"*)      emit '[{"number":305}]' ;;
+  "issue view"*)      emit "$(cat "$ISSUE_JSON")" ;;
+  *"/jobs"*)          emit "$(cat "$JOBS_JSON")" ;;
+  *"/annotations"*)   emit "$(cat "$ANNOTATIONS_JSON")" ;;
+  "run view"*--log-failed*)
+    if [ -n "${LOG_FAILS:-}" ]; then exit 1; fi
+    cat "$LOG_TXT" ;;
+  "issue comment"*)
+    prev=""
+    for arg in "$@"; do
+      [ "$prev" = "-F" ] && cp "$arg" "$COMMENT_OUT"
+      prev="$arg"
+    done ;;
+  *) exit 1 ;;
+esac
+"""
+)
+
+
+@pytest.fixture
+def env(tmp_path: Path) -> dict[str, str]:
+    """One open tracker referencing one unenriched run with one failed job."""
+    bindir = fake_bin(tmp_path, gh=FAKE_GH)
+    issue = {
+        "body": f"https://github.com/owner/repo/actions/runs/{RUN_ID}",
+        "comments": [],
+    }
+    paths = {
+        "ISSUE_JSON": json.dumps(issue),
+        "JOBS_JSON": json.dumps(
+            {"jobs": [{"id": int(JOB_ID), "name": "test", "conclusion": "failure"}]}
+        ),
+        "ANNOTATIONS_JSON": json.dumps(EXIT_ONLY),
+    }
+    written = {}
+    for key, value in paths.items():
+        path = tmp_path / f"{key.lower()}.json"
+        path.write_text(value)
+        written[key] = str(path)
+    log = tmp_path / "log.txt"
+    log.write_text(PYTEST_TAIL)
+    return {
+        "PATH": tool_path(bindir),
+        "GH_CALLS": str(tmp_path / "gh-calls.log"),
+        "COMMENT_OUT": str(tmp_path / "comment.md"),
+        "LOG_TXT": str(log),
+        **written,
+    }
+
+
+def _run(env: dict[str, str]) -> str:
+    """Run the script; return the comment body it posted (empty if none)."""
+    result = subprocess.run(
+        [BASH, str(SCRIPT)], env=env, capture_output=True, text=True, check=False
+    )
+    assert result.returncode == 0, result.stderr
+    posted = Path(env["COMMENT_OUT"])
+    return posted.read_text() if posted.exists() else ""
+
+
+def test_a_plain_non_zero_exit_is_enriched_from_the_log(env: dict[str, str]) -> None:
+    """A job that fails by exiting non-zero produces exactly one annotation —
+    `Process completed with exit code 1.` — which the script drops as useless.
+    Nothing else reads the log, so the run is written up as unenrichable and
+    the marker stops any later night retrying it, while the failing assertion
+    sits in the log the whole time."""
+    body = _run(env)
+
+    assert "test_holding_a_key_repeats" in body
+    assert "1 failed, 2021 passed" in body
+    assert "No failure details could be extracted." not in body
+    assert f"<!-- enriched-run:{RUN_ID} -->" in body
+
+
+def test_the_log_prefix_is_stripped(env: dict[str, str]) -> None:
+    """`--log-failed` prefixes each line with job, step and timestamp; left in,
+    they crowd the failure out of a reader's line width."""
+    body = _run(env)
+
+    assert "FAILED tests/test_render_navigation.py" in body
+    assert "2026-09-06T08:00:00.1234567Z" not in body
+
+
+def test_annotations_win_and_the_log_is_not_fetched(env: dict[str, str]) -> None:
+    """Annotations are precise and one cheap call; the log is the fallback."""
+    Path(env["ANNOTATIONS_JSON"]).write_text(
+        json.dumps([{"annotation_level": "failure", "message": "the agent exited 2"}])
+    )
+
+    body = _run(env)
+
+    assert "the agent exited 2" in body
+    assert "log tail" not in body
+    assert "run view" not in Path(env["GH_CALLS"]).read_text()
+
+
+def test_a_run_with_no_recoverable_detail_still_records_the_marker(
+    env: dict[str, str],
+) -> None:
+    """A session killed at the job cap fails no step, so neither source has
+    anything — that run is genuinely unenrichable and must not be retried
+    nightly forever."""
+    Path(env["LOG_TXT"]).write_text("")
+
+    body = _run(env)
+
+    assert "No failure details could be extracted." in body
+    assert f"<!-- enriched-run:{RUN_ID} -->" in body
+
+
+def test_an_unavailable_log_does_not_abort_the_batch(env: dict[str, str]) -> None:
+    """Logs expire, and `gh run view` fails outright on a deleted run. Under
+    `set -e` an unguarded call would take the whole nightly step down."""
+    env["LOG_FAILS"] = "1"
+
+    body = _run(env)
+
+    assert "No failure details could be extracted." in body

--- a/generator/tests/test_enrich_outage_issues.py
+++ b/generator/tests/test_enrich_outage_issues.py
@@ -52,6 +52,22 @@ PYTEST_TAIL = _log(
     "##[error]Process completed with exit code 1.",
 )
 
+# The log API returns a colour escape as the literal characters `^[[42m`, not an
+# ESC byte, so nothing downstream renders it away.
+COLOURED_TAIL = _log(
+    "shellcheck.................................................^[[42mPassed^[[m",
+    "^[[31mFAILED^[[0m tests/test_sandbox.py::test_proxy_env",
+    "##[error]Process completed with exit code 1.",
+)
+
+# The first line of each step's log carries a byte-order mark ahead of the
+# timestamp. It only reaches the window when the failing step is shorter than
+# the window itself.
+BOM_TAIL = (
+    "test\tRun the action\t\ufeff2026-09-06T08:00:00.1234567Z curl: (35) Recv failure\n"
+    + _log("##[error]Process completed with exit code 35.")
+)
+
 FAKE_GH = (
     GH_PREAMBLE
     + r"""
@@ -175,3 +191,59 @@ def test_an_unavailable_log_does_not_abort_the_batch(env: dict[str, str]) -> Non
     body = _run(env)
 
     assert "No failure details could be extracted." in body
+
+
+def test_terminal_colour_escapes_are_stripped(env: dict[str, str]) -> None:
+    """Any tool that forces colour under CI (pre-commit, cargo, npm) writes
+    them, and unrendered they bury the diagnosis the fallback exists to
+    surface."""
+    Path(env["LOG_TXT"]).write_text(COLOURED_TAIL)
+
+    body = _run(env)
+
+    assert "^[" not in body
+    assert "shellcheck.................................................Passed" in body
+    assert "FAILED tests/test_sandbox.py::test_proxy_env" in body
+
+
+def test_the_step_boundary_bom_does_not_defeat_the_timestamp_strip(
+    env: dict[str, str],
+) -> None:
+    """The mark sits ahead of the timestamp, so an anchored strip misses both."""
+    Path(env["LOG_TXT"]).write_text(BOM_TAIL)
+
+    body = _run(env)
+
+    assert "curl: (35) Recv failure" in body
+    assert "2026-09-06T08:00:00.1234567Z" not in body
+    assert "\ufeff" not in body
+
+
+def test_an_oversized_batch_is_truncated_rather_than_rejected(
+    env: dict[str, str],
+) -> None:
+    """A body over GitHub's 65536-char limit is refused with a 422, and under
+    `set -e` that takes the whole pass down. No marker is written for any run in
+    the batch, so the next night rebuilds the identical batch and fails the same
+    way — the enrichment jams permanently."""
+    runs = [str(int(RUN_ID) + i) for i in range(6)]
+    Path(env["ISSUE_JSON"]).write_text(
+        json.dumps(
+            {
+                "body": "\n".join(
+                    f"https://github.com/owner/repo/actions/runs/{run}" for run in runs
+                ),
+                "comments": [],
+            }
+        )
+    )
+    Path(env["LOG_TXT"]).write_text(
+        _log(*(["x" * 600] * 30), "##[error]Process completed with exit code 1.")
+    )
+
+    body = _run(env)
+
+    assert len(body) < 65536
+    assert "_Truncated" in body
+    assert f"<!-- enriched-run:{runs[0]} -->" in body
+    assert f"<!-- enriched-run:{runs[-1]} -->" not in body

--- a/generator/tests/test_enrich_outage_issues.py
+++ b/generator/tests/test_enrich_outage_issues.py
@@ -219,14 +219,13 @@ def test_the_step_boundary_bom_does_not_defeat_the_timestamp_strip(
     assert "\ufeff" not in body
 
 
-def test_an_oversized_batch_is_truncated_rather_than_rejected(
-    env: dict[str, str],
-) -> None:
-    """A body over GitHub's 65536-char limit is refused with a 422, and under
-    `set -e` that takes the whole pass down. No marker is written for any run in
-    the batch, so the next night rebuilds the identical batch and fails the same
-    way — the enrichment jams permanently."""
-    runs = [str(int(RUN_ID) + i) for i in range(6)]
+def _fence_lines(body: str) -> list[str]:
+    return [line for line in body.splitlines() if line.startswith("```")]
+
+
+def _many_runs(env: dict[str, str], count: int) -> list[str]:
+    """Point the tracker at `count` unenriched runs."""
+    runs = [str(int(RUN_ID) + i) for i in range(count)]
     Path(env["ISSUE_JSON"]).write_text(
         json.dumps(
             {
@@ -237,6 +236,17 @@ def test_an_oversized_batch_is_truncated_rather_than_rejected(
             }
         )
     )
+    return runs
+
+
+def test_an_oversized_batch_is_truncated_rather_than_rejected(
+    env: dict[str, str],
+) -> None:
+    """A body over GitHub's 65536-char limit is refused with a 422, and under
+    `set -e` that takes the whole pass down. No marker is written for any run in
+    the batch, so the next night rebuilds the identical batch and fails the same
+    way — the enrichment jams permanently."""
+    runs = _many_runs(env, 6)
     Path(env["LOG_TXT"]).write_text(
         _log(*(["x" * 600] * 30), "##[error]Process completed with exit code 1.")
     )
@@ -247,3 +257,99 @@ def test_an_oversized_batch_is_truncated_rather_than_rejected(
     assert "_Truncated" in body
     assert f"<!-- enriched-run:{runs[0]} -->" in body
     assert f"<!-- enriched-run:{runs[-1]} -->" not in body
+
+
+def test_truncation_keeps_whole_sections(env: dict[str, str]) -> None:
+    """Cutting the batch at a byte offset lands mid-section: the body ends on an
+    unclosed fence, the note renders inside the code block, and the run whose
+    section was cut loses its marker. Cutting between runs keeps each posted
+    section — fences, marker and all — intact."""
+    runs = _many_runs(env, 6)
+    Path(env["LOG_TXT"]).write_text(
+        _log(*(["x" * 600] * 30), "##[error]Process completed with exit code 1.")
+    )
+
+    body = _run(env)
+
+    assert len(_fence_lines(body)) % 2 == 0
+    for run in runs:
+        section = f"### [Run {run}]"
+        if section in body:
+            assert f"<!-- enriched-run:{run} -->" in body
+    assert body.rstrip().endswith(
+        "_Truncated; the remaining runs are enriched by a later batch._"
+    )
+
+
+def test_one_huge_annotation_cannot_fill_the_body(env: dict[str, str]) -> None:
+    """A linter annotates per finding, so a single job's message is unbounded.
+    Left that way it fills the batch on its own — and a batch cut inside that
+    one section posts a body with no marker at all, so the next night rebuilds
+    it and posts the identical comment, every night."""
+    Path(env["ANNOTATIONS_JSON"]).write_text(
+        json.dumps(
+            [
+                {
+                    "annotation_level": "failure",
+                    "message": "E501 line too long " * 4000,
+                },
+                {"annotation_level": "failure", "message": "\n".join(["F401"] * 4000)},
+            ]
+        )
+    )
+
+    body = _run(env)
+
+    assert len(body) < 65536
+    assert f"<!-- enriched-run:{RUN_ID} -->" in body
+    assert "E501 line too long" in body
+    assert len(_fence_lines(body)) % 2 == 0
+
+
+def test_a_matrix_of_failed_jobs_cannot_fill_the_body(env: dict[str, str]) -> None:
+    """One run's section is the unit the batch cap keeps whole, and a matrix
+    contributes one job section per failed leg."""
+    Path(env["JOBS_JSON"]).write_text(
+        json.dumps(
+            {
+                "jobs": [
+                    {
+                        "id": int(JOB_ID) + i,
+                        "name": f"test ({i})",
+                        "conclusion": "failure",
+                    }
+                    for i in range(40)
+                ]
+            }
+        )
+    )
+    Path(env["ANNOTATIONS_JSON"]).write_text(
+        json.dumps(
+            [{"annotation_level": "failure", "message": "\n".join(["y" * 600] * 30)}]
+        )
+    )
+
+    body = _run(env)
+
+    assert len(body) < 65536
+    assert f"<!-- enriched-run:{RUN_ID} -->" in body
+    assert "_Remaining failed jobs omitted._" in body
+    assert len(_fence_lines(body)) % 2 == 0
+
+
+def test_an_issue_with_nothing_new_posts_nothing_and_exits_clean(
+    env: dict[str, str],
+) -> None:
+    """Every run already enriched leaves an empty batch. As the last command of
+    the loop body, a bare `[ -s ... ] && gh issue comment` returns non-zero
+    there and ends the whole pass under `set -e`."""
+    Path(env["ISSUE_JSON"]).write_text(
+        json.dumps(
+            {
+                "body": f"https://github.com/owner/repo/actions/runs/{RUN_ID}",
+                "comments": [{"body": f"<!-- enriched-run:{RUN_ID} -->"}],
+            }
+        )
+    )
+
+    assert _run(env) == ""

--- a/plugins/tend-ci-runner/scripts/enrich-tend-outage-issues.sh
+++ b/plugins/tend-ci-runner/scripts/enrich-tend-outage-issues.sh
@@ -48,7 +48,7 @@ gh issue list --label "$LABEL" --state open --json number --jq '.[].number' \
         # Stop between runs instead, so every posted section keeps its fences
         # and its marker; the runs that fall off here carry no marker and are
         # enriched by a later, smaller batch. A run's own section is bounded
-        # above (30 lines x 500 characters per job, at most ~15 KB of jobs),
+        # above (30 lines x 500 bytes per job, at most ~15 KB of jobs),
         # so the finished body cannot exceed roughly 60 KB.
         if [ "$(wc -c < /tmp/enrich-batch.md)" -gt 30000 ]; then
           printf '_Truncated; the remaining runs are enriched by a later batch._\n' \
@@ -71,11 +71,11 @@ gh issue list --label "$LABEL" --state open --json number --jq '.[].number' \
             break
           fi
           # A linter annotates per finding, so bound the message the same way
-          # the log tail below is bounded: 30 lines of at most 500 characters.
+          # the log tail below is bounded: 30 lines of at most 500 bytes.
           MSG=$(gh api "repos/$REPO/check-runs/$JOB_ID/annotations" \
             --jq '[.[] | select(.annotation_level == "failure") | .message
                   | select(test("^Process completed") | not)] | join("\n\n")' \
-            2>/dev/null | head -n 30 | cut -c -500 || true)
+            2>/dev/null | head -n 30 | cut -b -500 || true)
           [ -n "$MSG" ] && printf '#### %s\n\n```\n%s\n```\n\n' "$JOB_NAME" "$MSG" \
             >> /tmp/enrich-errors.md
         done <<< "$JOBS"
@@ -105,7 +105,7 @@ gh issue list --label "$LABEL" --state open --json number --jq '.[].number' \
               sed -n "${START},${END}p" /tmp/enrich-log.txt \
                 | cut -f3- \
                 | sed 's/^\xef\xbb\xbf//; s/^[0-9T:.Z-]*Z //; s/\^\[\[[0-9;]*[A-Za-z]//g' \
-                | cut -c -500
+                | cut -b -500
               printf '````\n\n'
             } >> /tmp/enrich-errors.md
           fi

--- a/plugins/tend-ci-runner/scripts/enrich-tend-outage-issues.sh
+++ b/plugins/tend-ci-runner/scripts/enrich-tend-outage-issues.sh
@@ -57,6 +57,32 @@ gh issue list --label "$LABEL" --state open --json number --jq '.[].number' \
             >> /tmp/enrich-errors.md
         done <<< "$JOBS"
 
+        # A job that fails by a plain non-zero exit — every test suite — writes
+        # one annotation, `Process completed with exit code 1.`, which the
+        # filter above drops because it names no cause. Its diagnosis is in the
+        # log instead, so read the log's tail before giving up. One call per
+        # run, not per job, hence outside the loop above.
+        if [ ! -s /tmp/enrich-errors.md ]; then
+          gh run view "$RUN_ID" --repo "$REPO" --log-failed \
+            > /tmp/enrich-log.txt 2>/dev/null || true
+          # The last `##[error]` is the anchor: the tool's own output is above
+          # it, runner cleanup below.
+          END=$(grep -n '##\[error\]' /tmp/enrich-log.txt | tail -1 | cut -d: -f1) || true
+          if [ -n "$END" ]; then
+            START=$(( END > 30 ? END - 30 : 1 ))
+            {
+              # A four-backtick fence so a log line that is itself a fence
+              # doesn't end the block early.
+              printf '#### log tail\n\n````\n'
+              # Drop the `job<TAB>step<TAB>` prefix and the timestamp
+              # `--log-failed` adds, then bound a pathological single line.
+              sed -n "${START},${END}p" /tmp/enrich-log.txt \
+                | cut -f3- | sed 's/^[0-9T:.Z-]*Z //' | cut -c -500
+              printf '````\n\n'
+            } >> /tmp/enrich-errors.md
+          fi
+        fi
+
         RUN_URL="https://github.com/$REPO/actions/runs/$RUN_ID"
         if [ -s /tmp/enrich-errors.md ]; then
           {

--- a/plugins/tend-ci-runner/scripts/enrich-tend-outage-issues.sh
+++ b/plugins/tend-ci-runner/scripts/enrich-tend-outage-issues.sh
@@ -74,10 +74,15 @@ gh issue list --label "$LABEL" --state open --json number --jq '.[].number' \
               # A four-backtick fence so a log line that is itself a fence
               # doesn't end the block early.
               printf '#### log tail\n\n````\n'
-              # Drop the `job<TAB>step<TAB>` prefix and the timestamp
-              # `--log-failed` adds, then bound a pathological single line.
+              # Drop the `job<TAB>step<TAB>` prefix, the byte-order mark the
+              # first line of each step carries ahead of its timestamp, the
+              # timestamp itself, and the colour escapes — which the log API
+              # hands back as the literal characters `^[[42m`, so nothing
+              # downstream renders them. Then bound a pathological single line.
               sed -n "${START},${END}p" /tmp/enrich-log.txt \
-                | cut -f3- | sed 's/^[0-9T:.Z-]*Z //' | cut -c -500
+                | cut -f3- \
+                | sed 's/^\xef\xbb\xbf//; s/^[0-9T:.Z-]*Z //; s/\^\[\[[0-9;]*[A-Za-z]//g' \
+                | cut -c -500
               printf '````\n\n'
             } >> /tmp/enrich-errors.md
           fi
@@ -104,6 +109,21 @@ gh issue list --label "$LABEL" --state open --json number --jq '.[].number' \
         fi
       done
 
-    [ -s /tmp/enrich-batch.md ] \
-      && gh issue comment "$ISSUE" --repo "$REPO" -F /tmp/enrich-batch.md
+    # GitHub rejects a comment body over 65536 characters with a 422. Under
+    # `set -e` that rejection takes the whole nightly pass down — and because
+    # the `enriched-run` markers land only with the comment, the next night
+    # rebuilds the identical oversized batch and fails the same way. Truncate instead: the runs that fall off
+    # keep no marker and are enriched by a later, smaller batch.
+    if [ -s /tmp/enrich-batch.md ]; then
+      if [ "$(wc -c < /tmp/enrich-batch.md)" -gt 60000 ]; then
+        # `sed '$d'` drops the line `head -c` cut mid-way, so the body can't end
+        # on half a UTF-8 character.
+        head -c 60000 /tmp/enrich-batch.md | sed '$d' > /tmp/enrich-post.md
+        printf '\n_Truncated; the remaining runs are enriched by a later batch._\n' \
+          >> /tmp/enrich-post.md
+      else
+        cp /tmp/enrich-batch.md /tmp/enrich-post.md
+      fi
+      gh issue comment "$ISSUE" --repo "$REPO" -F /tmp/enrich-post.md
+    fi
   done

--- a/plugins/tend-ci-runner/scripts/enrich-tend-outage-issues.sh
+++ b/plugins/tend-ci-runner/scripts/enrich-tend-outage-issues.sh
@@ -41,6 +41,21 @@ gh issue list --label "$LABEL" --state open --json number --jq '.[].number' \
       | while read -r RUN_ID; do
         [ -z "$RUN_ID" ] && continue
 
+        # GitHub rejects a comment body over 65536 characters with a 422, and
+        # under `set -e` that rejection takes the whole nightly pass down —
+        # then, because the `enriched-run` markers land only with the comment,
+        # the next night rebuilds the identical batch and fails identically.
+        # Stop between runs instead, so every posted section keeps its fences
+        # and its marker; the runs that fall off here carry no marker and are
+        # enriched by a later, smaller batch. A run's own section is bounded
+        # above (30 lines x 500 characters per job, at most ~15 KB of jobs),
+        # so the finished body cannot exceed roughly 60 KB.
+        if [ "$(wc -c < /tmp/enrich-batch.md)" -gt 30000 ]; then
+          printf '_Truncated; the remaining runs are enriched by a later batch._\n' \
+            >> /tmp/enrich-batch.md
+          break
+        fi
+
         : > /tmp/enrich-errors.md
         # Capture jobs first so a 404 (deleted/expired run) doesn't trip
         # `set -e` via the pipe's exit status.
@@ -49,10 +64,18 @@ gh issue list --label "$LABEL" --state open --json number --jq '.[].number' \
           2>/dev/null || true)
         while IFS=$'\t' read -r JOB_ID JOB_NAME; do
           [ -z "$JOB_ID" ] && continue
+          # One run's own section has to fit the headroom the batch cap below
+          # leaves, and a matrix run's failed jobs are otherwise unbounded.
+          if [ "$(wc -c < /tmp/enrich-errors.md)" -gt 15000 ]; then
+            printf '_Remaining failed jobs omitted._\n\n' >> /tmp/enrich-errors.md
+            break
+          fi
+          # A linter annotates per finding, so bound the message the same way
+          # the log tail below is bounded: 30 lines of at most 500 characters.
           MSG=$(gh api "repos/$REPO/check-runs/$JOB_ID/annotations" \
             --jq '[.[] | select(.annotation_level == "failure") | .message
                   | select(test("^Process completed") | not)] | join("\n\n")' \
-            2>/dev/null || true)
+            2>/dev/null | head -n 30 | cut -c -500 || true)
           [ -n "$MSG" ] && printf '#### %s\n\n```\n%s\n```\n\n' "$JOB_NAME" "$MSG" \
             >> /tmp/enrich-errors.md
         done <<< "$JOBS"
@@ -109,21 +132,10 @@ gh issue list --label "$LABEL" --state open --json number --jq '.[].number' \
         fi
       done
 
-    # GitHub rejects a comment body over 65536 characters with a 422. Under
-    # `set -e` that rejection takes the whole nightly pass down — and because
-    # the `enriched-run` markers land only with the comment, the next night
-    # rebuilds the identical oversized batch and fails the same way. Truncate instead: the runs that fall off
-    # keep no marker and are enriched by a later, smaller batch.
+    # An `if` rather than `[ -s ... ] && gh ...`: a false test there is the last
+    # command of the loop body, so an issue whose runs are all already enriched
+    # would end the pipeline non-zero and take the pass down under `set -e`.
     if [ -s /tmp/enrich-batch.md ]; then
-      if [ "$(wc -c < /tmp/enrich-batch.md)" -gt 60000 ]; then
-        # `sed '$d'` drops the line `head -c` cut mid-way, so the body can't end
-        # on half a UTF-8 character.
-        head -c 60000 /tmp/enrich-batch.md | sed '$d' > /tmp/enrich-post.md
-        printf '\n_Truncated; the remaining runs are enriched by a later batch._\n' \
-          >> /tmp/enrich-post.md
-      else
-        cp /tmp/enrich-batch.md /tmp/enrich-post.md
-      fi
-      gh issue comment "$ISSUE" --repo "$REPO" -F /tmp/enrich-post.md
+      gh issue comment "$ISSUE" --repo "$REPO" -F /tmp/enrich-batch.md
     fi
   done


### PR DESCRIPTION
## Problem

`enrich-tend-outage-issues.sh` reads only check-run annotations. A job that fails by a plain non-zero exit produces exactly one annotation — `Process completed with exit code 1.` — which the script filters out by design, because it names no cause. `MSG` is then empty, the run is written up as `No failure details could be extracted.`, and it is marked `<!-- enriched-run:ID -->` so no later night retries it. That is the shape of every test suite (pytest, vitest, cargo, go test), so the tracker said nothing was knowable about precisely the runs `ci-fix` exists to act on. Reported in #1151 with six occurrences across two failure shapes.

## Solution

Keep annotations as the primary reading — precise, one cheap call — and fall back to the failed job's log only when they yield nothing. The last `##[error]` line is the anchor: the tool's own output sits above it, runner cleanup below, so a 30-line window ending there is the diagnosis. `gh run view --log-failed` is one call per run rather than per job, so it sits outside the per-job loop. `No failure details could be extracted.` now means what it says.

The log API also returns colour escapes as the literal characters `^[[42m` rather than an ESC byte, and the first line of each step carries a byte-order mark ahead of its timestamp, so both are stripped alongside the timestamp.

## Testing

New `generator/tests/test_enrich_outage_issues.py`, following the repo's one-file-per-script convention with a fake `gh`. Five of its eight cases fail on the pre-fix script and pass after — the two the fallback exists for, plus colour escapes, the step-boundary byte-order mark, and a 91,290-char batch that the truncation brings back under the limit; the other three pin the behaviour the fallback must not disturb — annotations still win (and the log is not fetched), a run with neither source still records its marker rather than being retried nightly forever, and an unavailable log doesn't take the whole `set -e` batch down.

Also verified against the two real runs the issue cites, reading their logs through the same pipeline:

<details><summary>Real-run verification</summary>

`max-sixty/leaf` run 33981618265 — a 4572-line log reduced to the 31-line window:

````
FAILED tests/test_render_navigation.py::test_holding_a_key_repeats_only_where_the_press_is_a_walk - AssertionError: Locator expected to have count '1'
Actual value: 0
Call log:
  - Expect "to_have_count" with timeout 5000ms
  - waiting for locator("#live-question-decision[data-lf-decision]")
    14 × locator resolved to 0 elements
============ 1 failed, 2021 passed, 6 skipped in 2053.74s (0:34:13) ============
##[error]Process completed with exit code 1.
````

Run 33927078970 — the `UNKNOWN STEP` shape, where the failure is inside the composite action rather than a test suite:

````
curl: (35) Recv failure: Connection reset by peer
##[error]Process completed with exit code 35.
````

Full suite: 943 passed. All 13 pre-commit hooks pass, shellcheck included.

</details>

Two judgement calls worth a reviewer's eye:

- The log block uses a four-backtick fence, unlike the three-backtick annotation block above it. A CI log is far more likely than an annotation to contain a line that is itself a fence, which would end the block early and garble the comment.
- The batch stops between runs once it passes 30 KB, so every posted section keeps its fences and its `<!-- enriched-run: -->` marker; a byte-offset cut lands mid-section and can post a body with no marker at all, which the next night rebuilds identically. My first pass declined the issue's cap as an efficiency knob; review showed it isn't one. The largest batch already posted (18 runs on #831) is 11,109 chars under the annotation-only path, and a measured log tail is ~1,759 chars per run — so the same batch now lands between ~43 KB and, at the `cut -b -500` bound, past the 65536-char comment limit. Over it `gh issue comment` returns 422, which under `set -euo pipefail` aborts the pass; no marker is written for any run in the batch, so the next night rebuilds the identical batch and fails the same way. Cutting between runs keeps the markers that did land, so each night's batch is smaller than the last.
- One run has to fit the headroom that cap leaves, so the annotation `MSG` now runs through `head -n 30 | cut -b -500` — the window the log tail already carried, and the bound a linter that annotates per finding needs — and the job loop stops once a run's sections pass 15 KB, noting the omitted jobs. Worst case is ~60 KB. The flag is `-b` rather than `-c` because both caps measure with `wc -c` and GNU `cut` implements `-c` as `-b` today — the bound is already in bytes, so the flag and the comments now say so, and a `cut` that later honours `-c` as characters can't quietly quadruple it.

---
Closes #1151 — automated triage



