### PR TITLE
fix(codex): parse cumulative rollout token usage

### DIFF
--- a/codex/action.yaml
+++ b/codex/action.yaml
@@ -442,9 +442,10 @@ runs:
     # Codex writes rollouts under the sandbox user's ~/.codex/sessions. The
     # step consolidates them into a runner-owned directory only after reaping
     # the sandbox and drops every symlink before artifact upload.
-    # Each event includes a token_count field (input/output/cached). Sum
-    # them. Cost is left at 0 — Codex CLI doesn't surface API list prices
-    # and computing them ourselves would require maintaining a price table.
+    # Token-count events are cumulative within each rollout. Take the last
+    # complete total from every rollout, then sum the independent rollouts.
+    # Cost is left at 0 — Codex CLI doesn't surface API list prices and
+    # computing it ourselves would require maintaining a price table.
     # Shares shared/steps/token_usage.py with the Claude harness, which is
     # what keeps the record's shape and the summary table's shell the same
     # across harnesses; the rows and the parsers differ per `--harness`.

--- a/shared/steps/test_token_usage.py
+++ b/shared/steps/test_token_usage.py
@@ -75,6 +75,23 @@ def _assistant(msg_id: str, usage: dict[str, int], *, final: bool) -> dict[str, 
     }
 
 
+def _codex_token_count(**usage: int) -> dict[str, object]:
+    return {
+        "type": "event_msg",
+        "payload": {
+            "type": "token_count",
+            "info": {"total_token_usage": usage},
+        },
+    }
+
+
+def _codex_message() -> dict[str, object]:
+    return {
+        "type": "response_item",
+        "payload": {"type": "message", "role": "assistant"},
+    }
+
+
 def _ndjson(path: Path, lines: list[dict[str, object]]) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("".join(json.dumps(line) + "\n" for line in lines))
@@ -331,31 +348,26 @@ def test_reports_zero_when_the_agent_never_ran(logs_dir: Path) -> None:
     assert usage["partial"] is False
 
 
-def test_codex_sums_token_counts_across_rollouts(tmp_path: Path) -> None:
-    """Codex accounting is the sum over every rollout, turns being its messages."""
-    sessions = tmp_path / "sessions"
-    _ndjson(
-        sessions / "2026" / "08" / "25" / "rollout-a.jsonl",
-        [
-            {"type": "turn_context", "payload": {"model": "gpt-recommended"}},
-            {"type": "agent_message", "token_count": {"input_tokens": 100}},
-            {
-                "type": "token_count",
-                "token_count": {
-                    "input_tokens": 20,
-                    "output_tokens": 30,
-                    "cached_input_tokens": 90,
-                },
-            },
-        ],
-    )
-    _ndjson(
-        sessions / "2026" / "08" / "26" / "rollout-b.jsonl",
-        [{"type": "agent_message", "token_count": {"output_tokens": 7}}],
-    )
-
+def test_codex_sums_final_cumulative_counts_across_rollouts() -> None:
+    """Each rollout's last count is cumulative; independent rollouts are additive."""
     usage = token_usage.codex_usage(
-        token_usage.read_all(sorted(sessions.rglob("rollout-*.jsonl"))), ""
+        [
+            [
+                {"type": "turn_context", "payload": {"model": "gpt-recommended"}},
+                _codex_token_count(
+                    input_tokens=20, output_tokens=5, cached_input_tokens=10
+                ),
+                _codex_message(),
+                _codex_token_count(
+                    input_tokens=100, output_tokens=30, cached_input_tokens=90
+                ),
+            ],
+            [
+                _codex_message(),
+                _codex_token_count(input_tokens=20, output_tokens=7),
+            ],
+        ],
+        "",
     )
 
     assert usage == {
@@ -377,18 +389,19 @@ def test_codex_counts_an_absent_token_count_as_zero() -> None:
     """
     usage = token_usage.codex_usage(
         [
-            {"type": "agent_message"},
-            {"type": "event_msg", "token_count": None},
-            {"type": "turn_context", "token_count": {"input_tokens": None}},
-            {"type": "token_count", "token_count": {"input_tokens": 42}},
+            [
+                {"type": "response_item", "payload": {"type": "reasoning"}},
+                {"type": "event_msg", "payload": {"type": "token_count"}},
+                {"type": "turn_context", "payload": {"model": "gpt-ignored"}},
+            ]
         ],
         "gpt-5",
     )
 
-    assert usage["input_tokens"] == 42
+    assert usage["input_tokens"] == 0
     assert usage["output_tokens"] == 0
     assert usage["cached_input_tokens"] == 0
-    assert usage["turns"] == 1
+    assert usage["turns"] == 0
 
 
 def test_claude_main_publishes_the_record_three_ways(
@@ -471,8 +484,8 @@ def test_codex_main_publishes_the_record_three_ways(
     _ndjson(
         home / ".codex" / "sessions" / "2026" / "08" / "25" / "rollout-a.jsonl",
         [
-            {"type": "agent_message", "token_count": {"input_tokens": 100}},
-            {"type": "token_count", "token_count": {"output_tokens": 30}},
+            _codex_message(),
+            _codex_token_count(input_tokens=100, output_tokens=30),
         ],
     )
     monkeypatch.setenv("AGENT_HOME", str(home))

--- a/shared/steps/test_token_usage.py
+++ b/shared/steps/test_token_usage.py
@@ -392,6 +392,13 @@ def test_codex_counts_an_absent_token_count_as_zero() -> None:
             [
                 {"type": "response_item", "payload": {"type": "reasoning"}},
                 {"type": "event_msg", "payload": {"type": "token_count"}},
+                {
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "token_count",
+                        "info": {"total_token_usage": {"input_tokens": None}},
+                    },
+                },
                 {"type": "turn_context", "payload": {"model": "gpt-ignored"}},
             ]
         ],
@@ -525,9 +532,9 @@ def test_codex_main_publishes_the_record_three_ways(
         "## Token Usage (Codex)\n"
         "| Metric | Value |\n"
         "|--------|-------|\n"
-        "| Input | 100 |\n"
+        "| Total input | 100 |\n"
         "| Output | 30 |\n"
-        "| Cached input | 0 |\n"
+        "| Cached input (included in total) | 0 |\n"
         "| Turns | 1 |\n"
         "| Model | gpt-5-codex |\n"
         "\n"

--- a/shared/steps/token_usage.py
+++ b/shared/steps/token_usage.py
@@ -70,8 +70,9 @@ Codex has one path: consolidate the sandbox user's rollouts, then take the last
 cumulative token count from each ``sessions/**/rollout-*.jsonl``. That schema
 isn't versioned, so a missing field counts as zero — and no rollouts at all is
 the same computation over no events, which yields the all-zero record on its
-own. Cost stays 0: the Codex CLI doesn't surface API list prices and computing
-them here would mean maintaining a price table.
+own. Codex includes cached tokens in ``input_tokens``; ``cached_input_tokens``
+is the subset served from cache. Cost stays 0: the Codex CLI doesn't surface
+API list prices and computing them here would mean maintaining a price table.
 """
 
 from __future__ import annotations
@@ -105,9 +106,9 @@ CLAUDE_TABLE = (
 CODEX_TABLE = (
     "## Token Usage (Codex)",
     (
-        ("Input", "input_tokens"),
+        ("Total input", "input_tokens"),
         ("Output", "output_tokens"),
-        ("Cached input", "cached_input_tokens"),
+        ("Cached input (included in total)", "cached_input_tokens"),
         ("Turns", "turns"),
         ("Model", "model"),
     ),

--- a/shared/steps/token_usage.py
+++ b/shared/steps/token_usage.py
@@ -66,12 +66,12 @@ have. A ``0`` there would repeat the bug the fallback exists to fix, one field
 down; ``partial`` is what keeps a reconstructed total distinguishable from a
 run that really cost nothing.
 
-Codex has one path: consolidate the sandbox user's rollouts, then sum
-``sessions/**/rollout-*.jsonl``. That schema isn't versioned, so a
-missing field counts as zero — and no rollouts at all is the same computation
-over no events, which yields the all-zero record on its own. Cost stays 0: the
-Codex CLI doesn't surface API list prices and computing them here would mean
-maintaining a price table.
+Codex has one path: consolidate the sandbox user's rollouts, then take the last
+cumulative token count from each ``sessions/**/rollout-*.jsonl``. That schema
+isn't versioned, so a missing field counts as zero — and no rollouts at all is
+the same computation over no events, which yields the all-zero record on its
+own. Cost stays 0: the Codex CLI doesn't surface API list prices and computing
+them here would mean maintaining a price table.
 """
 
 from __future__ import annotations
@@ -298,7 +298,9 @@ def codex_step(model: str) -> tuple[dict[str, Any], Path]:
     if os.environ.get("SANDBOX_REAPED") == "true":
         copy_agent_tree(agent_home / ".codex" / "sessions", logs_dir / "sessions")
     rollouts = sorted((logs_dir / "sessions").rglob("rollout-*.jsonl"))
-    return codex_usage(read_all(rollouts), model), logs_dir
+    return codex_usage(
+        (_common.read_ndjson(path) for path in rollouts), model
+    ), logs_dir
 
 
 def consolidate_logs(logs_dir: Path, runner_temp: Path) -> None:
@@ -484,27 +486,48 @@ def session_usage(
     )
 
 
-def codex_usage(events: Iterable[dict[str, Any]], model: str) -> dict[str, Any]:
-    """Sum a Codex run's rollout events; no events is the all-zero record."""
-    events = list(events)
-    if not model:
-        for event in events:
+def codex_usage(
+    rollouts: Iterable[Iterable[dict[str, Any]]], model: str
+) -> dict[str, Any]:
+    """Account Codex's cumulative usage events across independent rollouts."""
+    final_usage: list[dict[str, Any]] = []
+    turns = 0
+    for rollout in rollouts:
+        last_usage: dict[str, Any] = {}
+        for event in rollout:
             payload = event.get("payload")
-            if event.get("type") != "turn_context" or not isinstance(payload, dict):
+            if not isinstance(payload, dict):
                 continue
-            value = payload.get("model")
-            if isinstance(value, str) and value:
-                model = value
-                break
+            if event.get("type") == "turn_context" and not model:
+                value = payload.get("model")
+                if isinstance(value, str) and value:
+                    model = value
+            if (
+                event.get("type") == "event_msg"
+                and payload.get("type") == "token_count"
+            ):
+                info = payload.get("info")
+                usage = (
+                    info.get("total_token_usage") if isinstance(info, dict) else None
+                )
+                if isinstance(usage, dict):
+                    last_usage = usage
+            if (
+                event.get("type") == "response_item"
+                and payload.get("type") == "message"
+                and payload.get("role") == "assistant"
+            ):
+                turns += 1
+        final_usage.append(last_usage)
 
     def total(field: str) -> float:
-        return sum(number(event.get("token_count"), field) for event in events)
+        return sum(number(usage, field) for usage in final_usage)
 
     return {
         "input_tokens": total("input_tokens"),
         "output_tokens": total("output_tokens"),
         "cached_input_tokens": total("cached_input_tokens"),
-        "turns": sum(1 for event in events if event.get("type") == "agent_message"),
+        "turns": turns,
         "model": model,
         "cost_usd": 0,
     }


### PR DESCRIPTION
The live Codex subscription test completed successfully, but its token-usage summary reported zeros because Codex now records cumulative counts inside nested `event_msg` events.

Parse each rollout through its final readable cumulative token event, sum those independent rollout totals, count assistant response messages as turns, and recover the model from turn context when the action did not supply one. The parser retains the last complete count if a rollout has a truncated tail. The Codex summary now labels cached input as a subset of total input.

The updated parser reports 2,570,502 input tokens, 2,464,384 cached input tokens, 7,558 output tokens, and 7 turns against the captured subscription-backed rollout. The full Python and worker test suites, typecheck, pre-commit hooks, and diff check pass.

> _This was written by Codex on behalf of max-sixty_
