### PR TITLE
fix(running-tend): make the restamp check see nested action paths

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -114,17 +114,16 @@ Run this after the regen step, whether or not it produced a PR:
 rg -o --no-filename 'max-sixty/tend/[a-z/-]+@[0-9.]+' .github/workflows/ | sort -u
 ```
 
-The character class must admit the `/` in a nested action path, or a stale
-`codex/refresh` pin never appears in the output at all.
-
 Several action paths are pinned at once (`claude`, `codex`, `codex/refresh`),
-so several lines is the normal case. Compare the versions instead — pipe the
-same output through `sed 's/.*@//' | sort -u` and expect exactly one. Two or
-more, restamp the hand-maintained files onto the generated files' ref and fold
-it into the regen PR — same worktree, same commit. A hand-maintained file
-naming a different *harness* from the generated ones is the worse case: a
-config change reached the generated workflows and stopped there, so check what
-else that change was supposed to carry.
+so several lines is the normal case — as are two harnesses, while
+`.config/tend.yaml` overrides one workflow to `codex`. The check is on the
+versions: pipe the same output through `sed 's/.*@//' | sort -u` and expect
+exactly one. Two or more, restamp the hand-maintained files onto the generated
+files' ref and fold it into the regen PR — same worktree, same commit. Whether
+a hand-maintained file names the right *harness* is a separate question the
+listing cannot answer; compare it against the harness `.config/tend.yaml`
+configures, and on a mismatch check what else that config change was supposed
+to carry.
 
 ## Weekly: refresh `data/consumers.json`
 

--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -111,14 +111,20 @@ regenerating skips them entirely.
 Run this after the regen step, whether or not it produced a PR:
 
 ```bash
-rg -o --no-filename 'max-sixty/tend/[a-z-]+@[0-9.]+' .github/workflows/ | sort -u
+rg -o --no-filename 'max-sixty/tend/[a-z/-]+@[0-9.]+' .github/workflows/ | sort -u
 ```
 
-One line means every workflow agrees. Two or more, restamp the hand-maintained
-files onto the generated files' ref and fold it into the regen PR — same
-worktree, same commit. A differing *harness* rather than a differing version is
-the worse case: a config change reached the generated workflows and stopped
-there, so check what else that change was supposed to carry.
+The character class must admit the `/` in a nested action path, or a stale
+`codex/refresh` pin never appears in the output at all.
+
+Several action paths are pinned at once (`claude`, `codex`, `codex/refresh`),
+so several lines is the normal case. Compare the versions instead — pipe the
+same output through `sed 's/.*@//' | sort -u` and expect exactly one. Two or
+more, restamp the hand-maintained files onto the generated files' ref and fold
+it into the regen PR — same worktree, same commit. A hand-maintained file
+naming a different *harness* from the generated ones is the worse case: a
+config change reached the generated workflows and stopped there, so check what
+else that change was supposed to carry.
 
 ## Weekly: refresh `data/consumers.json`
 

--- a/generator/tests/test_cross_file_contracts.py
+++ b/generator/tests/test_cross_file_contracts.py
@@ -458,28 +458,22 @@ def test_nightly_regen_stages_every_path_init_writes(
     )
 
 
-def test_restamp_check_sees_every_action_ref_the_workflows_pin() -> None:
-    """The overlay's drift check must match every `max-sixty/tend/...` pin.
+def test_every_workflow_pins_the_same_tend_release() -> None:
+    """`init` rewrites only the generated `tend-*.yaml` files.
 
-    Its regex is what decides whether a hand-maintained workflow's ref is
-    reported as stale, so a nested action path (`codex/refresh`) that the
-    character class cannot spell is a pin the nightly never restamps.
+    Every other workflow keeps whatever `max-sixty/tend/...` ref it was last
+    given by hand, so each release leaves it a version behind until someone
+    restamps it. The nightly sweep does the restamping; this is what decides
+    whether it is needed.
     """
-    skill = _read(".claude", "skills", "running-tend", "SKILL.md")
-    block = next(
-        block
-        for block in _bash_blocks(skill)
-        if "max-sixty/tend/" in block and ".github/workflows/" in block
-    )
-    match = re.search(r"'(max-sixty/tend/[^']+)'", block)
-    assert match
-    pattern = match.group(1)
-
     refs = {
         ref
         for path in (REPO_ROOT / ".github" / "workflows").glob("*.yaml")
-        for ref in re.findall(r"max-sixty/tend/[\w./-]+@[0-9.]+", path.read_text())
+        for ref in re.findall(r"max-sixty/tend/[\w./-]+@[^\s\"']+", path.read_text())
     }
     assert refs
-    unmatched = sorted(ref for ref in refs if not re.fullmatch(pattern, ref))
-    assert not unmatched, f"{pattern} does not match {unmatched}"
+
+    assert len({ref.split("@")[1] for ref in refs}) == 1, (
+        f"workflows pin more than one tend release: {sorted(refs)}. "
+        "Restamp the hand-maintained workflows onto the generated files' ref."
+    )

--- a/generator/tests/test_cross_file_contracts.py
+++ b/generator/tests/test_cross_file_contracts.py
@@ -468,7 +468,7 @@ def test_every_workflow_pins_the_same_tend_release() -> None:
     """
     refs = {
         ref
-        for path in (REPO_ROOT / ".github" / "workflows").glob("*.yaml")
+        for path in (REPO_ROOT / ".github" / "workflows").glob("*.y*ml")
         for ref in re.findall(r"max-sixty/tend/[\w./-]+@[^\s\"']+", path.read_text())
     }
     assert refs

--- a/generator/tests/test_cross_file_contracts.py
+++ b/generator/tests/test_cross_file_contracts.py
@@ -456,3 +456,30 @@ def test_nightly_regen_stages_every_path_init_writes(
         f"`tend init` writes paths the nightly regeneration never stages: {uncovered}. "
         "Widen Step 7's `git add -A` pathspecs so the regeneration PR carries them."
     )
+
+
+def test_restamp_check_sees_every_action_ref_the_workflows_pin() -> None:
+    """The overlay's drift check must match every `max-sixty/tend/...` pin.
+
+    Its regex is what decides whether a hand-maintained workflow's ref is
+    reported as stale, so a nested action path (`codex/refresh`) that the
+    character class cannot spell is a pin the nightly never restamps.
+    """
+    skill = _read(".claude", "skills", "running-tend", "SKILL.md")
+    block = next(
+        block
+        for block in _bash_blocks(skill)
+        if "max-sixty/tend/" in block and ".github/workflows/" in block
+    )
+    match = re.search(r"'(max-sixty/tend/[^']+)'", block)
+    assert match
+    pattern = match.group(1)
+
+    refs = {
+        ref
+        for path in (REPO_ROOT / ".github" / "workflows").glob("*.yaml")
+        for ref in re.findall(r"max-sixty/tend/[\w./-]+@[0-9.]+", path.read_text())
+    }
+    assert refs
+    unmatched = sorted(ref for ref in refs if not re.fullmatch(pattern, ref))
+    assert not unmatched, f"{pattern} does not match {unmatched}"


### PR DESCRIPTION
The nightly restamp check in the `running-tend` overlay told every session to restamp workflows that were already correct. Its rule — "one line means every workflow agrees" — was written when one action path was pinned; three are pinned now (`claude`, `codex`, `codex/refresh`), so on today's `main` a repo in full agreement at `0.2.5` prints two lines and the recipe reads that as drift. The check is on the versions, so the section says so and gives the `sed 's/.*@//' | sort -u` pipe. Harness drift — a hand-maintained file naming a harness the config no longer selects — is called out as a separate question the listing cannot answer, because `.config/tend.yaml` overrides `review-runs` to `codex` and a listing naming two harnesses is this repo's normal state.

The listing regex was blind to nested action paths in the other direction: `max-sixty/tend/[a-z-]+@[0-9.]+` has no `/` in its character class, so `max-sixty/tend/codex/refresh@X.Y.Z` never appeared in the output at all. That one is latent rather than live — `codex/refresh` is pinned only in the generated `tend-codex-auth-refresh.yaml`, which `init` restamps with every other generated file — but it would hide a stale pin the day a hand-maintained workflow names a nested path. The class now admits `/`, and the listing prints all three pinned paths.

`test_every_workflow_pins_the_same_tend_release` asserts the property the restamp step exists to detect: every `max-sixty/tend/...` ref committed under `.github/workflows/` carries one version. A pin left behind at an older release now fails CI on every run rather than waiting for a nightly session to run the prose recipe, and the ref pattern accepts any pin, so a hand-edited `@main` is caught too. It globs `*.y*ml` to match the recipe's directory scan, since Actions loads `.yml` as readily as `.yaml`. Verified both failure modes locally by re-pinning `review-reviewers.yaml` to `0.2.4` and by dropping a `.yml` at an older pin into the directory: `assert 2 == 1 … workflows pin more than one tend release`.

The invariant holds on `main` continuously because the release skill already requires the hand-maintained restamp in the same commit as the regeneration (step 11). The harness half of the recipe is prose with no code path to pin, so it stays uncovered.

Found while running the restamp step of a nightly sweep.
