### PR TITLE
review: decide the pre-approval check in the script, not in prose

### DIFF
--- a/generator/tests/test_poll_scripts.py
+++ b/generator/tests/test_poll_scripts.py
@@ -65,6 +65,9 @@ FAKE_GH = (
   "pr view")
     emit "$(cat "$HEAD_JSON")"
     ;;
+  "run view")
+    emit "$(cat "$RUN_DIR/$3.json")"
+    ;;
   "run rerun")
     ;;
   api*)
@@ -157,6 +160,7 @@ def env(tmp_path: Path) -> dict[str, str]:
     rollups.mkdir()
     jobs_dir = tmp_path / "jobs"
     jobs_dir.mkdir()
+    (tmp_path / "runs").mkdir()
     (tmp_path / "head.json").write_text(json.dumps({"headRefOid": HEAD_SHA}))
     (tmp_path / "jobs.json").write_text(json.dumps({"jobs": []}))
     (tmp_path / "attempts").write_text("1\n")
@@ -169,6 +173,7 @@ def env(tmp_path: Path) -> dict[str, str]:
         "HEAD_JSON": str(tmp_path / "head.json"),
         "JOBS_JSON": str(tmp_path / "jobs.json"),
         "JOB_DIR": str(jobs_dir),
+        "RUN_DIR": str(tmp_path / "runs"),
         "ATTEMPTS": str(tmp_path / "attempts"),
         "GITHUB_REPOSITORY": "owner/repo",
         "GITHUB_RUN_ID": "555",
@@ -212,8 +217,8 @@ def _poll(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
     return _poll_args(env, "7", HEAD_SHA)
 
 
-def _snapshot(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
-    return _invoke(poll_pr_checks, env, ["snapshot", "7", HEAD_SHA])
+def _approval(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return _invoke(poll_pr_checks, env, ["approval", "7", HEAD_SHA])
 
 
 def test_settled_green(env: dict[str, str]) -> None:
@@ -225,40 +230,96 @@ def test_settled_green(env: dict[str, str]) -> None:
     assert "green" in result.stdout
 
 
-def test_snapshot_prints_the_pinned_rollup_and_live_head(env: dict[str, str]) -> None:
-    _serve(env, _resp(_check_run("tests"), _status_ctx("codecov/patch", "PENDING")))
-
-    result = _snapshot(env)
-
-    assert result.returncode == 0, result.stderr
-    assert json.loads(result.stdout) == {
-        "sha": HEAD_SHA,
-        "head_sha": HEAD_SHA,
-        "pending": ["codecov/patch"],
-        "failed": [],
-    }
+OMNIBUS_RED = _check_run("check-ok-to-merge", conclusion="FAILURE", run_id=100)
+MATRIX_RUNNING = _check_run("matrix", status="IN_PROGRESS", run_id=200)
 
 
-def test_snapshot_treats_filtered_empty_as_a_clean_preapproval_view(
-    env: dict[str, str],
-) -> None:
-    _serve(
-        env,
-        _resp(
-            _check_run("own", status="IN_PROGRESS", workflow="other", run_id=555),
-            _check_run("review", status="IN_PROGRESS", workflow="tend-review"),
+@pytest.mark.parametrize(
+    ("responses", "runs", "verdict", "named", "polled"),
+    [
+        # Nothing failing approves at once, even beside a running check.
+        ((_resp(_check_run("tests"), MATRIX_RUNNING),), {}, "approve:", "", False),
+        # This run and tend-review are all there is: nothing else gates.
+        (
+            (
+                _resp(
+                    _check_run("own", status="IN_PROGRESS", workflow="x", run_id=555),
+                    _check_run("review", status="IN_PROGRESS", workflow="tend-review"),
+                ),
+            ),
+            {},
+            "approve:",
+            "",
+            False,
         ),
-    )
+        # A red with nothing pending is terminal.
+        (
+            (_resp(OMNIBUS_RED, _check_run("matrix")),),
+            {},
+            "withhold: red",
+            "check-ok-to-merge",
+            False,
+        ),
+        # A red beside a running check waits, and its replacement settles green.
+        (
+            (
+                _resp(OMNIBUS_RED, MATRIX_RUNNING),
+                _resp(
+                    _check_run("check-ok-to-merge", run_id=101), _check_run("matrix")
+                ),
+            ),
+            {},
+            "approve:",
+            "",
+            True,
+        ),
+        # Still pending at the cap: a red from a cancelled run approves, naming
+        # what never finished ...
+        (
+            (_resp(OMNIBUS_RED, MATRIX_RUNNING),),
+            {100: "cancelled"},
+            "approve:",
+            "matrix",
+            True,
+        ),
+        # ... a real failure withholds ...
+        (
+            (_resp(OMNIBUS_RED, MATRIX_RUNNING),),
+            {100: "failure"},
+            "withhold: red",
+            "check-ok-to-merge",
+            True,
+        ),
+        # ... and so does a status context, which names no run to inspect.
+        (
+            (_resp(_status_ctx("codecov/patch", "FAILURE"), MATRIX_RUNNING),),
+            {},
+            "withhold: red",
+            "codecov/patch",
+            True,
+        ),
+    ],
+)
+def test_approval_verdict(
+    env: dict[str, str],
+    responses: tuple[str, ...],
+    runs: dict[int, str],
+    verdict: str,
+    named: str,
+    polled: bool,
+) -> None:
+    _serve(env, *responses)
+    for run_id, conclusion in runs.items():
+        (Path(env["RUN_DIR"]) / f"{run_id}.json").write_text(
+            json.dumps({"conclusion": conclusion})
+        )
 
-    result = _snapshot(env)
+    result = _approval(env)
 
-    assert result.returncode == 0, result.stderr
-    assert json.loads(result.stdout) == {
-        "sha": HEAD_SHA,
-        "head_sha": HEAD_SHA,
-        "pending": [],
-        "failed": [],
-    }
+    assert result.stdout.startswith(verdict), result.stdout + result.stderr
+    assert result.returncode == (0 if verdict == "approve:" else 1)
+    assert named in result.stdout
+    assert (Path(env["GRAPHQL_CALLS"]).read_text().strip() != "1") is polled
 
 
 def test_red_names_the_failing_check_with_its_url(env: dict[str, str]) -> None:

--- a/generator/tests/test_poll_scripts.py
+++ b/generator/tests/test_poll_scripts.py
@@ -66,6 +66,7 @@ FAKE_GH = (
     emit "$(cat "$HEAD_JSON")"
     ;;
   "run view")
+    [ -f "$RUN_DIR/$3.json" ] || exit 1
     emit "$(cat "$RUN_DIR/$3.json")"
     ;;
   "run rerun")
@@ -320,6 +321,31 @@ def test_approval_verdict(
     assert result.returncode == (0 if verdict == "approve:" else 1)
     assert named in result.stdout
     assert (Path(env["GRAPHQL_CALLS"]).read_text().strip() != "1") is polled
+
+
+@pytest.mark.parametrize(
+    ("also_failing", "returncode", "stdout"),
+    [
+        # The only failure's run can't be read: nothing is decided.
+        ((), 2, ""),
+        # Another failure is real, so the unreadable run can't change the verdict.
+        ((_check_run("lint", conclusion="FAILURE", run_id=300),), 1, "withhold: red"),
+    ],
+)
+def test_approval_with_a_run_it_cannot_read(
+    env: dict[str, str], also_failing: tuple[dict, ...], returncode: int, stdout: str
+) -> None:
+    """`gh run view` exits 1 on a 5xx or a run id this repo can't resolve, which
+    is also `withhold:`'s code — so the failure has to be decided, not escape."""
+    _serve(env, _resp(OMNIBUS_RED, MATRIX_RUNNING, *also_failing))
+    (Path(env["RUN_DIR"]) / "300.json").write_text(
+        json.dumps({"conclusion": "failure"})
+    )
+
+    result = _approval(env)
+
+    assert result.returncode == returncode, result.stdout + result.stderr
+    assert result.stdout.startswith(stdout)
 
 
 def test_red_names_the_failing_check_with_its_url(env: dict[str, str]) -> None:

--- a/plugins/tend-ci-runner/scripts/poll_pr_checks.py
+++ b/plugins/tend-ci-runner/scripts/poll_pr_checks.py
@@ -17,6 +17,7 @@ from typing import Any
 import github_cli
 
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+RUN_ID_RE = re.compile(r"/actions/runs/(\d+)/")
 RED_CONCLUSIONS = {
     "FAILURE",
     "TIMED_OUT",
@@ -205,15 +206,58 @@ def head_note(*, pr: str, repo: str, sha: str) -> None:
         )
 
 
-def _head_sha(pr: str, repo: str) -> str:
-    response = github_cli.json_call(
-        "pr", "view", pr, "--repo", repo, "--json", "headRefOid"
+def _settle(
+    *, repo: str, sha: str, sleep: Callable[[float], None]
+) -> tuple[bool, dict[str, list[str]] | None]:
+    """Poll until nothing pends on two reads 30s apart, or the cap expires.
+
+    Returns whether the rollup settled, and the last complete rollup read.
+    """
+    run_id = os.environ.get("GITHUB_RUN_ID", "")
+    workflow = os.environ.get("GITHUB_WORKFLOW", "")
+    last: dict[str, list[str]] | None = None
+    for _ in range(9):
+        sleep(60)
+        current = fetch_rollup(repo=repo, sha=sha, run_id=run_id, workflow=workflow)
+        if current is None:
+            continue
+        last = current
+        if current["pending"]:
+            continue
+        sleep(30)
+        current = fetch_rollup(repo=repo, sha=sha, run_id=run_id, workflow=workflow)
+        if current is None:
+            continue
+        last = current
+        if not current["pending"]:
+            return True, current
+    return False, last
+
+
+def _run_conclusion(repo: str, failure: str) -> str:
+    """The conclusion of the Actions run behind a failed check, "" for a status."""
+    match = RUN_ID_RE.search(failure)
+    if not match:
+        return ""
+    view = github_cli.json_call(
+        "run", "view", match.group(1), "--repo", repo, "--json", "conclusion"
     )
-    return str(response["headRefOid"])
+    return str(view["conclusion"])
 
 
-def snapshot(pr: str, sha: str) -> int:
-    """Print the current non-own check state for one pinned PR commit."""
+def approval(pr: str, sha: str, *, sleep: Callable[[float], None] = time.sleep) -> int:
+    """Decide whether one pinned PR commit's checks allow an approval.
+
+    A failure beside checks still running is often a cancellation cascade: a
+    concurrency group cancels a run, an `if: always()` merge-gate omnibus
+    reports that as FAILURE rather than cancelled, and a replacement run is
+    already under way. So a red with checks pending waits for them to settle,
+    and a red still standing at the cap approves only when every failing check
+    belongs to a cancelled Actions run.
+
+    Whether *sha* is still the head is not judged here: the review skill posts
+    every review behind `review_preflight.py post`, which refuses a moved head.
+    """
     repo = os.environ["GITHUB_REPOSITORY"]
     rollup = fetch_rollup(
         repo=repo,
@@ -225,7 +269,24 @@ def snapshot(pr: str, sha: str) -> int:
     if rollup is None:
         print(f"could not read a complete check rollup for {sha}", file=sys.stderr)
         return 2
-    github_cli.dump({"sha": sha, "head_sha": _head_sha(pr, repo), **rollup})
+    if rollup["failed"] and rollup["pending"]:
+        _, rollup = _settle(repo=repo, sha=sha, sleep=sleep)
+        if rollup is None:
+            print(f"no complete rollup read for {sha} while waiting", file=sys.stderr)
+            return 2
+
+    failures = rollup["failed"]
+    if failures and rollup["pending"]:
+        failures = [f for f in failures if _run_conclusion(repo, f) != "cancelled"]
+        if not failures:
+            print(f"approve: every failure on {sha} is a cancelled run; unverified:")
+            print(*rollup["pending"], sep="\n")
+            return 0
+    if failures:
+        print(f"withhold: red on {sha}:")
+        print(*failures, sep="\n")
+        return 1
+    print(f"approve: no failing check on {sha}")
     return 0
 
 
@@ -244,41 +305,16 @@ def poll(pr: str, sha: str, *, sleep: Callable[[float], None] = time.sleep) -> i
             )
             return 2
 
-    last: dict[str, list[str]] | None = None
-    for _ in range(9):
-        sleep(60)
-        current = fetch_rollup(
-            repo=repo,
-            sha=sha,
-            run_id=os.environ.get("GITHUB_RUN_ID", ""),
-            workflow=os.environ.get("GITHUB_WORKFLOW", ""),
-        )
-        if current is None:
-            continue
-        last = current
-        if current["pending"]:
-            continue
-        sleep(30)
-        current = fetch_rollup(
-            repo=repo,
-            sha=sha,
-            run_id=os.environ.get("GITHUB_RUN_ID", ""),
-            workflow=os.environ.get("GITHUB_WORKFLOW", ""),
-        )
-        if current is None:
-            continue
-        last = current
-        if current["pending"]:
-            continue
-        if current["failed"]:
-            print(f"red on {sha}:")
-            print(*current["failed"], sep="\n")
-            head_note(pr=pr, repo=repo, sha=sha)
-            return 1
+    settled, last = _settle(repo=repo, sha=sha, sleep=sleep)
+    if settled and last["failed"]:
+        print(f"red on {sha}:")
+        print(*last["failed"], sep="\n")
+        head_note(pr=pr, repo=repo, sha=sha)
+        return 1
+    if settled:
         print(f"green: every gating check on {sha} settled green")
         head_note(pr=pr, repo=repo, sha=sha)
         return 0
-
     if last is None:
         print(f"no gating check settled on {sha} — UNVERIFIED, not green")
         head_note(pr=pr, repo=repo, sha=sha)
@@ -302,14 +338,14 @@ def main(
     sha = args[1] if len(args) > 1 else ""
     if len(args) != 2 or not SHA_RE.fullmatch(sha):
         print(
-            "poll_pr_checks.py: poll|snapshot <pr-number> <sha>; <sha> must be "
+            "poll_pr_checks.py: poll|approval <pr-number> <sha>; <sha> must be "
             "a full 40-char lowercase commit "
             f"OID, got '{sha}' — UNVERIFIED, not green",
             file=sys.stderr,
         )
         return 2
-    if command == "snapshot":
-        return snapshot(pr, sha)
+    if command == "approval":
+        return approval(pr, sha, sleep=sleep)
     if command == "poll":
         return poll(pr, sha, sleep=sleep)
     print(f"unknown command: {command or '<none>'}", file=sys.stderr)

--- a/plugins/tend-ci-runner/scripts/poll_pr_checks.py
+++ b/plugins/tend-ci-runner/scripts/poll_pr_checks.py
@@ -234,15 +234,28 @@ def _settle(
     return False, last
 
 
-def _run_conclusion(repo: str, failure: str) -> str:
-    """The conclusion of the Actions run behind a failed check, "" for a status."""
+def _run_conclusion(repo: str, failure: str) -> str | None:
+    """The conclusion of the Actions run behind a failed check.
+
+    "" for a status context, which names no run; None when the run can't be read.
+    """
     match = RUN_ID_RE.search(failure)
     if not match:
         return ""
-    view = github_cli.json_call(
-        "run", "view", match.group(1), "--repo", repo, "--json", "conclusion"
-    )
-    return str(view["conclusion"])
+    try:
+        view = github_cli.json_call(
+            "run",
+            "view",
+            match.group(1),
+            "--repo",
+            repo,
+            "--json",
+            "conclusion",
+            quiet=True,
+        )
+        return str(view["conclusion"])
+    except (subprocess.CalledProcessError, ValueError, KeyError, TypeError):
+        return None
 
 
 def approval(pr: str, sha: str, *, sleep: Callable[[float], None] = time.sleep) -> int:
@@ -253,7 +266,8 @@ def approval(pr: str, sha: str, *, sleep: Callable[[float], None] = time.sleep) 
     reports that as FAILURE rather than cancelled, and a replacement run is
     already under way. So a red with checks pending waits for them to settle,
     and a red still standing at the cap approves only when every failing check
-    belongs to a cancelled Actions run.
+    belongs to a cancelled Actions run. A run that can't be read decides nothing,
+    unless another failure is already real.
 
     Whether *sha* is still the head is not judged here: the review skill posts
     every review behind `review_preflight.py post`, which refuses a moved head.
@@ -277,7 +291,14 @@ def approval(pr: str, sha: str, *, sleep: Callable[[float], None] = time.sleep) 
 
     failures = rollup["failed"]
     if failures and rollup["pending"]:
-        failures = [f for f in failures if _run_conclusion(repo, f) != "cancelled"]
+        conclusions = [(f, _run_conclusion(repo, f)) for f in failures]
+        failures = [f for f, c in conclusions if c not in {"cancelled", None}]
+        unread = [f for f, c in conclusions if c is None]
+        if unread and not failures:
+            print(
+                f"could not read the run behind: {', '.join(unread)}", file=sys.stderr
+            )
+            return 2
         if not failures:
             print(f"approve: every failure on {sha} is a cancelled run; unverified:")
             print(*rollup["pending"], sep="\n")

--- a/plugins/tend-ci-runner/skills/review/SKILL.md
+++ b/plugins/tend-ci-runner/skills/review/SKILL.md
@@ -18,7 +18,7 @@ Follow these steps in order. Four references carry guidance a minority of review
 
 - `references/draft-mode.md` — under **Pre-flight checks**, when `is_draft` is true: the lighter pass, COMMENT only, the hidden marker.
 - `references/re-targeting.md` — under **Submit**, when the posting preflight prints `delta:`: reviewing a push that landed mid-review before posting against the new head.
-- `references/approving.md` — under **Submit** before an APPROVE, and under **Monitor CI** after one: the settled-rollup check and the CI outcomes.
+- `references/approving.md` — under **Submit** before an APPROVE, and under **Monitor CI** after one: the approval check and the CI outcomes.
 - `references/inline-suggestions.md` — under **Submit**, when the review carries findings: the payload, multi-line suggestion rules, and 422 recovery.
 
 ### 0. Load environment skills
@@ -210,7 +210,7 @@ Every review POST passes its `gh api` command to the preflight after `--`, which
 
 **Pin every review to the commit you read** — `commit_id` in every posting recipe, read back from `$TMPDIR/reviewed-head`, which **Pre-flight checks** wrote and the posting preflight rewrites if HEAD moved. Two things depend on the pin. GitHub otherwise anchors the review at whatever is live when the POST lands, so the review claims code this session never saw. And the anchor is what the next run's pre-flight reads as `already_reviewed`: pinned to the head you re-targeted onto, the queued run finds that head already reviewed and finishes without posting a second review of the same code.
 
-**Before APPROVE specifically**, run the settled-rollup check in `references/approving.md` — a head mismatch, a real red, or an author-stated blocker withholds the approval.
+**Before APPROVE specifically**, run the approval check in `references/approving.md` — a real red or an author-stated blocker withholds the approval.
 
 Post at most one review per run. Give a verdict (**approve** or **comment**, never "request changes") when this pass has something to say: a new diff-grounded finding, or an approval because the last open concern is now resolved. If the dedup rule above left nothing new and a prior unresolved bot thread still stands, post nothing; the earlier review remains the active verdict. Post reviews through the reviews endpoint, not `gh pr comment`. Note: a COMMENT review requires a non-empty body — if there's nothing to say and no prior concern stands, use the approve-with-empty-body pattern.
 

--- a/plugins/tend-ci-runner/skills/review/references/approving.md
+++ b/plugins/tend-ci-runner/skills/review/references/approving.md
@@ -7,43 +7,23 @@ Depth behind `/tend-ci-runner:review`'s **Submit** and **Monitor CI** steps: rea
 
 ## Before the APPROVE
 
-**Before APPROVE specifically**, run the snapshot below and require its `head_sha` to equal `$TMPDIR/reviewed-head`. The rollup is pinned to `$TMPDIR/reviewed-head`; a head mismatch means it does not cover the live head, so post findings if you have them, otherwise finish and leave the approval to the queued run. Then inspect that rollup: if any check has reached terminal `FAILURE`, do not emit an empty-body APPROVE — the close-out reads as the bot rubber-stamping over the visibly red signal. Re-check the author-readiness gate on the same pass — a comment withholding merge readiness can land after the review began, and the conversation you read under **Pre-flight checks** is by now stale.
-
-An approval you post at a re-targeted head is yours to stand behind: the queued run reads that head as reviewed and finishes, so no successor session dismisses the approval if a check goes red. **Monitor CI**'s poll is the whole net — run it to terminal before ending the session.
-
-Reduce the rollup to the **latest entry per check name and workflow** before reading it. When a concurrency-cancelled run is replaced, GitHub keeps *both* check runs on the commit, so an un-deduped scan reports the superseded `FAILURE` alongside the replacement's `SUCCESS` — and keeps reporting it forever. Key on `workflowName` as well as the name: two workflows can register the same check name, and collapsing those into one entry would hide a genuine red behind an unrelated green.
+Run the approval check against the commit this session reviewed, in the foreground with `timeout: 600000` — a failure showing while other checks still run makes it wait for them:
 
 ```bash
 uv run --script "${CLAUDE_PLUGIN_ROOT}/scripts/poll_pr_checks.py" \
-  snapshot <number> "$(cat "$TMPDIR/reviewed-head")"
+  approval <number> "$(cat "$TMPDIR/reviewed-head")"
 ```
 
-The JSON reports `head_sha`, `pending`, and `failed` for the pinned commit after
-dropping this run, this workflow, and superseded check runs. When those filters
-leave no external contexts, both lists are empty; that is the clean `failed`
-empty branch for this pre-approval snapshot, not evidence that the repository
-registered a gating check. Re-run the snapshot after any poll; no shell state
-survives between calls.
+It judges the latest run of each check outside this run and this workflow, and prints one verdict:
 
-**Don't treat a mid-flight rollup as settled.** A `FAILURE` co-existing with a non-empty `pending` list is often a *stale cancellation-cascade* artifact, not a real failure: when several events fire near-simultaneously (e.g. Dependabot opening a PR), the `tests` concurrency group cancels all but the latest, and a cancelled contributor makes an `if: always()` merge-gate omnibus (like PRQL's `check-ok-to-merge`) resolve to conclusion `FAILURE` — *not* `cancelled`, so it slips past the post-approve cancellation awareness below and reads as red. A fresh replacement run is already in flight and will re-register the omnibus. So decide on the **settled** rollup:
+- **`approve:`** — post the APPROVE. When it lists checks as unverified, every remaining failure came from a cancelled run whose replacement hasn't finished; name those checks in the review body.
+- **`withhold:`** — a check failed on its own merits. Skip the close-out and finish. If **no prior substantive bot review** stands on this PR, post a brief COMMENT stating the diff assessment and the failing check that withholds approval, so a clean dependency bump isn't left with no review signal; an earlier substantive review already stands as the verdict. On a bot PR where you intend to push the fix yourself (**Push fixes**), post that COMMENT before pushing, while the checks it names are still the current ones.
 
-- **`failed` non-empty and `pending` non-empty** — the rollup hasn't settled. Foreground-poll until non-own checks are terminal (the loop in `/tend-ci-runner:running-in-ci`'s `references/ci-monitoring.md`), then re-run the snapshot. Judge the settled state, not the mid-flight snapshot — a stale cancellation-cascade `FAILURE` drops out once the replacement omnibus registers, but *only* via the reduction above; the superseded check run itself never leaves the commit.
-- **`failed` non-empty and the poll cap expired with `pending` non-empty** — settlement is out of reach this session; a release or nightly matrix routinely outlasts the cap. Re-run the snapshot first. Then decide on **provenance**, not on settlement: resolve each remaining failure URL to its run and read that run's own conclusion.
+Any other exit decided nothing: don't approve, and report the approval as unverified.
 
-  For each snapshot URL containing `/actions/runs/<run-id>/`, inspect that run:
+Re-check the author-readiness gate on the same pass — a comment withholding merge readiness can land after the review began, and the conversation you read under **Pre-flight checks** is by now stale.
 
-  ```bash
-  gh run view <run-id> --json conclusion --jq '.conclusion'
-  ```
-
-  A URL without an Actions run id is unresolved third-party status, not a
-  cancellation you can prove.
-
-  Every one `cancelled` — the red is superseded, so APPROVE and name the still-unverified checks in the body. `cancelled` is the only conclusion that earns an approval here: a real `failure`, an empty conclusion (the run is still going, so the job failed on its own merits), or an unresolvable URL (a third-party status context like `codecov/patch`, never an Actions run) all take the terminal-red branch below. Don't leave this to improvisation: the same stale red must not draw an APPROVE on one PR and a withheld approval on the next.
-- **`failed` non-empty and `pending` empty** — genuine terminal red. Skip the close-out and finish. But if **no prior substantive bot review** stands on this PR, don't exit fully silent or leave only a `+1` reaction — a clean external-dependency bump then carries zero review signal. Post a brief COMMENT stating the diff assessment and the failing check that withholds approval. Any earlier substantive review already stands as the active verdict — leave it. On a bot PR where you intend to push the fix yourself (**Push fixes**), post that COMMENT before pushing, while the rollup it describes is still the current one.
-- **`failed` empty** — proceed with APPROVE.
-
-**Monitor CI**'s "approve, foreground-poll CI, dismiss if a check fails" pattern only recovers while the session is still alive — the job timeout or a poll cap can leave a post-approve failure undismissed and the PR carrying a misleading APPROVED state. A synchronous pre-APPROVE peek catches the case where the failure is already in the rollup — including non-required checks like `codecov/patch` that an overlay treats as a merge gate. Reducing to the latest entry per name and workflow — and, when the cap expires first, checking each `FAILURE`'s run conclusion — is what keeps a superseded red from being mistaken for a real one.
+An approval you post at a re-targeted head is yours to stand behind: the queued run reads that head as reviewed and finishes, so no successor session dismisses the approval if a check goes red. **Monitor CI**'s poll is the whole net — run it to terminal before ending the session.
 
 ## After the approval
 


### PR DESCRIPTION
Before an empty-body APPROVE, `review/references/approving.md` had the agent run `poll_pr_checks.py snapshot` and then branch on its fields in prose. A failure beside pending checks meant poll until they settle and re-snapshot. A failure still standing at the poll cap meant resolving each failing check to its Actions run and approving only when every one was `cancelled`, because a cancelled contributor makes an `if: always()` merge-gate omnibus report `FAILURE`. The reference said so itself: "Don't leave this to improvisation: the same stale red must not draw an APPROVE on one PR and a withheld approval on the next." Every input to that decision was already in the script's hands.

`poll_pr_checks.py approval <pr> <sha>` replaces `snapshot` (this reference was its only caller) and prints one verdict, `approve:` or `withhold:`. It reuses the settle loop `poll` already ran, now extracted as `_settle`, and resolves run conclusions itself. A run it can't read — a 5xx, or a run id the repo doesn't resolve — decides nothing: it exits 2, the code the module already uses for an unreadable rollup, unless another failing check is confirmed real, which still withholds. `approving.md` keeps what the agent does with each verdict, and drops from 65 lines to 45.

The head-moved check goes rather than moving. Every review POST in the review skill runs behind `review_preflight.py post -- …`, which refuses a moved head at the moment of posting, so a second comparison before the wait guarded the same thing earlier and more weakly.

`generator/tests/test_poll_scripts.py` replaces the two snapshot tests with one seven-case table: nothing failing, only this run and `tend-review` in the rollup, terminal red, a red that settles green, and at the cap a cancelled run, a real failure, and a status context with no run to inspect. A second test covers a run that can't be read, alone and beside a real failure. Disabling the settle wait, the cancelled-run approval, or the unreadable-run guard each fails a test.

Follows #1215, which pushed the review pre-flight's decisions into `review_preflight.py` the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PoS7vwmM9mqPmS2UGBLJiw

> _This was written by Claude Code on behalf of max-sixty_

