### PR TITLE
skills(running-tend): check for the release's regen PR before nightly opens its own

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -115,9 +115,10 @@ gh pr list --state open --limit 100 --json number,title,headRefName \
 ```
 
 If one is open, diff its head against the prepared worktree. Where it already
-carries the same regenerated files, remove the worktree (`git worktree remove
-<path> --force`), skip the PR, and name the covering PR in the run summary.
-Ship only what it is missing — most often the restamp below.
+carries the same regenerated files, skip the PR, name the covering PR in the
+run summary, and remove the worktree (`git worktree remove <path> --force`).
+Ship anything it is missing on its own branch — the release skill asks for the
+restamp below in the release commit, so usually there is nothing to ship.
 
 ## Nightly: restamp the hand-maintained workflow refs
 

--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -101,6 +101,24 @@ have recent activity on GitHub — that localizes the fault to the Worker. The
 bot can't rotate the Worker's Cloudflare-side secret itself, so leave the
 diagnosis to a maintainer; `worker/README.md` covers the Worker's setup.
 
+## Nightly: don't duplicate the release's regeneration PR
+
+The `release` skill's deploy step opens `chore: regenerate workflows with tend
+X.Y.Z` from the `release` branch and leaves it open through CI and review. A
+nightly firing in that window still sees the committed workflows on the old
+version, so `prepare` reports a change and Step 7 ships a second PR for the
+same regeneration. Before shipping it:
+
+```bash
+gh pr list --state open --limit 100 --json number,title,headRefName \
+  --jq '.[] | select(.title | test("regenerate workflows with tend"))'
+```
+
+If one is open, diff its head against the prepared worktree. Where it already
+carries the same regenerated files, remove the worktree (`git worktree remove
+<path> --force`), skip the PR, and name the covering PR in the run summary.
+Ship only what it is missing — most often the restamp below.
+
 ## Nightly: restamp the hand-maintained workflow refs
 
 `init` rewrites only the generated `tend-*.yaml` files, so the workflows under


### PR DESCRIPTION
Two documented processes in this repo collide. The `release` skill's deploy step opens `chore: regenerate workflows with tend X.Y.Z` from the `release` branch and holds it open through CI and review before squash-merging. Nightly's Step 7 reads the *committed* workflows, which are still on the previous version for as long as that PR is open, so `nightly_workflow_update.py prepare` reports `changed: true` and the step ships a second PR carrying byte-identical regenerated files.

Nothing in Step 7 looks for it. The script dedups only against its own `tend/update-workflows` head, and Step 8's open-PR listing runs after the regen has already shipped. Tonight's sweep hit this: #1194 was open with the 0.2.5 regeneration when the sweep prepared its own, and the two differed in nothing but #1194 additionally restamping `review-reviewers.yaml`. I skipped the PR by hand; that judgement is what this section makes repeatable.

The check is a title filter, since the release skill mandates that exact title:

```bash
gh pr list --state open --limit 100 --json number,title,headRefName \
  --jq '.[] | select(.title | test("regenerate workflows with tend"))'
```

It selects #1194, #1191, #1187, and #1183 out of the recent merged set, and returns nothing now that #1194 has landed.

The guidance sends the reader to diff the covering PR's head against the prepared worktree rather than trusting the title. The covering PR is normally complete — the release skill's step 11 asks the release commit to carry the hand-maintained restamp too — so the usual outcome is to skip and say so in the run summary. When something *is* missing, it ships on its own branch: skipping the regen PR removes the worktree that the restamp section immediately below tells the reader to fold the restamp into, so there is no shared commit left to add it to.

No test: this is skill prose with no code path to pin, and the script it guards is not the thing making the decision.
