### PR TITLE
fix(nightly): read the covering PR's diff before surveying a path it already changes

### DIFF
--- a/generator/tests/test_nightly_survey_files.py
+++ b/generator/tests/test_nightly_survey_files.py
@@ -71,10 +71,10 @@ def test_main_lists_the_tracked_files_in_the_fixed_days_bucket(
     captured = capsys.readouterr()
     bucket, selected = survey.survey_files(sorted(files), unix_day=10_000)
     assert captured.out.splitlines() == selected
-    assert captured.err == f"# bucket={bucket}/28 files={len(selected)} skipped=0\n"
+    assert captured.err == f"# bucket={bucket}/28 files={len(selected)} covered=0\n"
 
 
-def test_paths_an_open_pr_already_changes_are_dropped_from_the_days_list(
+def test_paths_an_open_pr_already_changes_stay_listed_and_are_named(
     survey: ModuleType,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -87,7 +87,7 @@ def test_paths_an_open_pr_already_changes_are_dropped_from_the_days_list(
     subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
     monkeypatch.chdir(tmp_path)
     _, selected = survey.survey_files(sorted(files), unix_day=10_000)
-    covered, kept = selected[0], selected[1:]
+    covered = selected[0]
 
     assert (
         survey.main(
@@ -102,13 +102,13 @@ def test_paths_an_open_pr_already_changes_are_dropped_from_the_days_list(
     )
 
     captured = capsys.readouterr()
-    assert captured.out.splitlines() == kept
+    assert captured.out.splitlines() == selected
     assert captured.err == (
-        f"# bucket=4/28 files={len(kept)} skipped=1\n# skipped {covered} (#7, #9)\n"
+        f"# bucket=4/28 files={len(selected)} covered=1\n# covered {covered} (#7, #9)\n"
     )
 
 
-def test_the_days_list_excludes_the_open_prs_gh_reports(
+def test_the_days_list_names_the_open_prs_gh_reports(
     survey: ModuleType, tmp_path: Path
 ) -> None:
     """The whole `gh` surface, on whichever bucket today's real clock picks."""
@@ -139,8 +139,8 @@ def test_the_days_list_excludes_the_open_prs_gh_reports(
         check=True,
     )
 
-    assert result.stdout.splitlines() == [kept]
-    assert f"# skipped {covered} (#12)" in result.stderr
+    assert sorted(result.stdout.splitlines()) == sorted([covered, kept])
+    assert f"# covered {covered} (#12)" in result.stderr
     assert calls.read_text().splitlines() == [
         "pr list --state open --limit 200 --json number,files"
     ]

--- a/generator/tests/test_nightly_survey_files.py
+++ b/generator/tests/test_nightly_survey_files.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 
 import importlib.util
 import subprocess
+import sys
+import time
+import zlib
 from pathlib import Path
 from types import ModuleType
 
 import pytest
+
+from tests import GH_PREAMBLE, fake_bin, tool_path, uv_script
 
 SCRIPT = (
     Path(__file__).resolve().parents[2]
@@ -23,7 +28,13 @@ def survey() -> ModuleType:
     spec = importlib.util.spec_from_file_location("nightly_survey_files", SCRIPT)
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    # `uv run --script` puts the script's own directory on the path; an
+    # in-process import of its `github_cli` sibling needs the same.
+    sys.path.insert(0, str(SCRIPT.parent))
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.remove(str(SCRIPT.parent))
     return module
 
 
@@ -55,9 +66,81 @@ def test_main_lists_the_tracked_files_in_the_fixed_days_bucket(
     subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
     monkeypatch.chdir(tmp_path)
 
-    assert survey.main([], now=10_000 * 86400) == 0
+    assert survey.main([], now=10_000 * 86400, pull_requests=[]) == 0
 
     captured = capsys.readouterr()
     bucket, selected = survey.survey_files(sorted(files), unix_day=10_000)
     assert captured.out.splitlines() == selected
-    assert captured.err == f"# bucket={bucket}/28 files={len(selected)}\n"
+    assert captured.err == f"# bucket={bucket}/28 files={len(selected)} skipped=0\n"
+
+
+def test_paths_an_open_pr_already_changes_are_dropped_from_the_days_list(
+    survey: ModuleType,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    files = [f"file-{index}.py" for index in range(100)]
+    for path in files:
+        (tmp_path / path).write_text("\n")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+    monkeypatch.chdir(tmp_path)
+    _, selected = survey.survey_files(sorted(files), unix_day=10_000)
+    covered, kept = selected[0], selected[1:]
+
+    assert (
+        survey.main(
+            [],
+            now=10_000 * 86400,
+            pull_requests=[
+                {"number": 7, "files": [{"path": covered}]},
+                {"number": 9, "files": [{"path": covered}, {"path": "untracked.py"}]},
+            ],
+        )
+        == 0
+    )
+
+    captured = capsys.readouterr()
+    assert captured.out.splitlines() == kept
+    assert captured.err == (
+        f"# bucket=4/28 files={len(kept)} skipped=1\n# skipped {covered} (#7, #9)\n"
+    )
+
+
+def test_the_days_list_excludes_the_open_prs_gh_reports(
+    survey: ModuleType, tmp_path: Path
+) -> None:
+    """The whole `gh` surface, on whichever bucket today's real clock picks."""
+    today = int(time.time()) // 86400 % survey.CYCLE_LENGTH
+    in_bucket = [
+        name
+        for name in (f"file-{index}.py" for index in range(2000))
+        if zlib.crc32(name.encode()) % survey.CYCLE_LENGTH == today
+    ]
+    covered, kept = in_bucket[0], in_bucket[1]
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    for path in (covered, kept):
+        (tmp_path / path).write_text("\n")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+    calls = tmp_path / "gh-calls"
+    bindir = fake_bin(
+        tmp_path,
+        gh=GH_PREAMBLE
+        + f"""emit '[{{"number": 12, "files": [{{"path": "{covered}"}}]}}]'\n""",
+    )
+
+    result = subprocess.run(
+        uv_script(SCRIPT),
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        env={"PATH": tool_path(bindir), "HOME": str(tmp_path), "GH_CALLS": str(calls)},
+        check=True,
+    )
+
+    assert result.stdout.splitlines() == [kept]
+    assert f"# skipped {covered} (#12)" in result.stderr
+    assert calls.read_text().splitlines() == [
+        "pr list --state open --limit 200 --json number,files"
+    ]

--- a/generator/tests/test_nightly_survey_files.py
+++ b/generator/tests/test_nightly_survey_files.py
@@ -74,7 +74,7 @@ def test_main_lists_the_tracked_files_in_the_fixed_days_bucket(
     assert captured.err == f"# bucket={bucket}/28 files={len(selected)} covered=0\n"
 
 
-def test_paths_an_open_pr_already_changes_stay_listed_and_are_named(
+def test_covered_paths_stay_listed_and_are_named_with_each_pulls_author(
     survey: ModuleType,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -94,8 +94,16 @@ def test_paths_an_open_pr_already_changes_stay_listed_and_are_named(
             [],
             now=10_000 * 86400,
             pull_requests=[
-                {"number": 7, "files": [{"path": covered}]},
-                {"number": 9, "files": [{"path": covered}, {"path": "untracked.py"}]},
+                {
+                    "number": 7,
+                    "author": {"login": "tend-agent"},
+                    "files": [{"path": covered}],
+                },
+                {
+                    "number": 9,
+                    "author": {"login": "a-human"},
+                    "files": [{"path": covered}, {"path": "untracked.py"}],
+                },
             ],
         )
         == 0
@@ -104,7 +112,8 @@ def test_paths_an_open_pr_already_changes_stay_listed_and_are_named(
     captured = capsys.readouterr()
     assert captured.out.splitlines() == selected
     assert captured.err == (
-        f"# bucket=4/28 files={len(selected)} covered=1\n# covered {covered} (#7, #9)\n"
+        f"# bucket=4/28 files={len(selected)} covered=1\n"
+        f"# covered {covered} (#7 tend-agent, #9 a-human)\n"
     )
 
 
@@ -127,7 +136,8 @@ def test_the_days_list_names_the_open_prs_gh_reports(
     bindir = fake_bin(
         tmp_path,
         gh=GH_PREAMBLE
-        + f"""emit '[{{"number": 12, "files": [{{"path": "{covered}"}}]}}]'\n""",
+        + """emit '[{"number": 12, "author": {"login": "tend-agent"}, """
+        + f""""files": [{{"path": "{covered}"}}]}}]'\n""",
     )
 
     result = subprocess.run(
@@ -140,7 +150,7 @@ def test_the_days_list_names_the_open_prs_gh_reports(
     )
 
     assert sorted(result.stdout.splitlines()) == sorted([covered, kept])
-    assert f"# covered {covered} (#12)" in result.stderr
+    assert f"# covered {covered} (#12 tend-agent)" in result.stderr
     assert calls.read_text().splitlines() == [
-        "pr list --state open --limit 200 --json number,files"
+        "pr list --state open --limit 200 --json number,files,author"
     ]

--- a/plugins/tend-ci-runner/scripts/nightly_survey_files.py
+++ b/plugins/tend-ci-runner/scripts/nightly_survey_files.py
@@ -6,9 +6,12 @@
 
 Both the day and the path pick a bucket by arithmetic, so bucket *N* returns to
 the same file set every cycle. On a repository whose pull requests sit unmerged
-longer than that, a path whose last pass left an open PR would be re-surveyed on
-the anniversary and re-derive that PR's findings, so paths an open pull request
-already changes are dropped before the survey reads anything.
+longer than that, a path whose last pass left an open PR comes round again and
+its findings get re-derived on the anniversary. So each path an open pull
+request already changes is reported with the pulls covering it, for the survey
+to read before it reads the file. The path stays in the list: on the repositories
+where this fires the backlog can cover most of the tree, and dropping those paths
+would leave them unsurveyed for as long as it stands.
 """
 
 from __future__ import annotations
@@ -63,18 +66,17 @@ def main(
             "pr", "list", "--state", "open", "--limit", "200", "--json", "number,files"
         )
     covering = covering_pulls(pull_requests)
-    skipped = [path for path in selected if path in covering]
-    selected = [path for path in selected if path not in covering]
+    covered = [path for path in selected if path in covering]
     if selected:
         print(*selected, sep="\n")
     print(
         f"# bucket={bucket}/{CYCLE_LENGTH} files={len(selected)}"
-        f" skipped={len(skipped)}",
+        f" covered={len(covered)}",
         file=sys.stderr,
     )
-    for path in skipped:
+    for path in covered:
         pulls = ", ".join(f"#{number}" for number in covering[path])
-        print(f"# skipped {path} ({pulls})", file=sys.stderr)
+        print(f"# covered {path} ({pulls})", file=sys.stderr)
     return 0
 
 

--- a/plugins/tend-ci-runner/scripts/nightly_survey_files.py
+++ b/plugins/tend-ci-runner/scripts/nightly_survey_files.py
@@ -2,7 +2,14 @@
 # requires-python = ">=3.12"
 # dependencies = []
 # ///
-"""Select today's deterministic slice of tracked files for the nightly survey."""
+"""Select today's deterministic slice of tracked files for the nightly survey.
+
+Both the day and the path pick a bucket by arithmetic, so bucket *N* returns to
+the same file set every cycle. On a repository whose pull requests sit unmerged
+longer than that, a path whose last pass left an open PR would be re-surveyed on
+the anniversary and re-derive that PR's findings, so paths an open pull request
+already changes are dropped before the survey reads anything.
+"""
 
 from __future__ import annotations
 
@@ -10,6 +17,9 @@ import subprocess
 import sys
 import time
 import zlib
+from typing import Any
+
+import github_cli
 
 CYCLE_LENGTH = 28
 
@@ -23,7 +33,21 @@ def survey_files(files: list[str], *, unix_day: int) -> tuple[int, list[str]]:
     return bucket, selected
 
 
-def main(argv: list[str] | None = None, *, now: float | None = None) -> int:
+def covering_pulls(pull_requests: list[dict[str, Any]]) -> dict[str, list[int]]:
+    """Map each path an open pull request changes to the pulls changing it."""
+    covering: dict[str, list[int]] = {}
+    for pull in pull_requests:
+        for changed in pull["files"]:
+            covering.setdefault(changed["path"], []).append(pull["number"])
+    return covering
+
+
+def main(
+    argv: list[str] | None = None,
+    *,
+    now: float | None = None,
+    pull_requests: list[dict[str, Any]] | None = None,
+) -> int:
     args = sys.argv[1:] if argv is None else argv
     if args:
         print(f"usage: {sys.argv[0]}", file=sys.stderr)
@@ -34,9 +58,23 @@ def main(argv: list[str] | None = None, *, now: float | None = None) -> int:
     bucket, selected = survey_files(
         tracked, unix_day=int(time.time() if now is None else now) // 86400
     )
+    if pull_requests is None:
+        pull_requests = github_cli.json_call(
+            "pr", "list", "--state", "open", "--limit", "200", "--json", "number,files"
+        )
+    covering = covering_pulls(pull_requests)
+    skipped = [path for path in selected if path in covering]
+    selected = [path for path in selected if path not in covering]
     if selected:
         print(*selected, sep="\n")
-    print(f"# bucket={bucket}/{CYCLE_LENGTH} files={len(selected)}", file=sys.stderr)
+    print(
+        f"# bucket={bucket}/{CYCLE_LENGTH} files={len(selected)}"
+        f" skipped={len(skipped)}",
+        file=sys.stderr,
+    )
+    for path in skipped:
+        pulls = ", ".join(f"#{number}" for number in covering[path])
+        print(f"# skipped {path} ({pulls})", file=sys.stderr)
     return 0
 
 
@@ -44,4 +82,4 @@ if __name__ == "__main__":
     try:
         raise SystemExit(main())
     except subprocess.CalledProcessError as error:
-        raise SystemExit(error.returncode or 1) from None
+        raise SystemExit(github_cli.exit_code(error))

--- a/plugins/tend-ci-runner/scripts/nightly_survey_files.py
+++ b/plugins/tend-ci-runner/scripts/nightly_survey_files.py
@@ -8,10 +8,12 @@ Both the day and the path pick a bucket by arithmetic, so bucket *N* returns to
 the same file set every cycle. On a repository whose pull requests sit unmerged
 longer than that, a path whose last pass left an open PR comes round again and
 its findings get re-derived on the anniversary. So each path an open pull
-request already changes is reported with the pulls covering it, for the survey
-to read before it reads the file. The path stays in the list: on the repositories
-where this fires the backlog can cover most of the tree, and dropping those paths
-would leave them unsurveyed for as long as it stands.
+request already changes is reported with the pulls covering it and who wrote
+them, for the survey to read before it reads the file. The author decides where
+a new finding goes: onto the covering pull request where the bot wrote it, into
+a pull request of its own where anyone else did. The path stays in the list: on
+the repositories where this fires the backlog can cover most of the tree, and
+dropping those paths would leave them unsurveyed for as long as it stands.
 """
 
 from __future__ import annotations
@@ -36,12 +38,13 @@ def survey_files(files: list[str], *, unix_day: int) -> tuple[int, list[str]]:
     return bucket, selected
 
 
-def covering_pulls(pull_requests: list[dict[str, Any]]) -> dict[str, list[int]]:
+def covering_pulls(pull_requests: list[dict[str, Any]]) -> dict[str, list[str]]:
     """Map each path an open pull request changes to the pulls changing it."""
-    covering: dict[str, list[int]] = {}
+    covering: dict[str, list[str]] = {}
     for pull in pull_requests:
+        label = f"#{pull['number']} {pull['author']['login']}"
         for changed in pull["files"]:
-            covering.setdefault(changed["path"], []).append(pull["number"])
+            covering.setdefault(changed["path"], []).append(label)
     return covering
 
 
@@ -63,7 +66,14 @@ def main(
     )
     if pull_requests is None:
         pull_requests = github_cli.json_call(
-            "pr", "list", "--state", "open", "--limit", "200", "--json", "number,files"
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--limit",
+            "200",
+            "--json",
+            "number,files,author",
         )
     covering = covering_pulls(pull_requests)
     covered = [path for path in selected if path in covering]
@@ -75,8 +85,7 @@ def main(
         file=sys.stderr,
     )
     for path in covered:
-        pulls = ", ".join(f"#{number}" for number in covering[path])
-        print(f"# covered {path} ({pulls})", file=sys.stderr)
+        print(f"# covered {path} ({', '.join(covering[path])})", file=sys.stderr)
     return 0
 
 

--- a/plugins/tend-ci-runner/scripts/nightly_survey_files.py
+++ b/plugins/tend-ci-runner/scripts/nightly_survey_files.py
@@ -42,7 +42,7 @@ def covering_pulls(pull_requests: list[dict[str, Any]]) -> dict[str, list[str]]:
     """Map each path an open pull request changes to the pulls changing it."""
     covering: dict[str, list[str]] = {}
     for pull in pull_requests:
-        label = f"#{pull['number']} {pull['author']['login']}"
+        label = f"#{pull['number']} {github_cli.actor_login(pull.get('author'))}"
         for changed in pull["files"]:
             covering.setdefault(changed["path"], []).append(label)
     return covering

--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -129,6 +129,8 @@ uv run --script \
   "${CLAUDE_PLUGIN_ROOT}/scripts/nightly_survey_files.py"
 ```
 
+The rotation is deterministic in both directions, so a bucket returns to the same files every cycle. The script therefore drops any path an open PR already changes, printing `# skipped <path> (#N)` on stderr for each: whatever the survey would find there is either already in that PR or belongs as a comment on it, and the PR is where a maintainer is already looking. Carry the skipped paths into the Step 9 summary.
+
 Skip files that aren't meaningfully reviewable: lock files (`uv.lock`, `Cargo.lock`, `package-lock.json`), binary assets, vendored dependencies, and generated files (build output, compiled protobuf, auto-generated workflow YAML). When unsure, check the file — a quick glance is cheaper than missing something.
 
 Before reviewing files, read the project's CLAUDE.md and any project-specific skills or review criteria it references. Apply the review checklist below to each file in full.
@@ -232,4 +234,4 @@ Keep the project's changelog up to date with recent changes. The `running-tend` 
 
 ## Step 9: Summary
 
-Report: commits reviewed, files surveyed, findings, actions taken, assessment (clean / minor issues / needs attention).
+Report: commits reviewed, files surveyed, files skipped for an open PR (with that PR), findings, actions taken, assessment (clean / minor issues / needs attention).

--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -129,7 +129,7 @@ uv run --script \
   "${CLAUDE_PLUGIN_ROOT}/scripts/nightly_survey_files.py"
 ```
 
-The script prints `# covered <path> (#N)` on stderr for each path an open PR already changes. Read that PR's diff before reading the file: drop the findings it already carries, and raise anything new as a comment on that PR rather than a second PR against the same file. Carry the covered paths into the Step 9 summary.
+The script prints `# covered <path> (#N author)` on stderr for each path an open PR already changes. Read that PR's diff before reading the file and drop the findings it already carries. Raise anything new as a comment on the covering PR only where the bot authored it; on anyone else's PR, open your own per Step 8 rather than commenting on their in-flight work. Carry the covered paths into the Step 9 summary.
 
 Skip files that aren't meaningfully reviewable: lock files (`uv.lock`, `Cargo.lock`, `package-lock.json`), binary assets, vendored dependencies, and generated files (build output, compiled protobuf, auto-generated workflow YAML). When unsure, check the file — a quick glance is cheaper than missing something.
 

--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -129,7 +129,7 @@ uv run --script \
   "${CLAUDE_PLUGIN_ROOT}/scripts/nightly_survey_files.py"
 ```
 
-The script drops any path an open PR already changes — a file with a pending PR is where a maintainer is already looking — printing `# skipped <path> (#N)` on stderr for each. Carry the skipped paths into the Step 9 summary.
+The script prints `# covered <path> (#N)` on stderr for each path an open PR already changes. Read that PR's diff before reading the file: drop the findings it already carries, and raise anything new as a comment on that PR rather than a second PR against the same file. Carry the covered paths into the Step 9 summary.
 
 Skip files that aren't meaningfully reviewable: lock files (`uv.lock`, `Cargo.lock`, `package-lock.json`), binary assets, vendored dependencies, and generated files (build output, compiled protobuf, auto-generated workflow YAML). When unsure, check the file — a quick glance is cheaper than missing something.
 
@@ -234,4 +234,4 @@ Keep the project's changelog up to date with recent changes. The `running-tend` 
 
 ## Step 9: Summary
 
-Report: commits reviewed, files surveyed, files skipped for an open PR (with that PR), findings, actions taken, assessment (clean / minor issues / needs attention).
+Report: commits reviewed, files surveyed, files an open PR already covers (with that PR), findings, actions taken, assessment (clean / minor issues / needs attention).

--- a/plugins/tend-ci-runner/skills/nightly/SKILL.md
+++ b/plugins/tend-ci-runner/skills/nightly/SKILL.md
@@ -129,7 +129,7 @@ uv run --script \
   "${CLAUDE_PLUGIN_ROOT}/scripts/nightly_survey_files.py"
 ```
 
-The rotation is deterministic in both directions, so a bucket returns to the same files every cycle. The script therefore drops any path an open PR already changes, printing `# skipped <path> (#N)` on stderr for each: whatever the survey would find there is either already in that PR or belongs as a comment on it, and the PR is where a maintainer is already looking. Carry the skipped paths into the Step 9 summary.
+The script drops any path an open PR already changes — a file with a pending PR is where a maintainer is already looking — printing `# skipped <path> (#N)` on stderr for each. Carry the skipped paths into the Step 9 summary.
 
 Skip files that aren't meaningfully reviewable: lock files (`uv.lock`, `Cargo.lock`, `package-lock.json`), binary assets, vendored dependencies, and generated files (build output, compiled protobuf, auto-generated workflow YAML). When unsure, check the file — a quick glance is cheaper than missing something.
 


### PR DESCRIPTION
## Problem

The survey's rotation is deterministic on both sides — the day picks the bucket (`unix_day % 28`) and the path picks the bucket (`crc32(path) % 28`) — so a bucket returns to exactly the same file set every 28 days. Nothing between the script and the review told the survey that a path already had an open PR against it. Where the bot's PRs merge promptly that costs nothing; where a backlog outlives the cycle, every bucket whose last pass left an unmerged PR re-derives that PR's findings on the anniversary, spending a full read-branch-build-test cycle before the pre-`gh pr create` recheck discards the branch. The existing guards all sit downstream of the read: Step 8's projection matches on titles, and `running-in-ci`'s prior-rejection search only has a symbol to search for once a finding exists.

## Solution

`nightly_survey_files.py` now asks `gh` which paths open PRs change and prints `# covered <path> (#N author)` on stderr for each path in the day's bucket that one of them touches. Step 6 reads that PR's diff before reading the file and drops the findings it already carries. Step 9 reports the covered paths.

The covered path stays in the day's list. Dropping it — the first shape here — saves more, but it blinds the survey exactly where the mechanism fires: the backlog that produces the aliasing is the same backlog that covers the tree. On [max-sixty/cargo-affected](https://github.com/max-sixty/cargo-affected), the repo that surfaced this, 36 open bot PRs cover 38 of 58 tracked files and 11 of 13 under `src/`, none of them wide (the largest touches 9 files) — so a drop would have left most of that repo unsurveyed for as long as the backlog stands, rather than for one cycle. Reading the covering PR's diff first still recovers the branch-build-test cycle the aliasing wasted, which was nearly all of its cost, and a file whose open PR fixes one line stays surveyable for the other hundred.

The query is unscoped by author, so a covering PR can be a maintainer's or an outside contributor's rather than the bot's — knowing a human PR is mid-rewrite of a file is worth having before the survey reads it, but the survey's own findings have no business in that thread. So the author rides along in the `# covered` line and gates the routing without a second lookup: a new finding goes onto the covering PR only where the bot wrote it, and into a PR of its own per Step 8 otherwise.

A `gh` failure fails the step rather than silently surveying unannotated. That is deliberate: a fallback would be machinery, and a run that cannot reach the API cannot open the PRs Step 8 exists for either.

## Testing

Two new tests in `generator/tests/test_nightly_survey_files.py`: one drives `main` with an injected PR list and asserts the covered path stays in stdout and is named on stderr with every PR covering it and its author; the other runs the script through `uv run --script` against a fake `gh`, pinning the actual `pr list --state open --limit 200 --json number,files,author` invocation. Full `uv run pytest` (1120 tests) and every pre-commit hook pass.

Closes #1176 — automated triage
