### PR TITLE
skills(running-tend): name bundled skills as /tend-ci-runner:<name>

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -1,15 +1,16 @@
 ---
 name: running-tend
-description: Tend-specific guidance for tend CI workflows. Adds non-standard workflow inclusion for usage analysis and repo conventions on top of the generic tend-* skills.
+description: Tend-specific guidance for tend CI workflows. Adds non-standard workflow inclusion for usage analysis and repo conventions on top of the bundled tend-ci-runner skills.
 metadata:
   internal: true
 ---
 
 # Tend CI
 
-Repo-specific guidance for tend workflows running on tend itself. The generic
-skills (`tend-running-in-ci`, `tend-review`, `tend-triage`, etc.) provide the
-workflow framework; this skill adds tend conventions.
+Repo-specific guidance for tend workflows running on tend itself. The bundled
+skills (`/tend-ci-runner:running-in-ci`, `/tend-ci-runner:review`,
+`/tend-ci-runner:triage`, etc.) provide the workflow framework; this skill adds
+tend conventions.
 
 ## Filing issues in other repos
 

--- a/.claude/skills/running-tend/references/integration-test.md
+++ b/.claude/skills/running-tend/references/integration-test.md
@@ -244,7 +244,7 @@ Clone, create a branch with a trivial README edit, open a PR, wait for
 `tend-review` to register and finish, assert the action invoked the
 Claude session (artifact present).
 
-The `tend-review` skill is explicitly directed to exit silently on
+The `/tend-ci-runner:review` skill is explicitly directed to exit silently on
 self-authored, trivial PRs (GitHub blocks self-approval; the skill keeps
 quiet when there are no concerns). So an "is there a bot review on the
 PR?" assertion can't distinguish "the action never ran" from "the action


### PR DESCRIPTION
Tend's own overlay (`.claude/skills/running-tend/SKILL.md`) named the bundled skills `tend-running-in-ci`, `tend-review`, and `tend-triage`. No skills by those names exist — the last two are generated workflow names — and every tend-on-tend session reads that line. This rewrites them as `/tend-ci-runner:running-in-ci`, `/tend-ci-runner:review`, and `/tend-ci-runner:triage`, fixes the frontmatter description's "generic tend-* skills" to match, and repoints the one `tend-review` skill citation in `references/integration-test.md`. The remaining `tend-review` / `tend-triage` mentions there name workflows and stay as they are.

> _This was written by Claude Code on behalf of max-sixty_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nTUeWiMoSoAuPgdB1ZJZt
