### PR TITLE
fix(review-runs): re-query the closure read before reporting a path as still red

### DIFF
--- a/generator/tests/test_cross_file_contracts.py
+++ b/generator/tests/test_cross_file_contracts.py
@@ -215,6 +215,17 @@ def test_review_runs_pins_current_state_recovery() -> None:
     assert "failing default-branch CI with no bot fix in progress" in skill
 
 
+def test_review_runs_rechecks_a_stale_closure_read() -> None:
+    skill = _read("plugins", "tend-ci-runner", "skills", "review-runs", "SKILL.md")
+
+    assert (
+        "# Can serve a stale row; re-query once before reporting a path as still red."
+        in skill
+    )
+    assert "can never wrongly close a live red row" in skill
+    assert "re-run its closure call once and take the newer answer" in skill
+
+
 def test_outage_tracker_title_stays_in_sync() -> None:
     title = "Bot temporarily unavailable"
     reporter = _read("shared", "steps", "report_failure.py")

--- a/generator/tests/test_cross_file_contracts.py
+++ b/generator/tests/test_cross_file_contracts.py
@@ -222,7 +222,6 @@ def test_review_runs_rechecks_a_stale_closure_read() -> None:
         "# Can serve a stale row; re-query once before reporting a path as still red."
         in skill
     )
-    assert "can never wrongly close a live red row" in skill
     assert "re-run its closure call once and take the newer answer" in skill
 
 

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -106,7 +106,7 @@ As a daily backstop for delayed notifications, retention, edited activity, and r
     --jq '.workflow_runs[0] | {name, conclusion, created_at}'
   ```
 
-  The closure call sometimes serves a cached row weeks behind the true latest green, and an immediate re-query returns the current one. Staleness only moves the answer backwards, so it can never wrongly close a live red row — the one failure direction is a green too old to close a red one, which reports a fixed workflow as still red. So before reporting any path as still failing, re-run its closure call once and take the newer answer.
+  The closure call sometimes serves a cached row weeks behind the true latest green, and staleness only moves the answer backwards — so before reporting any path as still failing, re-run its closure call once and take the newer answer.
 
   Unwindowed on purpose: a failure nobody fixed is still live on the nights after it ran, so anchoring on `$TMPDIR/review-runs-since` would surface each one the night it happened and read as an all-clear afterwards. The page reaches back weeks, so most rows are already fixed and the closure call is what separates them. What it cannot close stays live: Dependabot's security updates have no workflow file, and each run's `name` carries a per-update ID that never recurs, so those rows close only through a fix PR or a tracker. Step 1's census reaches back 49h at most, so skip only the tend rows inside its window — a tend workflow red for longer than that, with no green since, is news here like any other row. Report the scope the claim rests on — "`main` is green" is read later as covering every workflow — naming the workflows checked and how far back the page reached.
 

--- a/plugins/tend-ci-runner/skills/review-runs/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review-runs/SKILL.md
@@ -101,9 +101,12 @@ As a daily backstop for delayed notifications, retention, edited activity, and r
   # Closure: for each distinct `path` above that is a real workflow file, its
   # latest green default-branch run closes that path's older red rows.
   # `dynamic/dependabot/...` paths are not files and 404 here.
+  # Can serve a stale row; re-query once before reporting a path as still red.
   gh api "repos/$GITHUB_REPOSITORY/actions/workflows/<basename of path>/runs?branch=$DEFAULT_BRANCH&status=success&per_page=1" \
     --jq '.workflow_runs[0] | {name, conclusion, created_at}'
   ```
+
+  The closure call sometimes serves a cached row weeks behind the true latest green, and an immediate re-query returns the current one. Staleness only moves the answer backwards, so it can never wrongly close a live red row — the one failure direction is a green too old to close a red one, which reports a fixed workflow as still red. So before reporting any path as still failing, re-run its closure call once and take the newer answer.
 
   Unwindowed on purpose: a failure nobody fixed is still live on the nights after it ran, so anchoring on `$TMPDIR/review-runs-since` would surface each one the night it happened and read as an all-clear afterwards. The page reaches back weeks, so most rows are already fixed and the closure call is what separates them. What it cannot close stays live: Dependabot's security updates have no workflow file, and each run's `name` carries a per-update ID that never recurs, so those rows close only through a fix PR or a tracker. Step 1's census reaches back 49h at most, so skip only the tend rows inside its window — a tend workflow red for longer than that, with no green since, is news here like any other row. Report the scope the claim rests on — "`main` is green" is read later as covering every workflow — naming the workflows checked and how far back the page reached.
 


### PR DESCRIPTION
## Problem

`review-runs`'s live-work closure read — the per-workflow `status=success&per_page=1` call that decides whether a red default-branch row is already fixed — sometimes serves a cached row weeks behind the true latest green. An immediate re-query of the identical URL returns the current row. The recipe had no freshness check, so a stale answer decided the verdict on its own.

I reproduced it on `PRQL/prql` while triaging: the first call for `tests.yaml` returned `2026-08-16T10:53:22Z`, the next two returned `2026-09-11T03:35:45Z`. That first value is byte-identical to what the reporter saw on two separate days, which rules out random jitter and points at a durable cached entry.

Staleness only moves the answer backwards, so it can never wrongly close a live red row. The single failure direction is the other one: a green older than the red row it has to close leaves that row uncloseable, and the sweep publishes "this workflow has been red on `main` since X with no green since" about a workflow that is green.

## Solution

A one-line condition on the existing call rather than new machinery: when the returned green predates the red row it has to close, re-run the call once and take the newer answer. That is exactly the case where a stale read is indistinguishable from a real unfixed failure, and the only case where the extra call can change the verdict.

## Testing

`test_review_runs_rechecks_a_stale_closure_read` in `generator/tests/test_cross_file_contracts.py` pins the re-query instruction in the closure recipe, matching the existing contract tests over this skill. It fails on `main` and passes here.

Closes #1209 — automated triage
