### PR TITLE
chore: bump claude_version to 2.1.263

### DIFF
--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -360,8 +360,8 @@ runs:
     #   - `--permission-mode bypassPermissions` on argv sets the mode.
     #     settings.local.json restates it alongside
     #     skipDangerousModePermissionPrompt, but only the flag is load-bearing:
-    #     Claude Code 2.1.257 ignores `permissions.defaultMode` in a project
-    #     settings file. bypassPermissions lets the bot write Claude Code's
+    #     Claude Code 2.1.257 ignores `defaultMode: bypassPermissions` in a
+    #     project settings file. That mode lets the bot write Claude Code's
     #     protected paths (.devcontainer/, .github/, .husky/, .cargo/, dotfiles)
     #     that every other mode hard-denies — which blocked autonomous fixes.
     #     Safe here: the run is sandboxed and can only land via reviewed PRs.

--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -54,7 +54,7 @@ inputs:
     default: "false"
     description: Include the rendered Claude transcript in the workflow step summary.
   claude_version:
-    default: "2.1.251"
+    default: "2.1.263"
     description: >-
       Version of the `claude` binary to install via
       `https://claude.ai/install.sh`, pinned to a specific
@@ -357,13 +357,15 @@ runs:
     # sentinel. The step body is shared/steps/run_claude.py; keeping it out of
     # this file is what lets the suite drive it (nothing lints or runs an inline
     # `run:` block in a composite action).
-    #   - settings.local.json sets `permissions.defaultMode: bypassPermissions`
-    #     plus skipDangerousModePermissionPrompt. bypassPermissions lets the bot
-    #     write Claude Code's protected paths (.devcontainer/, .github/, .husky/,
-    #     .cargo/, dotfiles) that every other mode hard-denies — which blocked
-    #     autonomous fixes. Safe here: the run is sandboxed and can only land via
-    #     reviewed PRs. No Stop/StopFailure hooks — headless completion is the
-    #     process exit.
+    #   - `--permission-mode bypassPermissions` on argv sets the mode.
+    #     settings.local.json restates it alongside
+    #     skipDangerousModePermissionPrompt, but only the flag is load-bearing:
+    #     Claude Code 2.1.257 ignores `permissions.defaultMode` in a project
+    #     settings file. bypassPermissions lets the bot write Claude Code's
+    #     protected paths (.devcontainer/, .github/, .husky/, .cargo/, dotfiles)
+    #     that every other mode hard-denies — which blocked autonomous fixes.
+    #     Safe here: the run is sandboxed and can only land via reviewed PRs.
+    #     No Stop/StopFailure hooks — headless completion is the process exit.
     #     TODO: research a more hawkish posture that keeps this write capability —
     #     e.g. an auto-mode classifier, or scoped overrides of specific protected
     #     paths — without reintroducing hard blocks.

--- a/shared/steps/run_claude.py
+++ b/shared/steps/run_claude.py
@@ -66,10 +66,12 @@ def settings(allowed_tools: str) -> dict[str, Any]:
     """``.claude/settings.local.json`` for the run.
 
     ``permissions.allow`` is built from the comma-separated ``allowed_tools``
-    input. With ``defaultMode: bypassPermissions`` the allow list is largely
-    moot (every tool is permitted), but it is retained so the listed tools stay
-    granted via the layered settings if an adopter overrides ``defaultMode`` to
-    a stricter mode.
+    input. The mode itself comes from ``--permission-mode`` on argv, not from
+    here: Claude Code 2.1.257 ignores ``defaultMode: bypassPermissions`` in a
+    project ``settings.json``/``settings.local.json`` and names the flag as the
+    way to set it. The key is left in place as the declaration of intent that
+    the flag carries out; the allow list is what a user- or managed-settings
+    layer would still narrow against.
 
     ``skipDangerousModePermissionPrompt`` pre-accepts the one-time bypass-mode
     "I accept the risks" disclaimer — the key the dialog's accept button writes,
@@ -110,9 +112,9 @@ def launch_argv(
     assignments are the caller-appended names that docstring allows for.
 
     The model, tools and prompts are argv rather than environment: nothing on
-    the far side reads them, and ``--permission-mode`` restates what
-    ``settings.local.json`` already says so the mode survives an adopter
-    overriding that file.
+    the far side reads them, and ``--permission-mode`` is what actually sets
+    the mode — a project ``settings.local.json`` cannot, since Claude Code
+    2.1.257 ignores ``defaultMode: bypassPermissions`` there.
     """
     agent_env = _sandbox.launch_env(agent_env_file)
     if settings_file:


### PR DESCRIPTION
Moves the pinned `claude` binary from 2.1.251 to 2.1.263, npm's current `latest` dist-tag (`CLAUDE.md` pins `latest`, not `stable`). A stale pin resolves `--model opus`/`sonnet` to a superseded alias target, so the bump is what keeps the harness on the model the workflows name. `uv run pytest` passes (935).

The skim turned up one release that changes a path this action depends on, and the comments in `claude/action.yaml` and `shared/steps/run_claude.py` were describing the old behavior — corrected here, since they only become wrong at this version. **2.1.257 ignores `permissions.defaultMode: "bypassPermissions"` in a project `.claude/settings.json`/`settings.local.json`** and names `--permission-mode` as the way to set it. `run_claude.py` already passes `--permission-mode bypassPermissions` on argv, so the run's mode is unchanged; what changed is that the settings file is no longer what carries it. The old wording had it backwards — it described the flag as restating the settings file, and the settings file as the thing an adopter could override to a stricter mode.

The now-inert `permissions.defaultMode` key is left in the emitted settings; deleting it is a separate call, and the flag makes it a no-op either way.

<details><summary>CHANGELOG skim, 2.1.252 → 2.1.263</summary>

Seven releases carry notes (2.1.252, .257, .258, .259, .260, .261, .263), skimmed for the paths this action exercises — plugin/skill loading, slash-command dispatch, headless `-p`, `--model` alias resolution, first-run onboarding, Stop-hook behavior, and sandboxing.

**Permission mode (2.1.257) — the one item that lands.** Covered above.

**Plugin symlink refusal (2.1.257) — checked empirically, does not land.** "Fixed plugins being able to read files outside their own directory through a declared command, agent, skill, hooks or other component path that is a symlink; such paths are now refused with an error." The marketplace has five symlinks, and one of them escapes its plugin: `plugins/install-tend/skills/install-tend/README.md -> ../../../../README.md`. Since `install-tend-plugins.sh` copies only `.claude-plugin/` and `plugins/` into the sandbox marketplace, that link is *dangling* in every CI run, and both plugins are installed there — so a broadened refusal would have failed the install step on every Claude run. Verified rather than reasoned about: installed 2.1.263 into a temp prefix, rebuilt the sandbox marketplace copy exactly as the script does, and ran `plugin marketplace add` + `plugin install install-tend@tend` + `plugin install tend-ci-runner@tend` under an isolated `CLAUDE_CONFIG_DIR` on both 2.1.251 and 2.1.263. Both versions: exit 0, both plugins enabled. The refusal applies to *declared component paths*, not to resources sitting inside a skill directory.

(The dangling `README.md` link is pre-existing and unrelated to this bump — it means the `install-tend` skill can't read its own README from a CI-installed copy. Noting it here rather than fixing it in a version bump.)

**Headless exit with a Monitor armed (2.1.257) — worth knowing, not a blocker.** "Fixed `claude -p` exiting about 5 seconds after its final result while a Monitor the model armed was still running; it now waits for the watch to fire or time out." `bypassPermissions` permits `Monitor` regardless of what `--allowedTools` lists, so from this version a session that arms one holds the process open until the watch resolves rather than exiting shortly after the `result` event — and `run_claude.py`'s `TEND_TIMEOUT_SEC` supervisor would turn that into a step failure (`Claude headless run exceeded Ns timeout`) on a turn that had actually completed. Nothing in the bundled skills or this repo's overlay arms a Monitor today, so it changes no current run.

**Stop hooks (2.1.259).** "Fixed blocking Stop hooks causing the turn after a block to lose the model's reasoning." No-op: the action sets no Stop/StopFailure hooks — headless completion is the process exit plus the `result` event.

**Skill and command frontmatter `model:` (2.1.259).** Two fixes make frontmatter `model:` take effect where it previously didn't. No `SKILL.md` under `plugins/*/skills/` or `.claude/skills/` declares `model:`, so the harness keeps running every skill on the `--model` the workflow names.

**`Skill(name)` deny rules and managed `skillOverrides` (2.1.259).** Scoped to managed settings and deny rules; the action configures neither.

**Sandbox and permission-rule items (2.1.258, 2.1.259, 2.1.261).** Parenthesised paths in `Edit`/`Write`/`Read` rules, `blockReadsOutsideWorkingDirectories` on macOS, trailing-dot sandbox network hosts, stale sandbox mask files, sandboxed git in linked worktrees, `!`-prompt commands under strict sandbox mode. All concern Claude Code's *own* Bash sandbox, which this action doesn't use — isolation is a separate non-sudo OS user, and the proxy is wired through the environment by `proxy/setup-sandbox.sh`.

**Headless-relevant but neutral.** `--permission-prompts none` for unattended hosts (2.1.258) and `/reload-plugins`, `/advisor` in headless sessions (2.1.260) are additions the action doesn't opt into. "Improved idle CPU usage of non-interactive (`-p`/SDK) sessions" (2.1.259) and "headless/SDK session start begins up to 50 ms sooner" (2.1.259) are free wins. `claude -p --resume` fixes (2.1.261) don't apply — runs here are one-shot and never resumed.

**Everything else** in the range is VS Code extension work, Remote Control, Claude apps gateway, MCP, `/btw`, Vim-mode and TUI rendering — none of it reachable from `claude -p` in this action. 2.1.263 is "Bug fixes and reliability improvements" with no itemised notes.

</details>

