### PR TITLE
fix(sandbox): point zsh here-document scratch at the writable temp dir

### DIFF
--- a/docs/tend.example.yaml
+++ b/docs/tend.example.yaml
@@ -236,8 +236,8 @@ bot_name: my-project-bot
 #     `OPENAI_API_KEY`, `CODEX_API_KEY`, `CODEX_AUTH_JSON`, `CODEX_HOME`
 #   - the disposable checkout identity — `GITHUB_WORKSPACE`
 #   - prompt suppression — `CLAUDE_CODE_REMOTE`
-#   - the sandbox's own locations — `HOME`, `PATH`, `TMPDIR`, `XDG_CONFIG_HOME`,
-#     `XDG_CACHE_HOME`, `XDG_DATA_HOME`, `XDG_STATE_HOME`
+#   - the sandbox's own locations — `HOME`, `PATH`, `TMPDIR`, `TMPPREFIX`,
+#     `XDG_CONFIG_HOME`, `XDG_CACHE_HOME`, `XDG_DATA_HOME`, `XDG_STATE_HOME`
 #
 #     sandbox_env:
 #       RUST_BACKTRACE: "1"

--- a/generator/src/tend/config.py
+++ b/generator/src/tend/config.py
@@ -147,6 +147,7 @@ RESERVED_SANDBOX_ENV = {
     "CODEX_AUTH_JSON",
     "CODEX_HOME",
     "TMPDIR",
+    "TMPPREFIX",
 }
 
 

--- a/plugins/install-tend/skills/install-tend/references/tend.example.yaml
+++ b/plugins/install-tend/skills/install-tend/references/tend.example.yaml
@@ -236,8 +236,8 @@ bot_name: my-project-bot
 #     `OPENAI_API_KEY`, `CODEX_API_KEY`, `CODEX_AUTH_JSON`, `CODEX_HOME`
 #   - the disposable checkout identity — `GITHUB_WORKSPACE`
 #   - prompt suppression — `CLAUDE_CODE_REMOTE`
-#   - the sandbox's own locations — `HOME`, `PATH`, `TMPDIR`, `XDG_CONFIG_HOME`,
-#     `XDG_CACHE_HOME`, `XDG_DATA_HOME`, `XDG_STATE_HOME`
+#   - the sandbox's own locations — `HOME`, `PATH`, `TMPDIR`, `TMPPREFIX`,
+#     `XDG_CONFIG_HOME`, `XDG_CACHE_HOME`, `XDG_DATA_HOME`, `XDG_STATE_HOME`
 #
 #     sandbox_env:
 #       RUST_BACKTRACE: "1"

--- a/proxy/setup_sandbox.py
+++ b/proxy/setup_sandbox.py
@@ -69,6 +69,7 @@ RESERVED_SANDBOX_ENV = {
     "CODEX_AUTH_JSON",
     "CODEX_HOME",
     "TMPDIR",
+    "TMPPREFIX",
 }
 BLOCKED_COMMAND = """#!/bin/sh
 printf "tend: %s came from the runner home and is unavailable; install it into ~/.local/bin with sandbox_setup, or point sandbox_path at a copy outside the runner home\n" "${0##*/}" >&2
@@ -311,6 +312,10 @@ def base_agent_env(
         "GITHUB_WORKSPACE": str(workspace),
         "CLAUDE_CODE_REMOTE": "1",
         "TMPDIR": str(AGENT_TMP_DIR),
+        # zsh names here-document temp files from TMPPREFIX, not TMPDIR, and
+        # its default sits in the read-only root /tmp. A prefix needs only its
+        # directory to exist, which AGENT_TMP_DIR already does.
+        "TMPPREFIX": str(AGENT_TMP_DIR / "zsh"),
     }
     if anthropic_dummy:
         values[anthropic_dummy[0]] = anthropic_dummy[1]

--- a/proxy/test_setup_sandbox.py
+++ b/proxy/test_setup_sandbox.py
@@ -117,6 +117,20 @@ def test_every_fixed_agent_assignment_is_reserved() -> None:
     assert f"TMPDIR={setup_sandbox.AGENT_TMP_DIR}" in assignments
 
 
+def test_agent_environment_keeps_zsh_heredoc_scratch_writable() -> None:
+    """zsh names here-document temp files from TMPPREFIX, which ignores TMPDIR.
+
+    Left at its `/tmp/zsh` default every heredoc fails against the sandbox's
+    read-only root `/tmp` — after the shell has already truncated the
+    redirection target to zero bytes.
+    """
+    assignments = setup_sandbox.base_agent_env(
+        "/usr/bin", None, workspace=Path("/agent")
+    )
+
+    assert f"TMPPREFIX={setup_sandbox.AGENT_TMP_DIR / 'zsh'}" in assignments
+
+
 def test_github_only_agent_environment_has_no_model_credential() -> None:
     assignments = setup_sandbox.base_agent_env(
         "/usr/bin", None, workspace=Path("/agent")


### PR DESCRIPTION
## Problem

zsh names its here-document temp file from `TMPPREFIX`, which defaults to `/tmp/zsh` and never consults `TMPDIR`. The sandbox's `allowWrite` set covers the agent workspace and the agent home only, so root `/tmp` stays read-only and every heredoc in an agent Bash call fails — including the `--body-file` idiom `running-in-ci` recommends for composing comment bodies. #1199 made `TMPDIR` writable but left `TMPPREFIX` untouched, so it did not reach this.

The redirection is the sharp edge: zsh opens `> file` before it creates the heredoc temp file, so the target is truncated to zero bytes and then the command exits 1. A session that doesn't check the exit code has an empty body file where its comment should be.

## Solution

Set `TMPPREFIX` to `$AGENT_TMP_DIR/zsh` alongside the `TMPDIR` entry in the agent environment. `TMPPREFIX` is a prefix, so only its directory has to exist, and `AGENT_TMP_DIR` is already created during workspace handoff — no new `mkdir`. The key joins `RESERVED_SANDBOX_ENV` in both `proxy/setup_sandbox.py` and `generator/src/tend/config.py` (the env dict is asserted against the runtime set, and the parity hook requires the two to match), which also stops an adopter's `sandbox_env` from pointing it back outside the write set. The `sandbox_env` list in `docs/tend.example.yaml` names it, and the pre-commit mirror hook propagated that to the `install-tend` reference copy.

bash reads `TMPDIR` for its own heredocs, so it was already fine; this affects the shells that read `TMPPREFIX`.

## Testing

`test_agent_environment_keeps_zsh_heredoc_scratch_writable` asserts the assignment is present; it fails before the change and passes after. The reserved-set parity pre-commit hook passes with the three sets aligned.

Seven tests fail both on this branch and on a clean `main` checkout in this environment — `test_run_claude.py` argv assertions, `test_codex_runner.py`'s `AUTH_MODE`, `test_prepare_agent_workspace.py`, and the two `test_refresh_consumers.py` cases that need DNS. They are the sandbox-environment-leakage class #1207 addresses, not this change.

Closes #1208 — automated triage
