### PR TITLE
chore: release 0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ published verbatim as that version's GitHub Release notes
 0.1.1 predate this changelog; see the compare views at
 https://github.com/max-sixty/tend/compare for their history.
 
+## 0.2.4
+
+### Fixed
+
+- **Claude and Codex can start from GitHub's private action cache.** The runner stages the trusted lifecycle bundle in a sandbox-traversable runtime directory before changing users, and the hosted sandbox test exercises the same unreadable-cache boundary. ([#1189](https://github.com/max-sixty/tend/pull/1189))
+
 ## 0.2.3
 
 ### Fixed

--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "tend"
-version = "0.2.3"
+version = "0.2.4"
 description = "An autonomous junior maintainer for GitHub repos, powered by Claude or OpenAI Codex — reviews PRs, triages issues, fixes CI"
 license = "MIT"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -955,7 +955,7 @@ wheels = [
 
 [[package]]
 name = "tend"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "generator" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- release Tend 0.2.4 with the sandbox runtime access repair from #1189
- publish matching changelog notes and lockfile metadata

## Testing

- `wt test`
- `uv run pytest generator/tests/test_repo_pins.py generator/tests/test_generate.py -q`
- `uv tool run pre-commit run --all-files`

The Tend reviewer remains expected to fail on the broken 0.2.3 action this release replaces. Ordinary CI remains required.

> _This was written by Codex on behalf of max-sixty_