### PR TITLE
skills(shared): correct the authorAssociation claim — it is nested, not absent

### DIFF
--- a/plugins/tend-ci-runner/shared/author-association.md
+++ b/plugins/tend-ci-runner/shared/author-association.md
@@ -9,7 +9,7 @@ GitHub classifies authors of comments and events by `author_association`. Use th
 gh api repos/{owner}/{repo}/issues/comments/{comment_id} --jq '.author_association'
 ```
 
-`authorAssociation` is a field *on* the comment and review objects, not a top-level `--json` key. `gh issue view <n> --json comments --jq '.comments[].authorAssociation'` and `gh pr view <n> --json reviews --jq '.reviews[].authorAssociation'` both work, and cover every comment or review in one call. `gh issue view <n> --json authorAssociation` errors with `Unknown JSON field` — for the issue or PR author's own tier, use the REST call above.
+`authorAssociation` is a field *on* the comment and review objects, not a top-level `--json` key. `gh issue view <n> --json comments --jq '.comments[].authorAssociation'` and `gh pr view <n> --json reviews --jq '.reviews[].authorAssociation'` both work, and cover every comment or review in one call. `gh issue view <n> --json authorAssociation` errors with `Unknown JSON field` — for the issue or PR author's own tier, use `gh api repos/{owner}/{repo}/issues/{number} --jq '.author_association'`; the block above is the per-comment form.
 
 | Tier | Values | Meaning |
 |---|---|---|

--- a/plugins/tend-ci-runner/shared/author-association.md
+++ b/plugins/tend-ci-runner/shared/author-association.md
@@ -9,7 +9,7 @@ GitHub classifies authors of comments and events by `author_association`. Use th
 gh api repos/{owner}/{repo}/issues/comments/{comment_id} --jq '.author_association'
 ```
 
-`gh issue view --json` / `gh pr view --json` / `gh issue list --json` do **not** expose an `authorAssociation` field — only the REST API does. Use `gh api … --jq '.author_association'`, never `gh … --json authorAssociation` (which errors with `Unknown JSON field`).
+`authorAssociation` is a field *on* the comment and review objects, not a top-level `--json` key. `gh issue view <n> --json comments --jq '.comments[].authorAssociation'` and `gh pr view <n> --json reviews --jq '.reviews[].authorAssociation'` both work, and cover every comment or review in one call. `gh issue view <n> --json authorAssociation` errors with `Unknown JSON field` — for the issue or PR author's own tier, use the REST call above.
 
 | Tier | Values | Meaning |
 |---|---|---|


### PR DESCRIPTION
The shared author-association block tells every session that `gh issue view --json` / `gh pr view --json` "do **not** expose an `authorAssociation` field — only the REST API does." That is false for the case skills actually need. `authorAssociation` is a field on the *comment and review objects*, so it comes back inside `--json comments` and `--json reviews`; only the top-level `--json` key is rejected.

```
$ gh pr view 1172 --json comments --jq '.comments[0] | {author:.author.login, authorAssociation}'
{"author":"tend-agent","authorAssociation":"COLLABORATOR"}
$ gh pr view 1172 --json reviews  --jq '.reviews[].authorAssociation'
COLLABORATOR
OWNER
$ gh pr view 1172 --json authorAssociation
Unknown JSON field: "authorAssociation"
```

Two costs. The blanket claim sends a session to `gh api …/issues/comments/{id}` per comment when one `gh pr view --json comments` already carries the tier for all of them — and the tier a skill checks is nearly always a *commenter's*, which is exactly the nested case. And a session that has seen the nested form work reads the denial as untrue, which is a poor position from which to be discouraged from the top-level form: `gh … --json authorAssociation` errored in three sessions in the last 24 h despite this warning being loaded in all of them.

The replacement states the distinction that makes the error predictable — field on the object, not a top-level key — gives the working invocation for comments and for reviews, and keeps the REST call where it is still the only option: the issue or PR author's own tier.

No test: the file is skill prose with no code path, and nothing in `generator/tests/` asserts its content. `pre-commit run --all-files` passes all thirteen hooks, including the `sync install-tend references/` mirror check that covers this path.

<details><summary>Evidence and gate assessment</summary>

Observed by `review-runs` [34201227916](https://github.com/max-sixty/tend/actions/runs/34201227916) over the window `2026-09-07T07:52Z → 2026-09-08T07:50Z`. Prior occurrences of the same failed invocation are recorded in #1125 under 2026-09-05 and 2026-09-06.

Three sessions in this window issued a top-level `--json …,authorAssociation,…` and got `Unknown JSON field`, each retrying afterwards:

- [34096079332](https://github.com/max-sixty/tend/actions/runs/34096079332) — `gh issue view 1167 --json number,title,state,author,authorAssociation,…`
- [34170292235](https://github.com/max-sixty/tend/actions/runs/34170292235) — `gh pr view 1172 --json number,title,body,state,author,authorAssociation,…`
- [34187002758](https://github.com/max-sixty/tend/actions/runs/34187002758) — `gh pr view 1172 --json number,title,state,author,authorAssociation,…`

The lineage of the warning is #570 → #571 (triage skill) → #597 → #600 (moved to the shared block). Each round treated the top-level form as a hallucination to discourage; none checked whether the nested form is valid, so the over-broad half has never been corrected.

**Gates.** Confidence: the claim is false by direct execution, not by sampling — one verification settles it, and the text asserts it on every load, so this is structural rather than stochastic. Magnitude: a targeted fix to one incorrect sentence in one file, replacing a false blanket claim rather than adding guidance — no new rule for a session to carry. Cost: waste-class in what each occurrence leaves behind (an unnecessary REST call, a retried tool call), which limits the remedy to a knob-sized change; correcting one sentence in place, with the file no longer than before, is that shape.

</details>
