### PR TITLE
chore: bump uv_version to 0.12.10

### DIFF
--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -77,7 +77,7 @@ inputs:
       Pinned `mitmproxy` version for the credential-injection proxy. Pinned
       so the uv download cache key is stable; bump to upgrade.
   uv_version:
-    default: "0.12.7"
+    default: "0.12.10"
     description: >-
       Pinned `uv` version. The credential-injection proxy always uses a private
       copy off $PATH. The agent gets a separate fallback after the adopter PATH,

--- a/codex/action.yaml
+++ b/codex/action.yaml
@@ -61,7 +61,7 @@ inputs:
       first set; stable carries it now, so this tracks `latest`. CI's
       `test-codex-surface` job confirms whichever version is pinned.
   uv_version:
-    default: "0.12.7"
+    default: "0.12.10"
     description: >-
       Pinned fallback `uv` version. The agent PATH appends it after any
       adopter-provided version.


### PR DESCRIPTION
Moves the pinned `uv` from 0.12.7 to 0.12.10 in both harness actions, together as the sweep rule requires. `mitmproxy` is not moved with it this time — 12.2.3 is still the current PyPI release, so the root `pyproject.toml` `==` pin and the lockfile are unchanged.

Under Claude, `uv` fetches and runs the `mitmdump` that holds the real PAT and model credential, and supplies the agent's PATH fallback; under Codex it supplies the fallback alone. `uv build` and `uv run pytest` (935) pass here on 0.12.10, which also confirms `generator/pyproject.toml`'s `uv_build>=0.12,<0.13` still contains the uv doing the build — the one check nothing else in CI performs, since a stale backend range only warns.

<details><summary>Release-note skim, 0.12.8 → 0.12.10</summary>

Three releases. Nothing changes the `uv` surface these actions use (`uv tool run`, `uv run`, the pinned-version install, the download cache key), and no behavior change reaches the proxy's `mitmdump` flags. The credential-adjacent fixes, all in 0.12.9, are why this is worth landing rather than deferring:

- **Sensitive headers survived redirects across authentication realms**, including same-host redirects that change the URL scheme ([#21382](https://github.com/astral-sh/uv/pull/21382)). `uv` runs inside the sandbox with the proxy's CA trusted, so a redirect-driven header leak is the shape that matters most here.
- **Secrets in signed URLs appeared in retry diagnostics**, including nested request errors ([#21381](https://github.com/astral-sh/uv/pull/21381)). Session logs are uploaded as workflow artifacts, so anything `uv` prints on a retry is retained.
- **`async_http_range_reader` bumped to 0.11.1** for a potential memory-safety issue when reading metadata ranges from untrusted wheels ([#21401](https://github.com/astral-sh/uv/pull/21401)).

0.12.8 adds a related hardening — `--require-hashes` no longer trusts hashes from direct URLs discovered only in wheel metadata ([#21348](https://github.com/astral-sh/uv/pull/21348)) — and redacts Azure SAS `sig` parameters from displayed URLs. Neither path is exercised here; the actions pass no `--require-hashes` and use no Azure index.

The rest is performance work (concurrent processes no longer re-extract the same wheel, faster lockfile traversal and cold wheel installs), `exclude-newer` lock-check fixes, `--no-locked`/`--no-frozen` flags, CPython 3.15.0rc2, and `uv publish` token revocation. The publish change touches `pypi-release.yaml`'s path only in the safe direction: it revokes short-lived trusted-publishing tokens after the upload, including on failure.

</details>
