### PR TITLE
fix(actions): install agent uv across sandbox boundary

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -31,6 +31,8 @@ metadata:
 10. **Wait for the release workflow**: Poll until `uvx tend@X.Y.Z --help` succeeds and the release appears (`gh release view X.Y.Z`).
 11. **Regenerate tend's own workflows**: Stay on the `release` branch (don't create a new one — same as step 7). The squash-merge deleted `origin/release`, so `git fetch && git reset --hard origin/main` to realign with the squashed history. Then `uvx tend@latest init`. `init` rewrites only the generated `tend-*.yaml` files, so follow `running-tend`'s **Nightly: restamp the hand-maintained workflow refs** and restamp the rest onto the new ref in the same commit — otherwise they keep the previous release's pin. Commit, push, and open a PR titled `chore: regenerate workflows with tend X.Y.Z`. Until this merges, tend's deployed workflows lag the just-released generator, so critical fixes (e.g. loop-prevention filters) remain unreachable on tend itself.
 
+    If review blocks this PR on a fix that must release first, wait until the fix reaches `main`. Revert the regeneration commit on `release`, merge `origin/main`, and restart at step 1 for the patch release. Reuse the open PR by updating its title and body; the revert keeps the branch fast-forwardable, and the squash merge keeps the release commit clean. After publication, regenerate again from the patch release.
+
 ## CHANGELOG
 
 `CHANGELOG.md` holds one `## X.Y.Z` section per release, newest first. The header must be exactly `## X.Y.Z` — the release workflow matches it literally to extract the notes.

--- a/claude/action.yaml
+++ b/claude/action.yaml
@@ -326,6 +326,8 @@ runs:
         CLAUDE_VERSION: ${{ inputs.claude_version }}
 
     # Install a pinned fallback after the adopter PATH, as the sandbox user.
+    # The runner opens the script because its action cache is outside the
+    # sandbox user's traversable paths.
     - name: Install agent uv fallback (sandbox)
       shell: bash
       run: |
@@ -334,7 +336,8 @@ runs:
           PATH=/usr/bin:/bin \
           UV_VERSION="$UV_VERSION" \
           UV_INSTALL_DIR="$TEND_AGENT_UV_DIR" \
-          /usr/bin/bash "${{ github.action_path }}/../shared/steps/install-uv.sh"
+          /usr/bin/bash -s -- \
+          < "${{ github.action_path }}/../shared/steps/install-uv.sh"
       env:
         UV_VERSION: ${{ inputs.uv_version }}
 

--- a/codex/action.yaml
+++ b/codex/action.yaml
@@ -357,10 +357,13 @@ runs:
       env:
         UV_VERSION: ${{ inputs.uv_version }}
       run: |
+        # The runner opens the script because its action cache is outside the
+        # sandbox user's traversable paths.
         sudo -u "$SANDBOX" env \
           HOME="$AGENT_HOME" PATH=/usr/bin:/bin \
           UV_VERSION="$UV_VERSION" UV_INSTALL_DIR="$TEND_AGENT_UV_DIR" \
-          /usr/bin/bash "${{ github.action_path }}/../shared/steps/install-uv.sh"
+          /usr/bin/bash -s -- \
+          < "${{ github.action_path }}/../shared/steps/install-uv.sh"
 
     # Install the tend-ci-runner plugin from the action's own checkout.
     # `github.action_path` is .../<runner-cache>/max-sixty/tend/<ref>/codex/;

--- a/proxy/test-setup-sandbox.sh
+++ b/proxy/test-setup-sandbox.sh
@@ -149,12 +149,24 @@ setup() {
 }
 
 install_agent_uv() {
-  local action_run
+  local action_run harness private_action
+  private_action=$(mktemp -d "$RUNNER_TEMP/tend-private-action.XXXXXX")
+  mkdir -p "$private_action/claude" "$private_action/codex" \
+    "$private_action/shared/steps"
+  cp "$TEND_TEST_ACTION_PATH/shared/steps/install-uv.sh" \
+    "$private_action/shared/steps/"
+  if sudo -u "$SANDBOX" test -r "$private_action/shared/steps/install-uv.sh"; then
+    echo "::error::private action fixture is readable by the sandbox user"
+    exit 1
+  fi
   UV_VERSION=$(yq -e '.inputs.uv_version.default' claude/action.yaml)
   export UV_VERSION
-  action_run=$(yq -er '.runs.steps[] | select(.name == "Install agent uv fallback (sandbox)") | .run' claude/action.yaml)
-  action_run=${action_run//'${{ github.action_path }}'/"$TEND_TEST_ACTION_PATH/claude"}
-  /usr/bin/bash --noprofile --norc -eo pipefail -c "$action_run"
+  for harness in claude codex; do
+    action_run=$(yq -er '.runs.steps[] | select(.name == "Install agent uv fallback (sandbox)") | .run' "$harness/action.yaml")
+    action_run=${action_run//'${{ github.action_path }}'/"$private_action/$harness"}
+    /usr/bin/bash --noprofile --norc -eo pipefail -c "$action_run"
+  done
+  rm -rf "$private_action"
 }
 
 verify() {


### PR DESCRIPTION
Runs the agent uv installer as the sandbox user while having the runner shell open the installer script. This fixes action runs on GitHub-hosted runners, where the action cache lives under a runner-home path the sandbox user cannot traverse. The hosted sandbox test now executes both harness snippets from a deliberately unreadable action fixture.

Also documents the forward-only release recovery when a workflow regeneration PR uncovers a fix that must ship first: revert the obsolete regeneration commit, merge the fix from `main`, rerun release validation, and reuse the open PR without a force-push.

Validated with 1,138 Python tests, 32 worker tests, worker typecheck, and all repository pre-commit hooks.

> _This was written by Codex on behalf of max-sixty_
