### PR TITLE
Read the failing attempt when enriching outage rows, so a rerun-green run keeps its diagnosis

### DIFF
--- a/generator/tests/test_enrich_tend_outage_issues.py
+++ b/generator/tests/test_enrich_tend_outage_issues.py
@@ -59,7 +59,10 @@ case "$*" in
   *"/annotations"*) emit "$(cat "$ANNOTATIONS_JSON")" ;;
   "run view"*--log-failed*)
     if [ -n "${LOG_FAILS:-}" ]; then exit 1; fi
-    cat "$LOG_TXT"
+    case "$*" in
+      *--attempt*) cat "$LOG_TXT" ;;
+      *) cat "${LATEST_LOG_TXT:-$LOG_TXT}" ;;
+    esac
     ;;
   "issue comment"*)
     prev=""
@@ -223,6 +226,58 @@ def test_a_rerun_that_went_green_is_enriched_from_the_failed_attempt(
     assert "filter=all" in Path(env["GH_CALLS"]).read_text()
     assert "#### review (attempt 1)\n\n```\nassertion failed\n```" in body
     assert "No failure details could be extracted." not in body
+
+
+def test_a_rerun_that_went_green_reads_the_failed_attempt_log(
+    env: dict[str, str], tmp_path: Path
+) -> None:
+    # A transient failure annotates only `Process completed with exit code N`,
+    # so its diagnosis lives solely in the log — and `--log-failed` reads the
+    # rerun's green attempt unless it is told which attempt failed.
+    Path(env["JOBS_JSON"]).write_text(
+        json.dumps(
+            {
+                "jobs": [
+                    {
+                        "id": int(JOB_ID),
+                        "name": "review",
+                        "conclusion": "failure",
+                        "run_attempt": 1,
+                    },
+                    {
+                        "id": 102,
+                        "name": "review",
+                        "conclusion": "success",
+                        "run_attempt": 2,
+                    },
+                ]
+            }
+        )
+    )
+    Path(env["ANNOTATIONS_JSON"]).write_text(json.dumps(EXIT_ONLY))
+    Path(env["LOG_TXT"]).write_text(BOM_TAIL)
+    latest = tmp_path / "latest-log.txt"
+    latest.write_text("")
+    env["LATEST_LOG_TXT"] = str(latest)
+
+    body = _run(env)
+
+    assert "--attempt 1" in Path(env["GH_CALLS"]).read_text()
+    assert "curl: (35) Recv failure" in body
+    assert "No failure details could be extracted." not in body
+
+
+def test_a_run_with_no_readable_jobs_still_reads_the_latest_log(
+    env: dict[str, str],
+) -> None:
+    # With the jobs read unavailable there is no attempt to name, so the log
+    # source stays on the latest attempt rather than losing its one fallback.
+    Path(env["JOBS_JSON"]).write_text("not json")
+
+    body = _run(env)
+
+    assert "--attempt" not in Path(env["GH_CALLS"]).read_text()
+    assert "1 failed, 2021 passed" in body
 
 
 def test_a_single_attempt_job_heading_carries_no_attempt(env: dict[str, str]) -> None:

--- a/generator/tests/test_enrich_tend_outage_issues.py
+++ b/generator/tests/test_enrich_tend_outage_issues.py
@@ -190,6 +190,48 @@ def test_a_run_with_no_recoverable_detail_still_records_the_marker(
     assert f"<!-- enriched-run:{RUN_ID} -->" in body
 
 
+def test_a_rerun_that_went_green_is_enriched_from_the_failed_attempt(
+    env: dict[str, str],
+) -> None:
+    # The row is recorded when the run fails; a rerun that then succeeds leaves
+    # the default `latest` job view with nothing failed and no failed log, so
+    # the only copy of the diagnosis lives on the earlier attempt.
+    Path(env["JOBS_JSON"]).write_text(
+        json.dumps(
+            {
+                "jobs": [
+                    {
+                        "id": int(JOB_ID),
+                        "name": "review",
+                        "conclusion": "failure",
+                        "run_attempt": 1,
+                    },
+                    {
+                        "id": 102,
+                        "name": "review",
+                        "conclusion": "success",
+                        "run_attempt": 2,
+                    },
+                ]
+            }
+        )
+    )
+    Path(env["LOG_TXT"]).write_text("")
+
+    body = _run(env)
+
+    assert "filter=all" in Path(env["GH_CALLS"]).read_text()
+    assert "#### review (attempt 1)\n\n```\nassertion failed\n```" in body
+    assert "No failure details could be extracted." not in body
+
+
+def test_a_single_attempt_job_heading_carries_no_attempt(env: dict[str, str]) -> None:
+    body = _run(env)
+
+    assert "#### tests\n\n" in body
+    assert "attempt" not in body
+
+
 def test_an_unavailable_log_does_not_abort_the_batch(env: dict[str, str]) -> None:
     Path(env["ANNOTATIONS_JSON"]).write_text(json.dumps(EXIT_ONLY))
     env["LOG_FAILS"] = "1"

--- a/plugins/tend-ci-runner/scripts/enrich_tend_outage_issues.py
+++ b/plugins/tend-ci-runner/scripts/enrich_tend_outage_issues.py
@@ -77,8 +77,8 @@ def job_heading(job: dict[str, Any], label_attempt: bool) -> str:
     return f"{job['name']} (attempt {job.get('run_attempt') or 1})"
 
 
-def annotation_details(repo: str, run_id: str) -> list[str]:
-    """Render bounded failure annotations for one run.
+def run_jobs(repo: str, run_id: str) -> list[dict[str, Any]]:
+    """Read the run's jobs across every attempt.
 
     ``filter=all`` reads every attempt, not just the latest. A row is recorded
     when the run fails, and a rerun that then goes green leaves the default
@@ -91,8 +91,23 @@ def annotation_details(repo: str, run_id: str) -> list[str]:
         )
     except (subprocess.CalledProcessError, ValueError):
         return []
+    return response.get("jobs", [])
 
-    jobs = response.get("jobs", [])
+
+def failed_attempt(jobs: list[dict[str, Any]]) -> int | None:
+    """The latest attempt that failed — the one whose log holds the error."""
+    return max(
+        (
+            job.get("run_attempt") or 1
+            for job in jobs
+            if job.get("conclusion") == "failure"
+        ),
+        default=None,
+    )
+
+
+def annotation_details(repo: str, jobs: list[dict[str, Any]]) -> list[str]:
+    """Render bounded failure annotations for one run."""
     label_attempt = len({job.get("run_attempt") or 1 for job in jobs}) > 1
     details: list[str] = []
     rendered_bytes = 0
@@ -133,12 +148,19 @@ def clean_log_line(line: str) -> str:
     return truncate_line(LITERAL_ANSI_ESCAPE.sub("", line))
 
 
-def log_details(repo: str, run_id: str) -> list[str]:
-    """Render the tail ending at the run's last error, when available."""
+def log_details(repo: str, run_id: str, attempt: int | None) -> list[str]:
+    """Render the tail ending at the failing attempt's last error, when available.
+
+    ``--log-failed`` reads the latest attempt unless told otherwise, so a rerun
+    that went green yields no failed log at all — the same blanking ``filter=all``
+    fixes for annotations, and the source that carries a transient failure whose
+    only annotation is a bare ``Process completed with exit code N``.
+    """
+    args = ["run", "view", run_id, "--repo", repo, "--log-failed"]
+    if attempt is not None:
+        args += ["--attempt", str(attempt)]
     try:
-        output = github_cli.run(
-            "run", "view", run_id, "--repo", repo, "--log-failed", quiet=True
-        )
+        output = github_cli.run(*args, quiet=True)
     except subprocess.CalledProcessError:
         return []
 
@@ -153,8 +175,11 @@ def log_details(repo: str, run_id: str) -> list[str]:
 
 
 def failure_details(repo: str, run_id: str) -> list[str]:
-    """Prefer precise annotations, falling back to the failed-log tail."""
-    return annotation_details(repo, run_id) or log_details(repo, run_id)
+    """Prefer precise annotations, falling back to the failing attempt's log tail."""
+    jobs = run_jobs(repo, run_id)
+    return annotation_details(repo, jobs) or log_details(
+        repo, run_id, failed_attempt(jobs)
+    )
 
 
 def render_run(repo: str, run_id: str, details: list[str]) -> str:

--- a/plugins/tend-ci-runner/scripts/enrich_tend_outage_issues.py
+++ b/plugins/tend-ci-runner/scripts/enrich_tend_outage_issues.py
@@ -70,18 +70,33 @@ def bounded_message(messages: list[str]) -> str:
     )
 
 
+def job_heading(job: dict[str, Any], label_attempt: bool) -> str:
+    """Name a failed job, distinguishing it from its siblings on other attempts."""
+    if not label_attempt:
+        return str(job["name"])
+    return f"{job['name']} (attempt {job.get('run_attempt') or 1})"
+
+
 def annotation_details(repo: str, run_id: str) -> list[str]:
-    """Render bounded failure annotations for one run."""
+    """Render bounded failure annotations for one run.
+
+    ``filter=all`` reads every attempt, not just the latest. A row is recorded
+    when the run fails, and a rerun that then goes green leaves the default
+    ``latest`` view with no failed job at all — so the attempt carrying the
+    diagnosis is exactly the one that view drops.
+    """
     try:
         response = github_cli.json_call(
-            "api", f"repos/{repo}/actions/runs/{run_id}/jobs", quiet=True
+            "api", f"repos/{repo}/actions/runs/{run_id}/jobs?filter=all", quiet=True
         )
     except (subprocess.CalledProcessError, ValueError):
         return []
 
+    jobs = response.get("jobs", [])
+    label_attempt = len({job.get("run_attempt") or 1 for job in jobs}) > 1
     details: list[str] = []
     rendered_bytes = 0
-    for job in response.get("jobs", []):
+    for job in jobs:
         if job.get("conclusion") != "failure":
             continue
         if rendered_bytes > MAX_RUN_BYTES:
@@ -101,7 +116,8 @@ def annotation_details(repo: str, run_id: str) -> list[str]:
         ]
         messages = [message for message in messages if message]
         if messages:
-            detail = f"#### {job['name']}\n\n{fenced(bounded_message(messages))}"
+            heading = job_heading(job, label_attempt)
+            detail = f"#### {heading}\n\n{fenced(bounded_message(messages))}"
             details.append(detail)
             rendered_bytes += len(detail.encode())
     return details


### PR DESCRIPTION
Four of the six rows on the current outage tracker (#1164) say `No failure details could be extracted.` — and all four are runs whose failing attempt still carries the annotation naming the cause.

A `tend-outage` row is recorded the moment a run fails. If that run is then rerun and goes green, both of the enrichment's sources go blank against the latest attempt: `GET /actions/runs/{id}/jobs` defaults to `filter=latest`, whose jobs all succeeded, and `gh run view --log-failed` defaults to the same latest attempt and returns no failed log. The tracker ends up asserting nothing is knowable about precisely the runs where the diagnosis is one query parameter away.

This reads both sources at the attempt that actually failed.

**Annotations.** `filter=all` returns every attempt's jobs. Against run [34065324135](https://github.com/max-sixty/tend/actions/runs/34065324135) — one of the four stubs — the attempt-1 job yields `claude -p exited non-zero (exit=1): You've hit your session limit`, which is the whole diagnosis and, in this case, the reason the whole night's rows exist. Job headings gain an `(attempt N)` suffix only when the run has more than one attempt, so single-attempt runs render byte-identically to today.

**Log tail.** The fallback now passes the latest failing attempt to `gh run view --attempt`. This is the source that carries transient failures specifically: a `curl: (35) Recv failure` in "Run the action" annotates only `Process completed with exit code N`, which the annotation path discards as uninformative, so its diagnosis lives solely in the log — and a transient failure is exactly the kind that gets rerun to green. The attempt comes from the jobs response the annotation path already reads, so it costs no extra call. When that read is unavailable there is no attempt to name and the log source stays on the latest attempt, as before.

The four stubs already on #1164 stay stubs — their `<!-- enriched-run:ID -->` markers suppress a retry by design. Deleting those four marker comments after this merges would let the next nightly re-enrich them.

Regression tests, both failing on `main`: a run whose attempt 1 failed and attempt 2 succeeded renders the attempt-1 annotation instead of the stub; and one whose attempt-1 failure is annotation-free renders its log tail instead of the stub.
