### PR TITLE
List the codex-auth-refresh workflow in the CLAUDE.md concurrency table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,6 +291,7 @@ Concurrency groups:
 | notifications | `tend-notifications` | **no** — one poll drains notifications and repairs bot PRs at a time |
 | ci-fix | `workflow-<watched workflow>-<branch>` | **no** — a session mid-fix may already have pushed a branch or opened a PR |
 | nightly / weekly | none | cron-serialized |
+| codex-auth-refresh (codex only) | `tend-codex-auth-refresh` | **no** — only this workflow may rotate the refresh-token chain, so a second refresher must never race it |
 
 **Fork guard.** Workflows whose triggers can fire from a fork's own
 Actions (`schedule`, `workflow_dispatch`, `workflow_run`, `issues`) carry


### PR DESCRIPTION
The concurrency table in `CLAUDE.md` enumerates each generated workflow's group and why it does or doesn't cancel in progress. `tend-codex-auth-refresh`, generated whenever `codex` is an enabled harness, wasn't in it.

Its serialization is the load-bearing kind the table exists to record: it is the only workflow permitted to rotate the refresh-token chain, and a second refresher racing it would invalidate the access token every consumer job shares. The template already carries that reasoning in a comment; this puts it where someone reasoning about serialization will look.

Docs only, so no test.
