### PR TITLE
chore: release 0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ published verbatim as that version's GitHub Release notes
 0.1.1 predate this changelog; see the compare views at
 https://github.com/max-sixty/tend/compare for their history.
 
+## 0.2.6
+
+### Improved
+
+- **The review session applies its own findings on PRs the bot authored.** As on Dependabot and renovate PRs, the review run submits its review, pushes the fixes in one batch, and polls CI to green. The queued `synchronize` run then reviews the pushed head. A review the bot wrote no longer dispatches a `tend-mention` author session. Human-authored PRs are unchanged. ([#1203](https://github.com/max-sixty/tend/pull/1203))
+
+### Fixed
+
+- **Sandboxed agents get a writable `TMPDIR` under the sandbox home.** Bundled scripts and skill recipes use it instead of `/tmp/claude`, and root `/tmp` stays read-only. `TMPDIR` is now a reserved `sandbox_env` key. ([#1199](https://github.com/max-sixty/tend/pull/1199))
+- **Nightly bases its workflow-regeneration branch on the fetched default branch** rather than the checkout's current `HEAD`, so a regeneration PR opened after the sweep's survey PR no longer stacks on it. ([#1201](https://github.com/max-sixty/tend/pull/1201))
+
+### Documentation
+
+- The `authorAssociation` reference shows the field nested on comment and review objects in `gh --json` output, with the REST form for the issue or PR author's own tier. ([#1178](https://github.com/max-sixty/tend/pull/1178))
+
 ## 0.2.5
 
 ### Improved

--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "tend"
-version = "0.2.5"
+version = "0.2.6"
 description = "An autonomous junior maintainer for GitHub repos, powered by Claude or OpenAI Codex — reviews PRs, triages issues, fixes CI"
 license = "MIT"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -955,7 +955,7 @@ wheels = [
 
 [[package]]
 name = "tend"
-version = "0.2.5"
+version = "0.2.6"
 source = { editable = "generator" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Bumps the generator to 0.2.6, syncs the lockfile, and adds the `## 0.2.6` changelog section the release workflow publishes as the GitHub Release notes.

Ships #1203 (the review session applies its own findings on PRs the bot authored), #1199 (writable `TMPDIR` for sandboxed agents), #1201 (nightly bases its regeneration branch on the fetched default branch), #1178, #1195, and #1196.

> _This was written by Claude Code on behalf of max-sixty_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016aR4DdFRBB5X4C1bYUGoGu
