### PR TITLE
fix(tests): stop the suite reading the agent session's own sandbox environment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,11 @@ shellcheck alone) skips ten of the thirteen hooks, including the three
 `repo: local` guards — the bang-backtick check, the install-tend mirror sync,
 and the `sandbox_env` reserved-set parity check.
 
+Inside a tend session the sandbox has no DNS, so the two tests in
+`generator/tests/test_refresh_consumers.py` fail: they drive the script
+through `uv run --script`, which resolves its dependencies from PyPI. Nothing
+else in the suite reaches the network, so a third failure is a real one.
+
 ## Architecture
 
 Four pieces:

--- a/generator/tests/test_codex_runner.py
+++ b/generator/tests/test_codex_runner.py
@@ -40,6 +40,11 @@ def _set_sandbox_env(
     monkeypatch.setenv("AGENT_ENV_FILE", str(agent_env))
     monkeypatch.setenv("SANDBOX", "tend-sandbox")
     monkeypatch.setenv("CODEX_BIN", "/opt/codex/bin/codex")
+    # The two the runner refuses to start without, cleared rather than set: a
+    # test that wants them sets them itself, and the suite run inside a tend
+    # session would otherwise inherit the live lifecycle's own values.
+    monkeypatch.delenv("TEND_INSIDE_SANDBOX", raising=False)
+    monkeypatch.delenv("AUTH_MODE", raising=False)
     return action, agent_home, agent_env
 
 
@@ -301,6 +306,11 @@ def test_run_uses_staged_subscription_auth_without_responses_proxy(
 def test_run_refuses_to_create_a_second_execution_boundary(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    # Seeded rather than left absent: these are the values a suite run inside a
+    # tend session inherits from the live lifecycle, and the refusal has to
+    # hold against them the same way it holds on a bare runner.
+    monkeypatch.setenv("TEND_INSIDE_SANDBOX", "1")
+    monkeypatch.setenv("AUTH_MODE", "api-key")
     _set_sandbox_env(tmp_path, monkeypatch)
 
     with pytest.raises(RuntimeError, match="only inside the SRT lifecycle"):

--- a/generator/tests/test_codex_runner.py
+++ b/generator/tests/test_codex_runner.py
@@ -306,9 +306,9 @@ def test_run_uses_staged_subscription_auth_without_responses_proxy(
 def test_run_refuses_to_create_a_second_execution_boundary(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # Seeded rather than left absent: these are the values a suite run inside a
-    # tend session inherits from the live lifecycle, and the refusal has to
-    # hold against them the same way it holds on a bare runner.
+    # Seeded because `_set_sandbox_env` clears them below: with them set the
+    # runner would proceed past the refusal, so that clearing is what the
+    # assertion tests — absent the seeds it is vacuous on a bare runner.
     monkeypatch.setenv("TEND_INSIDE_SANDBOX", "1")
     monkeypatch.setenv("AUTH_MODE", "api-key")
     _set_sandbox_env(tmp_path, monkeypatch)

--- a/shared/steps/test_prepare_agent_workspace.py
+++ b/shared/steps/test_prepare_agent_workspace.py
@@ -295,7 +295,16 @@ def test_a_mention_on_an_issue_never_asks_the_pull_request_endpoint(
         raise urllib.error.HTTPError(path, 404, "Not Found", {}, None)
 
     clone_workspace = prepare.clone_workspace
+    # The step roots the agent workspace at the runner's own /tmp, which a
+    # suite run inside a tend session cannot write to. Keep the real call and
+    # move only its parent, so the assertions below still read a real clone.
+    mkdtemp = prepare.tempfile.mkdtemp
     monkeypatch.setattr(prepare, "api_json", refuse)
+    monkeypatch.setattr(
+        prepare.tempfile,
+        "mkdtemp",
+        lambda **arguments: mkdtemp(**{**arguments, "dir": tmp_path}),
+    )
     monkeypatch.setattr(
         prepare,
         "clone_workspace",
@@ -317,6 +326,7 @@ def test_a_mention_on_an_issue_never_asks_the_pull_request_endpoint(
 
     exported = dict(line.split("=", 1) for line in github_env.read_text().splitlines())
     workspace = Path(exported["TEND_AGENT_WORKSPACE"])
+    assert workspace.is_relative_to(tmp_path)
     try:
         assert command("rev-parse", "HEAD", cwd=workspace) == base
         assert command("rev-parse", "--abbrev-ref", "HEAD", cwd=workspace) == "main"

--- a/shared/steps/test_run_claude.py
+++ b/shared/steps/test_run_claude.py
@@ -466,6 +466,10 @@ def launch(
             "TEND_SYSTEM_PROMPT": "tend directives",
             "TEND_PROMPT": "review the PR",
             "TEND_TIMEOUT_SEC": "900",
+            # Empty, not absent: a suite run inside a tend session inherits the
+            # live run's settings file otherwise, and every argv assertion here
+            # grows the auto-memory flags it never asked for.
+            "TEND_AUTO_MEMORY_SETTINGS": "",
             "SHOW_FULL_OUTPUT": "false",
             "BOT_NAME": "tend-bot",
             "BOT_ID": "42",
@@ -580,8 +584,13 @@ def test_launch_adds_the_restored_auto_memory_settings(
 
 def test_launch_only_adds_harness_names_inside_srt(
     launch: Launcher,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The curated and SRT-adjusted environment is inherited, not replayed."""
+    # The auto-memory settings path of whatever tend run is hosting this suite.
+    # The fixture has to overwrite it, or the crossing below carries that run's
+    # flags into a launch the test never configured for them.
+    monkeypatch.setenv("TEND_AUTO_MEMORY_SETTINGS", "/host-run/.tend-settings.json")
     result = launch(stream=_ev_result())
     argv = result.command("claude").argv
     crossing = argv[1 : argv.index("claude")]


### PR DESCRIPTION
Five tests read tend's own runtime environment instead of setting it, so `uv run pytest` — the command CLAUDE.md gives every agent — comes back red inside a tend session and green on a CI runner. A session that runs the suite before pushing sees five failures that have nothing to do with its change, and has to work out from `ValueError: unknown AUTH_MODE: <unset>` that the cause is the lifecycle hosting it.

Three independent leaks:

- `generator/tests/test_codex_runner.py` asserts `codex run` refuses to start a second execution boundary, which holds only while `TEND_INSIDE_SANDBOX` is unset. Inside a session it is `1`, so the run proceeds past the refusal and dies later on the auth mode. `_set_sandbox_env` now clears it and `AUTH_MODE`, the way `shared/steps/test_sandbox_setup.py`'s `step_env` already clears `TEND_SANDBOX_SETUP`.
- `shared/steps/test_run_claude.py`'s `launch` fixture builds an explicit environment for every variable `run_claude` reads except `TEND_AUTO_MEMORY_SETTINGS`. The host run's settings file falls through, and three argv assertions pick up `-u CLAUDE_CODE_DISABLE_AUTO_MEMORY` and a `--settings` pair the test never asked for. Set to `""` alongside the other explicit empties.
- `shared/steps/test_prepare_agent_workspace.py` calls `prepare.main()`, which roots the agent workspace at the runner's `/tmp` — read-only under the SRT boundary, so the step reports `[Errno 30] Read-only file system`. The real `mkdtemp` still runs, with `tmp_path` as its parent, so the clone the assertions read is unchanged and pytest now owns the cleanup.

Each fix carries an assertion that fails on `main` in any environment, since CI cannot reproduce the leak on its own: the first two seed the inherited value before the fixture runs, and the third pins the workspace under `tmp_path` — `mkdtemp(dir="/tmp")` can never satisfy it. Verified by applying the three assertions alone to a `main` worktree, where all three fail.

Not addressed: `generator/tests/test_refresh_consumers.py` (2 tests) drives `refresh_consumers.py` through `uv run --script`, which resolves `ruamel.yaml` from PyPI. The sandbox has no DNS, so those two still fail in-session. That is the boundary working as designed rather than a test defect, and the failure names `pypi.org` and `dns error` directly, so it does not mislead the way these five did.
