### PR TITLE
fix(sandbox): stage runtime outside action cache

### DIFF
--- a/proxy/test-setup-sandbox.sh
+++ b/proxy/test-setup-sandbox.sh
@@ -362,6 +362,7 @@ PY
     sudo -u "$SANDBOX" grep -qxF -- "$want" "$claude_argv"
   done
 
+  rm -rf -- "$TEND_RUNTIME_ROOT/action"
   rm -rf -- "$RUNNER_TEMP/tend-agent-export"
   : > "$github_output"
   rc=0

--- a/proxy/test-setup-sandbox.sh
+++ b/proxy/test-setup-sandbox.sh
@@ -213,7 +213,7 @@ verify_refusals() {
 
 verify_srt() {
   local claude_argv claude_env claude_stub codex_argv codex_env codex_stub dummy_token
-  local github_output probe_info probe_pid probe_port rc runner_summary
+  local github_output private_action probe_info probe_pid probe_port rc runner_summary
   local setup_commands setup_proxy stream_json tool_root
   github_output="$RUNNER_TEMP/srt-github-output"
   runner_summary="$RUNNER_TEMP/srt-step-summary"
@@ -224,6 +224,15 @@ verify_srt() {
   mkdir -p "$tool_root"
   printf '#!/bin/sh\necho tend-srt-tool-ok\n' > "$tool_root/probe"
   chmod +x "$tool_root/probe"
+
+  private_action=$(mktemp -d "$RUNNER_TEMP/tend-private-runtime.XXXXXX")
+  mkdir -p "$private_action/shared" "$private_action/codex"
+  cp -R "$TEND_TEST_ACTION_PATH/shared/steps" "$private_action/shared/"
+  cp "$TEND_TEST_ACTION_PATH/codex/runner.py" "$private_action/codex/"
+  if sudo -u "$SANDBOX" test -r "$private_action/shared/steps/sandbox_runtime.mjs"; then
+    echo "::error::private runtime fixture is readable by the sandbox user"
+    exit 1
+  fi
 
   claude_stub="$TEND_AGENT_WORKSPACE/.tend-explicit/bin/claude"
   claude_env="$TEND_AGENT_WORKSPACE/.tend-claude-env"
@@ -315,9 +324,9 @@ PY
 
   rm -rf -- "$RUNNER_TEMP/tend-agent-export"
   rc=0
-  ACTION_PATH="$TEND_TEST_ACTION_PATH" \
+  ACTION_PATH="$private_action" \
     TEND_HARNESS=claude \
-    TEND_LIFECYCLE="$TEND_TEST_ACTION_PATH/shared/steps/agent_lifecycle.py" \
+    TEND_LIFECYCLE="$private_action/shared/steps/agent_lifecycle.py" \
     TEND_SANDBOX_SETUP="$setup_commands" \
     TEND_BOUNDARY_PROBE_URL="http://127.0.0.1:$probe_port/" \
     TEND_BOUNDARY_PROBE_EXECUTABLE="$tool_root/probe" \
@@ -356,10 +365,10 @@ PY
   rm -rf -- "$RUNNER_TEMP/tend-agent-export"
   : > "$github_output"
   rc=0
-  ACTION_PATH="$TEND_TEST_ACTION_PATH" \
+  ACTION_PATH="$private_action" \
     TEND_HARNESS=codex \
-    TEND_LIFECYCLE="$TEND_TEST_ACTION_PATH/shared/steps/agent_lifecycle.py" \
-    TEND_CODEX_RUNNER="$TEND_TEST_ACTION_PATH/codex/runner.py" \
+    TEND_LIFECYCLE="$private_action/shared/steps/agent_lifecycle.py" \
+    TEND_CODEX_RUNNER="$private_action/codex/runner.py" \
     TEND_SANDBOX_SETUP='' \
     TEND_BOUNDARY_PROBE_URL="http://127.0.0.1:$probe_port/" \
     TEND_BOUNDARY_PROBE_EXECUTABLE="$tool_root/probe" \
@@ -373,6 +382,7 @@ PY
     GITHUB_STEP_SUMMARY="$runner_summary" \
     /usr/bin/python3 -E -s \
       "$TEND_TEST_ACTION_PATH/shared/steps/launch_sandbox_runtime.py" || rc=$?
+  rm -rf "$private_action"
   kill "$probe_pid" 2>/dev/null || true
   wait "$probe_pid" 2>/dev/null || true
   test "$rc" -eq 0

--- a/shared/steps/launch_sandbox_runtime.py
+++ b/shared/steps/launch_sandbox_runtime.py
@@ -61,6 +61,15 @@ PASSTHROUGH = {
 MAX_FIXED_EXPORT = 64 * 1024 * 1024
 MAX_FINAL_MESSAGE = 256 * 1024
 MAX_STEP_SUMMARY = 512 * 1024
+MAX_RUNTIME_FILE = 2 * 1024 * 1024
+RUNTIME_STEP_FILES = (
+    "_common.py",
+    "_sandbox.py",
+    "agent_lifecycle.py",
+    "run_claude.py",
+    "sandbox_runtime.mjs",
+    "sandbox_setup.py",
+)
 
 
 class Cancelled(BaseException):
@@ -111,18 +120,54 @@ def reap(sandbox: str) -> bool:
     )
 
 
-def write_trusted(path: Path, body: bytes) -> None:
+def write_trusted(path: Path, body: bytes, *, mode: int = 0o600) -> None:
     descriptor = os.open(
         path,
         os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
-        0o600,
+        mode,
     )
     try:
+        os.fchmod(descriptor, mode)
         view = memoryview(body)
         while view:
             view = view[os.write(descriptor, view) :]
     finally:
         os.close(descriptor)
+
+
+def mkdir_traversable(path: Path) -> None:
+    path.mkdir(mode=0o755)
+    path.chmod(0o755)
+
+
+def stage_runtime_bundle(runtime_root: Path) -> tuple[Path, Path, Path | None]:
+    """Copy the trusted lifecycle behind a sandbox-traversable path."""
+    source_root = Path(required("ACTION_PATH")).resolve(strict=True)
+    bundle_root = runtime_root / "action"
+    shared_root = bundle_root / "shared"
+    step_root = shared_root / "steps"
+    for directory in (bundle_root, shared_root, step_root):
+        mkdir_traversable(directory)
+    for name in RUNTIME_STEP_FILES:
+        body = read_regular_nofollow(
+            source_root / "shared/steps" / name, max_bytes=MAX_RUNTIME_FILE
+        )
+        if body is None:
+            raise ValueError(f"runtime bundle source is missing: shared/steps/{name}")
+        write_trusted(step_root / name, body, mode=0o644)
+
+    codex_runner: Path | None = None
+    if os.environ.get("TEND_CODEX_RUNNER"):
+        body = read_regular_nofollow(
+            source_root / "codex/runner.py", max_bytes=MAX_RUNTIME_FILE
+        )
+        if body is None:
+            raise ValueError("runtime bundle source is missing: codex/runner.py")
+        codex_runner = bundle_root / "codex/runner.py"
+        mkdir_traversable(codex_runner.parent)
+        write_trusted(codex_runner, body, mode=0o644)
+
+    return bundle_root, step_root / "agent_lifecycle.py", codex_runner
 
 
 def main() -> int:
@@ -133,13 +178,18 @@ def main() -> int:
     export_dir.mkdir(mode=0o700)
     run_dir = Path(required("TEND_RUN_DIR"))
     step_summary_dir = Path(required("TEND_STEP_SUMMARY_DIR"))
+    runtime_root = Path(required("TEND_RUNTIME_ROOT")).resolve(strict=True)
+    bundle_root, lifecycle, codex_runner = stage_runtime_bundle(runtime_root)
 
     environment = _sandbox.launch_env(required("AGENT_ENV_FILE"))
-    environment.extend(
-        f"{name}={os.environ[name]}"
-        for name in sorted(PASSTHROUGH)
-        if os.environ.get(name)
-    )
+    passthrough = {
+        name: os.environ[name] for name in sorted(PASSTHROUGH) if os.environ.get(name)
+    }
+    passthrough["ACTION_PATH"] = str(bundle_root)
+    passthrough["TEND_LIFECYCLE"] = str(lifecycle)
+    if codex_runner is not None:
+        passthrough["TEND_CODEX_RUNNER"] = str(codex_runner)
+    environment.extend(f"{name}={value}" for name, value in passthrough.items())
     environment.extend(
         [
             f"GITHUB_STEP_SUMMARY={step_summary_dir / 'step-summary.md'}",
@@ -154,7 +204,7 @@ def main() -> int:
         "-i",
         *environment,
         required("NODE_BIN"),
-        str(Path(__file__).with_name("sandbox_runtime.mjs")),
+        str(bundle_root / "shared/steps/sandbox_runtime.mjs"),
     ]
 
     status = 1

--- a/shared/steps/test_launch_sandbox_runtime.py
+++ b/shared/steps/test_launch_sandbox_runtime.py
@@ -12,6 +12,15 @@ from typing import Any
 import launch_sandbox_runtime as launch
 import pytest
 
+RUNTIME_STEP_FILES = (
+    "_common.py",
+    "_sandbox.py",
+    "agent_lifecycle.py",
+    "run_claude.py",
+    "sandbox_runtime.mjs",
+    "sandbox_setup.py",
+)
+
 
 def configure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, harness: str
@@ -26,7 +35,17 @@ def configure(
     output.touch()
     summary = runner_temp / "step-summary"
     summary.touch()
-    for name, value in {
+    runtime_root = tmp_path / "runtime"
+    runtime_root.mkdir()
+    action = tmp_path / "private/action"
+    steps = action / "shared/steps"
+    steps.mkdir(parents=True)
+    for name in RUNTIME_STEP_FILES:
+        (steps / name).write_text(f"{name}\n")
+    codex = action / "codex/runner.py"
+    codex.parent.mkdir()
+    codex.write_text("runner\n")
+    environment = {
         "SANDBOX": "tend-sandbox",
         "RUNNER_TEMP": str(runner_temp),
         "GITHUB_OUTPUT": str(output),
@@ -37,7 +56,13 @@ def configure(
         "AGENT_HOME": str(run_dir.parent),
         "TEND_STEP_SUMMARY_DIR": str(run_dir.parent),
         "GITHUB_STEP_SUMMARY": str(summary),
-    }.items():
+        "TEND_RUNTIME_ROOT": str(runtime_root),
+        "ACTION_PATH": str(action),
+        "TEND_LIFECYCLE": str(steps / "agent_lifecycle.py"),
+    }
+    if harness == "codex":
+        environment["TEND_CODEX_RUNNER"] = str(codex)
+    for name, value in environment.items():
         monkeypatch.setenv(name, value)
     return run_dir, output, summary
 
@@ -111,6 +136,26 @@ def test_codex_base64_encodes_the_fixed_final_message(
     assert base64.b64decode(values["final_message"]) == b"finished\n"
     assert values["sandbox_reaped"] == "true"
     assert summary.read_bytes() == b"skill result\n\n"
+
+
+def test_runtime_bundle_is_staged_outside_the_private_action(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run_dir, _output, _summary = configure(tmp_path, monkeypatch, harness="codex")
+    calls = fake_runtime(monkeypatch, run_dir, harness="codex")
+
+    assert launch.main() == 0
+
+    runtime = next(args for args in calls if "sandbox_runtime.mjs" in args[-1])
+    bundle = tmp_path / "runtime/action"
+    assert runtime[-1] == str(bundle / "shared/steps/sandbox_runtime.mjs")
+    assert f"ACTION_PATH={bundle}" in runtime
+    assert f"TEND_LIFECYCLE={bundle / 'shared/steps/agent_lifecycle.py'}" in runtime
+    assert f"TEND_CODEX_RUNNER={bundle / 'codex/runner.py'}" in runtime
+    assert (bundle / "shared/steps/sandbox_setup.py").read_text() == (
+        "sandbox_setup.py\n"
+    )
+    assert (bundle / "shared/steps").stat().st_mode & 0o777 == 0o755
 
 
 def test_agent_step_summary_symlink_is_not_followed(


### PR DESCRIPTION
## Summary

- stage the trusted SRT lifecycle bundle under the sandbox-traversable runtime root
- retarget the sandbox lifecycle and Codex runner to the staged bundle
- exercise the hosted boundary with an action fixture the sandbox UID cannot read

## Testing

- `wt test`
- `uv tool run pre-commit run --all-files`

The current Tend reviewer is expected to fail before starting because this change repairs the released action path it invokes. Ordinary CI and the hosted sandbox test remain required.

> _This was written by Codex on behalf of max-sixty_