### PR TITLE
chore: release 0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ published verbatim as that version's GitHub Release notes
 0.1.1 predate this changelog; see the compare views at
 https://github.com/max-sixty/tend/compare for their history.
 
+## 0.2.3
+
+### Fixed
+
+- **Agent uv installation works across the sandbox user boundary on GitHub-hosted runners.** The runner opens the shared installer before passing it to the sandbox shell, so both harnesses can install uv without traversing the private action cache. The hosted sandbox test now exercises this boundary directly. ([#1185](https://github.com/max-sixty/tend/pull/1185))
+
 ## 0.2.2
 
 ### Fixed

--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "tend"
-version = "0.2.2"
+version = "0.2.3"
 description = "An autonomous junior maintainer for GitHub repos, powered by Claude or OpenAI Codex — reviews PRs, triages issues, fixes CI"
 license = "MIT"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -955,7 +955,7 @@ wheels = [
 
 [[package]]
 name = "tend"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "generator" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- release the sandbox-boundary uv installer repair as Tend 0.2.3
- add the 0.2.3 GitHub release notes
- synchronize the package version and workspace lockfile

## Validation

- `wt test` (1,138 Python tests, 32 worker tests, worker typecheck)
- `uv tool run pre-commit run --all-files` (all 13 hooks)
- `uv build --package tend` (wheel metadata reports 0.2.3)

The Tend review check is expected to fail before Claude starts because `pull_request_target` still resolves the immutable base action at 0.2.2. The hosted sandbox test on #1185 passed against this repair; publishing 0.2.3 and regenerating the workflow pins is the recovery path.

> _This was written by Codex on behalf of max-sixty_
