### PR TITLE
fix(prepare-agent-workspace): stop a mention on an issue or closed PR mishandling the checkout

### DIFF
--- a/shared/steps/prepare_agent_workspace.py
+++ b/shared/steps/prepare_agent_workspace.py
@@ -210,9 +210,11 @@ def checkout_mention(
 ) -> tuple[str, str]:
     pr = api_json(f"/repos/{repository}/pulls/{number}", token)
     if pr.get("state") != "open":
-        return checkout_base(workspace, base_branch, base_sha), pull_base_sha(
-            pr, number
-        )
+        # The fallback selects the default branch, which is reviewed code — so
+        # there is nothing to pin away, and pinning to the closed PR's base
+        # would revert this tree's instruction files to whatever they were
+        # when that PR opened.  Same answer as an `issue_comment` on an issue.
+        return checkout_base(workspace, base_branch, base_sha), ""
     head = pr.get("head")
     if not isinstance(head, dict) or not isinstance(head.get("repo"), dict):
         raise TypeError(f"PR #{number} has no fetchable head repository")

--- a/shared/steps/prepare_agent_workspace.py
+++ b/shared/steps/prepare_agent_workspace.py
@@ -130,9 +130,17 @@ def event_number(payload: dict[str, Any]) -> int:
     return raw
 
 
-def issue_comment_targets_pull_request(payload: dict[str, Any]) -> bool:
+def event_targets_pull_request(payload: dict[str, Any]) -> bool:
+    """True where a mention event names a pull request rather than an issue.
+
+    `issues` and `issue_comment` both carry an `issue`, which names a PR only
+    through its `pull_request` link; a relayed review names one outright in
+    `client_payload`.  Anything else has no PR head to fetch.
+    """
     issue = payload.get("issue")
-    return isinstance(issue, dict) and isinstance(issue.get("pull_request"), dict)
+    if isinstance(issue, dict):
+        return isinstance(issue.get("pull_request"), dict)
+    return isinstance(payload.get("client_payload"), dict)
 
 
 def git(
@@ -213,7 +221,7 @@ def checkout_mention(
         # The fallback selects the default branch, which is reviewed code — so
         # there is nothing to pin away, and pinning to the closed PR's base
         # would revert this tree's instruction files to whatever they were
-        # when that PR opened.  Same answer as an `issue_comment` on an issue.
+        # when that PR opened.  Same answer as a mention on an issue thread.
         return checkout_base(workspace, base_branch, base_sha), ""
     head = pr.get("head")
     if not isinstance(head, dict) or not isinstance(head.get("repo"), dict):
@@ -354,12 +362,7 @@ def main() -> int:
             if mode == "review":
                 selected = checkout_review(destination, number, token)
                 config_base_sha = pull_base_sha(payload, number)
-            elif os.environ.get(
-                "GITHUB_EVENT_NAME"
-            ) == "issue_comment" and not issue_comment_targets_pull_request(payload):
-                selected = checkout_base(destination, base_branch, base_sha)
-                config_base_sha = ""
-            else:
+            elif event_targets_pull_request(payload):
                 selected, config_base_sha = checkout_mention(
                     destination,
                     repository=repository,
@@ -368,6 +371,12 @@ def main() -> int:
                     base_branch=base_branch,
                     base_sha=base_sha,
                 )
+            else:
+                # An issue thread: `number` is an issue number, which the PR
+                # endpoint 404s on.  The default branch is reviewed code, so
+                # it needs no pin either.
+                selected = checkout_base(destination, base_branch, base_sha)
+                config_base_sha = ""
             if config_base_sha:
                 ensure_commit(destination, config_base_sha, token)
 

--- a/shared/steps/test_prepare_agent_workspace.py
+++ b/shared/steps/test_prepare_agent_workspace.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import json
 import shutil
 import subprocess
+import urllib.error
 from pathlib import Path
 
 import prepare_agent_workspace as prepare
@@ -219,13 +221,12 @@ def test_event_number(payload: dict[str, object], number: int) -> None:
     [
         ({"issue": {"number": 1}}, False),
         ({"issue": {"number": 1, "pull_request": {"url": "example"}}}, True),
+        ({"client_payload": {"pr": "3"}}, True),
         ({}, False),
     ],
 )
-def test_issue_comment_targets_pull_request(
-    payload: dict[str, object], expected: bool
-) -> None:
-    assert prepare.issue_comment_targets_pull_request(payload) is expected
+def test_event_targets_pull_request(payload: dict[str, object], expected: bool) -> None:
+    assert prepare.event_targets_pull_request(payload) is expected
 
 
 def test_mention_on_a_closed_pr_keeps_the_default_branch_instructions(
@@ -258,8 +259,6 @@ def test_mention_on_a_closed_pr_keeps_the_default_branch_instructions(
         "api_json",
         lambda _path, _token: {"state": "closed", "base": {"sha": base}},
     )
-    monkeypatch.setattr(prepare, "BASH", Path(shutil.which("bash") or "/bin/bash"))
-
     selected, config_base = prepare.checkout_mention(
         destination,
         repository="owner/repo",
@@ -274,3 +273,52 @@ def test_mention_on_a_closed_pr_keeps_the_default_branch_instructions(
     prepare.restore_sensitive_config(destination, config_base)
     assert (destination / "CLAUDE.md").read_text() == "current guidance\n"
     assert command("status", "--porcelain", cwd=destination) == ""
+
+
+def test_a_mention_on_an_issue_never_asks_the_pull_request_endpoint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An `issues` event names an issue, and `/pulls/{number}` 404s on one.
+
+    The handle job runs one mention checkout for every mention event it
+    admits, `issues: edited` among them, so an issue number reaching the PR
+    endpoint fails the step before the agent starts — losing every mention
+    added by editing an issue body, silently from the thread's side.
+    """
+    origin, runner, base, _head = repository(tmp_path)
+    event = tmp_path / "event.json"
+    event.write_text(json.dumps({"action": "edited", "issue": {"number": 7}}))
+    github_env = tmp_path / "github.env"
+    github_env.write_text("")
+
+    def refuse(path: str, _token: str) -> dict[str, object]:
+        raise urllib.error.HTTPError(path, 404, "Not Found", {}, None)
+
+    clone_workspace = prepare.clone_workspace
+    monkeypatch.setattr(prepare, "api_json", refuse)
+    monkeypatch.setattr(
+        prepare,
+        "clone_workspace",
+        lambda **arguments: clone_workspace(**arguments, remote_url=str(origin)),
+    )
+    for name, value in {
+        "GITHUB_WORKSPACE": str(runner),
+        "GITHUB_REPOSITORY": "owner/repo",
+        "GITHUB_TOKEN": "unused",
+        "GITHUB_ENV": str(github_env),
+        "GITHUB_EVENT_PATH": str(event),
+        "GITHUB_EVENT_NAME": "issues",
+        "TEND_CHECKOUT_MODE": "mention",
+        "TEND_BASE_BRANCH": "main",
+    }.items():
+        monkeypatch.setenv(name, value)
+
+    assert prepare.main() == 0
+
+    exported = dict(line.split("=", 1) for line in github_env.read_text().splitlines())
+    workspace = Path(exported["TEND_AGENT_WORKSPACE"])
+    try:
+        assert command("rev-parse", "HEAD", cwd=workspace) == base
+        assert command("rev-parse", "--abbrev-ref", "HEAD", cwd=workspace) == "main"
+    finally:
+        shutil.rmtree(workspace.parent)

--- a/shared/steps/test_prepare_agent_workspace.py
+++ b/shared/steps/test_prepare_agent_workspace.py
@@ -226,3 +226,51 @@ def test_issue_comment_targets_pull_request(
     payload: dict[str, object], expected: bool
 ) -> None:
     assert prepare.issue_comment_targets_pull_request(payload) is expected
+
+
+def test_mention_on_a_closed_pr_keeps_the_default_branch_instructions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A closed PR's base commit must not pin the default branch's own tree.
+
+    The fallback checks out the default branch, which is reviewed code. Pinning
+    it to the base the PR opened against reverts every `CLAUDE.md`, `AGENTS.md`
+    and `.claude/**` the branch has gained since — so the session runs on stale
+    repo guidance, and the revert is staged by any later `git add -A`.
+    """
+    origin, runner, base, _head = repository(tmp_path)
+    (runner / "CLAUDE.md").write_text("current guidance\n")
+    command("add", "CLAUDE.md", cwd=runner)
+    command("commit", "-m", "guidance", cwd=runner)
+    tip = command("rev-parse", "HEAD", cwd=runner)
+    command("push", "origin", "main", cwd=runner)
+
+    destination = tmp_path / "agent"
+    prepare.clone_workspace(
+        runner_workspace=runner,
+        destination=destination,
+        repository="owner/repo",
+        token="unused",
+        remote_url=str(origin),
+    )
+    monkeypatch.setattr(
+        prepare,
+        "api_json",
+        lambda _path, _token: {"state": "closed", "base": {"sha": base}},
+    )
+    monkeypatch.setattr(prepare, "BASH", Path(shutil.which("bash") or "/bin/bash"))
+
+    selected, config_base = prepare.checkout_mention(
+        destination,
+        repository="owner/repo",
+        number=7,
+        token="unused",
+        base_branch="main",
+        base_sha=tip,
+    )
+
+    assert selected == f"base branch main at {tip}"
+    assert config_base == ""
+    prepare.restore_sensitive_config(destination, config_base)
+    assert (destination / "CLAUDE.md").read_text() == "current guidance\n"
+    assert command("status", "--porcelain", cwd=destination) == ""


### PR DESCRIPTION
Two mention events reach the disposable-workspace step with no PR head to fetch, and each one is mishandled: a mention on a **closed or merged PR** runs on stale repo guidance, and a mention added by **editing an issue body** kills the step before the agent starts. Both come out of the same branch in `main()`, so this PR replaces that branch rather than special-casing each.

**Closed PR — stale instruction files.** `checkout_mention` falls back to the default branch when the PR isn't open, but it still returned the closed PR's `base.sha` as the config base. `main()` hands that to `restore_sensitive_config`, whose job is to pin `CLAUDE.md`, `AGENTS.md`, `.claude/**` and the other startup-read paths to a reviewed commit — a real defence on a fork PR, where the checked-out tree is attacker-controlled. Here the tree is already the default branch, so there is nothing to pin away; the pin only rolls those files back to whatever they were when that PR opened, and every skill, convention and command the branch has gained since disappears for the run. The dirty worktree is the second cost — `git restore --worktree` leaves the index at `HEAD`, so a later `git add -A` stages the revert into whatever the run commits.

**Issue mention — the step dies.** `checkout_mention`'s first statement requests `/repos/{repository}/pulls/{number}`. The bypass around it was gated on `GITHUB_EVENT_NAME == "issue_comment"`, so an `issues: edited` event sent its *issue* number to the PR endpoint. That 404s, the `HTTPError` (an `OSError`) reaches `main()`'s handler, and the `Prepare disposable agent workspace` step exits non-zero with no `continue-on-error` above it. It is reachable from the workflow's own `if`, which admits `issues: edited` whenever the issue body mentions the bot, and `mention_verify.py` returns `verdict(True)` unconditionally for `kind == "issues"` — so every mention added by editing an issue body loses its entire run, silently from the thread's side. This is the other half of #1173's move of the PR checkout out of the workflow: the old runner step gated `gh pr checkout` on `github.event.issue.pull_request.url != '' || repository_dispatch`, which excluded `issues`; the condition that replaced it did not.

The fix is one question asked of the payload's own shape, `event_targets_pull_request` — an `issue` names a PR only through its `pull_request` link, and a relayed review names one in `client_payload` — plus an empty config base on the closed-PR return. Both no-PR cases then take the same answer: the reviewed default branch, unpinned.

<details><summary>Regression coverage</summary>

Both tests are in `shared/steps/test_prepare_agent_workspace.py` and fail on the previous code.

- The closed-PR test builds a `main` that has moved past the PR base, asserts the empty config base, and checks the restored tree still holds the current guidance with a clean `git status`. Pre-fix it fails with the base SHA where the empty string belongs.
- The issue-mention test drives `main()` with an `issues` payload and an `api_json` that raises the real 404, then reads `TEND_AGENT_WORKSPACE` back out of `GITHUB_ENV` and asserts the checkout is the default branch at its tip. Pre-fix `main()` prints `::error::HTTP Error 404: Not Found` and returns 1.

</details>
